### PR TITLE
feat(server): propagate caller_identity from transport into ToolContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,14 @@ serve(MySeller(), name="my-seller")
 
 **Atomicity caveat:** `MemoryBackend` commits the cache entry AFTER your handler returns, so a crash between `handler success` and `cache commit` causes the retry to re-execute. `PgBackend` (follow-up) will commit the cache row in the same transaction as your business writes. Read the module docstring at `adcp.server.idempotency` before shipping this against a production database.
 
+**How caller identity gets populated.** The middleware scopes its cache by `(caller_identity, idempotency_key)` — same key from two buyers must hit different cache slots, and a buyer's retry must replay only against its own prior call. `caller_identity` comes from `ToolContext`, which the transport layer builds per request:
+
+- **A2A** — the framework derives `caller_identity` from `ServerCallContext.user.user_name` when the user is authenticated. Wire your [a2a-sdk auth middleware](https://a2aproject.github.io/) (bearer tokens, mTLS, OAuth) and `@idempotency.wrap` works automatically. Unauthenticated requests → no identity → dedup is skipped (fail-closed, with a one-time `UserWarning` so you notice).
+
+- **MCP** — FastMCP exposes a session `client_id` but not an authenticated principal. The SDK does NOT auto-populate `caller_identity` for MCP tools today. If you're serving via MCP, wire your own FastMCP auth middleware and populate `ToolContext.caller_identity` before the idempotency middleware runs — either by overriding `adcp.server.mcp_tools.create_tool_caller` or by wrapping your handlers directly. Without this, `@idempotency.wrap` is a no-op on MCP (you'll get the one-time warning above).
+
+**Principal contract.** `caller_identity` MUST be a stable, globally-unique identifier per tenant — an opaque buyer ID, not an email or display name. Email reuse after account deletion would cause cross-principal cache collisions. The value is logged at DEBUG (prefix-truncated) and keyed on in the cache; treat it as you would any user-scoping identifier.
+
 ## Available Tools
 
 All AdCP tools with full type safety:

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -36,7 +36,7 @@ from a2a.types import (
 )
 
 from adcp.exceptions import ADCPError, ADCPTaskError
-from adcp.server.base import ADCPHandler
+from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.helpers import STANDARD_ERROR_CODES
 from adcp.server.mcp_tools import create_tool_caller, get_tools_for_handler
 from adcp.server.test_controller import TestControllerStore, _handle_test_controller
@@ -80,7 +80,9 @@ class ADCPAgentExecutor(AgentExecutor):
     def _register_test_controller(self, store: TestControllerStore) -> None:
         """Register comply_test_controller as a callable skill."""
 
-        async def _call_test_controller(params: dict[str, Any]) -> Any:
+        async def _call_test_controller(
+            params: dict[str, Any], context: ToolContext | None = None
+        ) -> Any:
             return await _handle_test_controller(store, params)
 
         self._tool_callers["comply_test_controller"] = _call_test_controller
@@ -103,8 +105,9 @@ class ADCPAgentExecutor(AgentExecutor):
             )
             return
 
+        tool_context = _tool_context_from_request(context)
         try:
-            result = await self._tool_callers[skill_name](params)
+            result = await self._tool_callers[skill_name](params, tool_context)
             await self._send_result(event_queue, context, skill_name, result)
         except ADCPError as exc:
             # Application-layer AdCP error (IdempotencyConflictError etc.).
@@ -261,6 +264,32 @@ class ADCPAgentExecutor(AgentExecutor):
             message=exc.message,
         )
         await event_queue.enqueue_event(task)
