### PR TITLE
fix: update MCP SDK to >=1.23.2 for streaming stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "typing-extensions>=4.5.0",
     "a2a-sdk>=0.3.0",
-    "mcp>=0.9.0",
+    "mcp>=1.23.2",
     "email-validator>=2.0.0",
 ]
 


### PR DESCRIPTION
Bumps minimum MCP SDK version to 1.23.2 which includes critical fixes for StreamableHTTP streaming stability. The v1.23.2 release fixes ClosedResourceError handling in the message router that was introduced in v1.12.0.

## What's fixed
- ClosedResourceError crashes when connections close unexpectedly during streaming
- Race condition in StreamableHTTP message router (merged PR #1384)
- Backward compatibility with older protocol versions

## Testing
All 344 existing tests pass with the new dependency.