### PR TITLE
feat: skill-based agent generation with storyboard validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,49 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
-Official Python client for the **Ad Context Protocol (AdCP)**. Build distributed advertising operations that work synchronously OR asynchronously with the same code.
+Official Python SDK for the **Ad Context Protocol (AdCP)**. Build and connect to advertising agents that work synchronously OR asynchronously with the same code.
+
+## Building an AdCP Agent
+
+The fastest path to a working agent: subclass `ADCPHandler`, use response builders, call `serve()`.
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import capabilities_response, products_response
+
+class MySeller(ADCPHandler):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["media_buy"])
+
+    async def get_products(self, params, context=None):
+        return products_response(MY_PRODUCTS)
+
+    # implement create_media_buy, get_media_buys, sync_creatives, etc.
+
+serve(MySeller(), name="my-seller")
+```
+
+Validate with storyboards:
+```bash
+python agent.py &
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+```
+
+| Agent type | Skill | Storyboard | Steps |
+|-----------|-------|-----------|-------|
+| Seller (publisher, SSP, retail media) | [`skills/build-seller-agent/`](skills/build-seller-agent/SKILL.md) | `media_buy_seller` | 9 |
+| Signals (audience data, CDP) | [`skills/build-signals-agent/`](skills/build-signals-agent/SKILL.md) | `signal_owned` | 4 |
+| Creative (ad server, CMP) | [`skills/build-creative-agent/`](skills/build-creative-agent/SKILL.md) | `creative_lifecycle` | 6 |
+
+For compliance testing, add a `TestControllerStore` so storyboards can force state transitions:
+```python
+from adcp.server.test_controller import TestControllerStore
+serve(MySeller(), name="my-seller", test_controller=MyStore())
+```
+
+Each skill file in [`skills/`](skills/) contains the complete pattern, response shapes, and validation loop for coding agents (Claude, Codex) to generate passing servers.
+
+## Connecting to AdCP Agents
 
 ## The Core Concept
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: build-creative-agent
+description: Use when building an AdCP creative agent — an ad server, creative management platform, or any system that accepts, stores, transforms, and serves ad creatives.
+---
+
+# Build a Creative Agent (Python)
+
+## Overview
+
+A creative agent manages the creative lifecycle: accepts assets from buyers, stores them in a library, builds serving tags, and renders previews. Unlike a generative seller (which also sells inventory), a creative agent is a standalone creative platform.
+
+## When to Use
+
+- User wants to build an ad server, creative management platform, or creative rendering service
+- User mentions `build_creative`, `preview_creative`, `sync_creatives`, or `list_creatives`
+- User references creative formats, VAST tags, serving tags, or creative libraries
+
+**Not this skill:**
+- Selling inventory + generating creatives → `skills/build-generative-seller-agent/`
+- Selling inventory (no creative management) → `skills/build-seller-agent/`
+- Serving audience segments → `skills/build-signals-agent/`
+
+## Before Writing Code
+
+Determine these things. Ask the user — don't guess.
+
+### 1. What kind of creative platform?
+
+- **Ad server** (Innovid, Flashtalking) — stateful library, builds serving tags (VAST, display tags)
+- **Creative management platform** (Celtra) — format transformation, template rendering
+- **Publisher creative service** — accepts buyer assets, validates against publisher specs
+
+### 2. What formats?
+
+Get specific formats. Each format needs: dimensions, accepted asset types, mime types.
+- **Display**: `display_300x250`, `display_728x90`
+- **Video**: `video_30s`, `vast_30s`
+- **Native**: `native_content` (image + headline + description)
+
+### 3. What operations?
+
+- **Sync** — accept and store creatives (always needed)
+- **List** — query the library with filtering (needed for storyboard)
+- **Preview** — render a visual preview (needed for storyboard)
+- **Build** — produce serving tags from stored creatives (needed for storyboard)
+
+## Architecture
+
+One file. Subclass `ADCPHandler`, override the tools you support, call `serve()`. Use an in-memory dict to store synced creatives.
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import (
+    capabilities_response, creative_formats_response, sync_creatives_response,
+    list_creatives_response, preview_creative_response, build_creative_response,
+)
+
+creatives: dict[str, dict] = {}  # in-memory creative library
+
+class MyCreativeAgent(ADCPHandler):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["creative"])
+    # ... implement tools
+
+serve(MyCreativeAgent(), name="my-creative-agent")
+```
+
+## Tools and Required Response Shapes
+
+Every tool uses a response builder from `adcp.server.responses`.
+
+**`get_adcp_capabilities`**
+```python
+from adcp.server.responses import capabilities_response
+
+async def get_adcp_capabilities(self, params, context=None):
+    return capabilities_response(["creative"])
+```
+
+**`list_creative_formats`**
+```python
+from adcp.server.responses import creative_formats_response
+
+AGENT_URL = "http://localhost:3001/mcp"
+
+async def list_creative_formats(self, params, context=None):
+    return creative_formats_response([
+        {
+            "format_id": {"agent_url": AGENT_URL, "id": "display_300x250"},
+            "name": "Display 300x250",
+            "description": "Standard IAB medium rectangle",
+            "renders": [{"width": 300, "height": 250}],
+            "assets": [{
+                "item_type": "individual",
+                "asset_id": "image",
+                "asset_type": "image",
+                "required": True,
+                "accepted_media_types": ["image/png", "image/jpeg"],
+            }],
+        },
+        {
+            "format_id": {"agent_url": AGENT_URL, "id": "video_30s"},
+            "name": "Video 30s Pre-Roll",
+            "renders": [{"width": 1920, "height": 1080}],
+            "assets": [{
+                "item_type": "individual",
+                "asset_id": "video",
+                "asset_type": "video",
+                "required": True,
+                "accepted_media_types": ["video/mp4"],
+            }],
+        },
+    ])
+```
+
+**`sync_creatives`** — store creatives in the library. Status must be a valid `CreativeStatus`: `processing`, `pending_review`, `approved`, `rejected`, `archived`.
+```python
+from adcp.server.responses import sync_creatives_response
+
+async def sync_creatives(self, params, context=None):
+    results = []
+    for c in params.get("creatives", []):
+        creative_id = c.get("creative_id", f"c-{uuid.uuid4().hex[:8]}")
+        creatives[creative_id] = {**c, "creative_id": creative_id, "status": "approved"}
+        results.append({
+            "creative_id": creative_id,
+            "action": "created",
+            "status": "approved",
+        })
+    return sync_creatives_response(results)
+```
+
+**`list_creatives`** — query the library. Must include `pagination` and `query_summary` fields. Status must be a valid `CreativeStatus`.
+```python
+from adcp.server.responses import list_creatives_response
+
+async def list_creatives(self, params, context=None):
+    results = list(creatives.values())
+
+    # Filter by format_ids if provided
+    filters = params.get("filters") or {}
+    if format_ids := filters.get("format_ids"):
+        format_id_set = {f.get("id", "") if isinstance(f, dict) else str(f) for f in format_ids}
+        results = [c for c in results if c.get("format_id", {}).get("id") in format_id_set]
+
+    serialized = [
+        {
+            "creative_id": c["creative_id"],
+            "name": c.get("name", ""),
+            "format_id": c.get("format_id"),
+            "status": c.get("status", "approved"),
+            "created_date": "2026-01-01T00:00:00Z",
+            "updated_date": "2026-01-01T00:00:00Z",
+        }
+        for c in results
+    ]
+    return list_creatives_response(serialized)
+```
+
+**`preview_creative`** — render a preview of a stored creative
+```python
+from adcp.server.responses import preview_creative_response
+
+async def preview_creative(self, params, context=None):
+    creative_id = params.get("creative_id")
+    creative = creatives.get(creative_id) if creative_id else None
+    format_id = params.get("format_id") or (creative or {}).get("format_id", {})
+
+    return preview_creative_response([{
+        "preview_id": f"prev-{uuid.uuid4().hex[:8]}",
+        "input": {
+            "format_id": format_id,
+            "name": (creative or {}).get("name", "Preview"),
+            "assets": (creative or {}).get("assets", {}),
+        },
+        "renders": [{
+            "render_id": f"render-{uuid.uuid4().hex[:8]}",
+            "output_format": "url",
+            "preview_url": f"https://example.com/preview/{creative_id or 'unknown'}.png",
+            "role": "primary",
+            "dimensions": {"width": 300, "height": 250},
+        }],
+    }])
+```
+
+**`build_creative`** — produce serving tags. The storyboard sends `target_format_id` (not `output_format`). Look up the creative by ID, by format match, or fall back to the first available.
+```python
+from adcp.server.responses import build_creative_response
+
+async def build_creative(self, params, context=None):
+    creative_id = params.get("creative_id")
+    creative = creatives.get(creative_id) if creative_id else None
+
+    # Resolve target format
+    target_format = params.get("target_format_id") or params.get("output_format") or params.get("format_id")
+
+    # Find creative by format if not found by ID
+    if not creative and target_format:
+        target_id = target_format.get("id", "") if isinstance(target_format, dict) else str(target_format)
+        for c in creatives.values():
+            if c.get("format_id", {}).get("id") == target_id:
+                creative = c
+                break
+
+    # Fall back to first available
+    if not creative and creatives:
+        creative = next(iter(creatives.values()))
+
+    format_id = target_format or (creative or {}).get("format_id", {})
+
+    # Build assets dict from stored creative
+    stored_assets = (creative or {}).get("assets", [])
+    built_assets = {}
+    if isinstance(stored_assets, list):
+        for asset in stored_assets:
+            built_assets[asset.get("asset_id", "unknown")] = asset
+    elif isinstance(stored_assets, dict):
+        built_assets = stored_assets
+
+    return build_creative_response({
+        "format_id": format_id,
+        "name": (creative or {}).get("name", "Built Creative"),
+        "assets": built_assets,
+    })
+```
+
+## SDK Quick Reference
+
+| Function | Usage |
+|----------|-------|
+| `serve(handler)` | Start server on `:3001/mcp` |
+| `capabilities_response(protocols)` | `get_adcp_capabilities` response |
+| `creative_formats_response(formats)` | `list_creative_formats` response |
+| `sync_creatives_response(creatives)` | `sync_creatives` response |
+| `list_creatives_response(creatives)` | `list_creatives` response (adds pagination, query_summary) |
+| `preview_creative_response(previews)` | `preview_creative` response (adds response_type, expires_at) |
+| `build_creative_response(manifest)` | `build_creative` response |
+
+Import handlers from `adcp.server`. Import response builders from `adcp.server.responses`.
+
+## Validation
+
+```bash
+python agent.py &
+npx @adcp/client storyboard run http://localhost:3001/mcp creative_lifecycle --json
+```
+
+**Keep iterating until all steps pass.**
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skip `get_adcp_capabilities` | Must be implemented |
+| Return raw dicts without builders | Use response builders for every tool |
+| Wrong creative status | Must be `approved`, not `accepted`. Valid: `processing`, `pending_review`, `approved`, `rejected`, `archived` |
+| `list_creatives` ignores format filter | Check `filters.format_ids` and filter results |
+| `list_creatives` missing pagination/query_summary | Use `list_creatives_response()` which adds them automatically |
+| `build_creative` can't find creative | Check `target_format_id` param (not `output_format`), fall back to first available |
+| No in-memory store for synced creatives | `list_creatives`, `preview_creative`, `build_creative` need previously synced creatives |
+
+## Reference
+
+This skill contains everything needed to build a 6/6 passing creative agent. The code blocks above are taken from a validated implementation.

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: build-generative-seller-agent
+description: Use when building an AdCP generative seller — an AI ad network, generative DSP, or platform that sells inventory AND generates creatives from briefs.
+---
+
+# Build a Generative Seller Agent (Python)
+
+## Overview
+
+A generative seller does everything a standard seller does (products, media buys, delivery) plus generates creatives from briefs. The buyer sends a creative brief instead of uploading pre-built assets.
+
+A generative seller that sells programmatic inventory MUST also accept standard IAB formats (display images, VAST tags). The generative capability is additive.
+
+## When to Use
+
+- User wants to build a generative DSP or AI ad network
+- User's platform both sells inventory and creates/generates creatives
+- User mentions "creative from brief", "AI-generated ads", or "generative"
+
+**Not this skill:**
+- Standard seller (no creative generation) → `skills/build-seller-agent/`
+- Standalone creative agent → `skills/build-creative-agent/`
+- Signals/audience data → `skills/build-signals-agent/`
+
+## Before Writing Code
+
+Same decisions as the seller skill, plus: what generative formats? What brief inputs (name, objective, tone, messaging)? How to handle invalid brand domains?
+
+## Architecture
+
+Start from `examples/seller_agent.py` (the 9/9 passing seller reference), then modify `list_creative_formats` and `sync_creatives` to handle generative formats.
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import (
+    capabilities_response, products_response, media_buy_response,
+    delivery_response, creative_formats_response, sync_creatives_response,
+)
+from adcp.server.test_controller import TestControllerStore
+
+class MyGenerativeSeller(ADCPHandler):
+    # All seller tools (see seller skill) with modified creative handling
+    ...
+
+serve(MyGenerativeSeller(), name="my-gen-seller", test_controller=MyStore())
+```
+
+## Seller Tools (Required)
+
+Implement all tools from the seller skill. Copy the pattern from `examples/seller_agent.py`:
+
+- `get_adcp_capabilities` → `capabilities_response(["media_buy", "compliance_testing"])`
+- `sync_accounts` → `sync_accounts_response(results)`
+- `sync_governance` → `sync_governance_response(results)`
+- `get_products` → `products_response(PRODUCTS)`
+- `create_media_buy` → `media_buy_response(mb_id, packages)`
+- `get_media_buys` → `media_buys_response(buys)`
+- `get_media_buy_delivery` → `delivery_response(deliveries, reporting_period=...)`
+
+See `skills/build-seller-agent/SKILL.md` for the exact response shapes of each.
+
+## Generative-Specific Changes
+
+**`list_creative_formats`** — return BOTH generative and standard formats:
+```python
+from adcp.server.responses import creative_formats_response
+
+async def list_creative_formats(self, params, context=None):
+    return creative_formats_response([
+        # Generative format — accepts brief input
+        {
+            "format_id": {"agent_url": AGENT_URL, "id": "display_300x250_generative"},
+            "name": "Generated Display 300x250",
+            "description": "AI-generated display ad from creative brief",
+            "renders": [{"width": 300, "height": 250}],
+            "assets": [{
+                "item_type": "individual",
+                "asset_id": "brief",
+                "asset_type": "brief",
+                "required": True,
+                "description": "Creative brief with messaging and brand guidelines",
+            }],
+        },
+        # Standard format — accepts pre-built assets
+        {
+            "format_id": {"agent_url": AGENT_URL, "id": "display_300x250"},
+            "name": "Display 300x250",
+            "renders": [{"width": 300, "height": 250}],
+            "assets": [{
+                "item_type": "individual",
+                "asset_id": "image",
+                "asset_type": "image",
+                "required": True,
+                "accepted_media_types": ["image/jpeg", "image/png"],
+            }],
+        },
+    ])
+```
+
+**`sync_creatives`** — handle both brief-based and standard creatives:
+```python
+from adcp.server.responses import sync_creatives_response
+
+async def sync_creatives(self, params, context=None):
+    results = []
+    for c in params.get("creatives", []):
+        creative_id = c.get("creative_id", f"c-{uuid.uuid4().hex[:8]}")
+        format_id = c.get("format_id", {}).get("id", "")
+
+        if "generative" in format_id:
+            # Brief-based: async generation, return pending_review
+            creatives[creative_id] = {**c, "status": "pending_review"}
+            results.append({"creative_id": creative_id, "action": "created", "status": "pending_review"})
+        else:
+            # Standard upload: immediate accept
+            creatives[creative_id] = {**c, "status": "accepted"}
+            results.append({"creative_id": creative_id, "action": "created", "status": "accepted"})
+
+    return sync_creatives_response(results)
+```
+
+## Compliance Testing
+
+Same as the seller skill. Copy the `TestControllerStore` from `examples/seller_agent.py`:
+
+```python
+serve(MyGenerativeSeller(), name="my-gen-seller", test_controller=MyStore())
+```
+
+## SDK Quick Reference
+
+All seller response builders apply. The generative delta is in `list_creative_formats` (both generative + standard formats) and `sync_creatives` (check format_id to decide processing path).
+
+| Function | Usage |
+|----------|-------|
+| `creative_formats_response(formats)` | `list_creative_formats` response |
+| `sync_creatives_response(creatives)` | `sync_creatives` response |
+
+## Validation
+
+```bash
+python agent.py &
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_seller --json
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Only generative formats, no standard IAB | Must accept pre-built assets too |
+| Same handler for brief and standard | Check format_id to decide processing path |
+| Skip seller tools | All seller tools are required — start from `examples/seller_agent.py` |
+| Wrong `delivery_response` signature | Takes `delivery_response(deliveries_list, reporting_period=...)`, not individual metrics |
+
+## Reference
+
+- `skills/build-seller-agent/SKILL.md` — base seller skill (start there, modify creative handling)
+- `skills/build-seller-agent/SKILL.md` — complete seller tool shapes

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: build-retail-media-agent
+description: Use when building an AdCP retail media network agent — a platform that sells on-site placements, supports product catalogs, tracks conversions, and reports performance.
+---
+
+# Build a Retail Media Agent (Python)
+
+## Overview
+
+A retail media agent sells advertising on a retailer's properties (sponsored products, homepage banners, search results). It extends the standard seller with catalog sync, event tracking, and performance feedback.
+
+## When to Use
+
+- User wants to build a retail media network, commerce media platform, or sponsored products agent
+- User mentions catalogs, product feeds, conversion tracking, or performance feedback
+
+**Not this skill:**
+- Standard seller without catalogs → `skills/build-seller-agent/`
+- Generative seller → `skills/build-generative-seller-agent/`
+- Signals/audience data → `skills/build-signals-agent/`
+
+## Before Writing Code
+
+Same decisions as the seller skill, plus: what catalogs does the platform accept? What conversion events? Does the buyer send performance metrics back?
+
+## Architecture
+
+Start from `examples/seller_agent.py` (the 9/9 passing seller reference), then add retail-specific tools. Same pattern: subclass `ADCPHandler`, use response builders, call `serve()`.
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import (
+    capabilities_response, products_response, media_buy_response,
+    delivery_response, sync_accounts_response, sync_governance_response,
+    creative_formats_response, sync_creatives_response, media_buys_response,
+    sync_catalogs_response, log_event_response,
+)
+from adcp.server.test_controller import TestControllerStore
+
+class MyRetailAgent(ADCPHandler):
+    # All seller tools (see seller skill) PLUS retail-specific tools below
+    ...
+
+serve(MyRetailAgent(), name="my-retail-agent", test_controller=MyStore())
+```
+
+## Seller Tools (Required)
+
+Implement all tools from the seller skill. Copy the pattern from `examples/seller_agent.py`:
+
+- `get_adcp_capabilities` → `capabilities_response(["media_buy", "compliance_testing"])`
+- `sync_accounts` → `sync_accounts_response(results)`
+- `sync_governance` → `sync_governance_response(results)`
+- `get_products` → `products_response(PRODUCTS)`
+- `create_media_buy` → `media_buy_response(mb_id, packages)`
+- `get_media_buys` → `media_buys_response(buys)`
+- `list_creative_formats` → `creative_formats_response(formats)`
+- `sync_creatives` → `sync_creatives_response(results)`
+- `get_media_buy_delivery` → `delivery_response(deliveries, reporting_period=...)`
+
+See `skills/build-seller-agent/SKILL.md` for the exact response shapes of each.
+
+## Retail-Specific Tools
+
+**`sync_catalogs`** — accept product catalog feeds
+```python
+from adcp.server.responses import sync_catalogs_response
+
+async def sync_catalogs(self, params, context=None):
+    results = []
+    for cat in params.get("catalogs", []):
+        catalog_id = cat.get("catalog_id", f"cat-{uuid.uuid4().hex[:8]}")
+        items = cat.get("items", [])
+        catalogs[catalog_id] = cat
+        results.append({
+            "catalog_id": catalog_id,
+            "action": "created",
+            "item_count": len(items),
+            "items_approved": len(items),
+        })
+    return sync_catalogs_response(results)
+```
+
+**`log_event`** — accept conversion events
+```python
+from adcp.server.responses import log_event_response
+
+async def log_event(self, params, context=None):
+    events = params.get("events", [])
+    return log_event_response(events_received=len(events), events_processed=len(events))
+```
+
+**`provide_performance_feedback`** — accept buyer metrics
+```python
+async def provide_performance_feedback(self, params, context=None):
+    return {"success": True, "sandbox": True}
+```
+
+**`sync_event_sources`** — register event tracking
+```python
+async def sync_event_sources(self, params, context=None):
+    results = []
+    for src in params.get("event_sources", []):
+        results.append({
+            "event_source_id": src.get("event_source_id", f"es-{uuid.uuid4().hex[:8]}"),
+            "action": "created",
+        })
+    return {"event_sources": results, "sandbox": True}
+```
+
+## Compliance Testing
+
+Same as the seller skill. Copy the `TestControllerStore` from `examples/seller_agent.py` and pass to `serve()`:
+
+```python
+serve(MyRetailAgent(), name="my-retail-agent", test_controller=MyStore())
+```
+
+## SDK Quick Reference
+
+All seller response builders apply, plus:
+
+| Function | Usage |
+|----------|-------|
+| `sync_catalogs_response(catalogs)` | `sync_catalogs` response |
+| `log_event_response(received, processed)` | `log_event` response |
+
+## Validation
+
+```bash
+python agent.py &
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_creative --json
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skip seller tools | All seller tools are required — start from `examples/seller_agent.py` |
+| `sync_catalogs` missing `item_count` | Required field |
+| `log_event` missing `events_received`/`events_processed` | Use `log_event_response()` |
+| Wrong `delivery_response` signature | Takes `delivery_response(deliveries_list, reporting_period=...)`, not individual metrics |
+
+## Reference
+
+- `skills/build-seller-agent/SKILL.md` — base seller skill (start there, add retail tools)
+- `skills/build-seller-agent/SKILL.md` — complete seller tool shapes

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: build-seller-agent
+description: Use when building an AdCP seller agent — a publisher, SSP, or retail media network that sells advertising inventory to buyer agents.
+---
+
+# Build a Seller Agent (Python)
+
+## Overview
+
+A seller agent receives briefs from buyers, returns products with pricing, accepts media buys, manages creatives, and reports delivery. The business model — what you sell, how you price it, and whether humans approve deals — shapes every implementation decision. Determine that first.
+
+## When to Use
+
+- User wants to build an agent that sells ad inventory
+- User mentions publisher, SSP, retail media, or media network in the context of AdCP
+- User references `get_products`, `create_media_buy`, or the media buy protocol
+
+**Not this skill:**
+- Buying ad inventory → buyer/DSP agent
+- Serving audience segments → `skills/build-signals-agent/`
+- Rendering creatives from briefs → creative agent
+
+## Before Writing Code
+
+Determine these five things. Ask the user — don't guess.
+
+### 1. What Kind of Seller?
+
+- **Premium publisher** — guaranteed inventory, fixed pricing, IO approval
+- **SSP / Exchange** — non-guaranteed, auction-based, instant activation
+- **Retail media network** — both guaranteed and non-guaranteed, catalog-driven
+
+### 2. Guaranteed or Non-Guaranteed?
+
+- **Guaranteed** — `delivery_type: "guaranteed"`, may require async approval
+- **Non-guaranteed** — `delivery_type: "non_guaranteed"`, buyer sets `bid_price`, instant activation
+
+### 3. Products and Pricing
+
+Each product needs: name, description, publisher_properties, format_ids, delivery_type, pricing_options.
+
+Pricing models:
+- `cpm` — `CpmPricingOption(pricing_option_id="...", pricing_model="cpm", floor_price=12.00, currency="USD")`
+- `flat_rate` — `FlatRatePricingOption(pricing_option_id="...", pricing_model="flat_rate", fixed_price=250.00, currency="USD")`
+
+### 4. Approval Workflow
+
+- **Instant** — `create_media_buy` returns confirmed status
+- **Async** — returns submitted, buyer polls `get_media_buys`
+
+### 5. Creative Management
+
+- **Standard** — `list_creative_formats` + `sync_creatives`
+- **None** — omit creative tools
+
+## Architecture
+
+One file. Subclass `ADCPHandler`, override the tools you support, call `serve()`.
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import capabilities_response, products_response
+from adcp.server.test_controller import TestControllerStore
+
+class MySeller(ADCPHandler):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["media_buy", "compliance_testing"])
+
+    async def get_products(self, params, context=None):
+        return products_response(MY_PRODUCTS)
+
+    # ... more tools ...
+
+serve(MySeller(), name="my-seller", test_controller=MyStore())
+```
+
+## Tools and Required Response Shapes
+
+Every tool below uses a response builder from `adcp.server.responses`. Use the builders — never return raw dicts.
+
+**`get_adcp_capabilities`**
+```python
+from adcp.server.responses import capabilities_response
+
+async def get_adcp_capabilities(self, params, context=None):
+    return capabilities_response(["media_buy", "compliance_testing"])
+```
+
+**`sync_accounts`**
+```python
+from adcp.server.responses import sync_accounts_response
+
+async def sync_accounts(self, params, context=None):
+    results = []
+    for acct in params.get("accounts", []):
+        account_id = f"acct-{uuid.uuid4().hex[:8]}"
+        # Store in memory so test controller can find it
+        accounts[account_id] = {"status": "active", "brand": acct.get("brand"), "operator": acct.get("operator")}
+        results.append({
+            "account_id": account_id,
+            "brand": acct.get("brand"),        # echo back
+            "operator": acct.get("operator"),   # echo back
+            "action": "created",
+            "status": "active",
+            "account_scope": "operator_brand",
+        })
+    return sync_accounts_response(results)
+```
+
+**`sync_governance`**
+```python
+from adcp.server.responses import sync_governance_response
+
+async def sync_governance(self, params, context=None):
+    results = []
+    for entry in params.get("accounts", []):
+        acct_ref = entry.get("account", {})
+        agents = entry.get("governance_agents", [])
+        results.append({
+            "account": acct_ref,
+            "status": "synced",
+            "governance_agents": [
+                {"url": a.get("url"), "categories": a.get("categories", [])}
+                for a in agents
+            ],
+        })
+    return sync_governance_response(results)
+```
+
+**`get_products`**
+```python
+from adcp.server.responses import products_response
+from adcp.types import Product, CpmPricingOption, FormatId, PublisherPropertiesAll, DeliveryType, DeliveryMeasurement
+
+async def get_products(self, params, context=None):
+    return products_response(PRODUCTS)
+```
+
+**`create_media_buy`**
+```python
+from adcp.server.responses import media_buy_response
+
+async def create_media_buy(self, params, context=None):
+    packages = []
+    for pkg in params.get("packages", []):
+        packages.append({
+            "package_id": f"pkg-{uuid.uuid4().hex[:8]}",
+            "product_id": pkg.get("product_id"),
+            "pricing_option_id": pkg.get("pricing_option_id"),
+            "budget": pkg.get("budget"),
+        })
+    mb_id = f"mb-{uuid.uuid4().hex[:8]}"
+    # Store so get_media_buys and test controller can find it
+    media_buys[mb_id] = {"status": "active", "currency": "USD", "packages": packages}
+    return media_buy_response(mb_id, packages)
+```
+
+**`get_media_buys`**
+```python
+from adcp.server.responses import media_buys_response
+
+async def get_media_buys(self, params, context=None):
+    requested_ids = params.get("media_buy_ids")
+    results = []
+    for mb_id, mb in media_buys.items():
+        if requested_ids and mb_id not in requested_ids:
+            continue
+        results.append({
+            "media_buy_id": mb_id,
+            "status": mb["status"],
+            "currency": mb.get("currency", "USD"),
+            "packages": mb.get("packages", []),
+        })
+    return media_buys_response(results)
+```
+
+**`list_creative_formats`**
+```python
+from adcp.server.responses import creative_formats_response
+
+async def list_creative_formats(self, params, context=None):
+    return creative_formats_response([
+        {
+            "format_id": {"agent_url": AGENT_URL, "id": "display_300x250"},
+            "name": "Display 300x250",
+            "renders": [{"width": 300, "height": 250}],
+            "assets": [{
+                "item_type": "individual",
+                "asset_id": "image",
+                "asset_type": "image",
+                "required": True,
+                "accepted_media_types": ["image/png", "image/jpeg"],
+            }],
+        },
+    ])
+```
+
+**`sync_creatives`**
+```python
+from adcp.server.responses import sync_creatives_response
+
+async def sync_creatives(self, params, context=None):
+    results = []
+    for c in params.get("creatives", []):
+        creative_id = c.get("creative_id", f"c-{uuid.uuid4().hex[:8]}")
+        # Store so test controller can find it
+        creatives[creative_id] = {**c, "status": "approved"}
+        results.append({
+            "creative_id": creative_id,
+            "action": "created",
+            "status": "approved",
+        })
+    return sync_creatives_response(results)
+```
+
+**`get_media_buy_delivery`**
+```python
+from adcp.server.responses import delivery_response
+
+async def get_media_buy_delivery(self, params, context=None):
+    requested_ids = params.get("media_buy_ids", [])
+    deliveries = []
+    for mb_id in requested_ids:
+        if mb_id in media_buys:
+            deliveries.append({
+                "media_buy_id": mb_id,
+                "status": "active",
+                "totals": {"impressions": 45000, "clicks": 680, "spend": 540.00},
+                "by_package": [],
+            })
+    return delivery_response(
+        deliveries,
+        reporting_period={"start": "2026-04-01T00:00:00Z", "end": "2026-04-09T23:59:59Z"},
+    )
+```
+
+## Compliance Testing
+
+Add a `TestControllerStore` so storyboard tests can force state transitions. Override the methods for scenarios your agent supports.
+
+```python
+from adcp.server.test_controller import TestControllerStore, TestControllerError
+
+class MyStore(TestControllerStore):
+    async def force_account_status(self, account_id, status):
+        acct = accounts.get(account_id)
+        if not acct:
+            raise TestControllerError("NOT_FOUND", f"Account {account_id} not found")
+        prev = acct["status"]
+        acct["status"] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def force_media_buy_status(self, media_buy_id, status, rejection_reason=None):
+        mb = media_buys.get(media_buy_id)
+        if not mb:
+            raise TestControllerError("NOT_FOUND", f"Media buy {media_buy_id} not found")
+        prev = mb["status"]
+        if prev in ("completed", "rejected", "canceled"):
+            raise TestControllerError("INVALID_TRANSITION", f"Cannot transition from {prev}", current_state=prev)
+        mb["status"] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def force_creative_status(self, creative_id, status, rejection_reason=None):
+        c = creatives.get(creative_id)
+        if not c:
+            raise TestControllerError("NOT_FOUND", f"Creative {creative_id} not found")
+        prev = c.get("status", "unknown")
+        if prev == "archived":
+            raise TestControllerError("INVALID_TRANSITION", "Cannot transition from archived", current_state=prev)
+        c["status"] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def simulate_delivery(self, media_buy_id, impressions=None, clicks=None, conversions=None, reported_spend=None):
+        if media_buy_id not in media_buys:
+            raise TestControllerError("NOT_FOUND", f"Media buy {media_buy_id} not found")
+        simulated = {"media_buy_id": media_buy_id}
+        if impressions is not None: simulated["impressions"] = impressions
+        if clicks is not None: simulated["clicks"] = clicks
+        return {"simulated": simulated, "cumulative": simulated}
+
+    async def simulate_budget_spend(self, spend_percentage, account_id=None, media_buy_id=None):
+        return {"simulated": {"spend_percentage": spend_percentage}}
+```
+
+Pass the store to `serve()`:
+```python
+serve(MySeller(), name="my-seller", test_controller=MyStore())
+```
+
+Declare `compliance_testing` in supported_protocols:
+```python
+return capabilities_response(["media_buy", "compliance_testing"])
+```
+
+## SDK Quick Reference
+
+| Function | Usage |
+|----------|-------|
+| `serve(handler, test_controller=store)` | Start server on `:3001/mcp` with test controller |
+| `create_mcp_server(handler)` | Create server without starting (for customization) |
+| `capabilities_response(protocols)` | `get_adcp_capabilities` response |
+| `products_response(products)` | `get_products` response |
+| `media_buy_response(id, packages)` | `create_media_buy` success response |
+| `media_buys_response(media_buys)` | `get_media_buys` response |
+| `delivery_response(deliveries, reporting_period=...)` | `get_media_buy_delivery` response |
+| `sync_accounts_response(accounts)` | `sync_accounts` response |
+| `sync_governance_response(accounts)` | `sync_governance` response |
+| `creative_formats_response(formats)` | `list_creative_formats` response |
+| `sync_creatives_response(creatives)` | `sync_creatives` response |
+| `error_response(code, message)` | Structured error |
+
+Import handlers from `adcp.server`. Import response builders from `adcp.server.responses`. Import types from `adcp.types`.
+
+## Validation
+
+**After writing the agent, validate it. Fix failures. Repeat.**
+
+```bash
+python agent.py &
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+```
+
+**Keep iterating until all steps pass.**
+
+## Storyboards
+
+| Storyboard | Use case |
+|-----------|----------|
+| `media_buy_seller` | Full lifecycle — every seller should pass this (9 steps) |
+| `deterministic_testing` | Test controller state machine validation |
+| `media_buy_non_guaranteed` | Auction flow with bid adjustment |
+| `media_buy_guaranteed_approval` | IO approval workflow |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skip `get_adcp_capabilities` | Must be implemented — buyers call it first |
+| Return raw dicts without builders | Use response builders from `adcp.server.responses` |
+| Missing `brand`/`operator` in sync_accounts | Echo them back from the request |
+| Not storing entities in memory | Test controller needs to find accounts, media buys, creatives |
+| Wrong `delivery_response` signature | Takes `delivery_response(deliveries_list, reporting_period=...)`, not individual metrics |
+
+## Reference
+
+This skill contains everything needed to build a 9/9 passing seller agent. The code blocks above are taken from a validated implementation.

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: build-signals-agent
+description: Use when building an AdCP signals agent, creating an audience data server, or standing up a data provider agent that serves targeting segments to buyers.
+---
+
+# Build a Signals Agent (Python)
+
+## Overview
+
+A signals agent serves audience segments to buyers for campaign targeting. Two tools: `get_signals` (discovery) and `activate_signal` (push to DSPs or sales agents). The business model — marketplace vs owned data — shapes every implementation decision. Determine that first.
+
+## When to Use
+
+- User wants to build an agent that serves audience/targeting data
+- User mentions signals, segments, audiences, data provider, or CDP in the context of AdCP
+- User references `get_signals`, `activate_signal`, or the signals protocol
+
+**Not this skill:**
+- Selling ad inventory → `skills/build-seller-agent/`
+- Rendering creatives → `skills/build-creative-agent/`
+- Building a client that *calls* a signals agent → see client docs
+
+## Before Writing Code
+
+Determine these four things. Ask the user — don't guess.
+
+### 1. Marketplace or Owned?
+
+**Marketplace** — aggregates third-party data providers. Each signal traces to a `data_provider_domain`. `signal_id.source: "catalog"`.
+
+**Owned** — first-party data (retailer CDP, publisher contextual, CRM). `signal_id.source: "agent"`.
+
+### 2. What Segments?
+
+Get specifics: names, definitions, what each represents. Push for 3-5 segments with variety. Each needs:
+- Clear behavioral/demographic definition
+- Realistic `coverage_percentage` (typically 5-30%)
+- Value type: `binary` (in/out), `categorical` (tier levels), or `numeric` (score range)
+
+### 3. Pricing
+
+At least one pricing option per signal:
+- `cpm` — `{"pricing_option_id": "po_cpm", "model": "cpm", "cpm": 2.50, "currency": "USD"}`
+- `flat_fee` — `{"pricing_option_id": "po_flat", "model": "flat_fee", "amount": 5000, "period": "monthly", "currency": "USD"}`
+
+### 4. Activation Destinations
+
+- **Platform** (DSP): `type: "platform"`, returns `activation_key: {"type": "segment_id", "segment_id": "..."}`
+- **Agent** (sales agent): `type: "agent"`, returns `activation_key: {"type": "key_value", "key": "...", "value": "..."}`
+
+## Architecture
+
+One file. Subclass `ADCPHandler`, override the tools you support, call `serve()`.
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import capabilities_response, signals_response, activate_signal_response
+
+class MySignalsAgent(ADCPHandler):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["signals"])
+
+    async def get_signals(self, params, context=None):
+        return signals_response(MY_SIGNALS)
+
+    async def activate_signal(self, params, context=None):
+        return activate_signal_response(deployments)
+
+serve(MySignalsAgent(), name="my-signals-agent")
+```
+
+## Tools and Required Response Shapes
+
+Every tool uses a response builder from `adcp.server.responses`.
+
+**`get_adcp_capabilities`**
+```python
+from adcp.server.responses import capabilities_response
+
+async def get_adcp_capabilities(self, params, context=None):
+    return capabilities_response(["signals"])
+```
+
+**`get_signals`** — supports two discovery modes:
+
+1. `signal_spec` — natural language. Match against segment names and descriptions.
+2. `signal_ids` — exact lookup by ID.
+
+If `signal_spec` doesn't match anything specific, return all signals (discovery query).
+
+```python
+from adcp.server.responses import signals_response
+
+async def get_signals(self, params, context=None):
+    results = list(SIGNALS.values())
+
+    # Natural language search — return all if no match (discovery)
+    if signal_spec := params.get("signal_spec"):
+        words = [w.lower() for w in signal_spec.split() if len(w) > 3]
+        matched = [s for s in results if any(
+            w in s["name"].lower() or w in s.get("description", "").lower()
+            for w in words
+        )]
+        if matched:
+            results = matched
+
+    # Exact ID lookup
+    if signal_ids := params.get("signal_ids"):
+        id_set = {sid.get("id") or sid for sid in signal_ids}
+        results = [s for s in results if s["signal_id"]["id"] in id_set]
+
+    # CPM filter
+    filters = params.get("filters") or {}
+    if max_cpm := filters.get("max_cpm"):
+        results = [s for s in results if any(
+            po.get("model") == "cpm" and po.get("cpm", 999) <= max_cpm
+            for po in s.get("pricing_options", [])
+        )]
+
+    return signals_response(results)
+```
+
+Each signal must include:
+```python
+{
+    "signal_agent_segment_id": "seg-001",       # required — key for activate_signal
+    "name": "Frequent Travelers",                # required
+    "description": "Users who travel 4+ times/year",  # required
+    "signal_type": "owned",                      # required: "marketplace" | "owned" | "custom"
+    "data_provider": "My Data Company",          # required
+    "coverage_percentage": 18.5,                 # required: 0-100
+    "deployments": [],                           # required — empty until activated
+    "pricing_options": [{                        # required — at least one
+        "pricing_option_id": "po_cpm",
+        "model": "cpm",
+        "cpm": 2.50,
+        "currency": "USD",
+    }],
+    "signal_id": {                               # required — shape depends on type
+        "source": "agent",                       # "agent" for owned, "catalog" for marketplace
+        "agent_url": "http://localhost:3001/mcp", # for owned
+        "id": "seg-001",
+    },
+    "value_type": "binary",                      # recommended: "binary" | "categorical" | "numeric"
+}
+```
+
+**`activate_signal`**
+```python
+from adcp.server.responses import activate_signal_response
+
+async def activate_signal(self, params, context=None):
+    segment_id = params.get("signal_agent_segment_id")
+    signal = SIGNALS.get(segment_id)
+    if not signal:
+        return {"errors": [{"code": "SIGNAL_NOT_FOUND", "message": f"Signal {segment_id} not found"}]}
+
+    deployments = []
+    for dest in params.get("destinations", []):
+        if dest.get("type") == "platform":
+            deployments.append({
+                "type": "platform",
+                "platform": dest.get("platform"),
+                "account": dest.get("account"),
+                "is_live": True,
+                "activation_key": {
+                    "type": "segment_id",
+                    "segment_id": f"plat-{uuid.uuid4().hex[:8]}",
+                },
+                "deployed_at": "2026-01-01T00:00:00Z",
+            })
+        elif dest.get("type") == "agent":
+            deployments.append({
+                "type": "agent",
+                "agent_url": dest.get("agent_url"),
+                "is_live": True,
+                "activation_key": {
+                    "type": "key_value",
+                    "key": "segment",
+                    "value": segment_id,
+                },
+                "deployed_at": "2026-01-01T00:00:00Z",
+            })
+
+    return activate_signal_response(deployments)
+```
+
+## SDK Quick Reference
+
+| Function | Usage |
+|----------|-------|
+| `serve(handler)` | Start server on `:3001/mcp` |
+| `capabilities_response(protocols)` | `get_adcp_capabilities` response |
+| `signals_response(signals)` | `get_signals` response |
+| `activate_signal_response(deployments)` | `activate_signal` response |
+| `error_response(code, message)` | Structured error |
+
+Import handlers from `adcp.server`. Import response builders from `adcp.server.responses`.
+
+## Validation
+
+```bash
+python agent.py &
+npx @adcp/client storyboard run http://localhost:3001/mcp signal_owned --json       # for owned data
+npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace --json  # for marketplace
+```
+
+**Keep iterating until all steps pass.**
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skip `get_adcp_capabilities` | Must be implemented — buyers call it first |
+| Return raw dicts without builders | Use `signals_response()` and `activate_signal_response()` |
+| `signal_spec` search returns empty for broad queries | Return all signals when no specific match (discovery) |
+| Missing `signal_agent_segment_id` | Buyers can't activate without it |
+| Wrong `signal_id` shape | Owned: `source: "agent"` + `agent_url`. Marketplace: `source: "catalog"` + `data_provider_domain` |
+| Empty `pricing_options` | Must have at least one per signal |
+| `is_live: True` in `get_signals` deployments | Signals aren't live until activated — use empty `deployments: []` |
+| Activation doesn't match destination type | Platform request → platform deployment. Agent request → agent deployment |
+
+## Reference
+
+This skill contains everything needed to build a 4/4 passing signals agent. The code blocks above are taken from a validated implementation.

