### PR TITLE
docs: add Python version requirement note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ AdCP operations are **distributed and asynchronous by default**. An agent might:
 pip install adcp
 ```
 
+> **Note**: This client requires Python 3.10 or later and supports both synchronous and asynchronous workflows.
+
 ## Quick Start: Distributed Operations
 
 ```python


### PR DESCRIPTION
## Summary
- Add Python 3.10+ requirement note to README installation section
- Clarifies async/sync workflow support

## Purpose
This is a documentation-only change to trigger a release. The previous schema improvements (v2.0.0) didn't release because the commit message wasn't in Conventional Commits format. This `docs:` commit will trigger release-please to create a release PR.

## Why This Release Matters
The unreleased commit e0e9adb contains significant schema improvements including oneOf discriminator patterns that should be released as v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)