### PR TITLE
feat: idempotency_key auto-injection, typed errors, and capability gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,72 @@ All exceptions include:
 - **Actionable suggestions**: specific steps to fix common issues
 - **Error classification**: proper HTTP status code handling
 
+### Idempotency and retries
+
+AdCP 3.0 requires an `idempotency_key` on every mutating request (`create_media_buy`, `sync_creatives`, and 26 others). The client handles this for you — you pass a key (or let the SDK generate one) and get back the key the seller cached under, plus a `replayed` flag indicating whether the seller served a cached response:
+
+```python
+import uuid
+from adcp import CreateMediaBuyRequest
+
+# Pass a fresh UUID v4 on each new logical operation — the request schema
+# requires idempotency_key at construction time.
+request = CreateMediaBuyRequest(
+    idempotency_key=uuid.uuid4().hex,
+    account=..., brand=..., start_time=..., end_time=..., packages=[...]
+)
+result = await client.create_media_buy(request)
+print(result.idempotency_key)    # The key the SDK sent
+print(result.replayed)           # True if the seller returned a cached response
+```
+
+**Retrying the same logical operation** — wrap the retry loop in `use_idempotency_key` so every attempt sends the same key. Otherwise each retry gets a new UUID and defeats the whole point.
+
+```python
+stored = uuid.uuid4().hex
+for attempt in range(3):
+    try:
+        with client.use_idempotency_key(stored):
+            result = await client.create_media_buy(request)
+        break
+    except TimeoutError:
+        continue
+```
+
+**Bring your own key** when you persist keys across process restarts (e.g., storing alongside a campaign row in your DB):
+
+```python
+with client.use_idempotency_key(campaign.stored_key):
+    result = await client.create_media_buy(request)
+```
+
+The pinned key is scoped to *this* client instance — a sibling `ADCPClient` running inside the same `with` block generates a fresh key (per AdCP §2315: keys must be unique per `(seller, request)` pair to prevent cross-seller correlation). The pinned key is also single-use within the scope: if you `asyncio.gather` two sibling calls inside the block, only the first gets the pinned key, the rest get fresh UUIDs — preventing accidental payload drift.
+
+**Typed errors** for the two idempotency-specific failure modes:
+
+```python
+from adcp import IdempotencyConflictError, IdempotencyExpiredError
+
+try:
+    await client.create_media_buy(request)
+except IdempotencyConflictError:
+    # Same key, different payload. Either mint a fresh uuid.uuid4() or resend original.
+    ...
+except IdempotencyExpiredError:
+    # Replay window closed; reconcile via a read before resubmitting with a new key.
+    ...
+```
+
+**Strict mode** refuses mutating calls against sellers that don't declare `adcp.idempotency.replay_ttl_seconds` in capabilities:
+
+```python
+client = ADCPClient(agent, strict_idempotency=True)  # default: False
+# First mutating call fetches capabilities and raises IdempotencyUnsupportedError
+# if the seller is silent. Set False to opt-out; you then own reconciliation.
+```
+
+**Security note on logs.** The SDK redacts `idempotency_key` in its own debug captures, but the underlying `httpx`/`httpcore` loggers log full request bodies at `DEBUG`. If you enable `logging.basicConfig(level=logging.DEBUG)` in production, raise those two loggers back to `INFO` — otherwise full keys end up in logs during the seller's replay TTL window and become a retry-pattern oracle for anyone who can read them.
+
 ## Available Tools
 
 All AdCP tools with full type safety:

--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -39,6 +39,9 @@ from adcp.exceptions import (  # noqa: F401
     ADCPToolNotFoundError,
     ADCPWebhookError,
     ADCPWebhookSignatureError,
+    IdempotencyConflictError,
+    IdempotencyExpiredError,
+    IdempotencyUnsupportedError,
     RegistryError,
 )
 from adcp.property_registry import PropertyRegistry

--- a/src/adcp/_idempotency.py
+++ b/src/adcp/_idempotency.py
@@ -1,0 +1,370 @@
+"""Internal helpers for AdCP idempotency_key handling.
+
+See adcontextprotocol/adcp#2308 and #2315 for the spec contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import warnings
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from adcp.types.core import TaskResult
+
+IDEMPOTENT_TASKS: frozenset[str] = frozenset(
+    {
+        "create_media_buy",
+        "update_media_buy",
+        "sync_creatives",
+        "activate_signal",
+        "acquire_rights",
+        "creative_approval",
+        "update_rights",
+        "build_creative",
+        "calibrate_content",
+        "create_content_standards",
+        "update_content_standards",
+        "create_property_list",
+        "update_property_list",
+        "delete_property_list",
+        "create_collection_list",
+        "update_collection_list",
+        "delete_collection_list",
+        "log_event",
+        "provide_performance_feedback",
+        "report_usage",
+        "report_plan_outcome",
+        "si_initiate_session",
+        "sync_accounts",
+        "sync_governance",
+        "sync_plans",
+        "sync_audiences",
+        "sync_catalogs",
+        "sync_event_sources",
+        "si_send_message",
+    }
+)
+
+# Text-mode fallback for MCP servers that emit error codes only in the message
+# body (is_error=true with no structuredContent). FastMCP's default behavior.
+_TEXT_CODE_PATTERN = re.compile(r"\b(IDEMPOTENCY_CONFLICT|IDEMPOTENCY_EXPIRED)\b")
+
+_KEY_CHARSET = re.compile(r"^[A-Za-z0-9_.:\-]+$")
+
+logger = logging.getLogger(__name__)
+
+# Module-level registry of keys pinned via ``ADCPClient.use_idempotency_key``,
+# keyed by the owning client's unique token. A dict (not a ContextVar) because
+# ContextVars are copied into each asyncio task at creation; two gather()
+# siblings inside a ``with`` block would each see their own copy of the pinned
+# key and both consume it, duplicating it across requests. A shared dict with
+# ``pop`` semantics gives us single-use-within-scope: the first mutating call
+# takes the key, concurrent siblings fall through to fresh-UUID generation.
+# Safe under asyncio because ``dict.pop`` is atomic under CPython's GIL.
+_scoped_keys: dict[str, str] = {}
+
+
+def generate_key() -> str:
+    """Generate a fresh UUID v4 suitable for use as an idempotency_key."""
+    return str(uuid4())
+
+
+def validate_key(key: str) -> str:
+    """Validate a caller-provided key against the spec pattern.
+
+    Raises ``ValueError`` with a specific message for length vs charset
+    violations. Returns the key unchanged on success.
+    """
+    if not isinstance(key, str):
+        raise ValueError(f"idempotency_key must be a string, got {type(key).__name__}")
+    if len(key) < 16 or len(key) > 255:
+        raise ValueError(
+            f"idempotency_key length must be 16-255 characters, got {len(key)}. "
+            "A UUID v4 (36 chars, e.g. uuid.uuid4()) satisfies this."
+        )
+    if not _KEY_CHARSET.match(key):
+        raise ValueError(
+            "idempotency_key contains invalid characters; only "
+            "letters, digits, and ._:- are allowed."
+        )
+    return key
+
+
+def redact(key: str | None) -> str:
+    """Return a short, safe representation of an idempotency_key for logging.
+
+    Keys live inside the seller's replay TTL window and can serve as a
+    retry-pattern oracle for anyone watching network traffic. Callers should
+    never log the full key; use this helper to emit a prefix only.
+    """
+    if not key:
+        return "<none>"
+    if len(key) <= 8:
+        return "<short>"
+    return f"{key[:8]}..."
+
+
+def is_mutating(tool_name: str) -> bool:
+    """True if the tool is in the idempotency-required set."""
+    return tool_name in IDEMPOTENT_TASKS
+
+
+def redact_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a params dict with the idempotency_key replaced by its prefix.
+
+    Use before emitting a request payload to logs or debug artifacts. Full
+    keys are an observable retry-pattern oracle inside the seller's TTL window
+    and should never appear in persistent logs.
+    """
+    if "idempotency_key" not in params:
+        return params
+    redacted = dict(params)
+    redacted["idempotency_key"] = redact(redacted.get("idempotency_key"))
+    return redacted
+
+
+def deep_redact(value: Any) -> Any:
+    """Recursively redact any ``idempotency_key`` field in a nested structure.
+
+    The server echoes ``idempotency_key`` in response envelopes so buyers can
+    correlate retries, which means the key can surface in debug-captured
+    response bodies even after the request-side redaction in
+    :func:`redact_params`. This helper walks dicts, lists, and Pydantic
+    ``BaseModel`` instances, replacing any ``idempotency_key`` string value
+    with its 8-char prefix. Originals are not mutated.
+    """
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            if k == "idempotency_key" and isinstance(v, str):
+                out[k] = redact(v)
+            else:
+                out[k] = deep_redact(v)
+        return out
+    if isinstance(value, list):
+        return [deep_redact(item) for item in value]
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        try:
+            return deep_redact(value.model_dump())
+        except Exception:
+            # Failing to dump a Pydantic model should not poison a debug path.
+            return value
+    return value
+
+
+def inject_key(
+    tool_name: str,
+    params: dict[str, Any],
+    client_token: str | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    """Resolve and inject an ``idempotency_key`` into a params dict for a tool call.
+
+    Does not mutate the caller's dict. Returns a new dict (or the original when
+    no injection is needed) plus the effective key (or None when the tool is
+    read-only and no key was supplied).
+
+    A caller-provided empty-string key is treated as absent (falls through to
+    context-scoped or auto-generated resolution) rather than raising a confusing
+    ValueError from deep in the adapter stack.
+
+    ``client_token`` identifies the owning client so a key pinned via
+    ``client_a.use_idempotency_key(...)`` is not reused by a different client
+    executing inside the same ``with`` block — see :func:`resolve_key`.
+    """
+    existing = params.get("idempotency_key")
+    if isinstance(existing, str) and existing == "":
+        existing = None
+    key = resolve_key(
+        tool_name,
+        existing if isinstance(existing, str) else None,
+        client_token=client_token,
+    )
+    if key is None:
+        return params, None
+    if existing == key:
+        return params, key
+    new_params = dict(params)
+    new_params["idempotency_key"] = key
+    return new_params, key
+
+
+_REPLAYED_TRUTHY = frozenset({"true", "1", "yes"})
+
+
+def extract_replayed(data: Any) -> bool:
+    """Pull the envelope-level ``replayed`` flag from a response payload.
+
+    Strictly the spec says this is a boolean. Real servers have been observed
+    to stringify booleans or use integer 1; we accept those permissively
+    because the alternative (False) risks the caller re-emitting side effects
+    on a replay. Unexpected shapes warn so incompliance is visible during rollout.
+    """
+    if not isinstance(data, dict) or "replayed" not in data:
+        return False
+    val = data.get("replayed")
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, int):  # includes 0/1; bool handled above
+        return val != 0
+    if isinstance(val, str):
+        logger.warning(
+            "Server returned replayed=%r as a string; spec requires a "
+            "JSON boolean. Treating as %s.",
+            val,
+            val.strip().lower() in _REPLAYED_TRUTHY,
+        )
+        return val.strip().lower() in _REPLAYED_TRUTHY
+    logger.warning(
+        "Server returned replayed=%r with unexpected type %s; treating as False.",
+        val,
+        type(val).__name__,
+    )
+    return False
+
+
+def collect_error_codes(data: Any) -> list[str]:
+    """Return the ``code`` values from a response's ``errors`` array, if present."""
+    if not isinstance(data, dict):
+        return []
+    errors = data.get("errors")
+    if not isinstance(errors, list):
+        return []
+    codes: list[str] = []
+    for err in errors:
+        code = None
+        if isinstance(err, dict):
+            code = err.get("code")
+        else:
+            code = getattr(err, "code", None)
+        if isinstance(code, str):
+            codes.append(code)
+    return codes
+
+
+def raise_for_idempotency_error(
+    tool_name: str,
+    data: Any,
+    agent_id: str | None,
+) -> None:
+    """Raise the matching typed exception if the response carries an idempotency error code.
+
+    Inspects the ``errors`` array on the response payload. No-op when no
+    matching code is present. Raises ``IdempotencyConflictError`` or
+    ``IdempotencyExpiredError`` populated with the full errors list.
+    """
+    from adcp.exceptions import (
+        IDEMPOTENCY_ERROR_CODE_MAP,
+        classify_task_error,
+    )
+
+    codes = collect_error_codes(data)
+    if not any(code in IDEMPOTENCY_ERROR_CODE_MAP for code in codes):
+        return
+    errors = data.get("errors", []) if isinstance(data, dict) else []
+    raise classify_task_error(tool_name, errors, agent_id=agent_id)
+
+
+def raise_for_idempotency_text(
+    tool_name: str,
+    message: str | None,
+    agent_id: str | None,
+) -> None:
+    """Raise a typed idempotency error if a text-only message carries the spec code.
+
+    Fallback for MCP servers that return ``is_error=true`` with plain text
+    content (e.g. FastMCP's default error shape) instead of a structured
+    errors array. Scans for whole-word ``IDEMPOTENCY_CONFLICT`` /
+    ``IDEMPOTENCY_EXPIRED`` tokens and raises the matching typed exception.
+    No-op when the message is absent or doesn't contain a known code.
+    """
+    from adcp.exceptions import IDEMPOTENCY_ERROR_CODE_MAP, classify_task_error
+
+    if not message:
+        return
+    match = _TEXT_CODE_PATTERN.search(message)
+    if not match:
+        return
+    code = match.group(1)
+    if code not in IDEMPOTENCY_ERROR_CODE_MAP:
+        return
+    synthetic_error = {"code": code, "message": message}
+    raise classify_task_error(tool_name, [synthetic_error], agent_id=agent_id)
+
+
+def annotate_result(
+    result: TaskResult[Any],
+    idempotency_key: str | None,
+) -> TaskResult[Any]:
+    """Surface the request's idempotency_key and the envelope ``replayed`` flag on a TaskResult.
+
+    Populates first-class ``result.idempotency_key`` and ``result.replayed``
+    attributes. Also mirrors into ``result.metadata`` under the legacy keys
+    ``idempotency_key`` and ``idempotency_replayed`` for callers that were
+    already reading from metadata; the mirror is a transitional convenience
+    and may be removed in a future release.
+    """
+    replayed = extract_replayed(result.data)
+    result.replayed = replayed
+    if idempotency_key is not None:
+        result.idempotency_key = idempotency_key
+    if idempotency_key is None and not replayed:
+        return result
+    metadata = dict(result.metadata or {})
+    if idempotency_key is not None:
+        metadata["idempotency_key"] = idempotency_key
+    metadata["idempotency_replayed"] = replayed
+    result.metadata = metadata
+    return result
+
+
+def resolve_key(
+    tool_name: str,
+    params_key: str | None,
+    client_token: str | None = None,
+) -> str | None:
+    """Resolve the effective idempotency_key for a tool call.
+
+    Order of precedence:
+    1. Explicit key already present in the params dict.
+    2. Single-use key pinned via ``client.use_idempotency_key(...)`` on the
+       SAME client. The scoped key is popped on first consume; concurrent
+       gather() siblings falling into this branch get fresh UUIDs instead
+       of duplicating the pinned key.
+    3. Freshly generated UUID v4 when the tool is mutating.
+    4. ``None`` for non-mutating tools — caller should not include the field.
+
+    When a scoped key exists on a DIFFERENT client's slot (cross-client leak
+    inside the same ``with`` block), this path falls through to fresh-key
+    generation and emits a ``UserWarning`` — keys must be unique per
+    (seller, request) pair (AdCP #2315).
+
+    Raises ``ValueError`` when an explicit key fails format validation.
+    """
+    if params_key is not None:
+        return validate_key(params_key)
+
+    if client_token is not None:
+        scoped = _scoped_keys.pop(client_token, None)
+        if scoped is not None:
+            return validate_key(scoped)
+
+    if _scoped_keys:
+        # Another client has a pinned key in scope but it's not this one.
+        # Almost always a caller mistake — e.g. using client_b inside a
+        # ``with client_a.use_idempotency_key(...)`` block.
+        warnings.warn(
+            "use_idempotency_key was set on a different client; the SDK is "
+            "generating a fresh key for this call to prevent cross-seller "
+            "correlation. Keys must be unique per (seller, request) pair "
+            "(AdCP #2315).",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    if is_mutating(tool_name):
+        return generate_key()
+
+    return None

--- a/src/adcp/client.py
+++ b/src/adcp/client.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 """Main client classes for AdCP."""
 
+import contextlib
 import hashlib
 import hmac
 import json
 import logging
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
 from typing import Any
 
@@ -291,6 +292,7 @@ class ADCPClient:
         webhook_timestamp_tolerance: int = 300,
         capabilities_ttl: float = 3600.0,
         validate_features: bool = False,
+        strict_idempotency: bool = False,
     ):
         """
         Initialize ADCP client for a single agent.
@@ -308,6 +310,12 @@ class ADCPClient:
             validate_features: When True, automatically check that the seller supports
                 required features before making task calls (e.g., sync_audiences requires
                 audience_targeting). Requires capabilities to have been fetched first.
+            strict_idempotency: When True, verify the seller declared
+                ``adcp.idempotency.replay_ttl_seconds`` in capabilities before any
+                mutating call. Fetches capabilities lazily on first use. Raises
+                ``IdempotencyUnsupportedError`` if the declaration is missing —
+                sellers that don't declare it provide no retry-safety guarantee
+                per AdCP #2315. Defaults to False for backward compatibility.
         """
         self.agent_config = agent_config
         self.webhook_url_template = webhook_url_template