--- a/src/adcp/server/__init__.py
+++ b/src/adcp/server/__init__.py
@@ -1,19 +1,18 @@
 """ADCP Server Framework.
 
-Provides base classes and adapters for building ADCP-compliant servers/agents.
-Supports selective protocol implementation via protocol-specific adapters.
+The simplest way to build an AdCP agent:
 
-Examples:
-    # Content Standards agent (stubs media buy operations)
-    from adcp.server import ContentStandardsHandler, create_mcp_tools
+    from adcp.server import ADCPHandler, serve
+    from adcp.server.responses import capabilities_response, products_response
 
-    class MyContentHandler(ContentStandardsHandler):
-        async def create_content_standards(self, request):
-            # Implement your logic
-            pass
+    class MySeller(ADCPHandler):
+        async def get_adcp_capabilities(self, params, context=None):
+            return capabilities_response(["media_buy"])
 
-    # Register with MCP server
-    tools = create_mcp_tools(MyContentHandler())
+        async def get_products(self, params, context=None):
+            return products_response(MY_PRODUCTS)
+
+    serve(MySeller(), name="my-seller")
 """
 
 from __future__ import annotations
@@ -31,7 +30,34 @@ from adcp.server.content_standards import ContentStandardsHandler
 from adcp.server.governance import GovernanceHandler
 from adcp.server.mcp_tools import MCPToolSet, create_mcp_tools, get_tools_for_handler
 from adcp.server.proposal import ProposalBuilder, ProposalNotSupported
