### PR TITLE
feat: export A2UI types from public API

### DIFF
--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -40,6 +40,8 @@ from adcp.types import _generated as generated  # noqa: F401
 # V3 Sponsored Intelligence types
 # V3 Governance (Property Lists) types
 from adcp.types._generated import (
+    A2UiComponent,
+    A2UiSurface,
     Account,
     ActivateSignalRequest,
     ActivateSignalResponse,
@@ -400,6 +402,8 @@ __all__ = [
     "ValidateContentDeliveryRequest",
     "ValidateContentDeliveryResponse",
     # V3 Sponsored Intelligence
+    "A2UiComponent",
+    "A2UiSurface",
     "SiCapabilities",
     "SiGetOfferingRequest",
     "SiGetOfferingResponse",


### PR DESCRIPTION
## Summary

- Export `A2UiComponent` and `A2UiSurface` from `adcp.types` module
- These types were added in the beta2 schema sync (#124) but were missing from the public API exports

## Why this triggers a release

The previous schema sync commit (#124) used `chore:` prefix which doesn't trigger release-please. This `feat:` commit will trigger a release that includes all the beta2 changes:
- `list_accounts` endpoint for billing account management
- Account type with CreditLimit
- A2UI types (A2UiComponent, A2UiSurface)
- Extended VideoAsset with HDR, color space, scan type, GOP settings
- Extended AudioAsset with bit depth and channel configuration

## Test plan

- [x] Import test passes: `from adcp.types import A2UiComponent, A2UiSurface`
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)