+
+
+# ------------------------------------------------------------------
+# Request context helpers
+# ------------------------------------------------------------------
+
+
+def _tool_context_from_request(request: RequestContext) -> ToolContext:
+    """Derive a :class:`ToolContext` from an A2A :class:`RequestContext`.
+
+    Extracts the authenticated principal from ``request.call_context.user``
+    when present. Unauthenticated / anonymous requests get a bare
+    ``ToolContext`` — server middleware that requires a principal (e.g. the
+    idempotency store's per-principal scoping) falls through to its
+    no-principal default rather than collapsing everyone into a shared
+    namespace.
+    """
+    ctx = ToolContext(request_id=request.task_id)
+    call_context = getattr(request, "call_context", None)
+    user = getattr(call_context, "user", None)
+    if user is not None:
+        is_auth = getattr(user, "is_authenticated", False)
+        user_name = getattr(user, "user_name", "") or ""
+        if is_auth and user_name:
+            ctx.caller_identity = user_name
+    return ctx
 
 
 # ------------------------------------------------------------------

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -280,6 +280,18 @@ def _tool_context_from_request(request: RequestContext) -> ToolContext:
     idempotency store's per-principal scoping) falls through to its
     no-principal default rather than collapsing everyone into a shared
     namespace.
+
+    Security invariant: ``ServerCallContext`` is populated by the seller's
+    server-side auth middleware from verified transport material (bearer
+    token, mTLS cert, OAuth identity). A malicious client cannot flip
+    ``is_authenticated`` or set ``user_name`` from the message payload.
+    The ``is_authenticated and user_name`` gate below relies on this
+    invariant — do not relax it.
+
+    PII note: the ``user_name`` string becomes ``caller_identity``, which
+    the idempotency middleware logs prefix-truncated at DEBUG. If your auth
+    layer sets ``user_name`` to an email address, treat idempotency debug
+    logs as containing PII. Prefer opaque principal IDs.
     """
     ctx = ToolContext(request_id=request.task_id)
     call_context = getattr(request, "call_context", None)

--- a/src/adcp/server/base.py
+++ b/src/adcp/server/base.py
@@ -80,6 +80,16 @@ class ToolContext:
 
     Contains metadata about the current request that may be useful
     for logging, authorization, or other cross-cutting concerns.
+
+    :param caller_identity: The authenticated principal making the request.
+        **MUST** be a stable, globally-unique identifier within the seller's
+        tenant — never an email, display name, or any other mutable handle.
+        The server-side idempotency middleware keys its cache by
+        ``(caller_identity, idempotency_key)`` — reuse of the same string for
+        two distinct principals (e.g. email reuse after account deletion)
+        causes cross-principal replay (confidentiality leak). Populated by
+        the transport layer (A2A: ``ServerCallContext.user.user_name``; MCP:
+        seller's FastMCP auth middleware).
     """
 
     request_id: str | None = None

--- a/src/adcp/server/idempotency/store.py
+++ b/src/adcp/server/idempotency/store.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import copy
 import logging
 import time
+import warnings
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import Any
@@ -198,8 +199,34 @@ class IdempotencyStore:
             # per-principal scope; anything else is a cross-principal replay
             # attack surface. Fall through to the handler (which will process
             # the request normally — no dedup, but no security regression).
+            self._warn_missing_principal_once()
             return None, None, params_dict
         return principal_id, idempotency_key, params_dict
