### PR TITLE
ci: add conventional commit validation to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
           # Check each commit since the base
           echo "Validating commits since $BASE_SHA..."
           git log --format="%H %s" $BASE_SHA..HEAD | while read sha message; do
+            # Skip merge commits (GitHub automatically creates these)
+            if echo "$message" | grep -qE '^Merge [0-9a-f]+ into [0-9a-f]+'; then
+              echo "⊙ Skipping merge commit: $sha"
+              continue
+            fi
+
             # Check if message matches conventional commit format
             if ! echo "$message" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+'; then
               echo "❌ Commit $sha does not follow Conventional Commits format:"


### PR DESCRIPTION
## Summary
- Adds CI validation for Conventional Commits format on all pull requests
- Validates both PR titles and individual commit messages
- Prevents releases from failing due to unparseable commit messages

## Why This Matters

The previous release attempt failed because commit e0e9adb had the message "Schema improvements and oneOf discriminator patterns (v2.0.0) (#23)" which doesn't follow Conventional Commits format. Release-please couldn't parse it, resulting in zero parseable commits and no release.

## How It Works

The new `conventional-commits` CI job:
1. **PR Title Validation**: Uses `action-semantic-pull-request` to validate PR titles
2. **Individual Commit Validation**: Custom script validates each commit message format
3. **Clear Error Messages**: Provides examples when validation fails

## Validation Rules

Commits must match: `<type>[optional scope][!]: <description>`

**Valid types**: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert

**Examples**:
- `feat: add new feature`
- `fix: resolve bug in parser`
- `feat(api): add new endpoint`
- `feat!: breaking change`
- `feat(api)!: breaking change with scope`

## Test Plan
- [x] Validated regex locally with test cases
- [x] Tested valid conventional commit formats
- [x] Tested invalid format (original problematic commit)
- [ ] Verify CI runs on this PR
- [ ] Verify release-please triggers after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)