### PR TITLE
fix: resolve property_ids and property_tags in get_all_properties()

### DIFF
--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -476,8 +476,61 @@ async def verify_agent_for_property(
     )
 
 
+def _resolve_agent_properties(
+    agent: dict[str, Any],
+    top_level_properties: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Resolve properties for a single agent entry based on its authorization_type.
+
+    Args:
+        agent: An authorized_agents entry
+        top_level_properties: The top-level properties array from adagents.json
+
+    Returns:
+        List of resolved property dicts for this agent
+    """
+    authorization_type = agent.get("authorization_type", "")
+
+    # Handle inline_properties (properties array directly on agent)
+    if authorization_type == "inline_properties" or "properties" in agent:
+        properties = agent.get("properties", [])
+        if not isinstance(properties, list):
+            return []
+        return [p for p in properties if isinstance(p, dict)]
+
+    # Handle property_ids (filter top-level properties by property_id)
+    if authorization_type == "property_ids":
+        authorized_ids = set(agent.get("property_ids", []))
+        return [
+            p
+            for p in top_level_properties
+            if isinstance(p, dict) and p.get("property_id") in authorized_ids
+        ]
+
+    # Handle property_tags (filter top-level properties by tags)
+    if authorization_type == "property_tags":
+        authorized_tags = set(agent.get("property_tags", []))
+        return [
+            p
+            for p in top_level_properties
+            if isinstance(p, dict) and set(p.get("tags", [])) & authorized_tags
+        ]
+
+    # Handle publisher_properties (cross-domain references)
+    if authorization_type == "publisher_properties":
+        publisher_props = agent.get("publisher_properties", [])
+        if not isinstance(publisher_props, list):
+            return []
+        return [p for p in publisher_props if isinstance(p, dict)]
+
+    return []
+
+
 def get_all_properties(adagents_data: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract all properties from adagents.json data.
+
+    Handles all authorization types: inline_properties, property_ids,
+    property_tags, and publisher_properties.
 
     Args:
         adagents_data: Parsed adagents.json data
@@ -495,6 +548,10 @@ def get_all_properties(adagents_data: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(authorized_agents, list):
         raise AdagentsValidationError("adagents.json must have 'authorized_agents' array")
 
+    top_level_properties = adagents_data.get("properties", [])
+    if not isinstance(top_level_properties, list):
+        top_level_properties = []
+
     properties = []
     for agent in authorized_agents:
         if not isinstance(agent, dict):
@@ -504,16 +561,11 @@ def get_all_properties(adagents_data: dict[str, Any]) -> list[dict[str, Any]]:
         if not agent_url:
             continue
 
-        agent_properties = agent.get("properties", [])
-        if not isinstance(agent_properties, list):
-            continue
+        agent_properties = _resolve_agent_properties(agent, top_level_properties)
 
-        # Add each property with the agent URL for reference
         for prop in agent_properties:
-            if isinstance(prop, dict):
-                # Create a copy and add agent_url
-                prop_with_agent = {**prop, "agent_url": agent_url}
-                properties.append(prop_with_agent)
+            prop_with_agent = {**prop, "agent_url": agent_url}
+            properties.append(prop_with_agent)
 
     return properties
 
@@ -570,12 +622,10 @@ def get_properties_by_agent(adagents_data: dict[str, Any], agent_url: str) -> li
     if not isinstance(authorized_agents, list):
         raise AdagentsValidationError("adagents.json must have 'authorized_agents' array")
 
-    # Get top-level properties for reference-based authorization types
     top_level_properties = adagents_data.get("properties", [])
     if not isinstance(top_level_properties, list):
         top_level_properties = []
 
-    # Normalize the agent URL for comparison
     normalized_agent_url = normalize_url(agent_url)
 
     for agent in authorized_agents:
@@ -586,48 +636,10 @@ def get_properties_by_agent(adagents_data: dict[str, Any], agent_url: str) -> li
         if not agent_url_from_json:
             continue
 
-        # Match agent URL (protocol-agnostic)
         if normalize_url(agent_url_from_json) != normalized_agent_url:
             continue
 
-        # Found the agent - determine authorization type
-        authorization_type = agent.get("authorization_type", "")
-
-        # Handle inline_properties (properties array directly on agent)
-        if authorization_type == "inline_properties" or "properties" in agent:
-            properties = agent.get("properties", [])
-            if not isinstance(properties, list):
-                return []
-            return [p for p in properties if isinstance(p, dict)]
-
-        # Handle property_ids (filter top-level properties by property_id)
-        if authorization_type == "property_ids":
-            authorized_ids = set(agent.get("property_ids", []))
-            return [
-                p
-                for p in top_level_properties
-                if isinstance(p, dict) and p.get("property_id") in authorized_ids
-            ]
-
-        # Handle property_tags (filter top-level properties by tags)
-        if authorization_type == "property_tags":
-            authorized_tags = set(agent.get("property_tags", []))
-            return [
-                p
-                for p in top_level_properties
-                if isinstance(p, dict) and set(p.get("tags", [])) & authorized_tags
-            ]
-
-        # Handle publisher_properties (cross-domain references)
-        # Returns the selector objects; caller must resolve against other domains
-        if authorization_type == "publisher_properties":
-            publisher_props = agent.get("publisher_properties", [])
-            if not isinstance(publisher_props, list):
-                return []
-            return [p for p in publisher_props if isinstance(p, dict)]
-
-        # No recognized authorization type - return empty
-        return []
+        return _resolve_agent_properties(agent, top_level_properties)
 
     return []
 

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -491,8 +491,10 @@ def _resolve_agent_properties(
     """
     authorization_type = agent.get("authorization_type", "")
 
-    # Handle inline_properties (properties array directly on agent)
-    if authorization_type == "inline_properties" or "properties" in agent:
+    # Handle inline_properties, or legacy entries with properties array but no authorization_type
+    if authorization_type == "inline_properties" or (
+        not authorization_type and "properties" in agent
+    ):
         properties = agent.get("properties", [])
         if not isinstance(properties, list):
             return []
@@ -509,11 +511,12 @@ def _resolve_agent_properties(
 
     # Handle property_tags (filter top-level properties by tags)
     if authorization_type == "property_tags":
-        authorized_tags = set(agent.get("property_tags", []))
+        authorized_tags = {t for t in agent.get("property_tags", []) if isinstance(t, str)}
         return [
             p
             for p in top_level_properties
-            if isinstance(p, dict) and set(p.get("tags", [])) & authorized_tags
+            if isinstance(p, dict)
+            and {t for t in p.get("tags", []) if isinstance(t, str)} & authorized_tags
         ]
 
     # Handle publisher_properties (cross-domain references)

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -8,6 +8,7 @@ https://{publisher_domain}/.well-known/adagents.json. This module provides utili
 for sales agents to verify they are authorized for specific properties.
 """
 
+import ipaddress
 from typing import Any
 from urllib.parse import urlparse
 
@@ -87,6 +88,38 @@ def _validate_publisher_domain(domain: str) -> str:
         raise AdagentsValidationError(f"Publisher domain must contain at least one dot: {domain!r}")
 
     return domain
+
+
+def _validate_redirect_url(url: str) -> None:
+    """Validate an authoritative_location URL is safe to follow.
+
+    Rejects private/reserved IP addresses and localhost to prevent SSRF attacks
+    where a malicious publisher redirects the SDK to internal services.
+
+    Args:
+        url: The HTTPS URL to validate
+
+    Raises:
+        AdagentsValidationError: If the URL targets a private/reserved address
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+
+    # Reject localhost by name
+    if hostname in ("localhost", "localhost.localdomain") or hostname.endswith(".local"):
+        raise AdagentsValidationError(
+            "authoritative_location must not target localhost"
+        )
+
+    # Reject private/reserved IP addresses
+    try:
+        ip = ipaddress.ip_address(hostname)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            raise AdagentsValidationError(
+                "authoritative_location must not target private/reserved addresses"
+            )
+    except ValueError:
+        pass  # Not an IP literal — hostname is fine
 
 
 def normalize_url(url: str) -> str:
@@ -327,13 +360,21 @@ async def fetch_adagents(
     # Track visited URLs to detect loops
     visited_urls: set[str] = set()
 
+    is_redirect = False
+
     for depth in range(MAX_REDIRECT_DEPTH + 1):
         # Check for redirect loop
         if url in visited_urls:
-            raise AdagentsValidationError(f"Circular redirect detected: {url} already visited")
+            raise AdagentsValidationError(
+                "Circular redirect detected in authoritative_location chain"
+            )
         visited_urls.add(url)
 
-        data = await _fetch_adagents_url(url, timeout, user_agent, client)
+        # Use the caller's client for the initial fetch only. Redirect targets
+        # use a fresh client to avoid leaking credentials to third-party URLs.
+        fetch_client = None if is_redirect else client
+
+        data = await _fetch_adagents_url(url, timeout, user_agent, fetch_client)
 
         # Check if this is a redirect. A response with authoritative_location but no
         # authorized_agents indicates a redirect. If both are present, authorized_agents
@@ -349,6 +390,9 @@ async def fetch_adagents(
                     f"authoritative_location must be an HTTPS URL, got: {authoritative_url!r}"
                 )
 
+            # Validate the redirect target is not a private/reserved address
+            _validate_redirect_url(authoritative_url)
+
             # Check if we've exceeded max depth
             if depth >= MAX_REDIRECT_DEPTH:
                 raise AdagentsValidationError(
@@ -357,6 +401,7 @@ async def fetch_adagents(
 
             # Follow the redirect
             url = authoritative_url
+            is_redirect = True
             continue
 
         # We have the final data with authorized_agents (or both fields present,

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 """Tests for adagents.json validation functionality."""
 
+import unittest.mock
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from adcp.adagents import (
@@ -403,6 +405,7 @@ class TestFetchAdagents:
     @pytest.mark.asyncio
     async def test_fetch_follows_authoritative_location(self):
         """Should follow authoritative_location redirect and return resolved data."""
+        import adcp.adagents as adagents_module
         from adcp.adagents import fetch_adagents
 
         # Initial response has authoritative_location redirect
@@ -426,21 +429,36 @@ class TestFetchAdagents:
             "last_updated": "2025-01-15T10:00:00Z",
         }
 
-        # Mock client that returns different responses based on URL
+        # Mock client for the initial fetch (returns redirect)
         called_urls: list[str] = []
-        responses = [redirect_response_data, resolved_data]
 
         async def mock_get(url, **kwargs):
             called_urls.append(url)
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.json.return_value = responses[len(called_urls) - 1]
+            mock_response.json.return_value = redirect_response_data
             return mock_response
 
         mock_client = MagicMock()
         mock_client.get = mock_get
 
-        result = await fetch_adagents("example.com", client=mock_client)
+        # Redirect hop uses a fresh client — mock httpx.AsyncClient for that
+        class MockRedirectClient:
+            async def get(self, url, **kwargs):
+                called_urls.append(url)
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = resolved_data
+                return mock_response
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with unittest.mock.patch.object(
+            adagents_module.httpx, "AsyncClient", MockRedirectClient
+        ):
+            result = await fetch_adagents("example.com", client=mock_client)
 
         assert result == resolved_data
         assert called_urls == [
@@ -486,12 +504,13 @@ class TestFetchAdagents:
 
         mock_client = create_mock_httpx_client(mock_response)
 
-        with pytest.raises(AdagentsValidationError, match="redirect loop|already visited"):
+        with pytest.raises(AdagentsValidationError, match="Circular redirect"):
             await fetch_adagents("example.com", client=mock_client)
 
     @pytest.mark.asyncio
     async def test_fetch_enforces_max_redirect_depth(self):
         """Should enforce maximum redirect depth to prevent abuse."""
+        import adcp.adagents as adagents_module
         from adcp.adagents import fetch_adagents
 
         # Create a long chain of redirects
@@ -512,11 +531,248 @@ class TestFetchAdagents:
         mock_client = MagicMock()
         mock_client.get = mock_get
 
-        with pytest.raises(AdagentsValidationError, match="redirect|depth"):
-            await fetch_adagents("example.com", client=mock_client)
+        # Redirect hops use a fresh client, so patch httpx.AsyncClient too
+        class MockRedirectClient:
+            async def get(self, url, **kwargs):
+                return await mock_get(url, **kwargs)
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with unittest.mock.patch.object(
+            adagents_module.httpx, "AsyncClient", MockRedirectClient
+        ):
+            with pytest.raises(AdagentsValidationError, match="redirect|depth"):
+                await fetch_adagents("example.com", client=mock_client)
 
         # Should stop after reasonable number of redirects (not go forever)
         assert call_count[0] <= 10
+
+
+class TestSSRFProtection:
+    """Test SSRF protections on authoritative_location redirects."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_localhost_redirect(self):
+        """Should reject authoritative_location pointing to localhost."""
+        from adcp.adagents import fetch_adagents
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://localhost/adagents.json",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = redirect_data
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsValidationError, match="localhost"):
+            await fetch_adagents("example.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_rejects_private_ip_redirect(self):
+        """Should reject authoritative_location pointing to private IP."""
+        from adcp.adagents import fetch_adagents
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://192.168.1.1/adagents.json",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = redirect_data
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsValidationError, match="private/reserved"):
+            await fetch_adagents("example.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_rejects_loopback_ip_redirect(self):
+        """Should reject authoritative_location pointing to 127.0.0.1."""
+        from adcp.adagents import fetch_adagents
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://127.0.0.1/adagents.json",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = redirect_data
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsValidationError, match="private/reserved"):
+            await fetch_adagents("example.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_rejects_cloud_metadata_ip_redirect(self):
+        """Should reject authoritative_location pointing to cloud metadata endpoint."""
+        from adcp.adagents import fetch_adagents
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://169.254.169.254/latest/meta-data/",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = redirect_data
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsValidationError, match="private/reserved"):
+            await fetch_adagents("example.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_rejects_dot_local_redirect(self):
+        """Should reject authoritative_location pointing to .local domain."""
+        from adcp.adagents import fetch_adagents
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://internal-service.local/adagents.json",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = redirect_data
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsValidationError, match="localhost"):
+            await fetch_adagents("example.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_redirect_uses_fresh_client(self):
+        """Redirect hops should not reuse the caller's client."""
+        import adcp.adagents as adagents_module
+        from adcp.adagents import fetch_adagents
+
+        resolved_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authorized_agents": [
+                {
+                    "url": "https://agent.example.com",
+                    "properties": [
+                        {
+                            "property_type": "website",
+                            "name": "Site",
+                            "identifiers": [{"type": "domain", "value": "example.com"}],
+                        }
+                    ],
+                }
+            ],
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://cdn.other-domain.com/adagents.json",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        caller_urls = []
+
+        async def mock_get(url, **kwargs):
+            caller_urls.append(url)
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = redirect_data
+            return mock_response
+
+        caller_client = MagicMock()
+        caller_client.get = mock_get
+
+        fresh_client_urls = []
+
+        class TrackingClient:
+            async def get(self, url, **kwargs):
+                fresh_client_urls.append(url)
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = resolved_data
+                return mock_response
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with unittest.mock.patch.object(adagents_module.httpx, "AsyncClient", TrackingClient):
+            result = await fetch_adagents("example.com", client=caller_client)
+
+        # Initial fetch used the caller's client
+        assert len(caller_urls) == 1
+        assert "example.com" in caller_urls[0]
+        # Redirect used a fresh client
+        assert len(fresh_client_urls) == 1
+        assert "cdn.other-domain.com" in fresh_client_urls[0]
+        assert "authorized_agents" in result
+
+    @pytest.mark.asyncio
+    async def test_allows_public_domain_redirect(self):
+        """Should allow redirects to legitimate public domains."""
+        import adcp.adagents as adagents_module
+        from adcp.adagents import fetch_adagents
+
+        resolved_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authorized_agents": [
+                {
+                    "url": "https://agent.example.com",
+                    "properties": [
+                        {
+                            "property_type": "website",
+                            "name": "Site",
+                            "identifiers": [{"type": "domain", "value": "example.com"}],
+                        }
+                    ],
+                }
+            ],
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        redirect_data = {
+            "$schema": "/schemas/2.6.0/adagents.json",
+            "authoritative_location": "https://cdn.example.com/adagents/v2/adagents.json",
+            "last_updated": "2025-01-15T10:00:00Z",
+        }
+
+        async def mock_get(url, **kwargs):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = redirect_data
+            return mock_response
+
+        mock_client = MagicMock()
+        mock_client.get = mock_get
+
+        class MockRedirectClient:
+            async def get(self, url, **kwargs):
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = resolved_data
+                return mock_response
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with unittest.mock.patch.object(
+            adagents_module.httpx, "AsyncClient", MockRedirectClient
+        ):
+            result = await fetch_adagents("example.com", client=mock_client)
+        assert "authorized_agents" in result
 
 
 class TestVerifyAgentForProperty:

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -623,6 +623,154 @@ class TestGetAllProperties:
         assert len(properties) == 1
         assert properties[0]["name"] == "Site"
 
+    def test_get_all_properties_with_property_ids(self):
+        """Should resolve property_ids against top-level properties."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "la_depeche",
+                    "property_type": "website",
+                    "name": "La Dépêche",
+                    "identifiers": [{"type": "domain", "value": "ladepeche.fr"}],
+                },
+                {
+                    "property_id": "midi_libre",
+                    "property_type": "website",
+                    "name": "Midi Libre",
+                    "identifiers": [{"type": "domain", "value": "midilibre.fr"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["la_depeche"],
+                },
+                {
+                    "url": "https://agent2.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["midi_libre"],
+                },
+            ],
+        }
+
+        properties = get_all_properties(adagents_data)
+        assert len(properties) == 2
+        assert properties[0]["name"] == "La Dépêche"
+        assert properties[0]["agent_url"] == "https://agent1.example.com"
+        assert properties[1]["name"] == "Midi Libre"
+        assert properties[1]["agent_url"] == "https://agent2.example.com"
+
+    def test_get_all_properties_with_property_tags(self):
+        """Should resolve property_tags against top-level properties."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site_a",
+                    "property_type": "website",
+                    "name": "Site A",
+                    "identifiers": [{"type": "domain", "value": "a.com"}],
+                    "tags": ["news", "premium"],
+                },
+                {
+                    "property_id": "site_b",
+                    "property_type": "website",
+                    "name": "Site B",
+                    "identifiers": [{"type": "domain", "value": "b.com"}],
+                    "tags": ["sports"],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorization_type": "property_tags",
+                    "property_tags": ["news"],
+                },
+            ],
+        }
+
+        properties = get_all_properties(adagents_data)
+        assert len(properties) == 1
+        assert properties[0]["name"] == "Site A"
+        assert properties[0]["agent_url"] == "https://agent1.example.com"
+
+    def test_get_all_properties_mixed_authorization_types(self):
+        """Should handle mix of inline, property_ids, and property_tags."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "ref_site",
+                    "property_type": "website",
+                    "name": "Referenced Site",
+                    "identifiers": [{"type": "domain", "value": "ref.com"}],
+                    "tags": ["premium"],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://inline-agent.example.com",
+                    "authorization_type": "inline_properties",
+                    "properties": [
+                        {
+                            "property_type": "website",
+                            "name": "Inline Site",
+                            "identifiers": [{"type": "domain", "value": "inline.com"}],
+                        }
+                    ],
+                },
+                {
+                    "url": "https://ids-agent.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["ref_site"],
+                },
+                {
+                    "url": "https://tags-agent.example.com",
+                    "authorization_type": "property_tags",
+                    "property_tags": ["premium"],
+                },
+            ],
+        }
+
+        properties = get_all_properties(adagents_data)
+        assert len(properties) == 3
+        names = {p["name"] for p in properties}
+        assert names == {"Inline Site", "Referenced Site", "Referenced Site"}
+        # Check agent_url attribution
+        by_agent = {p["agent_url"]: p["name"] for p in properties}
+        assert by_agent["https://inline-agent.example.com"] == "Inline Site"
+        assert by_agent["https://ids-agent.example.com"] == "Referenced Site"
+        assert by_agent["https://tags-agent.example.com"] == "Referenced Site"
+
+    def test_get_all_properties_deduplicates_not(self):
+        """Properties referenced by multiple agents should appear once per agent."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "shared",
+                    "property_type": "website",
+                    "name": "Shared Site",
+                    "identifiers": [{"type": "domain", "value": "shared.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["shared"],
+                },
+                {
+                    "url": "https://agent2.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["shared"],
+                },
+            ],
+        }
+
+        properties = get_all_properties(adagents_data)
+        assert len(properties) == 2
+        assert properties[0]["agent_url"] == "https://agent1.example.com"
+        assert properties[1]["agent_url"] == "https://agent2.example.com"
+
     def test_get_all_properties_invalid_data(self):
         """Should raise error for invalid data."""
         with pytest.raises(AdagentsValidationError):

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -733,8 +733,6 @@ class TestGetAllProperties:
 
         properties = get_all_properties(adagents_data)
         assert len(properties) == 3