@@ -316,11 +324,18 @@ class ADCPClient:
         self.webhook_timestamp_tolerance = webhook_timestamp_tolerance
         self.capabilities_ttl = capabilities_ttl
         self.validate_features = validate_features
+        self.strict_idempotency = strict_idempotency
 
         # Capabilities cache
         self._capabilities: GetAdcpCapabilitiesResponse | None = None
         self._feature_resolver: FeatureResolver | None = None
         self._capabilities_fetched_at: float | None = None
+        self._idempotency_capability_verified: bool = False
+        # Unique per-instance token so use_idempotency_key scopes to this
+        # client and does not bleed to siblings (AdCP #2315 cross-seller risk).
+        from uuid import uuid4 as _uuid4
+
+        self._idempotency_client_token: str = _uuid4().hex
 
         # Initialize protocol adapter
         self.adapter: ProtocolAdapter
@@ -331,10 +346,51 @@ class ADCPClient:
         else:
             raise ValueError(f"Unsupported protocol: {agent_config.protocol}")
 
+        self.adapter.idempotency_client_token = self._idempotency_client_token
+        if strict_idempotency:
+            self.adapter.idempotency_capability_check = self._ensure_idempotency_capability
+
         # Initialize simple API accessor (lazy import to avoid circular dependency)
         from adcp.simple import SimpleAPI
 
         self.simple = SimpleAPI(self)
+
+    async def _ensure_idempotency_capability(self) -> None:
+        """Verify the seller declared idempotency.replay_ttl_seconds in capabilities.
+
+        Called before every mutating request when ``strict_idempotency=True``.
+        Fetches capabilities on first invocation; subsequent calls are no-ops
+        once the declaration has been observed. Raises
+        ``IdempotencyUnsupportedError`` when the seller is missing the field.
+
+        Sets ``_idempotency_capability_verified = True`` BEFORE calling
+        ``fetch_capabilities`` so any recursive dispatch through the adapter
+        terminates (``get_adcp_capabilities`` is non-mutating, so it would
+        short-circuit anyway — but this guard protects against future refactors
+        that might add it to the mutating set).
+        """
+        from adcp.exceptions import IdempotencyUnsupportedError
+
+        if self._idempotency_capability_verified:
+            return
+
+        self._idempotency_capability_verified = True
+        try:
+            caps = await self.fetch_capabilities()
+            adcp_info = getattr(caps, "adcp", None)
+            idempotency_info = getattr(adcp_info, "idempotency", None) if adcp_info else None
+            ttl = (
+                getattr(idempotency_info, "replay_ttl_seconds", None) if idempotency_info else None
+            )
+
+            if ttl is None:
+                raise IdempotencyUnsupportedError(
+                    agent_id=self.agent_config.id,
+                    agent_uri=self.agent_config.agent_uri,
+                )
+        except Exception:
+            self._idempotency_capability_verified = False
+            raise
 
     def get_webhook_url(self, task_type: str, operation_id: str) -> str:
         """Generate webhook URL for a task."""
@@ -351,6 +407,50 @@ class ADCPClient:
         """Emit activity event."""
         if self.on_activity:
             self.on_activity(activity)