+from adcp.server.responses import (
+    activate_signal_response,
+    build_creative_response,
+    capabilities_response,
+    creative_formats_response,
+    delivery_response,
+    error_response,
+    list_creatives_response,
+    log_event_response,
+    media_buy_error_response,
+    media_buy_response,
+    media_buys_response,
+    preview_creative_response,
+    products_response,
+    signals_response,
+    sync_accounts_response,
+    sync_catalogs_response,
+    sync_creatives_response,
+    sync_governance_response,
+    update_media_buy_response,
+)
+from adcp.server.serve import create_mcp_server, serve
 from adcp.server.sponsored_intelligence import SponsoredIntelligenceHandler
+from adcp.server.test_controller import (
+    TestControllerError,
+    TestControllerStore,
+    register_test_controller,
+)
 from adcp.server.tmp import TmpHandler
 
 __all__ = [
@@ -55,5 +81,31 @@ __all__ = [
     # MCP integration
     "MCPToolSet",
     "create_mcp_tools",
+    "create_mcp_server",
     "get_tools_for_handler",
+    "serve",
+    # Test controller
+    "TestControllerStore",
+    "TestControllerError",
+    "register_test_controller",
+    # Response builders
+    "activate_signal_response",
+    "build_creative_response",
+    "capabilities_response",
+    "creative_formats_response",
+    "delivery_response",
+    "error_response",
+    "list_creatives_response",
+    "log_event_response",
+    "media_buy_error_response",
+    "media_buy_response",
+    "media_buys_response",
+    "preview_creative_response",
+    "products_response",
+    "signals_response",
+    "sync_accounts_response",
+    "sync_catalogs_response",
+    "sync_creatives_response",
+    "sync_governance_response",
+    "update_media_buy_response",
 ]

--- a/src/adcp/server/base.py
+++ b/src/adcp/server/base.py
@@ -288,6 +288,15 @@ class ADCPHandler(ABC):
         """
         return self._not_supported("sync_audiences")
 
+    async def sync_governance(
+        self, params: dict[str, Any], context: ToolContext | None = None
+    ) -> Any:
+        """Sync governance agents for accounts.
+
+        Override this to handle governance agent registration.
+        """
+        return self._not_supported("sync_governance")
+
     async def sync_catalogs(
         self, params: dict[str, Any], context: ToolContext | None = None
     ) -> Any:

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -5,10 +5,14 @@ Provides utilities for registering ADCP handlers with MCP servers.
 
 from __future__ import annotations
 
+import json
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from adcp.server.base import ADCPHandler, ToolContext
+
+logger = logging.getLogger(__name__)
 
 # Tool definitions for all ADCP operations
 ADCP_TOOL_DEFINITIONS: list[dict[str, Any]] = [
@@ -261,6 +265,18 @@ ADCP_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "catalogs": {"type": "array"},
             },
             "required": ["catalogs"],
+        },
+    },
+    # Governance Sync
+    {
+        "name": "sync_governance",
+        "description": "Register governance agents for accounts",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "accounts": {"type": "array"},
+            },
+            "required": ["accounts"],
         },
     },
     # Feedback Operations
@@ -728,6 +744,198 @@ for _handler_name, _tools in _HANDLER_TOOLS.items():
     assert not _unknown, f"{_handler_name} references unknown tools: {_unknown}"
 
 
+# ============================================================================
+# Pydantic schema generation — spec-accurate input schemas
+# ============================================================================
+
+def _generate_pydantic_schemas() -> dict[str, dict[str, Any]]:
+    """Generate JSON schemas from Pydantic request models.
+
+    Maps tool names to their corresponding request Pydantic types,
+    then generates JSON Schema via model_json_schema(). This produces
+    spec-accurate schemas with proper field types, descriptions,
+    required fields, and nested definitions.
+
+    Falls back to hand-crafted schemas for tools without a matching
+    Pydantic request type.
+    """
+    try:
+        from pydantic import TypeAdapter
+
+        from adcp.types import (
+            AcquireRightsRequest,
+            ActivateSignalRequest,
+            BuildCreativeRequest,
+            CalibrateContentRequest,
+            CheckGovernanceRequest,
+            ComplyTestControllerRequest,
+            ContextMatchRequest,
+            CreateContentStandardsRequest,
+            CreateMediaBuyRequest,
+            CreatePropertyListRequest,
+            DeletePropertyListRequest,
+            GetAccountFinancialsRequest,
+            GetAdcpCapabilitiesRequest,
+            GetBrandIdentityRequest,
+            GetContentStandardsRequest,
+            GetCreativeDeliveryRequest,
+            GetCreativeFeaturesRequest,
+            GetMediaBuyArtifactsRequest,
+            GetMediaBuyDeliveryRequest,
+            GetMediaBuysRequest,
+            GetPlanAuditLogsRequest,
+            GetProductsRequest,
+            GetPropertyListRequest,
+            GetRightsRequest,
+            GetSignalsRequest,
+            IdentityMatchRequest,
+            ListAccountsRequest,
+            ListContentStandardsRequest,
+            ListCreativeFormatsRequest,
+            ListCreativesRequest,
+            ListPropertyListsRequest,
+            LogEventRequest,
+            PreviewCreativeRequest,
+            ProvidePerformanceFeedbackRequest,
+            ReportPlanOutcomeRequest,
+            ReportUsageRequest,
+            SiGetOfferingRequest,
+            SiInitiateSessionRequest,
+            SiSendMessageRequest,
+            SiTerminateSessionRequest,
+            SyncAccountsRequest,
+            SyncAudiencesRequest,
+            SyncCatalogsRequest,
+            SyncCreativesRequest,
+            SyncEventSourcesRequest,
+            SyncPlansRequest,
+            UpdateContentStandardsRequest,
+            UpdateMediaBuyRequest,
+            UpdatePropertyListRequest,
+            ValidateContentDeliveryRequest,
+        )
+    except ImportError:
+        return {}
+
+    # Map tool names to their Pydantic request types
+    _tool_to_request: dict[str, Any] = {
+        # Catalog
+        "get_products": GetProductsRequest,
+        "list_creative_formats": ListCreativeFormatsRequest,
+        # Creative
+        "sync_creatives": SyncCreativesRequest,
+        "list_creatives": ListCreativesRequest,
+        "build_creative": BuildCreativeRequest,
+        "preview_creative": PreviewCreativeRequest,
+        "get_creative_delivery": GetCreativeDeliveryRequest,
+        # Media Buy
+        "create_media_buy": CreateMediaBuyRequest,
+        "update_media_buy": UpdateMediaBuyRequest,
+        "get_media_buy_delivery": GetMediaBuyDeliveryRequest,
+        "get_media_buys": GetMediaBuysRequest,
+        # Signals
+        "get_signals": GetSignalsRequest,
+        "activate_signal": ActivateSignalRequest,
+        # Account
+        "list_accounts": ListAccountsRequest,
+        "sync_accounts": SyncAccountsRequest,
+        "get_account_financials": GetAccountFinancialsRequest,
+        "report_usage": ReportUsageRequest,
+        # Events & Catalogs
+        "log_event": LogEventRequest,
+        "sync_event_sources": SyncEventSourcesRequest,
+        "sync_audiences": SyncAudiencesRequest,
+        "sync_catalogs": SyncCatalogsRequest,
+        # Feedback
+        "provide_performance_feedback": ProvidePerformanceFeedbackRequest,
+        # Protocol Discovery
+        "get_adcp_capabilities": GetAdcpCapabilitiesRequest,
+        # Compliance
+        "comply_test_controller": ComplyTestControllerRequest,
+        # Content Standards
+        "create_content_standards": CreateContentStandardsRequest,
+        "get_content_standards": GetContentStandardsRequest,
+        "list_content_standards": ListContentStandardsRequest,
+        "update_content_standards": UpdateContentStandardsRequest,
+        "calibrate_content": CalibrateContentRequest,
+        "validate_content_delivery": ValidateContentDeliveryRequest,
+        "get_media_buy_artifacts": GetMediaBuyArtifactsRequest,
+        # Governance
+        "get_creative_features": GetCreativeFeaturesRequest,
+        "sync_plans": SyncPlansRequest,
+        "check_governance": CheckGovernanceRequest,
+        "report_plan_outcome": ReportPlanOutcomeRequest,
+        "get_plan_audit_logs": GetPlanAuditLogsRequest,
+        # Property Lists
+        "create_property_list": CreatePropertyListRequest,
+        "get_property_list": GetPropertyListRequest,
+        "list_property_lists": ListPropertyListsRequest,
+        "update_property_list": UpdatePropertyListRequest,
+        "delete_property_list": DeletePropertyListRequest,
+        # Sponsored Intelligence
+        "si_get_offering": SiGetOfferingRequest,
+        "si_initiate_session": SiInitiateSessionRequest,
+        "si_send_message": SiSendMessageRequest,
+        "si_terminate_session": SiTerminateSessionRequest,
+        # Brand
+        "get_brand_identity": GetBrandIdentityRequest,
+        "get_rights": GetRightsRequest,
+        "acquire_rights": AcquireRightsRequest,
+        # TMP
+        "context_match": ContextMatchRequest,
+        "identity_match": IdentityMatchRequest,
+    }
+
+    schemas: dict[str, dict[str, Any]] = {}
+    for tool_name, request_type in _tool_to_request.items():
+        try:
+            # Handle union types (e.g. PreviewCreativeRequest, ComplyTestControllerRequest)
+            if isinstance(request_type, type) and hasattr(request_type, "model_json_schema"):
+                schema = request_type.model_json_schema()
+            else:
+                # Union types need TypeAdapter
+                adapter = TypeAdapter(request_type)
+                schema = adapter.json_schema()
+
+            schema.pop("title", None)
+
+            # Union types produce anyOf with $ref at root — these can't
+            # be represented as flat MCP schemas. Keep hand-crafted.
+            if "anyOf" in schema or "$ref" in schema:
+                continue
+
+            # Only strip $defs if no $ref references exist in the schema.
+            # If nested properties use $ref, keep $defs so references resolve.
+            schema_str = json.dumps(schema)
+            if '"$ref"' not in schema_str:
+                schema.pop("$defs", None)
+
+            schemas[tool_name] = schema
+        except Exception:
+            logger.debug(
+                "Pydantic schema generation failed for %s, using hand-crafted schema",
+                tool_name,
+                exc_info=True,
+            )
+
+    return schemas
+
+
+# Generate schemas once at import time
+_PYDANTIC_SCHEMAS = _generate_pydantic_schemas()
+
+
+def _apply_pydantic_schemas() -> None:
+    """Replace hand-crafted inputSchemas with Pydantic-generated ones."""
+    for tool_def in ADCP_TOOL_DEFINITIONS:
+        name = tool_def["name"]
+        if name in _PYDANTIC_SCHEMAS:
+            tool_def["inputSchema"] = _PYDANTIC_SCHEMAS[name]
+
+
+_apply_pydantic_schemas()
+
+
 def get_tools_for_handler(handler: ADCPHandler | type[ADCPHandler]) -> list[dict[str, Any]]:
     """Return tool definitions filtered by handler type.
 
@@ -769,9 +977,9 @@ def create_tool_caller(
     async def call_tool(params: dict[str, Any]) -> Any:
         context = ToolContext()
         result = await method(params, context)
-        # Convert Pydantic models to dicts for MCP serialization
+        # Convert Pydantic models to JSON-safe dicts for MCP serialization
         if hasattr(result, "model_dump"):
-            return result.model_dump(exclude_none=True)
+            return result.model_dump(mode="json", exclude_none=True)
         return result
 
     return call_tool

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -1,0 +1,426 @@
+"""Response builder helpers for ADCP servers.
+
+These functions produce correctly-shaped AdCP response dicts that match
+the generated Pydantic response schemas. They reduce boilerplate and
+ensure schema compliance.
+
+Every builder here matches the field names in the corresponding
+generated response type (e.g., SyncAccountsResponse uses "accounts",
+SyncCreativesResponse uses "creatives").
+
+Usage:
+    from adcp.server.responses import capabilities_response, products_response
+
+    @mcp.tool()
+    async def get_adcp_capabilities():
+        return capabilities_response(["media_buy"])
+
+    @mcp.tool()
+    async def get_products():
+        return products_response(MY_PRODUCTS)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _serialize(items: list[Any]) -> list[Any]:
+    """Serialize a list of dicts or Pydantic models to plain dicts."""
+    return [
+        p.model_dump(mode="json", exclude_none=True) if hasattr(p, "model_dump") else p
+        for p in items
+    ]
+
+
+# ============================================================================
+# Protocol Discovery
+# ============================================================================
+
+
+def capabilities_response(
+    supported_protocols: list[str],
+    *,
+    major_versions: list[int] | None = None,
+    sandbox: bool = True,
+    features: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a get_adcp_capabilities response.
+
+    Args:
+        supported_protocols: e.g. ["media_buy"], ["media_buy", "signals"],
+            ["media_buy", "compliance_testing"].
+        major_versions: AdCP major versions. Defaults to [3].
+        sandbox: Whether this is a sandbox agent. Defaults to True.
+        features: Additional feature flags.
+    """
+    resp: dict[str, Any] = {
+        "adcp": {"major_versions": major_versions or [3]},
+        "supported_protocols": supported_protocols,
+        "sandbox": sandbox,
+    }
+    if features:
+        resp["features"] = features
+    return resp
+
+
+# ============================================================================
+# Account Operations
+# ============================================================================
+
+
+def sync_accounts_response(
+    accounts: list[dict[str, Any]],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a sync_accounts success response.
+
+    Each account dict should include: account_id, brand, operator,
+    action ("created"|"updated"), status ("active"|"pending_approval").
+
+    Matches SyncAccountsResponse1 schema (field: "accounts").
+    """
+    return {"accounts": accounts, "sandbox": sandbox}
+
+
+def sync_governance_response(
+    accounts: list[dict[str, Any]],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a sync_governance response.
+
+    Each account dict should include: account, status ("synced"),
+    governance_agents ([{url, categories}]).
+    """
+    return {"accounts": accounts, "sandbox": sandbox}
+
+
+# ============================================================================
+# Product Catalog
+# ============================================================================
+
+
+def products_response(
+    products: list[Any],
+    *,
+    item_count: int | None = None,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a get_products response.
+
+    Matches GetProductsResponse schema.
+    """
+    serialized = _serialize(products)
+    resp: dict[str, Any] = {
+        "products": serialized,
+        "item_count": item_count if item_count is not None else len(serialized),
+        "sandbox": sandbox,
+    }
+    return resp
+
+
+# ============================================================================
+# Media Buy Operations
+# ============================================================================
+
+
+def media_buy_response(
+    media_buy_id: str,
+    packages: list[Any],
+    *,
+    buyer_ref: str | None = None,
+    status: str | None = None,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a create_media_buy success response.
+
+    Each package should include: package_id, product_id, pricing_option_id, budget.
+    Matches CreateMediaBuyResponse1 (success) schema.
+    """
+    resp: dict[str, Any] = {
+        "media_buy_id": media_buy_id,
+        "packages": _serialize(packages),
+        "sandbox": sandbox,
+    }
+    if buyer_ref is not None:
+        resp["buyer_ref"] = buyer_ref
+    if status is not None:
+        resp["status"] = status
+    return resp
+
+
+def media_buy_error_response(errors: list[dict[str, str]]) -> dict[str, Any]:
+    """Build a create_media_buy error response.
+
+    Each error dict: {"code": "...", "message": "..."}.
+    Matches CreateMediaBuyResponse2 (error) schema.
+    """
+    return {"errors": errors}
+
+
+def update_media_buy_response(
+    media_buy_id: str,
+    *,
+    affected_packages: list[Any] | None = None,
+    status: str | None = None,
+    revision: int | None = None,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build an update_media_buy success response.
+
+    Matches UpdateMediaBuyResponse1 (success) schema.
+    """
+    resp: dict[str, Any] = {
+        "media_buy_id": media_buy_id,
+        "sandbox": sandbox,
+    }
+    if affected_packages is not None:
+        resp["affected_packages"] = _serialize(affected_packages)
+    if status is not None:
+        resp["status"] = status
+    if revision is not None:
+        resp["revision"] = revision
+    return resp
+
+
+def media_buys_response(
+    media_buys: list[Any],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a get_media_buys response.
+
+    Each media buy should include: media_buy_id, status, currency, packages.
+    Matches GetMediaBuysResponse schema.
+    """
+    return {
+        "media_buys": _serialize(media_buys),
+        "sandbox": sandbox,
+    }
+
+
+def delivery_response(
+    media_buy_deliveries: list[dict[str, Any]],
+    *,
+    reporting_period: dict[str, str] | None = None,
+    currency: str = "USD",
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a get_media_buy_delivery response.
+
+    Each media_buy_delivery should include:
+        media_buy_id, status, totals (impressions, spend, etc.), by_package.
+
+    Matches GetMediaBuyDeliveryResponse schema.
+
+    Args:
+        media_buy_deliveries: Array of delivery data per media buy.
+        reporting_period: {"start": ISO timestamp, "end": ISO timestamp}.
+            Defaults to current timestamp for both.
+        currency: ISO 4217 currency code.
+        sandbox: Whether this is simulated data.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "reporting_period": reporting_period or {"start": now, "end": now},
+        "media_buy_deliveries": media_buy_deliveries,
+        "currency": currency,
+        "sandbox": sandbox,
+    }
+
+
+# ============================================================================
+# Creative Operations
+# ============================================================================
+
+
+def creative_formats_response(
+    formats: list[Any],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a list_creative_formats response.
+
+    Each format should include: format_id ({agent_url, id}), name.
+    Matches ListCreativeFormatsResponse schema.
+    """
+    return {
+        "formats": _serialize(formats),
+        "sandbox": sandbox,
+    }
+
+
+def sync_creatives_response(
+    creatives: list[dict[str, Any]],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a sync_creatives success response.
+
+    Each creative dict should include: creative_id, action ("created"|"updated").
+    Optionally: status ("accepted"|"pending_review"|"rejected").
+    Matches SyncCreativesResponse1 schema (field: "creatives").
+    """
+    return {"creatives": creatives, "sandbox": sandbox}
+
+
+def list_creatives_response(
+    creatives: list[Any],
+    *,
+    pagination: dict[str, Any] | None = None,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a list_creatives response.
+
+    Each creative should include: creative_id, name, format_id, status.
+    Matches ListCreativesResponse schema.
+    """
+    count = len(creatives)
+    return {
+        "creatives": _serialize(creatives),
+        "pagination": pagination or {"total": count, "has_more": False},
+        "query_summary": {"total_results": count, "total_matching": count, "returned": count},
+        "sandbox": sandbox,
+    }
+
+
+def preview_creative_response(
+    previews: list[dict[str, Any]],
+    *,
+    expires_at: str | None = None,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a preview_creative single response.
+
+    Each preview should include:
+        preview_id, input ({format_id, name, assets}),
+        renders ([{render_id, output_format, preview_url, role, dimensions}]).
+
+    Matches PreviewCreativeResponse1 (single) schema.
+    """
+    return {
+        "response_type": "single",
+        "previews": previews,
+        "expires_at": expires_at or "2099-12-31T23:59:59Z",
+        "sandbox": sandbox,
+    }
+
+
+def build_creative_response(
+    creative_manifest: dict[str, Any] | list[dict[str, Any]],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a build_creative success response.
+
+    Accepts either a single manifest dict or a list of manifests.
+    Each manifest should include: format_id, name, assets.
+
+    Single manifest matches BuildCreativeResponse1.
+    List matches BuildCreativeResponse2 (multi-format).
+    """
+    if isinstance(creative_manifest, list):
+        return {
+            "creative_manifests": creative_manifest,
+            "sandbox": sandbox,
+        }
+    return {
+        "creative_manifest": creative_manifest,
+        "sandbox": sandbox,
+    }
+
+
+# ============================================================================
+# Signal Operations
+# ============================================================================
+
+
+def signals_response(
+    signals: list[Any],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a get_signals response.
+
+    Each signal should include: signal_agent_segment_id, name, description,
+    signal_type, data_provider, coverage_percentage, deployments, pricing_options, signal_id.
+    Matches GetSignalsResponse schema.
+    """
+    return {
+        "signals": _serialize(signals),
+        "sandbox": sandbox,
+    }
+
+
+def activate_signal_response(
+    deployments: list[dict[str, Any]],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build an activate_signal success response.
+
+    Each deployment should include: type, is_live, activation_key.
+    For platform: platform, account.
+    For agent: agent_url.
+    Matches ActivateSignalResponse1 (success) schema.
+    """
+    return {
+        "deployments": deployments,
+        "sandbox": sandbox,
+    }
+
+
+# ============================================================================
+# Event & Catalog Operations
+# ============================================================================
+
+
+def log_event_response(
+    events_received: int,
+    events_processed: int,
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a log_event success response.
+
+    Matches LogEventResponse1 (success) schema.
+    """
+    return {
+        "events_received": events_received,
+        "events_processed": events_processed,
+        "sandbox": sandbox,
+    }
+
+
+def sync_catalogs_response(
+    catalogs: list[dict[str, Any]],
+    *,
+    sandbox: bool = True,
+) -> dict[str, Any]:
+    """Build a sync_catalogs success response.
+
+    Each catalog should include: catalog_id, action, item_count, items_approved.
+    Matches SyncCatalogsResponse1 (success) schema.
+    """
+    return {
+        "catalogs": catalogs,
+        "sandbox": sandbox,
+    }
+
+
+# ============================================================================
+# Generic Helpers
+# ============================================================================
+
+
+def error_response(code: str, message: str) -> dict[str, Any]:
+    """Build a standard AdCP error dict.
+
+    Args:
+        code: Error code (e.g., "INVALID_PRODUCT", "NOT_FOUND").
+        message: Human-readable error message.
+    """
+    return {"code": code, "message": message}

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -1,0 +1,180 @@
+"""One-liner MCP server for ADCP handlers.
+
+Stand up an ADCP-compliant MCP server with a single function call:
+
+    from adcp.server import ADCPHandler, serve
+    from adcp.server.responses import capabilities_response
+
+    class MyAgent(ADCPHandler):
+        async def get_adcp_capabilities(self, params, context=None):
+            return capabilities_response(["media_buy"])
+
+    serve(MyAgent())
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from adcp.server.base import ADCPHandler
+from adcp.server.mcp_tools import create_tool_caller, get_tools_for_handler
+
+if TYPE_CHECKING:
+    from adcp.server.test_controller import TestControllerStore
+
+
+def serve(
+    handler: ADCPHandler,
+    *,
+    name: str = "adcp-agent",
+    port: int | None = None,
+    mount: str = "/mcp",
+    transport: str = "streamable-http",
+    instructions: str | None = None,
+    test_controller: TestControllerStore | None = None,
+) -> None:
+    """Start an MCP server from an ADCP handler.
+
+    This is the simplest way to run an ADCP agent. It creates a FastMCP server,
+    registers all tools from the handler, optionally registers a test controller,
+    and starts serving.
+
+    Args:
+        handler: An ADCPHandler subclass instance with your tool implementations.
+        name: Server name shown to MCP clients.
+        port: Port to listen on. Defaults to PORT env var, then 3001.
+        mount: URL path to mount MCP endpoint on.
+        transport: MCP transport type. Default "streamable-http".
+        instructions: Optional system instructions for the agent.
+        test_controller: Optional TestControllerStore instance for storyboard testing.
+
+    Example:
+        from adcp.server import ADCPHandler, serve
+        from adcp.server.responses import capabilities_response
+
+        class MyAgent(ADCPHandler):
+            async def get_adcp_capabilities(self, params, context=None):
+                return capabilities_response(["media_buy"])
+
+        serve(MyAgent(), name="my-agent")
+
+    With test controller:
+        from adcp.server.test_controller import TestControllerStore
+
+        class MyStore(TestControllerStore):
+            async def force_account_status(self, account_id, status):
+                ...
+
+        serve(MyAgent(), name="my-agent", test_controller=MyStore())
+    """
+    mcp = create_mcp_server(handler, name=name, port=port, instructions=instructions)
+
+    if test_controller is not None:
+        from adcp.server.test_controller import register_test_controller
+
+        register_test_controller(mcp, test_controller)
+
+    mcp.run(transport=transport)
+
+
+def create_mcp_server(
+    handler: ADCPHandler,
+    *,
+    name: str = "adcp-agent",
+    port: int | None = None,
+    instructions: str | None = None,
+) -> Any:
+    """Create a FastMCP server from an ADCP handler without starting it.
+
+    Use this when you need to customize the server before running it,
+    or when you need to add extra non-ADCP tools.
+
+    Args:
+        handler: An ADCPHandler subclass instance.
+        name: Server name.
+        port: Port to listen on.
+        instructions: Optional system instructions.
+
+    Returns:
+        A configured FastMCP server instance. Call mcp.run() to start.
+
+    Example:
+        mcp = create_mcp_server(MyAgent(), name="my-agent")
+        mcp.run(transport="streamable-http")
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    resolved_port = port or int(os.environ.get("PORT", "3001"))
+    mcp = FastMCP(name, instructions=instructions, port=resolved_port)
+    _register_handler_tools(mcp, handler)
+    return mcp
+
+
+def _register_handler_tools(mcp: Any, handler: ADCPHandler) -> None:
+    """Register all ADCP tools from a handler onto a FastMCP server."""
+    tool_defs = get_tools_for_handler(handler)
+    for tool_def in tool_defs:
+        tool_name = tool_def["name"]
+        description = tool_def.get("description", "")
+        input_schema = tool_def.get("inputSchema", {"type": "object", "properties": {}})
+        caller = create_tool_caller(handler, tool_name)
+        _register_tool(mcp, tool_name, description, input_schema, caller)
+
+
+def _register_tool(
+    mcp: Any,
+    name: str,
+    description: str,
+    input_schema: dict[str, Any],
+    caller: Callable[[dict[str, Any]], Any],
+) -> None:
+    """Register a single ADCP tool on a FastMCP server.
+
+    Creates a Tool with a permissive arg model that accepts any fields,
+    then overrides the advertised schema with the Pydantic-generated one.
+    This ensures MCP clients see the correct schema while the handler
+    receives all parameters as a plain dict.
+    """
+    from mcp.server.fastmcp.tools import Tool
+    from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
+    from pydantic import ConfigDict
+
+    async def fn(**kwargs: Any) -> dict[str, Any]:
+        result = await caller(kwargs)
+        if hasattr(result, "model_dump"):
+            return result.model_dump(mode="json", exclude_none=True)  # type: ignore[no-any-return]
+        if isinstance(result, dict):
+            return result
+        return {"result": result}
+
+    # Create tool from function (gives us proper fn_metadata scaffolding)
+    tool = Tool.from_function(fn, name=name, description=description, structured_output=True)
+
+    # Override the advertised schema with the Pydantic-generated one
+    tool.parameters = input_schema
+
+    # Override fn_metadata with a permissive model that passes through
+    # all fields as individual kwargs (instead of wrapping in a "kwargs" field).
+    # Keep the output_schema/output_model so structuredContent is populated.
+    class _AdcpArgs(ArgModelBase):
+        model_config = ConfigDict(extra="allow")
+
+        def model_dump_one_level(self) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for field_name in self.__class__.model_fields:
+                result[field_name] = getattr(self, field_name)
+            if self.model_extra:
+                result.update(self.model_extra)
+            return result
+
+    tool.fn_metadata = FuncMetadata(
+        arg_model=_AdcpArgs,
+        output_schema=tool.fn_metadata.output_schema,
+        output_model=tool.fn_metadata.output_model,
+        wrap_output=False,
+    )
+
+    # Register directly in the tool manager's dict
+    mcp._tool_manager._tools[name] = tool

--- a/src/adcp/server/test_controller.py
+++ b/src/adcp/server/test_controller.py
@@ -1,0 +1,342 @@
+"""Built-in comply_test_controller for ADCP servers.
+
+Provides TestControllerStore and register_test_controller() so that
+storyboard tests can manipulate server state (force status transitions,
+simulate delivery, etc.) without agents needing to implement the
+comply_test_controller tool by hand.
+
+Usage:
+    from adcp.server import serve, ADCPHandler
+    from adcp.server.test_controller import TestControllerStore, register_test_controller
+
+    class MyStore(TestControllerStore):
+        async def force_account_status(self, account_id, status):
+            old = self.accounts[account_id]["status"]
+            self.accounts[account_id]["status"] = status
+            return {"previous_state": old, "current_state": status}
+
+    store = MyStore()
+    serve(MySeller(), name="my-agent", test_controller=store)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Scenario names — must match the AdCP comply_test_controller schema
+SCENARIOS = [
+    "force_creative_status",
+    "force_account_status",
+    "force_media_buy_status",
+    "force_session_status",
+    "simulate_delivery",
+    "simulate_budget_spend",
+]
+
+
+class TestControllerError(Exception):
+    """Typed error for test controller store methods.
+
+    Raise this from your TestControllerStore methods to return structured
+    error responses. The dispatcher catches it and converts to the AdCP
+    comply_test_controller error format.
+
+    Example:
+        async def force_media_buy_status(self, media_buy_id, status, rejection_reason=None):
+            prev = self.media_buys.get(media_buy_id)
+            if prev is None:
+                raise TestControllerError("NOT_FOUND", f"Media buy {media_buy_id} not found")
+            if prev in ("completed", "rejected", "canceled"):
+                raise TestControllerError(
+                    "INVALID_TRANSITION",
+                    f"Cannot transition from {prev}",
+                    current_state=prev,
+                )
+            self.media_buys[media_buy_id] = status
+            return {"previous_state": prev, "current_state": status}
+    """
+
+    def __init__(self, code: str, message: str, current_state: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.current_state = current_state
+
+
+class TestControllerStore:
+    """Base class for test controller state management.
+
+    Subclass this and override the methods for scenarios your agent supports.
+    Methods you don't override will be reported as unsupported scenarios
+    and excluded from list_scenarios.
+
+    Raise TestControllerError for structured error responses.
+    """
+
+    async def force_creative_status(
+        self, creative_id: str, status: str, rejection_reason: str | None = None
+    ) -> dict[str, Any]:
+        """Force a creative to a given status.
+
+        Returns:
+            {"previous_state": str, "current_state": str}
+        """
+        raise NotImplementedError
+
+    async def force_account_status(self, account_id: str, status: str) -> dict[str, Any]:
+        """Force an account to a given status.
+
+        Returns:
+            {"previous_state": str, "current_state": str}
+        """
+        raise NotImplementedError
+
+    async def force_media_buy_status(
+        self, media_buy_id: str, status: str, rejection_reason: str | None = None
+    ) -> dict[str, Any]:
+        """Force a media buy to a given status.
+
+        Returns:
+            {"previous_state": str, "current_state": str}
+        """
+        raise NotImplementedError
+
+    async def force_session_status(
+        self, session_id: str, status: str, termination_reason: str | None = None
+    ) -> dict[str, Any]:
+        """Force a session to a given status.
+
+        Returns:
+            {"previous_state": str, "current_state": str}
+        """
+        raise NotImplementedError
+
+    async def simulate_delivery(
+        self,
+        media_buy_id: str,
+        impressions: int | None = None,
+        clicks: int | None = None,
+        conversions: int | None = None,
+        reported_spend: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Simulate delivery metrics for a media buy.
+
+        Returns:
+            {"simulated": {...}, "cumulative": {...} | None}
+        """
+        raise NotImplementedError
+
+    async def simulate_budget_spend(
+        self,
+        spend_percentage: float,
+        account_id: str | None = None,
+        media_buy_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Simulate budget spend to a percentage.
+
+        Returns:
+            {"simulated": {...}}
+        """
+        raise NotImplementedError
+
+
+def _list_scenarios(store: TestControllerStore) -> list[str]:
+    """Detect which scenarios a store actually implements.
+
+    Checks whether each scenario method is overridden in the store's
+    own class (not just inherited from TestControllerStore).
+    """
+    implemented = []
+    store_cls = type(store)
+    for scenario in SCENARIOS:
+        # Check if this class or any non-TestControllerStore ancestor defines it
+        for cls in store_cls.__mro__:
+            if cls is TestControllerStore:
+                break
+            if scenario in cls.__dict__:
+                implemented.append(scenario)
+                break
+    return implemented
+
+
+def _controller_error(
+    error: str, detail: str, current_state: str | None = None
+) -> dict[str, Any]:
+    """Format a test controller error response."""
+    resp: dict[str, Any] = {
+        "success": False,
+        "error": error,
+        "error_detail": detail,
+    }
+    if current_state is not None:
+        resp["current_state"] = current_state
+    return resp
+
+
+async def _handle_test_controller(
+    store: TestControllerStore, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Dispatch a comply_test_controller request to the store."""
+    scenario = params.get("scenario")
+    implemented = _list_scenarios(store)
+
+    if scenario == "list_scenarios":
+        return {
+            "success": True,
+            "scenarios": implemented,
+        }
+
+    if scenario not in SCENARIOS:
+        return _controller_error(
+            "UNKNOWN_SCENARIO",
+            f"Unknown scenario: {scenario}",
+        )
+
+    if scenario not in implemented:
+        return _controller_error(
+            "UNKNOWN_SCENARIO",
+            f"Scenario {scenario} is not implemented by this agent",
+        )
+
+    method = getattr(store, scenario)
+    scenario_params = params.get("params", {})
+
+    try:
+        if scenario == "force_creative_status":
+            result = await method(
+                creative_id=scenario_params["creative_id"],
+                status=scenario_params["status"],
+                rejection_reason=scenario_params.get("rejection_reason"),
+            )
+        elif scenario == "force_account_status":
+            result = await method(
+                account_id=scenario_params["account_id"],
+                status=scenario_params["status"],
+            )
+        elif scenario == "force_media_buy_status":
+            result = await method(
+                media_buy_id=scenario_params["media_buy_id"],
+                status=scenario_params["status"],
+                rejection_reason=scenario_params.get("rejection_reason"),
+            )
+        elif scenario == "force_session_status":
+            result = await method(
+                session_id=scenario_params["session_id"],
+                status=scenario_params["status"],
+                termination_reason=scenario_params.get("termination_reason"),
+            )
+        elif scenario == "simulate_delivery":
+            result = await method(
+                media_buy_id=scenario_params["media_buy_id"],
+                impressions=scenario_params.get("impressions"),
+                clicks=scenario_params.get("clicks"),
+                conversions=scenario_params.get("conversions"),
+                reported_spend=scenario_params.get("reported_spend"),
+            )
+        elif scenario == "simulate_budget_spend":
+            result = await method(
+                spend_percentage=scenario_params["spend_percentage"],
+                account_id=scenario_params.get("account_id"),
+                media_buy_id=scenario_params.get("media_buy_id"),
+            )
+        else:
+            return _controller_error("UNKNOWN_SCENARIO", f"Unknown scenario: {scenario}")
+    except TestControllerError as e:
+        return _controller_error(e.code, str(e), current_state=e.current_state)
+    except KeyError as e:
+        return _controller_error("INVALID_PARAMS", f"Missing required parameter: {e}")
+    except NotImplementedError:
+        return _controller_error(
+            "UNKNOWN_SCENARIO",
+            f"Scenario {scenario} is not implemented by this agent",
+        )
+    except Exception as e:
+        return _controller_error("INTERNAL_ERROR", str(e))
+
+    # Wrap in success=True if the store didn't include it
+    if isinstance(result, dict) and "success" not in result:
+        result["success"] = True
+
+    return dict(result)
+
+
+def register_test_controller(mcp: Any, store: TestControllerStore) -> None:
+    """Register the comply_test_controller tool on an MCP server.
+
+    This is the Python equivalent of the JS SDK's registerTestController().
+    It adds the comply_test_controller MCP tool backed by your TestControllerStore.
+
+    Args:
+        mcp: A FastMCP server instance.
+        store: Your TestControllerStore implementation.
+
+    Example:
+        from adcp.server.test_controller import TestControllerStore, register_test_controller
+
+        class MyStore(TestControllerStore):
+            async def force_account_status(self, account_id, status):
+                old = self.accounts[account_id]["status"]
+                self.accounts[account_id]["status"] = status
+                return {"previous_state": old, "current_state": status}
+
+        mcp = create_mcp_server(MySeller(), name="my-agent")
+        register_test_controller(mcp, MyStore())
+        mcp.run(transport="streamable-http")
+    """
+
+    from mcp.server.fastmcp.tools import Tool
+    from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
+    from pydantic import ConfigDict
+
+    async def comply_test_controller(**kwargs: Any) -> str:
+        result = await _handle_test_controller(store, kwargs)
+        return json.dumps(result)
+
+    tool = Tool.from_function(
+        comply_test_controller,
+        name="comply_test_controller",
+        description="Compliance test controller. Sandbox only, not for production use.",
+    )
+
+    # Override schema with the proper comply_test_controller inputSchema
+    tool.parameters = {
+        "type": "object",
+        "properties": {
+            "scenario": {
+                "type": "string",
+                "enum": [
+                    "list_scenarios",
+                    "force_creative_status",
+                    "force_account_status",
+                    "force_media_buy_status",
+                    "force_session_status",
+                    "simulate_delivery",
+                    "simulate_budget_spend",
+                ],
+            },
+            "params": {"type": "object"},
+            "context": {"type": "object"},
+        },
+        "required": ["scenario"],
+    }
+
+    # Override fn_metadata with a permissive model
+    class _ControllerArgs(ArgModelBase):
+        model_config = ConfigDict(extra="allow")
+
+        def model_dump_one_level(self) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for field_name in self.__class__.model_fields:
+                result[field_name] = getattr(self, field_name)
+            if self.model_extra:
+                result.update(self.model_extra)
+            return result
+
+    tool.fn_metadata = FuncMetadata(
+        arg_model=_ControllerArgs,
+        output_schema=tool.fn_metadata.output_schema,
+        output_model=tool.fn_metadata.output_model,
+        wrap_output=tool.fn_metadata.wrap_output,
+    )
+
+    mcp._tool_manager._tools["comply_test_controller"] = tool

--- a/tests/test_server_dx.py
+++ b/tests/test_server_dx.py
@@ -1,0 +1,439 @@
+"""Tests for server DX improvements: serve(), test_controller, responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.server.responses import (
+    activate_signal_response,
+    build_creative_response,
+    capabilities_response,
+    creative_formats_response,
+    delivery_response,
+    error_response,
+    list_creatives_response,
+    log_event_response,
+    media_buy_error_response,
+    media_buy_response,
+    media_buys_response,
+    preview_creative_response,
+    products_response,
+    signals_response,
+    sync_accounts_response,
+    sync_governance_response,
+    sync_catalogs_response,
+    sync_creatives_response,
+    update_media_buy_response,
+)
+from adcp.server.test_controller import (
+    TestControllerError,
+    TestControllerStore,
+    _handle_test_controller,
+    _list_scenarios,
+)
+
+
+# ============================================================================
+# Response builder tests — match actual AdCP spec schemas
+# ============================================================================
+
+
+class TestCapabilitiesResponse:
+    def test_basic(self):
+        result = capabilities_response(["media_buy"])
+        assert result["supported_protocols"] == ["media_buy"]
+        assert result["adcp"]["major_versions"] == [3]
+        assert result["sandbox"] is True
+
+    def test_multiple_protocols(self):
+        result = capabilities_response(["media_buy", "compliance_testing"])
+        assert result["supported_protocols"] == ["media_buy", "compliance_testing"]
+
+    def test_custom_versions(self):
+        result = capabilities_response(["media_buy"], major_versions=[2, 3])
+        assert result["adcp"]["major_versions"] == [2, 3]
+
+    def test_sandbox_false(self):
+        result = capabilities_response(["media_buy"], sandbox=False)
+        assert result["sandbox"] is False
+
+
+class TestSyncAccountsResponse:
+    def test_uses_accounts_key(self):
+        """Spec field name is 'accounts', not 'results'."""
+        accts = [{"account_id": "a1", "status": "active"}]
+        result = sync_accounts_response(accts)
+        assert "accounts" in result
+        assert "results" not in result
+        assert result["accounts"] == accts
+
+    def test_includes_sandbox(self):
+        result = sync_accounts_response([])
+        assert result["sandbox"] is True
+
+
+class TestProductsResponse:
+    def test_basic(self):
+        products = [{"product_id": "p1", "name": "Product 1"}]
+        result = products_response(products)
+        assert result["products"] == products
+        assert result["item_count"] == 1
+        assert result["sandbox"] is True
+
+    def test_pydantic_models(self):
+        class FakeModel:
+            def model_dump(self, **kwargs):
+                return {"product_id": "p1"}
+
+        result = products_response([FakeModel()])
+        assert result["products"][0]["product_id"] == "p1"
+
+
+class TestMediaBuyResponse:
+    def test_basic(self):
+        result = media_buy_response("mb-123", [{"package_id": "pkg-1"}])
+        assert result["media_buy_id"] == "mb-123"
+        assert len(result["packages"]) == 1
+        assert result["sandbox"] is True
+
+    def test_with_buyer_ref_and_status(self):
+        result = media_buy_response("mb-123", [], buyer_ref="b1", status="active")
+        assert result["buyer_ref"] == "b1"
+        assert result["status"] == "active"
+
+
+class TestMediaBuyErrorResponse:
+    def test_basic(self):
+        result = media_buy_error_response([{"code": "INVALID_PRODUCT", "message": "bad"}])
+        assert result["errors"][0]["code"] == "INVALID_PRODUCT"
+
+
+class TestUpdateMediaBuyResponse:
+    def test_basic(self):
+        result = update_media_buy_response("mb-123", status="active", revision=2)
+        assert result["media_buy_id"] == "mb-123"
+        assert result["status"] == "active"
+        assert result["revision"] == 2
+
+
+class TestMediaBuysResponse:
+    def test_basic(self):
+        buys = [{"media_buy_id": "mb-1", "status": "active"}]
+        result = media_buys_response(buys)
+        assert result["media_buys"] == buys
+        assert result["sandbox"] is True
+
+
+class TestDeliveryResponse:
+    def test_spec_shape(self):
+        """delivery_response uses media_buy_deliveries and reporting_period per spec."""
+        deliveries = [
+            {
+                "media_buy_id": "mb-1",
+                "status": "active",
+                "totals": {"impressions": 1000, "spend": 50.0},
+                "by_package": [],
+            }
+        ]
+        result = delivery_response(
+            deliveries,
+            reporting_period={"start": "2026-01-01T00:00:00Z", "end": "2026-01-02T00:00:00Z"},
+        )
+        assert result["media_buy_deliveries"] == deliveries
+        assert result["reporting_period"]["start"] == "2026-01-01T00:00:00Z"
+        assert result["currency"] == "USD"
+
+    def test_default_reporting_period(self):
+        result = delivery_response([])
+        assert "start" in result["reporting_period"]
+        assert "end" in result["reporting_period"]
+
+
+class TestCreativeFormatsResponse:
+    def test_basic(self):
+        formats = [{"format_id": {"agent_url": "http://localhost", "id": "d300"}, "name": "Display"}]
+        result = creative_formats_response(formats)
+        assert result["formats"] == formats
+        assert result["sandbox"] is True
+
+
+class TestSyncCreativesResponse:
+    def test_uses_creatives_key(self):
+        """Spec field name is 'creatives', not 'results'."""
+        creatives = [{"creative_id": "c1", "action": "created"}]
+        result = sync_creatives_response(creatives)
+        assert "creatives" in result
+        assert "results" not in result
+        assert result["creatives"] == creatives
+
+
+class TestListCreativesResponse:
+    def test_basic(self):
+        creatives = [{"creative_id": "c1", "name": "Test", "status": "accepted"}]
+        result = list_creatives_response(creatives)
+        assert result["creatives"] == creatives
+        assert result["pagination"]["total"] == 1
+        assert result["query_summary"]["total_results"] == 1
+
+
+class TestPreviewCreativeResponse:
+    def test_basic(self):
+        previews = [{"preview_id": "p1", "input": {}, "renders": []}]
+        result = preview_creative_response(previews)
+        assert result["response_type"] == "single"
+        assert result["previews"] == previews
+        assert "expires_at" in result
+
+
+class TestBuildCreativeResponse:
+    def test_basic(self):
+        manifest = {"format_id": {"agent_url": "http://localhost", "id": "d300"}, "name": "Test"}
+        result = build_creative_response(manifest)
+        assert result["creative_manifest"] == manifest
+        assert result["sandbox"] is True
+
+
+class TestSignalsResponse:
+    def test_basic(self):
+        signals = [{"signal_agent_segment_id": "seg-1", "name": "Test"}]
+        result = signals_response(signals)
+        assert result["signals"] == signals
+        assert result["sandbox"] is True
+
+
+class TestActivateSignalResponse:
+    def test_basic(self):
+        deps = [{"type": "platform", "platform": "dsp-1", "is_live": True}]
+        result = activate_signal_response(deps)
+        assert result["deployments"] == deps
+        assert result["sandbox"] is True
+
+
+class TestLogEventResponse:
+    def test_basic(self):
+        result = log_event_response(5, 4)
+        assert result["events_received"] == 5
+        assert result["events_processed"] == 4
+
+
+class TestSyncCatalogsResponse:
+    def test_basic(self):
+        cats = [{"catalog_id": "c1", "action": "created", "item_count": 10}]
+        result = sync_catalogs_response(cats)
+        assert result["catalogs"] == cats
+
+
+class TestErrorResponse:
+    def test_basic(self):
+        result = error_response("NOT_FOUND", "Item not found")
+        assert result["code"] == "NOT_FOUND"
+
+
+# ============================================================================
+# Test controller — _list_scenarios fix
+# ============================================================================
+
+
+class MinimalStore(TestControllerStore):
+    """Only implements force_account_status and force_media_buy_status."""
+
+    def __init__(self):
+        self.accounts: dict[str, str] = {}
+        self.media_buys: dict[str, str] = {}
+
+    async def force_account_status(self, account_id: str, status: str) -> dict[str, Any]:
+        prev = self.accounts.get(account_id, "unknown")
+        self.accounts[account_id] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def force_media_buy_status(
+        self, media_buy_id: str, status: str, rejection_reason: str | None = None
+    ) -> dict[str, Any]:
+        prev = self.media_buys.get(media_buy_id, "unknown")
+        self.media_buys[media_buy_id] = status
+        return {"previous_state": prev, "current_state": status}
+
+
+class TestListScenarios:
+    def test_detects_only_overridden_methods(self):
+        """Must NOT report inherited-but-not-overridden methods."""
+        store = MinimalStore()
+        scenarios = _list_scenarios(store)
+        assert "force_account_status" in scenarios
+        assert "force_media_buy_status" in scenarios
+        # These are NOT overridden — must NOT be reported
+        assert "force_creative_status" not in scenarios
+        assert "force_session_status" not in scenarios
+        assert "simulate_delivery" not in scenarios
+        assert "simulate_budget_spend" not in scenarios
+
+    def test_empty_store(self):
+        """A bare TestControllerStore has no implemented scenarios."""
+        store = TestControllerStore()
+        assert _list_scenarios(store) == []
+
+
+class TestTestControllerError:
+    @pytest.mark.asyncio
+    async def test_error_is_caught(self):
+        class ErrorStore(TestControllerStore):
+            async def force_account_status(self, account_id: str, status: str) -> dict[str, Any]:
+                raise TestControllerError("NOT_FOUND", f"Account {account_id} not found")
+
+        store = ErrorStore()
+        result = await _handle_test_controller(
+            store, {"scenario": "force_account_status", "params": {"account_id": "x", "status": "active"}}
+        )
+        assert result["success"] is False
+        assert result["error"] == "NOT_FOUND"
+        assert "Account x not found" in result["error_detail"]
+
+    @pytest.mark.asyncio
+    async def test_error_with_current_state(self):
+        class ErrorStore(TestControllerStore):
+            async def force_media_buy_status(
+                self, media_buy_id: str, status: str, rejection_reason: str | None = None
+            ) -> dict[str, Any]:
+                raise TestControllerError("INVALID_TRANSITION", "Cannot transition", current_state="completed")
+
+        store = ErrorStore()
+        result = await _handle_test_controller(
+            store,
+            {"scenario": "force_media_buy_status", "params": {"media_buy_id": "mb-1", "status": "active"}},
+        )
+        assert result["error"] == "INVALID_TRANSITION"
+        assert result["current_state"] == "completed"
+
+
+class TestHandleTestController:
+    @pytest.mark.asyncio
+    async def test_list_scenarios(self):
+        store = MinimalStore()
+        result = await _handle_test_controller(store, {"scenario": "list_scenarios"})
+        assert result["success"] is True
+        assert "force_account_status" in result["scenarios"]
+        assert "simulate_delivery" not in result["scenarios"]
+
+    @pytest.mark.asyncio
+    async def test_force_account_status(self):
+        store = MinimalStore()
+        result = await _handle_test_controller(
+            store,
+            {"scenario": "force_account_status", "params": {"account_id": "acct-1", "status": "suspended"}},
+        )
+        assert result["success"] is True
+        assert result["current_state"] == "suspended"
+
+    @pytest.mark.asyncio
+    async def test_unimplemented_scenario_returns_error(self):
+        store = MinimalStore()
+        result = await _handle_test_controller(
+            store, {"scenario": "simulate_delivery", "params": {"media_buy_id": "mb-1"}}
+        )
+        assert result["success"] is False
+        assert result["error"] == "UNKNOWN_SCENARIO"
+
+    @pytest.mark.asyncio
+    async def test_unknown_scenario(self):
+        store = MinimalStore()
+        result = await _handle_test_controller(store, {"scenario": "nonexistent"})
+        assert result["success"] is False
+        assert result["error"] == "UNKNOWN_SCENARIO"
+
+    @pytest.mark.asyncio
+    async def test_missing_params(self):
+        store = MinimalStore()
+        result = await _handle_test_controller(
+            store, {"scenario": "force_account_status", "params": {}}
+        )
+        assert result["success"] is False
+        assert result["error"] == "INVALID_PARAMS"
+
+
+# ============================================================================
+# serve() and create_mcp_server tests
+# ============================================================================
+
+
+class TestCreateMcpServer:
+    def test_creates_server_with_tools(self):
+        from adcp.server import ADCPHandler
+        from adcp.server.serve import create_mcp_server
+
+        class TestHandler(ADCPHandler):
+            async def get_adcp_capabilities(self, params, context=None):
+                return {"adcp": {"major_versions": [3]}}
+
+        mcp = create_mcp_server(TestHandler(), name="test-agent")
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "get_adcp_capabilities" in tool_names
+
+
+class TestRegisterTestController:
+    def test_registers_tool(self):
+        from mcp.server.fastmcp import FastMCP
+
+        from adcp.server.test_controller import register_test_controller
+
+        mcp = FastMCP("test")
+        store = MinimalStore()
+        register_test_controller(mcp, store)
+
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "comply_test_controller" in tool_names
+
+
+class TestServeWithTestController:
+    def test_serve_accepts_test_controller(self):
+        """Verify serve() signature accepts test_controller kwarg."""
+        from adcp.server.serve import create_mcp_server
+
+        from adcp.server import ADCPHandler
+
+        class TestHandler(ADCPHandler):
+            async def get_adcp_capabilities(self, params, context=None):
+                return {}
+
+        # We can't call serve() (it blocks), but we can verify the integration path
+        mcp = create_mcp_server(TestHandler(), name="test")
+        store = MinimalStore()
+        from adcp.server.test_controller import register_test_controller
+        register_test_controller(mcp, store)
+
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "get_adcp_capabilities" in tool_names
+        assert "comply_test_controller" in tool_names
+
+
+class TestSyncGovernanceResponse:
+    def test_basic(self):
+        accts = [{"account": {"brand": {"domain": "test.com"}}, "status": "synced"}]
+        result = sync_governance_response(accts)
+        assert result["accounts"] == accts
+        assert result["sandbox"] is True
+
+
+class TestPydanticSchemas:
+    def test_schemas_are_generated(self):
+        from adcp.server.mcp_tools import _PYDANTIC_SCHEMAS
+
+        assert len(_PYDANTIC_SCHEMAS) > 0
+
+    def test_no_dangling_refs(self):
+        """Schemas with $ref must also have $defs to resolve them."""
+        import json as json_mod
+
+        from adcp.server.mcp_tools import _PYDANTIC_SCHEMAS
+
+        for name, schema in _PYDANTIC_SCHEMAS.items():
+            schema_str = json_mod.dumps(schema)
+            if '"$ref"' in schema_str:
+                assert "$defs" in schema, f"{name} has $ref but no $defs"
+
+    def test_key_tools_have_pydantic_schemas(self):
+        from adcp.server.mcp_tools import _PYDANTIC_SCHEMAS
+
+        for tool in ["get_products", "create_media_buy", "sync_accounts", "get_signals", "activate_signal"]:
+            assert tool in _PYDANTIC_SCHEMAS, f"{tool} missing Pydantic schema"


### PR DESCRIPTION
## Summary

- Add server DX infrastructure so coding agents (Claude, Codex) can generate storyboard-passing AdCP servers from a single prompt
- Validated against **19/19 storyboard steps** across 3 storyboards
- Ports the JS/TS SDK skill system (adcontextprotocol/adcp-client#453) to Python

## What's included

### Server infrastructure (`src/adcp/server/`)
- `serve(handler, test_controller=store)` — one-liner MCP server with built-in test controller
- `create_mcp_server()` — create server without starting (for customization)
- 19 response builders matching AdCP spec field names (`capabilities_response`, `products_response`, `media_buy_response`, `delivery_response`, etc.)
- `TestControllerStore` base class with automatic scenario detection via MRO walk
- `TestControllerError` for structured error responses from store methods
- 48/51 Pydantic-generated tool input schemas (spec-accurate, richer than JS SDK's Zod)
- `sync_governance` handler + tool definition

### Skills (`skills/`)
- `build-seller-agent/` — publisher, SSP, retail media (9/9 validated)
- `build-signals-agent/` — audience data, CDP (4/4 validated)
- `build-creative-agent/` — ad server, CMP (6/6 validated)
- `build-generative-seller-agent/` — AI ad network (extends seller)
- `build-retail-media-agent/` — catalog sync, events, feedback (extends seller)

### Tests
- 1071 tests passing, ruff clean, mypy clean
- Tests cover response builders, test controller dispatch, scenario detection, MCP server creation, Pydantic schema generation

## Storyboard results

| Storyboard | Steps | Result |
|-----------|-------|--------|
| `media_buy_seller` | 9/9 | PASS |
| `signal_owned` | 4/4 | PASS |
| `creative_lifecycle` | 6/6 | PASS |

## Test plan

- [x] All 1071 pytest tests pass
- [x] ruff check clean
- [x] mypy clean (480 files)
- [x] Seller storyboard 9/9
- [x] Signals storyboard 4/4
- [x] Creative storyboard 6/6
- [ ] CI pipeline passes

Closes #168, closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)