-        names = {p["name"] for p in properties}
-        assert names == {"Inline Site", "Referenced Site", "Referenced Site"}
         # Check agent_url attribution
         by_agent = {p["agent_url"]: p["name"] for p in properties}
         assert by_agent["https://inline-agent.example.com"] == "Inline Site"
@@ -770,6 +768,51 @@ class TestGetAllProperties:
         assert len(properties) == 2
         assert properties[0]["agent_url"] == "https://agent1.example.com"
         assert properties[1]["agent_url"] == "https://agent2.example.com"
+
+    def test_get_all_properties_unknown_authorization_type(self):
+        """Should return empty for agents with unrecognized authorization_type."""
+        adagents_data = {
+            "authorized_agents": [
+                {
+                    "url": "https://agent.example.com",
+                    "authorization_type": "some_future_type",
+                },
+            ],
+        }
+
+        properties = get_all_properties(adagents_data)
+        assert properties == []
+
+    def test_get_all_properties_authorization_type_takes_precedence(self):
+        """authorization_type should take precedence over stale properties key."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "correct",
+                    "property_type": "website",
+                    "name": "Correct Site",
+                    "identifiers": [{"type": "domain", "value": "correct.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["correct"],
+                    "properties": [
+                        {
+                            "property_type": "website",
+                            "name": "Stale Inline Site",
+                            "identifiers": [{"type": "domain", "value": "stale.com"}],
+                        }
+                    ],
+                },
+            ],
+        }
+
+        properties = get_all_properties(adagents_data)
+        assert len(properties) == 1
+        assert properties[0]["name"] == "Correct Site"
 
     def test_get_all_properties_invalid_data(self):
         """Should raise error for invalid data."""
@@ -837,6 +880,30 @@ class TestGetAllTags:
 
         tags = get_all_tags(adagents_data)
         assert tags == set()
+
+    def test_get_all_tags_with_property_ids(self):
+        """Should extract tags from properties resolved via property_ids."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site_a",
+                    "property_type": "website",
+                    "name": "Site A",
+                    "identifiers": [{"type": "domain", "value": "a.com"}],
+                    "tags": ["premium", "news"],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent.example.com",
+                    "authorization_type": "property_ids",
+                    "property_ids": ["site_a"],
+                },
+            ],
+        }
+
+        tags = get_all_tags(adagents_data)
+        assert tags == {"premium", "news"}
 
 
 class TestGetPropertiesByAgent:


### PR DESCRIPTION
## Summary
- `get_all_properties()` only extracted inline properties, ignoring `property_ids` and `property_tags` authorization types — the most common model for multi-property publishers
- Extracted `_resolve_agent_properties()` helper that handles all authorization types, used by both `get_all_properties()` and `get_properties_by_agent()`
- `authorization_type` now takes strict precedence over stale `properties` key on agent entries
- Added SSRF protections for `authoritative_location` redirects: rejects private/reserved IPs and localhost, uses fresh HTTP client for redirect hops to prevent credential leakage, removes internal URLs from error messages

Fixes #172

## Test plan
- [x] Existing `get_properties_by_agent` tests still pass (refactored to shared helper)
- [x] New `get_all_properties` tests for property_ids, property_tags, mixed types, shared properties, unknown authorization_type, and precedence behavior
- [x] New `get_all_tags` test with property_ids resolution
- [x] New SSRF protection tests: localhost, private IP, loopback, cloud metadata, .local domain, fresh client for redirects, public domain allowed
- [x] ruff, mypy, and full test suite pass (1085 passed across Python 3.10-3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)