+
+    @contextlib.contextmanager
+    def use_idempotency_key(self, key: str) -> Iterator[str]:
+        """Pin an ``idempotency_key`` for the next mutating call on THIS client.
+
+        Use when you've persisted a key (e.g., in a buyer-side database) and
+        want the SDK to send that exact key on resume or retry across process
+        restarts. The key is validated against ``^[A-Za-z0-9_.:-]{16,255}$`` on
+        entry; a ``ValueError`` is raised for malformed keys.
+
+        Scope rules:
+
+        * **Single-use within scope.** The first mutating call inside the
+          ``with`` block consumes the pinned key; a second mutating call falls
+          through to a fresh UUID. This protects against ``asyncio.gather``
+          siblings accidentally sharing the key (which would trigger
+          ``IDEMPOTENCY_CONFLICT`` or silently duplicate work). If you need to
+          retry, wrap each attempt in its own ``with`` block.
+        * **Client-scoped.** The pinned key applies only to calls on THIS
+          client. A mutating call on a sibling ``ADCPClient`` inside the same
+          ``with`` block generates a fresh key and emits a ``UserWarning`` —
+          keys must be unique per (seller, request) pair (AdCP #2315).
+        * **No nesting.** Nested ``use_idempotency_key`` on the same client
+          raises ``RuntimeError``.
+
+        Example::
+
+            with client.use_idempotency_key(campaign.stored_key):
+                result = await client.create_media_buy(request)
+        """
+        from adcp import _idempotency
+
+        _idempotency.validate_key(key)
+        token = self._idempotency_client_token
+        if token in _idempotency._scoped_keys:
+            raise RuntimeError(
+                "use_idempotency_key is already active on this client; "
+                "nested usage is not supported."
+            )
+        _idempotency._scoped_keys[token] = key
+        try:
+            yield key
+        finally:
+            _idempotency._scoped_keys.pop(token, None)
 
     # ========================================================================
     # Capability Validation
@@ -3013,9 +3113,7 @@ class ADCPClient:
             True if signature is valid, False otherwise
         """
         if not self.webhook_secret:
-            logger.warning(
-                "Webhook signature verification skipped: no webhook_secret configured"
-            )
+            logger.warning("Webhook signature verification skipped: no webhook_secret configured")
             return True
 
         # Reject stale or future timestamps to prevent replay attacks

--- a/src/adcp/exceptions.py
+++ b/src/adcp/exceptions.py
@@ -269,9 +269,7 @@ class ADCPTaskError(ADCPError):
         """
         self.operation = operation
         self.errors = errors
-        self.error_codes = [
-            e.code for e in errors if hasattr(e, "code") and e.code
-        ]
+        self.error_codes = [e.code for e in errors if hasattr(e, "code") and e.code]
 
         message = f"{operation} failed"
         if errors:
@@ -288,3 +286,117 @@ class ADCPTaskError(ADCPError):
         from adcp.server.helpers import TRANSIENT_CODES
 
         return bool(TRANSIENT_CODES & set(self.error_codes))
+
+
+class IdempotencyConflictError(ADCPTaskError):
+    """Server rejected a reused idempotency_key whose payload differs from the original.
+
+    The request used the same idempotency_key as an earlier request but with a
+    materially different (post-JCS-canonicalization) payload. Two valid recovery
+    paths: (a) mint a fresh ``uuid.uuid4()`` key and resubmit, or (b) resend the
+    exact original payload — whichever matches the caller's intent.
+
+    By design the rendered message does NOT include the server's error text
+    because non-compliant sellers may include payload hints that violate the
+    ``IDEMPOTENCY_CONFLICT`` spec requirement. Raw errors remain on
+    ``self.errors`` for callers that want to inspect.
+    """
+
+    def __init__(
+        self,
+        operation: str,
+        errors: list[Any],
+        agent_id: str | None = None,
+    ):
+        self.operation = operation
+        self.errors = errors
+        self.error_codes = [e.code for e in errors if hasattr(e, "code") and e.code] or [
+            "IDEMPOTENCY_CONFLICT"
+        ]
+        message = f"{operation}: idempotency_key reused with a different payload"
+        suggestion = (
+            "The server already has a response for this idempotency_key with a "
+            "different (JCS-canonicalized) payload. Either resend the exact original "
+            "payload, or mint a fresh key with uuid.uuid4() and resubmit. Do NOT "
+            "reuse this key with modified fields."
+        )
+        # Skip ADCPTaskError.__init__ to avoid leaking server-supplied text.
+        ADCPError.__init__(self, message, agent_id=agent_id, suggestion=suggestion)
+
+
+class IdempotencyExpiredError(ADCPTaskError):
+    """Server's replay cache for this idempotency_key has expired.
+
+    Per AdCP #2315 the seller MAY discard cached responses after
+    ``replay_ttl_seconds``. Re-executing is unsafe because the seller can no
+    longer distinguish "seen and evicted" from "never seen" — silently retrying
+    risks duplicate execution. Recovery: reconcile state via a read (e.g.
+    ``get_media_buys``) before resubmitting with a fresh key.
+    """
+
+    def __init__(
+        self,
+        operation: str,
+        errors: list[Any],
+        agent_id: str | None = None,
+    ):
+        self.operation = operation
+        self.errors = errors
+        self.error_codes = [e.code for e in errors if hasattr(e, "code") and e.code] or [
+            "IDEMPOTENCY_EXPIRED"
+        ]
+        message = f"{operation}: idempotency replay window has expired"
+        suggestion = (
+            "The seller's replay_ttl_seconds window for this key has passed. "
+            "Re-execution is unsafe — the seller can no longer guarantee "
+            "at-most-once. Reconcile state with a read (e.g. get_media_buys) "
+            "before resubmitting with a fresh uuid.uuid4() key."
+        )
+        ADCPError.__init__(self, message, agent_id=agent_id, suggestion=suggestion)
+
+
+class IdempotencyUnsupportedError(ADCPError):
+    """Seller did not declare adcp.idempotency.replay_ttl_seconds in capabilities.
+
+    Per AdCP #2315 sellers MUST declare their replay window; clients MUST NOT
+    assume a default. Raised before the first mutating call when
+    ``strict_idempotency=True`` and the seller's capabilities response is
+    missing this field.
+    """
+
+    def __init__(
+        self,
+        agent_id: str | None = None,
+        agent_uri: str | None = None,
+    ):
+        message = (
+            "Seller did not declare adcp.idempotency.replay_ttl_seconds; "
+            "retry safety for mutating requests cannot be guaranteed."
+        )
+        suggestion = (
+            "Recommended: ask the seller to declare replay_ttl_seconds in "
+            "get_adcp_capabilities (AdCP #2315 requirement). To proceed without "
+            "this guarantee — retries may double-charge or duplicate — construct "
+            "ADCPClient with strict_idempotency=False; the caller then owns "
+            "reconciliation on retry."
+        )
+        super().__init__(message, agent_id, agent_uri, suggestion)
+
+
+IDEMPOTENCY_ERROR_CODE_MAP: dict[str, type[ADCPTaskError]] = {
+    "IDEMPOTENCY_CONFLICT": IdempotencyConflictError,
+    "IDEMPOTENCY_EXPIRED": IdempotencyExpiredError,
+}
+
+
+def classify_task_error(
+    operation: str,
+    errors: list[Any],
+    agent_id: str | None = None,
+) -> ADCPTaskError:
+    """Build the most specific ADCPTaskError subclass matching the response codes."""
+    for err in errors:
+        code = getattr(err, "code", None) or (err.get("code") if isinstance(err, dict) else None)
+        if code and code in IDEMPOTENCY_ERROR_CODE_MAP:
+            return IDEMPOTENCY_ERROR_CODE_MAP[code](operation, errors, agent_id=agent_id)
+    return ADCPTaskError(operation, errors, agent_id=agent_id)

--- a/src/adcp/protocols/a2a.py
+++ b/src/adcp/protocols/a2a.py
@@ -20,10 +20,13 @@ from a2a.types import (
     TextPart,
 )
 
+from adcp import _idempotency
 from adcp.exceptions import (
     ADCPAuthenticationError,
     ADCPConnectionError,
     ADCPTimeoutError,
+    IdempotencyConflictError,
+    IdempotencyExpiredError,
 )
 from adcp.protocols.base import ProtocolAdapter
 from adcp.types.core import AgentConfig, DebugInfo, TaskResult, TaskStatus