+
+    _missing_principal_warned: bool = False
+
+    def _warn_missing_principal_once(self) -> None:
+        """Emit a one-time warning when the middleware sees a key but no principal.
+
+        Silent fall-through is the worst DX: the seller drops in
+        ``@idempotency.wrap``, ships, and doesn't discover until incident
+        review that no dedup ever happened. Fire once per store instance so
+        operators see the signal without filling logs on every request.
+        """
+        if self._missing_principal_warned:
+            return
+        self._missing_principal_warned = True
+        warnings.warn(
+            "IdempotencyStore received a request with idempotency_key but no "
+            "caller_identity on ToolContext — dedup is SKIPPED. This usually "
+            "means your transport isn't populating the authenticated principal. "
+            "A2A: wire an a2a-sdk auth middleware that sets ServerCallContext.user; "
+            "MCP: populate ToolContext.caller_identity from your FastMCP auth "
+            "middleware (see adcp.server.idempotency README). "
+            "This warning fires once per IdempotencyStore instance.",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 def _to_dict(value: Any) -> dict[str, Any]:

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -1168,7 +1168,7 @@ class MCPToolSet:
         """
         self.handler = handler
         self._filtered_definitions = get_tools_for_handler(handler)
-        self._tools: dict[str, Callable[[dict[str, Any]], Any]] = {}
+        self._tools: dict[str, Callable[..., Any]] = {}
 
         # Create tool callers only for filtered tools
         for tool_def in self._filtered_definitions:

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -1114,7 +1114,7 @@ def get_tools_for_handler(handler: ADCPHandler | type[ADCPHandler]) -> list[dict
 def create_tool_caller(
     handler: ADCPHandler,
     method_name: str,
-) -> Callable[[dict[str, Any]], Any]:
+) -> Callable[..., Any]:
     """Create a tool caller function for an ADCP handler method.
 
     Automatically injects context passthrough: if the request contains a
@@ -1126,15 +1126,23 @@ def create_tool_caller(
         method_name: Name of the method to call
 
     Returns:
-        Async callable that invokes the handler method
+        Async callable ``call_tool(params, context=None)``. The ``context``
+        parameter is optional — transports that can extract caller identity
+        from their auth layer (A2A's ``ServerCallContext.user``, custom
+        FastMCP auth middleware, etc.) should pass a populated
+        :class:`ToolContext` so the server middleware layer (idempotency
+        per-principal scoping, audit logging) gets the real principal. When
+        no context is supplied, a bare :class:`ToolContext` is used.
     """
     from adcp.server.helpers import inject_context
 
     method = getattr(handler, method_name)
 
-    async def call_tool(params: dict[str, Any]) -> Any:
-        context = ToolContext()
-        result = await method(params, context)
+    async def call_tool(
+        params: dict[str, Any], context: ToolContext | None = None
+    ) -> Any:
+        ctx = context if context is not None else ToolContext()
+        result = await method(params, ctx)
         # Convert Pydantic models to JSON-safe dicts for MCP serialization
         if hasattr(result, "model_dump"):
             result = result.model_dump(mode="json", exclude_none=True)

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -215,6 +215,15 @@ def _register_tool(
     from adcp.server.translate import translate_error
 
     async def fn(**kwargs: Any) -> dict[str, Any]:
+        # Note on caller identity: FastMCP does not expose an authenticated
+        # principal to tool handlers at the SDK level — ``Context.client_id``
+        # is a session hint, not an authenticated user identifier. Sellers
+        # who need per-principal server middleware (e.g. the idempotency
+        # store's per-principal scoping) should wire their own FastMCP auth
+        # middleware and either pre-populate ``params`` with a principal
+        # hint their handler reads, or override ``create_tool_caller`` to
+        # build a ToolContext from their auth layer. The A2A transport
+        # derives caller_identity from ServerCallContext.user automatically.
         try:
             result = await caller(kwargs)
         except ADCPError as exc:

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -198,7 +198,7 @@ def _register_tool(
     name: str,
     description: str,
     input_schema: dict[str, Any],
-    caller: Callable[[dict[str, Any]], Any],
+    caller: Callable[..., Any],
 ) -> None:
     """Register a single ADCP tool on a FastMCP server.
 

--- a/tests/test_server_caller_identity.py
+++ b/tests/test_server_caller_identity.py
@@ -1,0 +1,258 @@
+"""Caller-identity propagation from transport layer into ToolContext.
+
+Bridges the gap between the per-request authenticated principal (lives in the
+A2A ``ServerCallContext.user`` / sellers' FastMCP auth middleware) and the
+server-side middleware layer (idempotency per-principal scoping, future
+audit logging). Without this wiring, ``ToolContext.caller_identity`` is
+always ``None`` and the idempotency middleware's fail-closed path skips
+dedup entirely — effectively inert in production.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from adcp.server.a2a_server import ADCPAgentExecutor, _tool_context_from_request
+from adcp.server.base import ADCPHandler, ToolContext
+from adcp.server.idempotency import IdempotencyStore, MemoryBackend
+from adcp.server.mcp_tools import create_tool_caller
+
+
+class _FakeUser:
+    def __init__(self, name: str, authenticated: bool = True) -> None:
+        self._name = name
+        self._auth = authenticated
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self._auth
+
+    @property
+    def user_name(self) -> str:
+        return self._name
+
+
+class _FakeCallContext:
+    def __init__(self, user: Any = None) -> None:
+        self.user = user
+
+
+class _FakeRequestContext:
+    def __init__(self, *, task_id: str | None = None, user: Any = None) -> None:
+        self.task_id = task_id
+        self.call_context = _FakeCallContext(user=user) if user is not None else None
+
+
+class TestToolContextFromRequest:
+    def test_authenticated_user_populates_caller_identity(self) -> None:
+        req = _FakeRequestContext(user=_FakeUser("buyer-acme"))
+        ctx = _tool_context_from_request(req)
+        assert ctx.caller_identity == "buyer-acme"
+
+    def test_unauthenticated_user_leaves_identity_none(self) -> None:
+        req = _FakeRequestContext(user=_FakeUser("", authenticated=False))
+        ctx = _tool_context_from_request(req)
+        assert ctx.caller_identity is None
+
+    def test_missing_call_context_leaves_identity_none(self) -> None:
+        req = _FakeRequestContext(user=None)
+        ctx = _tool_context_from_request(req)
+        assert ctx.caller_identity is None
+
+    def test_authenticated_with_empty_user_name_leaves_identity_none(self) -> None:
+        req = _FakeRequestContext(user=_FakeUser("", authenticated=True))
+        ctx = _tool_context_from_request(req)
+        assert ctx.caller_identity is None
+
+    def test_task_id_propagates(self) -> None:
+        req = _FakeRequestContext(task_id="task-xyz", user=_FakeUser("buyer-1"))
+        ctx = _tool_context_from_request(req)
+        assert ctx.request_id == "task-xyz"
+        assert ctx.caller_identity == "buyer-1"
+
+
+class TestToolCallerContextPassthrough:
+    @pytest.mark.asyncio
+    async def test_caller_accepts_context_and_forwards_it(self) -> None:
+        class H(ADCPHandler):
+            def __init__(self) -> None:
+                self.seen_ctx: ToolContext | None = None
+
+            async def get_products(
+                self, params: Any, context: ToolContext | None = None
+            ) -> dict[str, Any]:
+                self.seen_ctx = context
+                return {"products": []}
+
+        h = H()
+        caller = create_tool_caller(h, "get_products")
+        injected = ToolContext(caller_identity="buyer-xyz")
+        await caller({"brief": "x"}, injected)
+        assert h.seen_ctx is injected
+        assert h.seen_ctx.caller_identity == "buyer-xyz"
+
+    @pytest.mark.asyncio
+    async def test_caller_defaults_to_bare_context(self) -> None:
+        class H(ADCPHandler):
+            def __init__(self) -> None:
+                self.seen_ctx: ToolContext | None = None
+
+            async def get_products(
+                self, params: Any, context: ToolContext | None = None
+            ) -> dict[str, Any]:
+                self.seen_ctx = context
+                return {"products": []}
+
+        h = H()
+        caller = create_tool_caller(h, "get_products")
+        # No context passed — backward-compatible behavior.
+        await caller({"brief": "x"})
+        assert isinstance(h.seen_ctx, ToolContext)
+        assert h.seen_ctx.caller_identity is None
+
+
+class TestEndToEndIdempotencyViaTransport:
+    @pytest.mark.asyncio
+    async def test_a2a_transport_identity_enables_middleware_dedup(self) -> None:
+        """Full wire: A2A authenticated user → ToolContext.caller_identity →
+        IdempotencyStore.wrap scopes per-principal and dedups the replay."""
+        store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
+
+        class Seller(ADCPHandler):
+            def __init__(self) -> None:
+                self.calls = 0
+
+            @store.wrap
+            async def create_media_buy(
+                self, params: Any, context: ToolContext | None = None
+            ) -> dict[str, Any]:
+                self.calls += 1
+                return {"media_buy_id": f"mb_{self.calls}", "status": "completed"}
+
+        seller = Seller()
+        executor = ADCPAgentExecutor(seller)
+        key = str(uuid.uuid4())
+
+        # Simulate two successive A2A calls from the same authenticated buyer.
+        params = {"idempotency_key": key, "brand": {"domain": "acme.test"}}
+        tool_context = _tool_context_from_request(
+            _FakeRequestContext(user=_FakeUser("buyer-acme"))
+        )
+        r1 = await executor._tool_callers["create_media_buy"](params, tool_context)
+        r2 = await executor._tool_callers["create_media_buy"](params, tool_context)
+        assert seller.calls == 1  # middleware dedup'd the second call
+        assert r1 == r2
+
+    @pytest.mark.asyncio
+    async def test_distinct_principals_scope_independently(self) -> None:
+        store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
+
+        class Seller(ADCPHandler):
+            def __init__(self) -> None:
+                self.calls = 0
+
+            @store.wrap
+            async def create_media_buy(
+                self, params: Any, context: ToolContext | None = None
+            ) -> dict[str, Any]:
+                self.calls += 1
+                return {"media_buy_id": f"mb_{self.calls}"}
+
+        seller = Seller()
+        executor = ADCPAgentExecutor(seller)
+        key = str(uuid.uuid4())
+        params = {"idempotency_key": key, "brand": "acme"}
+
+        ctx_a = _tool_context_from_request(
+            _FakeRequestContext(user=_FakeUser("buyer-a"))
+        )
+        ctx_b = _tool_context_from_request(
+            _FakeRequestContext(user=_FakeUser("buyer-b"))
+        )
+        r_a = await executor._tool_callers["create_media_buy"](params, ctx_a)
+        r_b = await executor._tool_callers["create_media_buy"](params, ctx_b)
+        # Same key under distinct principals must NOT collide.
+        assert seller.calls == 2
+        assert r_a["media_buy_id"] != r_b["media_buy_id"]
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_falls_through_no_dedup(self) -> None:
+        """Without a principal, the middleware's fail-closed path skips dedup."""
+        store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
+
+        class Seller(ADCPHandler):
+            def __init__(self) -> None:
+                self.calls = 0
+
+            @store.wrap
+            async def create_media_buy(
+                self, params: Any, context: ToolContext | None = None
+            ) -> dict[str, Any]:
+                self.calls += 1
+                return {"media_buy_id": f"mb_{self.calls}"}
+
+        seller = Seller()
+        executor = ADCPAgentExecutor(seller)
+        key = str(uuid.uuid4())
+        params = {"idempotency_key": key, "brand": "acme"}
+
+        anon_ctx = _tool_context_from_request(
+            _FakeRequestContext(user=_FakeUser("", authenticated=False))
+        )
+        await executor._tool_callers["create_media_buy"](params, anon_ctx)
+        await executor._tool_callers["create_media_buy"](params, anon_ctx)
+        # Both executed — no principal to scope by, middleware skipped dedup.
+        assert seller.calls == 2
+
+
+class TestA2AExecutorUsesRealContext:
+    """Integration with the real A2A execute() path."""
+
+    @pytest.mark.asyncio
+    async def test_execute_passes_tool_context_with_identity(self) -> None:
+        from a2a.types import DataPart, Message, Part, Role
+
+        seen: dict[str, Any] = {}
+
+        class CaptureHandler(ADCPHandler):
+            async def get_products(
+                self, params: Any, context: ToolContext | None = None
+            ) -> dict[str, Any]:
+                seen["identity"] = context.caller_identity if context else None
+                return {"products": []}
+
+        executor = ADCPAgentExecutor(CaptureHandler())
+
+        # Build a minimal A2A request with an authenticated user.
+        class _Req:
+            def __init__(self) -> None:
+                self.task_id = "task-1"
+                self.context_id = "ctx-1"
+                self.call_context = _FakeCallContext(user=_FakeUser("buyer-live"))
+                # Message with an explicit skill DataPart — mimics a real client.
+                self.message = Message(
+                    message_id="m1",
+                    role=Role.user,
+                    parts=[
+                        Part(
+                            root=DataPart(
+                                data={
+                                    "skill": "get_products",
+                                    "parameters": {"brief": "test"},
+                                }
+                            )
+                        )
+                    ],
+                )
+
+        captured_events: list[Any] = []
+
+        class FakeQueue:
+            async def enqueue_event(self, event: Any) -> None:
+                captured_events.append(event)
+
+        await executor.execute(_Req(), FakeQueue())
+        assert seen["identity"] == "buyer-live"

--- a/tests/test_server_idempotency.py
+++ b/tests/test_server_idempotency.py
@@ -329,12 +329,19 @@ class TestIdempotencyStoreWrap:
     async def test_no_caller_identity_falls_through(self) -> None:
         # Fail-closed: without a principal we can't safely scope the key,
         # so skip dedup rather than collapse every buyer into one namespace.
+        # Also fires a one-time UserWarning so operators notice.
         store = self._make_store()
         handler = _FakeHandler()
         wrapped = store.wrap(_FakeHandler.create_media_buy)
         params = {"idempotency_key": str(uuid.uuid4()), "brand": "A"}
-        r1 = await wrapped(handler, params, None)
-        r2 = await wrapped(handler, params, None)
+        with pytest.warns(UserWarning, match="dedup is SKIPPED"):
+            r1 = await wrapped(handler, params, None)
+        # Second call in the same store: warning must NOT fire again.
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            r2 = await wrapped(handler, params, None)
         assert handler.call_count == 2
         assert r1 != r2
 


### PR DESCRIPTION
Follow-up to #196 (server idempotency middleware). Without this wiring, the middleware is effectively inert: every seller who drops in \`@idempotency.wrap\` gets silent fall-through (no dedup, no per-principal scoping) because the framework always builds a bare \`ToolContext()\` with \`caller_identity=None\`.

## What

**\`create_tool_caller\` accepts an optional \`ToolContext\`.** The returned callable is now \`call_tool(params, context=None)\`. When a transport has identity available, it passes it in; the default remains a bare \`ToolContext()\`, so existing callers are unaffected.

**A2A transport populates \`caller_identity\` from \`ServerCallContext.user\`.** \`ADCPAgentExecutor.execute\` derives a \`ToolContext\` from the incoming \`RequestContext\`:
- \`request.call_context.user.user_name\` → \`ToolContext.caller_identity\` when the user is authenticated
- \`request.task_id\` → \`ToolContext.request_id\`
- Unauthenticated / anonymous requests pass a bare context; the middleware's fail-closed path skips dedup rather than collapsing distinct buyers into one namespace

**MCP transport: documented limitation.** FastMCP's \`Context.client_id\` is a session hint, not an authenticated principal; MCP auth is pluggable so the specific principal source depends on seller setup. The tool-registration \`fn\` carries a comment explaining this and pointing sellers at \`create_tool_caller\` as the override point for custom auth middleware. MCP-specific auto-injection deferred to a future PR.

## Tests

\`tests/test_server_caller_identity.py\` — 11 new tests covering:

- \`TestToolContextFromRequest\` — authenticated / unauthenticated / missing call_context / empty user_name / task_id propagation
- \`TestToolCallerContextPassthrough\` — caller forwards an injected context; defaults to bare context when omitted (backward compat)
- \`TestEndToEndIdempotencyViaTransport\` — full wire:
  - authenticated A2A user → middleware dedups the replay
  - distinct principals on the same key → distinct resources (per-principal scope enforced)
  - unauthenticated → middleware fails-closed, both calls execute
- \`TestA2AExecutorUsesRealContext\` — end-to-end through \`execute()\` with a real \`Message\` payload: seller handler sees the authenticated user's \`caller_identity\`

**1499 passing** (from 1488). mypy clean. ruff clean.

## Test plan

- [x] \`pytest tests/ --no-cov -q\` — 1499 passed
- [x] \`mypy src/adcp/\` — 0 errors, 660 files
- [x] \`ruff check\` — clean
- [x] Backward-compat: existing callers that invoke \`call_tool(params)\` without context still work

## Follow-up (explicitly out of scope)

MCP auto-injection of caller_identity once we have a concrete FastMCP auth middleware to wire against. Today sellers with custom FastMCP auth can override \`create_tool_caller\` or pre-populate \`params\` with a principal hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)