### PR TITLE
fix: export no-auth test helpers from main module

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -23,13 +23,17 @@ from adcp.exceptions import (
 from adcp.testing import (
     CREATIVE_AGENT_CONFIG,
     TEST_AGENT_A2A_CONFIG,
+    TEST_AGENT_A2A_NO_AUTH_CONFIG,
     TEST_AGENT_MCP_CONFIG,
+    TEST_AGENT_MCP_NO_AUTH_CONFIG,
     TEST_AGENT_TOKEN,
     create_test_agent,
     creative_agent,
     test_agent,
     test_agent_a2a,
+    test_agent_a2a_no_auth,
     test_agent_client,
+    test_agent_no_auth,
 )
 from adcp.types.core import AgentConfig, Protocol, TaskResult, TaskStatus, WebhookMetadata
 from adcp.types.generated import (
@@ -161,12 +165,16 @@ __all__ = [
     # Test helpers
     "test_agent",
     "test_agent_a2a",
+    "test_agent_no_auth",
+    "test_agent_a2a_no_auth",
     "creative_agent",
     "test_agent_client",
     "create_test_agent",
     "TEST_AGENT_TOKEN",
     "TEST_AGENT_MCP_CONFIG",
     "TEST_AGENT_A2A_CONFIG",
+    "TEST_AGENT_MCP_NO_AUTH_CONFIG",
+    "TEST_AGENT_A2A_NO_AUTH_CONFIG",
     "CREATIVE_AGENT_CONFIG",
     # Exceptions
     "ADCPError",


### PR DESCRIPTION
## Summary
Export the no-auth test helpers (`test_agent_no_auth`, `test_agent_a2a_no_auth`) and their config constants from the main `adcp` module. These helpers exist in `adcp.testing` but weren't exposed at the top level, forcing users to use a less discoverable import path.

## Changes
Added 4 exports to `src/adcp/__init__.py`:
- `test_agent_no_auth` and `test_agent_a2a_no_auth` (client instances)
- `TEST_AGENT_MCP_NO_AUTH_CONFIG` and `TEST_AGENT_A2A_NO_AUTH_CONFIG` (config objects)

Users can now use: `from adcp import test_agent_no_auth` instead of `from adcp.testing import test_agent_no_auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)