@@ -140,6 +143,11 @@ class A2AAdapter(ProtocolAdapter):
         See: https://docs.adcontextprotocol.org/docs/protocols/a2a-guide
         """
         start_time = time.time() if self.agent_config.debug else None
+        if _idempotency.is_mutating(tool_name) and self.idempotency_capability_check:
+            await self.idempotency_capability_check()
+        params, idempotency_key = _idempotency.inject_key(
+            tool_name, params, client_token=self.idempotency_client_token
+        )
         a2a_client = await self._get_a2a_client()
 
         # Build A2A message
@@ -185,7 +193,7 @@ class A2AAdapter(ProtocolAdapter):
                 "method": "send_message",
                 "message_id": message_id,
                 "tool": tool_name,
-                "params": params,
+                "params": _idempotency.redact_params(params),
             }
 
         try:
@@ -203,7 +211,7 @@ class A2AAdapter(ProtocolAdapter):
                     duration_ms = (time.time() - start_time) * 1000
                     debug_info = DebugInfo(
                         request=debug_request,
-                        response={"error": response.error.model_dump()},
+                        response=_idempotency.deep_redact({"error": response.error.model_dump()}),
                         duration_ms=duration_ms,
                     )
                 return TaskResult[Any](
@@ -211,6 +219,7 @@ class A2AAdapter(ProtocolAdapter):
                     error=error_msg,
                     success=False,
                     debug_info=debug_info,
+                    idempotency_key=idempotency_key,
                 )
 
             # Handle success response
@@ -221,13 +230,17 @@ class A2AAdapter(ProtocolAdapter):
                     duration_ms = (time.time() - start_time) * 1000
                     debug_info = DebugInfo(
                         request=debug_request,
-                        response={"result": result.model_dump()},
+                        response=_idempotency.deep_redact({"result": result.model_dump()}),
                         duration_ms=duration_ms,
                     )
 
                 # Result can be either Task or Message
                 if isinstance(result, Task):
-                    return self._process_task_response(result, debug_info)
+                    task_result = self._process_task_response(result, debug_info)
+                    _idempotency.raise_for_idempotency_error(
+                        tool_name, task_result.data, self.agent_config.id
+                    )
+                    return _idempotency.annotate_result(task_result, idempotency_key)
                 else:
                     # Message response (shouldn't happen for send_message, but handle it)
                     agent_id = self.agent_config.id
@@ -246,6 +259,7 @@ class A2AAdapter(ProtocolAdapter):
                 error="Invalid response from A2A client",
                 success=False,
                 debug_info=debug_info,
+                idempotency_key=idempotency_key,
             )
 
         except httpx.HTTPStatusError as e:
@@ -268,6 +282,7 @@ class A2AAdapter(ProtocolAdapter):
                 error=error_msg,
                 success=False,
                 debug_info=debug_info,
+                idempotency_key=idempotency_key,
             )
         except httpx.TimeoutException as e:
             if self.agent_config.debug and start_time:
@@ -282,7 +297,14 @@ class A2AAdapter(ProtocolAdapter):
                 error=f"Timeout: {e}",
                 success=False,
                 debug_info=debug_info,
+                idempotency_key=idempotency_key,
             )
+        except (IdempotencyConflictError, IdempotencyExpiredError):
+            # Propagate typed idempotency errors — callers MUST handle these
+            # distinctly (mint fresh key / reconcile state). Other ADCPError
+            # subclasses (connection, timeout, auth) continue to be converted
+            # to TaskResult(failed) below, preserving the existing contract.
+            raise
         except Exception as e:
             if self.agent_config.debug and start_time:
                 duration_ms = (time.time() - start_time) * 1000
@@ -296,6 +318,7 @@ class A2AAdapter(ProtocolAdapter):
                 error=str(e),
                 success=False,
                 debug_info=debug_info,
+                idempotency_key=idempotency_key,
             )
 
     def _process_task_response(self, task: Task, debug_info: DebugInfo | None) -> TaskResult[Any]:

--- a/src/adcp/protocols/base.py
+++ b/src/adcp/protocols/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Base protocol adapter interface."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
@@ -25,6 +26,14 @@ class ProtocolAdapter(ABC):
     def __init__(self, agent_config: AgentConfig):
         """Initialize adapter with agent configuration."""
         self.agent_config = agent_config
+        # Optional hook; ADCPClient sets this when strict_idempotency is enabled.
+        # Invoked before each mutating tool call to verify the seller declared
+        # adcp.idempotency.replay_ttl_seconds in capabilities. None = no check.
+        self.idempotency_capability_check: Callable[[], Awaitable[None]] | None = None
+        # Unique token for this adapter's owning client — used to scope
+        # ``use_idempotency_key`` so a key pinned on one client does not bleed
+        # to sibling clients (cross-seller correlation risk per AdCP #2315).
+        self.idempotency_client_token: str | None = None
 
     # ========================================================================
     # Helper methods for response parsing
@@ -60,6 +69,8 @@ class ProtocolAdapter(ABC):
                 error=raw_result.error,  # Only use error if one was set
                 metadata=raw_result.metadata,
                 debug_info=raw_result.debug_info,
+                idempotency_key=raw_result.idempotency_key,
+                replayed=raw_result.replayed,
             )
 
         try:
@@ -78,15 +89,21 @@ class ProtocolAdapter(ABC):
                 error=raw_result.error,
                 metadata=raw_result.metadata,
                 debug_info=raw_result.debug_info,
+                idempotency_key=raw_result.idempotency_key,
+                replayed=raw_result.replayed,
             )
         except ValueError as e:
-            # Parsing failed - return error result
+            # Parsing failed - return error result. Preserve idempotency_key
+            # and replayed so callers can still correlate/suppress side-effects
+            # even when response parsing fails.
             return TaskResult[T](
                 status=TaskStatus.FAILED,
                 error=f"Failed to parse response: {e}",
                 message=raw_result.message,
                 success=False,
                 debug_info=raw_result.debug_info,
+                idempotency_key=raw_result.idempotency_key,
+                replayed=raw_result.replayed,
             )
 
     # ========================================================================

--- a/src/adcp/protocols/mcp.py
+++ b/src/adcp/protocols/mcp.py
@@ -41,7 +41,13 @@ except ImportError:
     HTTPX_AVAILABLE = False
     HTTPStatusError = None  # type: ignore[assignment, misc]
 
-from adcp.exceptions import ADCPConnectionError, ADCPTimeoutError
+from adcp import _idempotency
+from adcp.exceptions import (
+    ADCPConnectionError,
+    ADCPTimeoutError,
+    IdempotencyConflictError,
+    IdempotencyExpiredError,
+)
 from adcp.protocols.base import ProtocolAdapter
 from adcp.types.core import DebugInfo, TaskResult, TaskStatus
 
@@ -310,6 +316,11 @@ class MCPAdapter(ProtocolAdapter):
         start_time = time.time() if self.agent_config.debug else None
         debug_info = None
         debug_request: dict[str, Any] = {}
+        if _idempotency.is_mutating(tool_name) and self.idempotency_capability_check:
+            await self.idempotency_capability_check()
+        params, idempotency_key = _idempotency.inject_key(
+            tool_name, params, client_token=self.idempotency_client_token
+        )
 
         try:
             session = await self._get_session()
@@ -318,7 +329,7 @@ class MCPAdapter(ProtocolAdapter):
                 debug_request = {
                     "protocol": "MCP",
                     "tool": tool_name,
-                    "params": params,
+                    "params": _idempotency.redact_params(params),
                     "transport": self.agent_config.mcp_transport,
                 }
 
@@ -344,6 +355,16 @@ class MCPAdapter(ProtocolAdapter):
                 # For error responses, structuredContent is optional
                 # Use the error message from content as the error
                 error_message = message_text or "Tool execution failed"
+                structured_error = getattr(result, "structuredContent", None)
+                # Prefer structured error codes when present, then fall back to
+                # scanning the text content — many MCP servers (FastMCP default)
+                # return is_error=true with only a text body carrying the code.
+                _idempotency.raise_for_idempotency_error(
+                    tool_name, structured_error, self.agent_config.id
+                )
+                _idempotency.raise_for_idempotency_text(
+                    tool_name, message_text, self.agent_config.id
+                )
                 if self.agent_config.debug and start_time:
                     duration_ms = (time.time() - start_time) * 1000
                     debug_info = DebugInfo(
@@ -359,6 +380,7 @@ class MCPAdapter(ProtocolAdapter):
                     error=error_message,
                     success=False,
                     debug_info=debug_info,
+                    idempotency_key=idempotency_key,
                 )
 
             # For successful responses, structuredContent is required
@@ -377,23 +399,36 @@ class MCPAdapter(ProtocolAdapter):
                 duration_ms = (time.time() - start_time) * 1000
                 debug_info = DebugInfo(
                     request=debug_request,
-                    response={
-                        "data": data_to_return,
-                        "message": message_text,
-                        "is_error": False,
-                    },
+                    response=_idempotency.deep_redact(
+                        {
+                            "data": data_to_return,
+                            "message": message_text,
+                            "is_error": False,
+                        }
+                    ),
                     duration_ms=duration_ms,
                 )
 
+            _idempotency.raise_for_idempotency_error(
+                tool_name, data_to_return, self.agent_config.id
+            )
+
             # Return both the structured data and the human-readable message
-            return TaskResult[Any](
+            task_result = TaskResult[Any](
                 status=TaskStatus.COMPLETED,
                 data=data_to_return,
                 message=message_text,
                 success=True,
                 debug_info=debug_info,
             )
+            return _idempotency.annotate_result(task_result, idempotency_key)
 
+        except (IdempotencyConflictError, IdempotencyExpiredError):
+            # Propagate typed idempotency errors — callers MUST handle these
+            # distinctly (mint fresh key / reconcile state). Other ADCPError
+            # subclasses (connection, timeout) continue to be converted to
+            # TaskResult(failed) below, preserving the existing contract.
+            raise
         except Exception as e:
             if self.agent_config.debug and start_time:
                 duration_ms = (time.time() - start_time) * 1000
@@ -407,6 +442,7 @@ class MCPAdapter(ProtocolAdapter):
                 error=str(e),
                 success=False,
                 debug_info=debug_info,
+                idempotency_key=idempotency_key,
             )
 
     # ========================================================================

--- a/src/adcp/types/core.py
+++ b/src/adcp/types/core.py
@@ -136,6 +136,16 @@ class TaskResult(BaseModel, Generic[T]):
     success: bool = Field(default=True)
     metadata: dict[str, Any] | None = None
     debug_info: DebugInfo | None = None
+    # The full idempotency_key the SDK used for this request — echoed here so
+    # buyers can correlate against their own records. SENSITIVE inside the
+    # seller's replay_ttl_seconds window (serves as a retry-pattern oracle);
+    # do not emit to shared logs. The SDK's debug capture redacts keys by
+    # default; avoid ``model_dump_json()``-ing a TaskResult into shared sinks.
+    idempotency_key: str | None = None
+    # True when the seller returned a cached response for a replayed key.
+    # Agents that emit side effects on success (notifications, memory writes,
+    # downstream tool calls) must check this flag and suppress duplicates.
+    replayed: bool = False
 
 
 class ActivityType(str, Enum):

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,809 @@
+"""Tests for idempotency_key auto-injection, typed errors, and fail-closed capability check."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adcp import _idempotency
+from adcp.client import ADCPClient
+from adcp.exceptions import (
+    ADCPTaskError,
+    IdempotencyConflictError,
+    IdempotencyExpiredError,
+    IdempotencyUnsupportedError,
+    classify_task_error,
+)
+from adcp.types.core import AgentConfig, Protocol, TaskResult, TaskStatus
+
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+class TestKeyHelpers:
+    def test_generate_key_returns_uuid_v4(self) -> None:
+        key = _idempotency.generate_key()
+        assert UUID_RE.match(key)
+        # Can be parsed as UUID
+        uuid.UUID(key)
+
+    def test_validate_key_accepts_uuid_v4(self) -> None:
+        k = str(uuid.uuid4())
+        assert _idempotency.validate_key(k) == k
+
+    def test_validate_key_accepts_spec_chars(self) -> None:
+        # All of [A-Za-z0-9_.:-] within bounds
+        k = "abc_ABC-123.:key000000"
+        assert _idempotency.validate_key(k) == k
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "too-short",
+            "contains spaces here please",
+            "contains/slash/chars/0000",
+            "x" * 256,
+            "unicode_key_é_key0000",
+        ],
+    )
+    def test_validate_key_rejects_bad_format(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="idempotency_key"):
+            _idempotency.validate_key(bad)
+
+    def test_validate_key_rejects_non_string(self) -> None:
+        with pytest.raises(ValueError, match="must be a string"):
+            _idempotency.validate_key(123)  # type: ignore[arg-type]
+
+    def test_redact_prefix_form(self) -> None:
+        key = "0123456789abcdef"
+        assert _idempotency.redact(key) == "01234567..."
+
+    def test_redact_none_and_short(self) -> None:
+        assert _idempotency.redact(None) == "<none>"
+        assert _idempotency.redact("short") == "<short>"
+
+    def test_is_mutating_coverage(self) -> None:
+        # Spot-check all 28 spec-required tasks
+        mutating = {
+            "create_media_buy",
+            "update_media_buy",
+            "sync_creatives",
+            "sync_accounts",
+            "si_send_message",
+            "si_initiate_session",
+        }
+        for t in mutating:
+            assert _idempotency.is_mutating(t), t
+        assert not _idempotency.is_mutating("get_products")
+        assert not _idempotency.is_mutating("si_terminate_session")
+        assert not _idempotency.is_mutating("get_adcp_capabilities")
+
+
+class TestInjectKey:
+    def test_injects_for_mutating_task(self) -> None:
+        params, key = _idempotency.inject_key("create_media_buy", {"foo": "bar"})
+        assert key is not None
+        assert params["idempotency_key"] == key
+        assert UUID_RE.match(key)
+
+    def test_skips_non_mutating_task(self) -> None:
+        params, key = _idempotency.inject_key("get_products", {"brief": "x"})
+        assert key is None
+        assert "idempotency_key" not in params
+
+    def test_respects_caller_provided_key(self) -> None:
+        mine = str(uuid.uuid4())
+        params, key = _idempotency.inject_key("create_media_buy", {"idempotency_key": mine})
+        assert key == mine
+        assert params["idempotency_key"] == mine
+
+    def test_rejects_bad_caller_key(self) -> None:
+        with pytest.raises(ValueError):
+            _idempotency.inject_key("create_media_buy", {"idempotency_key": "short"})
+
+    def test_does_not_mutate_original_dict(self) -> None:
+        original = {"foo": "bar"}
+        _idempotency.inject_key("create_media_buy", original)
+        assert "idempotency_key" not in original
+
+
+class TestContextManager:
+    def test_scoped_key_consumed_on_first_call(self) -> None:
+        client = ADCPClient(_cfg())
+        my_key = str(uuid.uuid4())
+        with client.use_idempotency_key(my_key):
+            params, key = _idempotency.inject_key(
+                "create_media_buy",
+                {"foo": "bar"},
+                client_token=client._idempotency_client_token,
+            )
+            assert key == my_key
+
+    def test_second_call_inside_scope_gets_fresh_key(self) -> None:
+        # Single-use within scope: gather() siblings must not share the key.
+        client = ADCPClient(_cfg())
+        my_key = str(uuid.uuid4())
+        with client.use_idempotency_key(my_key):
+            _, k1 = _idempotency.inject_key(
+                "create_media_buy",
+                {},
+                client_token=client._idempotency_client_token,
+            )
+            _, k2 = _idempotency.inject_key(
+                "create_media_buy",
+                {},
+                client_token=client._idempotency_client_token,
+            )
+        assert k1 == my_key
+        assert k2 != my_key  # fresh UUID generated
+        assert UUID_RE.match(k2 or "")
+
+    def test_caller_key_wins_over_scoped(self) -> None:
+        client = ADCPClient(_cfg())
+        scoped = str(uuid.uuid4())
+        explicit = str(uuid.uuid4())
+        with client.use_idempotency_key(scoped):
+            _, key = _idempotency.inject_key(
+                "create_media_buy",
+                {"idempotency_key": explicit},
+                client_token=client._idempotency_client_token,
+            )
+            assert key == explicit
+
+    def test_cleanup_on_exit(self) -> None:
+        client = ADCPClient(_cfg())
+        k = str(uuid.uuid4())
+        with client.use_idempotency_key(k):
+            pass
+        _, key = _idempotency.inject_key(
+            "create_media_buy",
+            {},
+            client_token=client._idempotency_client_token,
+        )
+        assert key != k
+
+    def test_nested_raises(self) -> None:
+        client = ADCPClient(_cfg())
+        k = str(uuid.uuid4())
+        with client.use_idempotency_key(k):
+            with pytest.raises(RuntimeError, match="nested"):
+                with client.use_idempotency_key(k):
+                    pass
+
+    def test_invalid_key_rejected_at_entry(self) -> None:
+        client = ADCPClient(_cfg())
+        with pytest.raises(ValueError):
+            with client.use_idempotency_key("too-short"):
+                pass
+
+    def test_scoped_key_does_not_leak_to_sibling_client(self) -> None:
+        # Key pinned on client_a must NOT be used by client_b inside the same
+        # block. A UserWarning is raised via warnings.warn so it shows up in
+        # pytest.warns / the Python warnings machinery.
+        client_a = ADCPClient(_cfg())
+        client_b = ADCPClient(_cfg())
+        pinned = str(uuid.uuid4())
+        with client_a.use_idempotency_key(pinned):
+            with pytest.warns(UserWarning, match="different client"):
+                _, key = _idempotency.inject_key(
+                    "create_media_buy",
+                    {},
+                    client_token=client_b._idempotency_client_token,
+                )
+        assert key != pinned
+        assert UUID_RE.match(key or "")
+
+    def test_scoped_key_used_when_client_token_matches(self) -> None:
+        client = ADCPClient(_cfg())
+        pinned = str(uuid.uuid4())
+        with client.use_idempotency_key(pinned):
+            _, key = _idempotency.inject_key(
+                "create_media_buy",
+                {},
+                client_token=client._idempotency_client_token,
+            )
+        assert key == pinned
+
+
+class TestTypedExceptions:
+    def test_classify_routes_to_conflict(self) -> None:
+        err = classify_task_error(
+            "create_media_buy",
+            [_fake_err("IDEMPOTENCY_CONFLICT", "payload drift")],
+        )
+        assert isinstance(err, IdempotencyConflictError)
+        assert err.error_codes == ["IDEMPOTENCY_CONFLICT"]
+
+    def test_classify_routes_to_expired(self) -> None:
+        err = classify_task_error(
+            "create_media_buy",
+            [_fake_err("IDEMPOTENCY_EXPIRED", "past TTL")],
+        )
+        assert isinstance(err, IdempotencyExpiredError)
+
+    def test_classify_falls_back_to_generic(self) -> None:
+        err = classify_task_error(
+            "create_media_buy",
+            [_fake_err("INVALID_BUDGET", "nope")],
+        )
+        assert isinstance(err, ADCPTaskError)
+        assert not isinstance(err, IdempotencyConflictError)
+        assert not isinstance(err, IdempotencyExpiredError)
+
+    def test_conflict_is_adcp_task_error(self) -> None:
+        err = IdempotencyConflictError("create_media_buy", [])
+        assert isinstance(err, ADCPTaskError)
+
+    def test_expired_is_adcp_task_error(self) -> None:
+        err = IdempotencyExpiredError("create_media_buy", [])
+        assert isinstance(err, ADCPTaskError)
+
+
+class TestRaiseForErrorData:
+    def test_raises_on_conflict_code(self) -> None:
+        data = {"errors": [{"code": "IDEMPOTENCY_CONFLICT", "message": "drift"}]}
+        with pytest.raises(IdempotencyConflictError):
+            _idempotency.raise_for_idempotency_error("create_media_buy", data, "agent-1")
+
+    def test_raises_on_expired_code(self) -> None:
+        data = {"errors": [{"code": "IDEMPOTENCY_EXPIRED", "message": "past ttl"}]}
+        with pytest.raises(IdempotencyExpiredError):
+            _idempotency.raise_for_idempotency_error("create_media_buy", data, "agent-1")
+
+    def test_noop_on_other_errors(self) -> None:
+        data = {"errors": [{"code": "INVALID_BUDGET"}]}
+        _idempotency.raise_for_idempotency_error("create_media_buy", data, "agent-1")
+
+    def test_noop_on_empty_data(self) -> None:
+        _idempotency.raise_for_idempotency_error("create_media_buy", None, "agent-1")
+        _idempotency.raise_for_idempotency_error("create_media_buy", {}, "agent-1")
+
+
+class TestAnnotateResult:
+    def test_surfaces_key_and_replayed_on_first_class_attrs(self) -> None:
+        key = str(uuid.uuid4())
+        result: TaskResult[Any] = TaskResult(
+            status=TaskStatus.COMPLETED,
+            data={"replayed": True, "media_buy_id": "mb_1"},
+            success=True,
+        )
+        _idempotency.annotate_result(result, key)
+        assert result.idempotency_key == key
+        assert result.replayed is True
+
+    def test_metadata_mirror_populated(self) -> None:
+        key = str(uuid.uuid4())
+        result: TaskResult[Any] = TaskResult(
+            status=TaskStatus.COMPLETED,
+            data={"replayed": True, "media_buy_id": "mb_1"},
+            success=True,
+        )
+        _idempotency.annotate_result(result, key)
+        assert result.metadata is not None
+        assert result.metadata["idempotency_key"] == key
+        assert result.metadata["idempotency_replayed"] is True
+
+    def test_replayed_defaults_false(self) -> None:
+        key = str(uuid.uuid4())
+        result: TaskResult[Any] = TaskResult(
+            status=TaskStatus.COMPLETED,
+            data={"media_buy_id": "mb_1"},
+            success=True,
+        )
+        _idempotency.annotate_result(result, key)
+        assert result.replayed is False
+
+    def test_preserves_existing_metadata(self) -> None:
+        key = str(uuid.uuid4())
+        result: TaskResult[Any] = TaskResult(
+            status=TaskStatus.COMPLETED,
+            data={},
+            success=True,
+            metadata={"task_id": "t_1"},
+        )
+        _idempotency.annotate_result(result, key)
+        assert result.metadata is not None
+        assert result.metadata["task_id"] == "t_1"
+        assert result.metadata["idempotency_key"] == key
+
+
+class TestRedactParams:
+    def test_redacts_key(self) -> None:
+        params = {"idempotency_key": "0123456789abcdef-xyz"}
+        out = _idempotency.redact_params(params)
+        assert out["idempotency_key"] == "01234567..."
+
+    def test_leaves_params_without_key_untouched(self) -> None:
+        params = {"brief": "x"}
+        out = _idempotency.redact_params(params)
+        assert out is params
+
+    def test_does_not_mutate_original(self) -> None:
+        full_key = "0123456789abcdef-xyz"
+        params = {"idempotency_key": full_key, "other": "v"}
+        _idempotency.redact_params(params)
+        assert params["idempotency_key"] == full_key
+
+
+class TestStrictIdempotencyCapabilityCheck:
+    @pytest.mark.asyncio
+    async def test_strict_off_skips_check(self) -> None:
+        cfg = _cfg()
+        client = ADCPClient(cfg, strict_idempotency=False)
+        assert client.adapter.idempotency_capability_check is None
+
+    @pytest.mark.asyncio
+    async def test_strict_raises_when_ttl_missing(self) -> None:
+        cfg = _cfg()
+        client = ADCPClient(cfg, strict_idempotency=True)
+        caps = MagicMock()
+        caps.adcp = MagicMock(idempotency=None)
+        with patch.object(client, "fetch_capabilities", AsyncMock(return_value=caps)):
+            with pytest.raises(IdempotencyUnsupportedError):
+                await client._ensure_idempotency_capability()
+
+    @pytest.mark.asyncio
+    async def test_strict_passes_when_ttl_declared(self) -> None:
+        cfg = _cfg()
+        client = ADCPClient(cfg, strict_idempotency=True)
+        caps = MagicMock()
+        caps.adcp = MagicMock(idempotency=MagicMock(replay_ttl_seconds=86400))
+        with patch.object(client, "fetch_capabilities", AsyncMock(return_value=caps)):
+            await client._ensure_idempotency_capability()
+            # Second call is a no-op (cached)
+            await client._ensure_idempotency_capability()
+
+    @pytest.mark.asyncio
+    async def test_strict_raises_when_adcp_info_missing(self) -> None:
+        cfg = _cfg()
+        client = ADCPClient(cfg, strict_idempotency=True)
+        caps = MagicMock(spec=[])  # no `adcp` attribute
+        with patch.object(client, "fetch_capabilities", AsyncMock(return_value=caps)):
+            with pytest.raises(IdempotencyUnsupportedError):
+                await client._ensure_idempotency_capability()
+
+    @pytest.mark.asyncio
+    async def test_capability_check_runs_once_across_calls(self) -> None:
+        cfg = _cfg()
+        client = ADCPClient(cfg, strict_idempotency=True)
+        caps = MagicMock()
+        caps.adcp = MagicMock(idempotency=MagicMock(replay_ttl_seconds=86400))
+        fetch = AsyncMock(return_value=caps)
+        with patch.object(client, "fetch_capabilities", fetch):
+            await client._ensure_idempotency_capability()
+            await client._ensure_idempotency_capability()
+            await client._ensure_idempotency_capability()
+        assert fetch.call_count == 1  # cached after first verification
+
+    @pytest.mark.asyncio
+    async def test_capability_check_clears_flag_on_error(self) -> None:
+        cfg = _cfg()
+        client = ADCPClient(cfg, strict_idempotency=True)
+        fetch = AsyncMock(side_effect=RuntimeError("network blip"))
+        with patch.object(client, "fetch_capabilities", fetch):
+            with pytest.raises(RuntimeError):
+                await client._ensure_idempotency_capability()
+        assert client._idempotency_capability_verified is False
+
+    def test_get_adcp_capabilities_is_not_mutating(self) -> None:
+        # Invariant: the capability-fetch tool MUST stay out of the mutating set;
+        # otherwise the strict-idempotency check would recurse on itself.
+        assert not _idempotency.is_mutating("get_adcp_capabilities")
+
+
+class TestA2AAdapterIntegration:
+    """End-to-end coverage on the A2A adapter — injection, raising, metadata surface."""
+
+    @pytest.mark.asyncio
+    async def test_injects_key_into_outbound_message(self) -> None:
+        from a2a.types import Artifact, DataPart, Part, SendMessageSuccessResponse, Task
+        from a2a.types import TaskStatus as A2ATaskStatus
+
+        from adcp.protocols.a2a import A2AAdapter
+
+        adapter = A2AAdapter(_cfg(Protocol.A2A))
+        task = Task(
+            id="t1",
+            context_id="c1",
+            status=A2ATaskStatus(state="completed"),
+            artifacts=[Artifact(artifact_id="a1", parts=[Part(root=DataPart(data={"ok": True}))])],
+        )
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(return_value=SendMessageSuccessResponse(result=task))
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+        sent = mock_client.send_message.call_args[0][0]
+        # Walk the outbound DataPart to find injected params
+        parts = sent.params.message.parts
+        data = next(p.root.data for p in parts if hasattr(p.root, "data"))
+        assert "idempotency_key" in data["parameters"]
+        assert UUID_RE.match(data["parameters"]["idempotency_key"])
+
+    @pytest.mark.asyncio
+    async def test_non_mutating_task_omits_key(self) -> None:
+        from a2a.types import Artifact, DataPart, Part, SendMessageSuccessResponse, Task
+        from a2a.types import TaskStatus as A2ATaskStatus
+
+        from adcp.protocols.a2a import A2AAdapter
+
+        adapter = A2AAdapter(_cfg(Protocol.A2A))
+        task = Task(
+            id="t1",
+            context_id="c1",
+            status=A2ATaskStatus(state="completed"),
+            artifacts=[Artifact(artifact_id="a1", parts=[Part(root=DataPart(data={}))])],
+        )
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(return_value=SendMessageSuccessResponse(result=task))
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            await adapter._call_a2a_tool("get_products", {"brief": "x"})
+        sent = mock_client.send_message.call_args[0][0]
+        data = next(p.root.data for p in sent.params.message.parts if hasattr(p.root, "data"))
+        assert "idempotency_key" not in data["parameters"]
+
+    @pytest.mark.asyncio
+    async def test_conflict_code_raises(self) -> None:
+        from a2a.types import Artifact, DataPart, Part, SendMessageSuccessResponse, Task
+        from a2a.types import TaskStatus as A2ATaskStatus
+
+        from adcp.protocols.a2a import A2AAdapter
+
+        adapter = A2AAdapter(_cfg(Protocol.A2A))
+        task = Task(
+            id="t1",
+            context_id="c1",
+            status=A2ATaskStatus(state="completed"),
+            artifacts=[
+                Artifact(
+                    artifact_id="a1",
+                    parts=[
+                        Part(
+                            root=DataPart(
+                                data={
+                                    "errors": [
+                                        {
+                                            "code": "IDEMPOTENCY_CONFLICT",
+                                            "message": "payload differs",
+                                        }
+                                    ]
+                                }
+                            )
+                        )
+                    ],
+                )
+            ],
+        )
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(return_value=SendMessageSuccessResponse(result=task))
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            with pytest.raises(IdempotencyConflictError):
+                await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+
+    @pytest.mark.asyncio
+    async def test_replayed_surfaces_on_result(self) -> None:
+        from a2a.types import Artifact, DataPart, Part, SendMessageSuccessResponse, Task
+        from a2a.types import TaskStatus as A2ATaskStatus
+
+        from adcp.protocols.a2a import A2AAdapter
+
+        adapter = A2AAdapter(_cfg(Protocol.A2A))
+        task = Task(
+            id="t1",
+            context_id="c1",
+            status=A2ATaskStatus(state="completed"),
+            artifacts=[
+                Artifact(
+                    artifact_id="a1",
+                    parts=[Part(root=DataPart(data={"replayed": True, "media_buy_id": "mb_1"}))],
+                )
+            ],
+        )
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(return_value=SendMessageSuccessResponse(result=task))
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            result = await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+        assert result.replayed is True
+        assert result.idempotency_key is not None
+        assert UUID_RE.match(result.idempotency_key)
+
+
+class TestMCPAdapterIntegration:
+    """End-to-end MCP adapter: injection, structured + text-only errors, replay."""
+
+    @pytest.mark.asyncio
+    async def test_injects_key_into_mcp_call(self) -> None:
+        from adcp.protocols.mcp import MCPAdapter
+
+        adapter = MCPAdapter(_cfg(Protocol.MCP))
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.isError = False
+        mock_result.content = []
+        mock_result.structuredContent = {"media_buy_id": "mb_1"}
+        session.call_tool = AsyncMock(return_value=mock_result)
+        with patch.object(adapter, "_get_session", AsyncMock(return_value=session)):
+            await adapter._call_mcp_tool("create_media_buy", {"brand": "acme"})
+        # call_tool is invoked with (tool_name, params_dict)
+        sent_name, sent_params = session.call_tool.call_args[0]
+        assert sent_name == "create_media_buy"
+        assert "idempotency_key" in sent_params
+        assert UUID_RE.match(sent_params["idempotency_key"])
+
+    @pytest.mark.asyncio
+    async def test_non_mutating_mcp_call_omits_key(self) -> None:
+        from adcp.protocols.mcp import MCPAdapter
+
+        adapter = MCPAdapter(_cfg(Protocol.MCP))
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.isError = False
+        mock_result.content = []
+        mock_result.structuredContent = {"products": []}
+        session.call_tool = AsyncMock(return_value=mock_result)
+        with patch.object(adapter, "_get_session", AsyncMock(return_value=session)):
+            await adapter._call_mcp_tool("get_products", {"brief": "x"})
+        _, sent_params = session.call_tool.call_args[0]
+        assert "idempotency_key" not in sent_params
+
+    @pytest.mark.asyncio
+    async def test_structured_conflict_raises(self) -> None:
+        from adcp.protocols.mcp import MCPAdapter
+
+        adapter = MCPAdapter(_cfg(Protocol.MCP))
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.isError = True
+        mock_result.content = [MagicMock(type="text", text="Conflict")]
+        mock_result.structuredContent = {
+            "errors": [{"code": "IDEMPOTENCY_CONFLICT", "message": "drift"}]
+        }
+        session.call_tool = AsyncMock(return_value=mock_result)
+        with patch.object(adapter, "_get_session", AsyncMock(return_value=session)):
+            with pytest.raises(IdempotencyConflictError):
+                await adapter._call_mcp_tool("create_media_buy", {"brand": "acme"})
+
+    @pytest.mark.asyncio
+    async def test_text_only_conflict_raises(self) -> None:
+        # FastMCP default: is_error=true, text content only (no structuredContent).
+        from adcp.protocols.mcp import MCPAdapter
+
+        adapter = MCPAdapter(_cfg(Protocol.MCP))
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.isError = True
+        # Dict-shaped content passes through _serialize_mcp_content unchanged.
+        mock_result.content = [
+            {"type": "text", "text": "IDEMPOTENCY_CONFLICT: payload differs from original request"}
+        ]
+        mock_result.structuredContent = None
+        session.call_tool = AsyncMock(return_value=mock_result)
+        with patch.object(adapter, "_get_session", AsyncMock(return_value=session)):
+            with pytest.raises(IdempotencyConflictError):
+                await adapter._call_mcp_tool("create_media_buy", {"brand": "acme"})
+
+    @pytest.mark.asyncio
+    async def test_text_only_expired_raises(self) -> None:
+        from adcp.protocols.mcp import MCPAdapter
+
+        adapter = MCPAdapter(_cfg(Protocol.MCP))
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.isError = True
+        mock_result.content = [
+            {"type": "text", "text": "IDEMPOTENCY_EXPIRED: replay window has closed"}
+        ]
+        mock_result.structuredContent = None
+        session.call_tool = AsyncMock(return_value=mock_result)
+        with patch.object(adapter, "_get_session", AsyncMock(return_value=session)):
+            with pytest.raises(IdempotencyExpiredError):
+                await adapter._call_mcp_tool("create_media_buy", {"brand": "acme"})
+
+    @pytest.mark.asyncio
+    async def test_replayed_surfaces_via_mcp(self) -> None:
+        from adcp.protocols.mcp import MCPAdapter
+
+        adapter = MCPAdapter(_cfg(Protocol.MCP))
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.isError = False
+        mock_result.content = []
+        mock_result.structuredContent = {"replayed": True, "media_buy_id": "mb_1"}
+        session.call_tool = AsyncMock(return_value=mock_result)
+        with patch.object(adapter, "_get_session", AsyncMock(return_value=session)):
+            result = await adapter._call_mcp_tool("create_media_buy", {"brand": "acme"})
+        assert result.replayed is True
+        assert result.idempotency_key is not None
+
+
+class TestGatherSemantics:
+    """Lock down single-use behavior under asyncio.gather inside use_idempotency_key."""
+
+    @pytest.mark.asyncio
+    async def test_gather_siblings_do_not_share_pinned_key(self) -> None:
+        import asyncio
+
+        from a2a.types import Artifact, DataPart, Part, SendMessageSuccessResponse, Task
+        from a2a.types import TaskStatus as A2ATaskStatus
+
+        from adcp.protocols.a2a import A2AAdapter
+
+        client = ADCPClient(_cfg())
+        adapter: A2AAdapter = client.adapter  # type: ignore[assignment]
+        task = Task(
+            id="t1",
+            context_id="c1",
+            status=A2ATaskStatus(state="completed"),
+            artifacts=[Artifact(artifact_id="a1", parts=[Part(root=DataPart(data={}))])],
+        )
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(return_value=SendMessageSuccessResponse(result=task))
+
+        pinned = str(uuid.uuid4())
+        sent_keys: list[str] = []
+
+        async def one_call() -> None:
+            await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            with client.use_idempotency_key(pinned):
+                await asyncio.gather(one_call(), one_call(), one_call())
+
+        # Walk the three send_message invocations and extract the keys sent.
+        for call in mock_client.send_message.call_args_list:
+            req = call[0][0]
+            parts = req.params.message.parts
+            data = next(p.root.data for p in parts if hasattr(p.root, "data"))
+            sent_keys.append(data["parameters"]["idempotency_key"])
+
+        assert pinned in sent_keys  # the pinned key was consumed exactly once
+        assert sum(1 for k in sent_keys if k == pinned) == 1
+        # The other two gather siblings got fresh UUIDs.
+        fresh = [k for k in sent_keys if k != pinned]
+        assert len(fresh) == 2
+        assert len(set(fresh)) == 2  # and they're distinct from each other
+
+
+class TestPydanticRoundTrip:
+    """Confirm the Pydantic request → params dict → adapter chain preserves keys.
+
+    Uses ``ReportUsageRequest`` because it's a minimal mutating request
+    (3 required fields) — sufficient to exercise the Pydantic → model_dump →
+    inject_key path without having to construct a full media-buy skeleton.
+    """
+
+    @pytest.mark.asyncio
+    async def test_caller_set_pydantic_key_reaches_adapter(self) -> None:
+        from a2a.types import Artifact, DataPart, Part, SendMessageSuccessResponse, Task
+        from a2a.types import TaskStatus as A2ATaskStatus
+
+        from adcp.types import ReportUsageRequest
+
+        client = ADCPClient(_cfg())
+        pinned = str(uuid.uuid4())
+        req = ReportUsageRequest.model_validate(
+            {
+                "idempotency_key": pinned,
+                "reporting_period": {
+                    "start": "2026-05-01T00:00:00Z",
+                    "end": "2026-05-31T23:59:59Z",
+                },
+                "usage": [
+                    {
+                        "account": {"account_id": "acct_1"},
+                        "vendor_cost": 1.0,
+                        "currency": "USD",
+                    }
+                ],
+            }
+        )
+
+        task = Task(
+            id="t1",
+            context_id="c1",
+            status=A2ATaskStatus(state="completed"),
+            artifacts=[
+                Artifact(artifact_id="a1", parts=[Part(root=DataPart(data={"status": "ok"}))])
+            ],
+        )
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(return_value=SendMessageSuccessResponse(result=task))
+        with patch.object(client.adapter, "_get_a2a_client", return_value=mock_client):
+            result = await client.report_usage(req)
+
+        sent = mock_client.send_message.call_args[0][0]
+        parts = sent.params.message.parts
+        data = next(p.root.data for p in parts if hasattr(p.root, "data"))
+        assert data["parameters"]["idempotency_key"] == pinned
+        assert result.idempotency_key == pinned
+
+
+class TestWireFormat:
+    """Capture the actual bytes the SDK puts on the wire — catches a class of
+    regressions (renames, re-encodings, double-wrapping) that assertions at the
+    adapter-object boundary cannot see."""
+
+    @pytest.mark.asyncio
+    async def test_outbound_http_body_contains_one_unredacted_key(self) -> None:
+        import json
+
+        import httpx
+
+        from adcp.protocols.a2a import A2AAdapter
+
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["body"] = request.content.decode()
+            # Minimal valid A2A send-message success response with a Task payload.
+            task_body = {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "result": {
+                    "kind": "task",
+                    "id": "t1",
+                    "context_id": "c1",
+                    "status": {"state": "completed"},
+                    "artifacts": [
+                        {
+                            "artifact_id": "a1",
+                            "parts": [{"kind": "data", "data": {"media_buy_id": "mb_1"}}],
+                        }
+                    ],
+                },
+            }
+            return httpx.Response(200, json=task_body)
+
+        adapter = A2AAdapter(_cfg(Protocol.A2A))
+        # Install the MockTransport so httpx routes calls to our handler.
+        transport = httpx.MockTransport(handler)
+        adapter._httpx_client = httpx.AsyncClient(transport=transport)
+
+        # Stub agent-card fetch + A2A client construction so we skip the
+        # well-known.json roundtrip and go straight to send_message.
+        mock_a2a_client = AsyncMock()
+
+        async def fake_send(request: Any) -> Any:
+            # Render through a real httpx request so the handler sees the body.
+            body = request.model_dump(by_alias=True, mode="json")
+            resp = await adapter._httpx_client.post("https://example.test/a2a", json=body)
+            from a2a.types import SendMessageSuccessResponse
+
+            return SendMessageSuccessResponse.model_validate(resp.json())
+
+        mock_a2a_client.send_message = fake_send
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_a2a_client):
+            await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+
+        # The outbound HTTP body must carry exactly one idempotency_key, full
+        # (not redacted), present in the parameters object.
+        assert captured
+        body_json = json.loads(captured["body"])
+        # Walk to the tool parameters
+        parts = body_json["params"]["message"]["parts"]
+        data_part = next(p for p in parts if p.get("kind") == "data")
+        params = data_part["data"]["parameters"]
+        assert "idempotency_key" in params
+        assert UUID_RE.match(params["idempotency_key"])
+        # And the full key appears exactly once in the body.
+        assert captured["body"].count(params["idempotency_key"]) == 1
+        # And it is NOT redacted (redacted form ends with "...").
+        assert "..." not in params["idempotency_key"]
+
+
+def _cfg(protocol: Protocol = Protocol.A2A) -> AgentConfig:
+    return AgentConfig(id="t", agent_uri="https://example.test", protocol=protocol)
+
+
+def _fake_err(code: str, message: str) -> Any:
+    class _E:
+        pass
+
+    e = _E()
+    e.code = code
+    e.message = message
+    return e

--- a/tests/test_idempotency_storyboard.py
+++ b/tests/test_idempotency_storyboard.py
@@ -1,0 +1,261 @@
+"""Client-side integration test that walks the AdCP idempotency compliance storyboard.
+
+Source storyboard: adcontextprotocol/adcp/static/compliance/source/universal/idempotency.yaml
+
+The storyboard is a SELLER compliance test (run via `npx @adcp/client storyboard`).
+This file exercises the same 6 phases from a BUYER-SDK perspective, verifying
+that our Python client drives each phase correctly against a mock seller:
+
+1. capability_discovery  — strict client fails closed when ttl undeclared
+2. missing_key           — client MUST NEVER send a mutating request without a key
+3. replay_same_payload   — replayed=True surfaces; idempotency_key echoes through
+4. key_reuse_conflict    — IDEMPOTENCY_CONFLICT maps to IdempotencyConflictError
+5. fresh_key_new_resource — fresh UUID on second call creates a new resource
+6. verify_media_buy_count — dedup actually held (single resource, two keys)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from a2a.types import (
+    Artifact,
+    DataPart,
+    Part,
+    SendMessageSuccessResponse,
+    Task,
+)
+from a2a.types import TaskStatus as A2ATaskStatus
+
+from adcp.client import ADCPClient
+from adcp.exceptions import IdempotencyConflictError, IdempotencyUnsupportedError
+from adcp.protocols.a2a import A2AAdapter
+from adcp.types.core import AgentConfig, Protocol
+
+
+def _task_with_data(data: dict[str, Any]) -> Task:
+    return Task(
+        id=f"task_{uuid.uuid4().hex[:8]}",
+        context_id=f"ctx_{uuid.uuid4().hex[:8]}",
+        status=A2ATaskStatus(state="completed"),
+        artifacts=[Artifact(artifact_id="a1", parts=[Part(root=DataPart(data=data))])],
+    )
+
+
+def _cfg() -> AgentConfig:
+    return AgentConfig(
+        id="storyboard_seller",
+        agent_uri="https://seller.test",
+        protocol=Protocol.A2A,
+    )
+
+
+class TestStoryboardPhase1CapabilityDiscovery:
+    """Phase 1 — strict mode refuses mutating calls without a declared TTL."""
+
+    @pytest.mark.asyncio
+    async def test_missing_ttl_fails_closed_in_strict_mode(self) -> None:
+        client = ADCPClient(_cfg(), strict_idempotency=True)
+        caps = MagicMock(spec=[])  # no adcp attribute at all
+        with patch.object(client, "fetch_capabilities", AsyncMock(return_value=caps)):
+            with pytest.raises(IdempotencyUnsupportedError) as exc_info:
+                await client._ensure_idempotency_capability()
+        # DX: suggestion should point to the workaround explicitly
+        assert "strict_idempotency=False" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_declared_ttl_passes(self) -> None:
+        client = ADCPClient(_cfg(), strict_idempotency=True)
+        caps = MagicMock()
+        caps.adcp = MagicMock(idempotency=MagicMock(replay_ttl_seconds=86400))
+        with patch.object(client, "fetch_capabilities", AsyncMock(return_value=caps)):
+            await client._ensure_idempotency_capability()  # no raise
+
+
+class TestStoryboardPhase2MissingKey:
+    """Phase 2 — our client must never send a mutating request without a key."""
+
+    @pytest.mark.asyncio
+    async def test_auto_injected_key_on_every_mutating_call(self) -> None:
+        adapter = A2AAdapter(_cfg())
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(
+            return_value=SendMessageSuccessResponse(result=_task_with_data({"ok": True}))
+        )
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            # Caller gives no idempotency_key; SDK must inject one.
+            await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+        sent = mock_client.send_message.call_args[0][0]
+        params = next(p.root.data for p in sent.params.message.parts if hasattr(p.root, "data"))[
+            "parameters"
+        ]
+        assert "idempotency_key" in params
+        assert len(params["idempotency_key"]) >= 16
+
+    @pytest.mark.asyncio
+    async def test_non_mutating_call_never_gets_injection(self) -> None:
+        # get_media_buys and get_products must stay payload-clean.
+        adapter = A2AAdapter(_cfg())
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(
+            return_value=SendMessageSuccessResponse(result=_task_with_data({"products": []}))
+        )
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            await adapter._call_a2a_tool("get_products", {"brief": "x"})
+        sent = mock_client.send_message.call_args[0][0]
+        params = next(p.root.data for p in sent.params.message.parts if hasattr(p.root, "data"))[
+            "parameters"
+        ]
+        assert "idempotency_key" not in params
+
+
+class TestStoryboardPhase3ReplaySamePayload:
+    """Phase 3 — replayed responses surface replayed=True and echo the key."""
+
+    @pytest.mark.asyncio
+    async def test_second_call_with_same_key_surfaces_replayed(self) -> None:
+        adapter = A2AAdapter(_cfg())
+        pinned = str(uuid.uuid4())
+
+        # First response: fresh. Second response: same media_buy_id, replayed=True.
+        seller_cache: dict[str, dict[str, Any]] = {}
+
+        async def mock_send(request: Any) -> SendMessageSuccessResponse:
+            parts = request.params.message.parts
+            params = next(p.root.data for p in parts if hasattr(p.root, "data"))["parameters"]
+            key = params["idempotency_key"]
+            if key in seller_cache:
+                data = dict(seller_cache[key])
+                data["replayed"] = True
+                return SendMessageSuccessResponse(result=_task_with_data(data))
+            fresh = {
+                "media_buy_id": f"mb_{uuid.uuid4().hex[:8]}",
+                "idempotency_key": key,
+            }
+            seller_cache[key] = fresh
+            return SendMessageSuccessResponse(result=_task_with_data(fresh))
+
+        mock_client = AsyncMock()
+        mock_client.send_message = mock_send
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            r1 = await adapter._call_a2a_tool(
+                "create_media_buy", {"brand": "acme", "idempotency_key": pinned}
+            )
+            r2 = await adapter._call_a2a_tool(
+                "create_media_buy", {"brand": "acme", "idempotency_key": pinned}
+            )
+
+        assert r1.replayed is False
+        assert r1.idempotency_key == pinned
+        assert r2.replayed is True
+        assert r2.idempotency_key == pinned
+        # Same seller-side resource — dedup held.
+        assert r1.data["media_buy_id"] == r2.data["media_buy_id"]
+
+
+class TestStoryboardPhase4KeyReuseConflict:
+    """Phase 4 — same key with a different payload maps to IdempotencyConflictError."""
+
+    @pytest.mark.asyncio
+    async def test_conflict_raises_typed_exception(self) -> None:
+        adapter = A2AAdapter(_cfg())
+        mock_client = AsyncMock()
+        mock_client.send_message = AsyncMock(
+            return_value=SendMessageSuccessResponse(
+                result=_task_with_data(
+                    {
+                        "errors": [
+                            {
+                                "code": "IDEMPOTENCY_CONFLICT",
+                                "message": "payload differs from the original request",
+                            }
+                        ]
+                    }
+                )
+            )
+        )
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            with pytest.raises(IdempotencyConflictError) as exc_info:
+                await adapter._call_a2a_tool(
+                    "create_media_buy",
+                    {"brand": "acme", "idempotency_key": str(uuid.uuid4())},
+                )
+        # DX: recovery hint is present and does NOT forward server message
+        assert "mint a fresh key" in str(exc_info.value)
+        assert "payload differs from the original request" not in str(exc_info.value)
+
+
+class TestStoryboardPhase5FreshKeyNewResource:
+    """Phase 5 — a fresh key with identical payload creates a distinct resource."""
+
+    @pytest.mark.asyncio
+    async def test_two_calls_without_pinned_key_create_two_resources(self) -> None:
+        adapter = A2AAdapter(_cfg())
+        seller_cache: dict[str, dict[str, Any]] = {}
+
+        async def mock_send(request: Any) -> SendMessageSuccessResponse:
+            parts = request.params.message.parts
+            params = next(p.root.data for p in parts if hasattr(p.root, "data"))["parameters"]
+            key = params["idempotency_key"]
+            if key in seller_cache:
+                data = dict(seller_cache[key])
+                data["replayed"] = True
+                return SendMessageSuccessResponse(result=_task_with_data(data))
+            fresh = {
+                "media_buy_id": f"mb_{uuid.uuid4().hex[:8]}",
+                "idempotency_key": key,
+            }
+            seller_cache[key] = fresh
+            return SendMessageSuccessResponse(result=_task_with_data(fresh))
+
+        mock_client = AsyncMock()
+        mock_client.send_message = mock_send
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            r1 = await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+            r2 = await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+
+        assert r1.idempotency_key != r2.idempotency_key  # SDK minted fresh each time
+        assert r1.data["media_buy_id"] != r2.data["media_buy_id"]
+        assert r1.replayed is False and r2.replayed is False
+
+
+class TestStoryboardPhase6VerifyDedupActuallyHeld:
+    """Phase 6 — client-side invariant: a pinned key across retries yields exactly one resource."""
+
+    @pytest.mark.asyncio
+    async def test_pinned_key_across_retry_yields_one_resource(self) -> None:
+        client = ADCPClient(_cfg())
+        adapter = client.adapter
+        seller_cache: dict[str, dict[str, Any]] = {}
+        created_ids: set[str] = set()
+
+        async def mock_send(request: Any) -> SendMessageSuccessResponse:
+            parts = request.params.message.parts
+            params = next(p.root.data for p in parts if hasattr(p.root, "data"))["parameters"]
+            key = params["idempotency_key"]
+            if key in seller_cache:
+                data = dict(seller_cache[key])
+                data["replayed"] = True
+                return SendMessageSuccessResponse(result=_task_with_data(data))
+            mb_id = f"mb_{uuid.uuid4().hex[:8]}"
+            created_ids.add(mb_id)
+            fresh = {"media_buy_id": mb_id, "idempotency_key": key}
+            seller_cache[key] = fresh
+            return SendMessageSuccessResponse(result=_task_with_data(fresh))
+
+        pinned = str(uuid.uuid4())
+        mock_client = AsyncMock()
+        mock_client.send_message = mock_send
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_client):
+            with client.use_idempotency_key(pinned):
+                r1 = await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+            with client.use_idempotency_key(pinned):
+                r2 = await adapter._call_a2a_tool("create_media_buy", {"brand": "acme"})
+
+        assert r1.idempotency_key == pinned
+        assert r2.idempotency_key == pinned
+        assert r2.replayed is True
+        assert len(created_ids) == 1  # seller dedup'd; only one resource exists


### PR DESCRIPTION
Closes #181. Implements the client-side ergonomics of [AdCP #2315](https://github.com/adcontextprotocol/adcp/pull/2315) (idempotency_key now required on every mutating request).

## Summary

- **Auto-inject** UUID v4 `idempotency_key` on every mutating tool call when the caller omits one. Applies to all 28 mutating tasks in the spec. Zero-config retry safety against any #2315-compliant seller.
- **`client.use_idempotency_key(key)`** contextmanager for bring-your-own-key (persist keys across process restarts, e.g. alongside a campaign row in your DB). Single-use within scope — concurrent `gather` siblings get fresh UUIDs instead of duplicating the pinned key. Cross-client reuse inside the same block emits a `UserWarning` (AdCP #2315: keys must be unique per `(seller, request)` pair).
- **First-class** `result.idempotency_key` and `result.replayed` on `TaskResult` — populated on success and failure so buyers can correlate retries.
- **Typed exceptions** `IdempotencyConflictError`, `IdempotencyExpiredError`, `IdempotencyUnsupportedError`. Fixed messages (no server text forwarded) prevent non-compliant sellers from leaking payload hints through the exception string. Actionable recovery hints included.
- **`strict_idempotency=True`** client option fails closed before the first mutating call if the seller hasn't declared `adcp.idempotency.replay_ttl_seconds`. Defaults to False.
- **Key format validation** `^[A-Za-z0-9_.:-]{16,255}$` with specific length vs charset error messages.
- **Debug-log redaction**: request params and response bodies are deep-redacted (recursive walk of dicts, lists, and Pydantic models) before landing in `DebugInfo`.
- **MCP text-only error fallback**: servers that return `is_error=true` with plain text like `"IDEMPOTENCY_CONFLICT: ..."` (FastMCP default) get the code parsed from the message and mapped to the typed exception.

## Testing

- **70 new tests** — `tests/test_idempotency.py` (62 units + adapter integration + gather semantics + Pydantic round-trip + wire-format via httpx MockTransport) + `tests/test_idempotency_storyboard.py` (8 — one per AdCP compliance storyboard phase).
- **1284 total pytest passing**, 8 skipped, 6 warnings. mypy clean (643 files). ruff clean on idempotency surface.
- **Live-tested** against the AdCP reference training agent at `test-agent.adcontextprotocol.org/mcp/` on 2026-04-18:
  - Phase 1 (capability discovery) ✅ — seller declares `replay_ttl_seconds=86400`
  - Phase 5 (fresh keys → distinct media_buys) ✅ — proves SDK sends keys on wire and surfaces them on results
  - Phases 3 (replay) and 4 (conflict) ❌ — training agent advertises idempotency but does not enforce it; filed upstream as [adcp#2346](https://github.com/adcontextprotocol/adcp/issues/2346)
- **SDK gap uncovered during live testing**: MCP adapter rejects text-JSON responses (training agent returns JSON inside `TextContent`, not `structuredContent`). Filed as [#193](https://github.com/adcontextprotocol/adcp-client-python/issues/193) for a separate follow-up PR.

## Behavioral note

Adapter error-passthrough is narrowed to `(IdempotencyConflictError, IdempotencyExpiredError)` only — `ADCPConnectionError`/`ADCPTimeoutError` continue to be converted to `TaskResult(failed)` as before, preserving the existing caller contract.

## Docs

README has a new "Idempotency and retries" section covering:
- Pass a fresh UUID v4 per logical operation (Pydantic construction now requires it per #2315)
- Retry-loop pattern wrapping `use_idempotency_key` (otherwise each retry gets a new UUID)
- BYO-key for process-restart recovery
- Typed errors and strict mode
- Security note on httpx/httpcore DEBUG logging leaking full keys

## Follow-ups (not in scope)

- [adcp-client-python#193](https://github.com/adcontextprotocol/adcp-client-python/issues/193) — MCP adapter text-JSON fallback (blocks live testing against reference seller)
- [adcp#2346](https://github.com/adcontextprotocol/adcp/issues/2346) — training agent needs to enforce declared idempotency semantics
- Nightly integration test against a #2315-compliant seller once one exists

## Test plan

- [x] `.venv/bin/pytest tests/ --no-cov -q` — 1284 passed
- [x] `.venv/bin/mypy src/adcp/` — 0 errors, 643 files
- [x] `.venv/bin/ruff check src/adcp/ tests/test_idempotency.py tests/test_idempotency_storyboard.py` — clean
- [x] Live probe against AdCP training agent — client-side verified, seller-side gap filed upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)