### PR TITLE
chore(dx): pre-4.0 skill + SDK DX sweep

### DIFF
--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Reference ADCPHandler seller agent.
+
+A complete, runnable seller for the AdCP media_buy_seller storyboard
+(9 steps, all core tools). Used as the reference for the seller,
+generative-seller, and retail-media skills.
+
+Run:
+    python examples/seller_agent.py
+
+Validate:
+    npx -y -p @adcp/client adcp storyboard run \\
+        http://localhost:3001/mcp media_buy_seller --json
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+from adcp.server import (
+    ADCPHandler,
+    adcp_error,
+    cancel_media_buy_response,
+    serve,
+)
+from adcp.server.responses import (
+    capabilities_response,
+    creative_formats_response,
+    delivery_response,
+    media_buy_response,
+    media_buys_response,
+    products_response,
+    sync_accounts_response,
+    sync_creatives_response,
+    sync_governance_response,
+    update_media_buy_response,
+)
+from adcp.server.test_controller import TestControllerError, TestControllerStore
+
+AGENT_URL = "http://localhost:3001/mcp"
+
+accounts: dict[str, dict[str, Any]] = {}
+media_buys: dict[str, dict[str, Any]] = {}
+creatives: dict[str, dict[str, Any]] = {}
+proposals: dict[str, dict[str, Any]] = {}
+
+PRODUCTS: list[dict[str, Any]] = [
+    {
+        "product_id": "premium-homepage",
+        "name": "Homepage Takeover",
+        "description": "Full-page homepage placement with 100% SOV",
+        "delivery_type": "guaranteed",
+        "publisher_properties": [{"publisher_domain": "example.com", "selection_type": "all"}],
+        "format_ids": [{"agent_url": AGENT_URL, "id": "display_970x250"}],
+        "pricing_options": [
+            {
+                "pricing_option_id": "po-cpm-homepage",
+                "pricing_model": "cpm",
+                "floor_price": 15.00,
+                "currency": "USD",
+            }
+        ],
+        "reporting_capabilities": {
+            "available_metrics": ["impressions", "spend", "clicks", "ctr"],
+            "available_reporting_frequencies": ["hourly", "daily"],
+            "date_range_support": "date_range",
+            "supports_webhooks": False,
+            "expected_delay_minutes": 60,
+            "timezone": "UTC",
+        },
+        "delivery_measurement": {"provider": "internal"},
+    },
+    {
+        "product_id": "run-of-site",
+        "name": "Run of Site Display",
+        "description": "300x250 display ads across example.com",
+        "delivery_type": "non_guaranteed",
+        "publisher_properties": [{"publisher_domain": "example.com", "selection_type": "all"}],
+        "format_ids": [{"agent_url": AGENT_URL, "id": "display_300x250"}],
+        "pricing_options": [
+            {
+                "pricing_option_id": "po-cpm-ros",
+                "pricing_model": "cpm",
+                "floor_price": 5.00,
+                "currency": "USD",
+            }
+        ],
+        "reporting_capabilities": {
+            "available_metrics": ["impressions", "spend", "clicks", "ctr"],
+            "available_reporting_frequencies": ["hourly", "daily"],
+            "date_range_support": "date_range",
+            "supports_webhooks": False,
+            "expected_delay_minutes": 60,
+            "timezone": "UTC",
+        },
+        "delivery_measurement": {"provider": "internal"},
+    },
+]
+
+
+class DemoSeller(ADCPHandler):
+    async def get_adcp_capabilities(
+        self, params: dict[str, Any], context: Any = None
+    ) -> dict[str, Any]:
+        return capabilities_response(["media_buy"])
+
+    async def sync_accounts(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        results = []
+        for acct in params.get("accounts", []):
+            account_id = f"acct-{uuid.uuid4().hex[:8]}"
+            accounts[account_id] = {
+                "status": "active",
+                "brand": acct.get("brand"),
+                "operator": acct.get("operator"),
+            }
+            results.append(
+                {
+                    "account_id": account_id,
+                    "brand": acct.get("brand"),
+                    "operator": acct.get("operator"),
+                    "action": "created",
+                    "status": "active",
+                    "account_scope": "operator_brand",
+                }
+            )
+        return sync_accounts_response(results)
+
+    async def sync_governance(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        results = []
+        for entry in params.get("accounts", []):
+            acct_ref = entry.get("account", {})
+            agents = entry.get("governance_agents", [])
+            results.append(
+                {
+                    "account": acct_ref,
+                    "status": "synced",
+                    "governance_agents": [
+                        {"url": a.get("url"), "categories": a.get("categories", [])} for a in agents
+                    ],
+                }
+            )
+        return sync_governance_response(results)
+
+    async def get_products(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        if params.get("buying_mode") == "refine":
+            proposal = params.get("proposal", {}) or {}
+            proposal_id = proposal.get("proposal_id") or f"prop-{uuid.uuid4().hex[:8]}"
+            proposals[proposal_id] = {
+                "status": "draft",
+                "packages": proposal.get("packages", []),
+            }
+            return {
+                **products_response(PRODUCTS),
+                "proposals": [{"proposal_id": proposal_id, "status": "draft"}],
+            }
+        return products_response(PRODUCTS)
+
+    async def create_media_buy(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        if not params.get("packages"):
+            return adcp_error(
+                "INVALID_REQUEST",
+                "At least one package required",
+                field="packages",
+            )
+
+        valid_ids = {p["product_id"] for p in PRODUCTS}
+        packages = []
+        for pkg in params["packages"]:
+            product_id = pkg.get("product_id")
+            if product_id not in valid_ids:
+                return adcp_error(
+                    "PRODUCT_NOT_FOUND",
+                    f"Product '{product_id}' not found",
+                    field="product_id",
+                    suggestion="Use get_products to discover available products",
+                )
+            packages.append(
+                {
+                    "package_id": f"pkg-{uuid.uuid4().hex[:8]}",
+                    "product_id": product_id,
+                    "pricing_option_id": pkg.get("pricing_option_id"),
+                    "budget": pkg.get("budget"),
+                }
+            )
+
+        mb_id = f"mb-{uuid.uuid4().hex[:8]}"
+        media_buys[mb_id] = {
+            "status": "active",
+            "currency": "USD",
+            "packages": packages,
+            "revision": 1,
+        }
+        return media_buy_response(mb_id, packages, status="active")
+
+    async def get_media_buys(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        requested_ids = params.get("media_buy_ids")
+        results = []
+        for mb_id, mb in media_buys.items():
+            if requested_ids and mb_id not in requested_ids:
+                continue
+            results.append(
+                {
+                    "media_buy_id": mb_id,
+                    "status": mb["status"],
+                    "currency": mb.get("currency", "USD"),
+                    "packages": mb.get("packages", []),
+                }
+            )
+        return media_buys_response(results)
+
+    async def update_media_buy(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        mb_id = params.get("media_buy_id")
+        mb = media_buys.get(mb_id) if mb_id else None
+        if not mb or not mb_id:
+            return adcp_error("MEDIA_BUY_NOT_FOUND", f"Media buy {mb_id} not found")
+
+        if params.get("revision") and params["revision"] != mb.get("revision", 1):
+            return adcp_error("CONFLICT", "Revision mismatch - refetch and retry")
+
+        status = mb["status"]
+        if params.get("paused") is True and status == "active":
+            mb["status"] = "paused"
+        elif params.get("paused") is False and status == "paused":
+            mb["status"] = "active"
+        elif params.get("canceled") is True:
+            if status in ("completed", "rejected", "canceled"):
+                return adcp_error("NOT_CANCELLABLE", f"Cannot cancel a {status} media buy")
+            mb["status"] = "canceled"
+            return cancel_media_buy_response(mb_id, "buyer")
+
+        mb["revision"] = mb.get("revision", 1) + 1
+        return update_media_buy_response(mb_id, status=mb["status"], revision=mb["revision"])
+
+    async def list_creative_formats(
+        self, params: dict[str, Any], context: Any = None
+    ) -> dict[str, Any]:
+        return creative_formats_response(
+            [
+                {
+                    "format_id": {
+                        "agent_url": AGENT_URL,
+                        "id": "display_300x250",
+                    },
+                    "name": "Display 300x250",
+                    "renders": [{"width": 300, "height": 250}],
+                    "assets": [
+                        {
+                            "item_type": "individual",
+                            "asset_id": "image",
+                            "asset_type": "image",
+                            "required": True,
+                            "accepted_media_types": [
+                                "image/png",
+                                "image/jpeg",
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "format_id": {
+                        "agent_url": AGENT_URL,
+                        "id": "display_970x250",
+                    },
+                    "name": "Display 970x250",
+                    "renders": [{"width": 970, "height": 250}],
+                    "assets": [
+                        {
+                            "item_type": "individual",
+                            "asset_id": "image",
+                            "asset_type": "image",
+                            "required": True,
+                            "accepted_media_types": [
+                                "image/png",
+                                "image/jpeg",
+                            ],
+                        }
+                    ],
+                },
+            ]
+        )
+
+    async def sync_creatives(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        results = []
+        for c in params.get("creatives", []):
+            creative_id = c.get("creative_id") or f"c-{uuid.uuid4().hex[:8]}"
+            creatives[creative_id] = {**c, "status": "approved"}
+            results.append(
+                {
+                    "creative_id": creative_id,
+                    "action": "created",
+                    "status": "approved",
+                }
+            )
+        return sync_creatives_response(results)
+
+    async def get_media_buy_delivery(
+        self, params: dict[str, Any], context: Any = None
+    ) -> dict[str, Any]:
+        requested_ids = params.get("media_buy_ids", [])
+        deliveries = []
+        for mb_id in requested_ids:
+            if mb_id in media_buys:
+                deliveries.append(
+                    {
+                        "media_buy_id": mb_id,
+                        "status": "active",
+                        "totals": {
+                            "impressions": 45000,
+                            "clicks": 680,
+                            "spend": 540.00,
+                        },
+                        "by_package": [],
+                    }
+                )
+        return delivery_response(
+            deliveries,
+            reporting_period={
+                "start": "2026-04-01T00:00:00Z",
+                "end": "2026-04-09T23:59:59Z",
+            },
+        )
+
+
+class DemoStore(TestControllerStore):
+    async def force_account_status(self, account_id: str, status: str) -> dict[str, Any]:
+        acct = accounts.get(account_id)
+        if not acct:
+            raise TestControllerError("NOT_FOUND", f"Account {account_id} not found")
+        prev = acct["status"]
+        acct["status"] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def force_media_buy_status(
+        self,
+        media_buy_id: str,
+        status: str,
+        rejection_reason: str | None = None,
+    ) -> dict[str, Any]:
+        mb = media_buys.get(media_buy_id)
+        if not mb:
+            raise TestControllerError("NOT_FOUND", f"Media buy {media_buy_id} not found")
+        prev = mb["status"]
+        if prev in ("completed", "rejected", "canceled"):
+            raise TestControllerError(
+                "INVALID_TRANSITION",
+                f"Cannot transition from {prev}",
+                current_state=prev,
+            )
+        mb["status"] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def force_creative_status(
+        self,
+        creative_id: str,
+        status: str,
+        rejection_reason: str | None = None,
+    ) -> dict[str, Any]:
+        c = creatives.get(creative_id)
+        if not c:
+            raise TestControllerError("NOT_FOUND", f"Creative {creative_id} not found")
+        prev = c.get("status", "unknown")
+        if prev == "archived":
+            raise TestControllerError(
+                "INVALID_TRANSITION",
+                "Cannot transition from archived",
+                current_state=prev,
+            )
+        c["status"] = status
+        return {"previous_state": prev, "current_state": status}
+
+    async def simulate_delivery(
+        self,
+        media_buy_id: str,
+        impressions: int | None = None,
+        clicks: int | None = None,
+        conversions: int | None = None,
+        reported_spend: float | None = None,
+    ) -> dict[str, Any]:
+        if media_buy_id not in media_buys:
+            raise TestControllerError("NOT_FOUND", f"Media buy {media_buy_id} not found")
+        simulated: dict[str, Any] = {"media_buy_id": media_buy_id}
+        if impressions is not None:
+            simulated["impressions"] = impressions
+        if clicks is not None:
+            simulated["clicks"] = clicks
+        if conversions is not None:
+            simulated["conversions"] = conversions
+        if reported_spend is not None:
+            simulated["reported_spend"] = reported_spend
+        return {"simulated": simulated, "cumulative": simulated}
+
+    async def simulate_budget_spend(
+        self,
+        spend_percentage: float,
+        account_id: str | None = None,
+        media_buy_id: str | None = None,
+    ) -> dict[str, Any]:
+        return {"simulated": {"spend_percentage": spend_percentage}}
+
+
+if __name__ == "__main__":
+    serve(
+        DemoSeller(),
+        name="demo-seller",
+        port=int(os.environ.get("PORT", 3001)),
+        test_controller=DemoStore(),
+    )

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -159,13 +159,39 @@ class DemoSeller(ADCPHandler):
         if params.get("buying_mode") == "refine":
             proposal = params.get("proposal", {}) or {}
             proposal_id = proposal.get("proposal_id") or f"prop-{uuid.uuid4().hex[:8]}"
+            incoming_packages = proposal.get("packages", []) or []
             proposals[proposal_id] = {
                 "status": "draft",
-                "packages": proposal.get("packages", []),
+                "packages": incoming_packages,
             }
+            # proposal.json requires: proposal_id, name, allocations (minItems: 1).
+            # Each allocation requires product_id + allocation_percentage (sum to 100).
+            if incoming_packages:
+                even_split = round(100 / len(incoming_packages), 2)
+                allocations = [
+                    {
+                        "product_id": p["product_id"],
+                        "allocation_percentage": even_split,
+                    }
+                    for p in incoming_packages
+                ]
+            else:
+                allocations = [
+                    {
+                        "product_id": PRODUCTS[0]["product_id"],
+                        "allocation_percentage": 100.0,
+                    }
+                ]
             return {
                 **products_response(PRODUCTS),
-                "proposals": [{"proposal_id": proposal_id, "status": "draft"}],
+                "proposals": [
+                    {
+                        "proposal_id": proposal_id,
+                        "name": proposal.get("name", "Draft proposal"),
+                        "proposal_status": "draft",
+                        "allocations": allocations,
+                    }
+                ],
             }
         return products_response(PRODUCTS)
 

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -105,7 +105,18 @@ class DemoSeller(ADCPHandler):
     async def get_adcp_capabilities(
         self, params: dict[str, Any], context: Any = None
     ) -> dict[str, Any]:
-        return capabilities_response(["media_buy"])
+        return capabilities_response(
+            ["media_buy"],
+            compliance_testing={
+                "scenarios": [
+                    "force_account_status",
+                    "force_media_buy_status",
+                    "force_creative_status",
+                    "simulate_delivery",
+                    "simulate_budget_spend",
+                ],
+            },
+        )
 
     async def sync_accounts(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         results = []

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -39,7 +39,8 @@ from adcp.server.responses import (
 )
 from adcp.server.test_controller import TestControllerError, TestControllerStore
 
-AGENT_URL = "http://localhost:3001/mcp"
+PORT = int(os.environ.get("ADCP_PORT") or os.environ.get("PORT") or 3001)
+AGENT_URL = f"http://localhost:{PORT}/mcp"
 
 accounts: dict[str, dict[str, Any]] = {}
 media_buys: dict[str, dict[str, Any]] = {}
@@ -404,6 +405,6 @@ if __name__ == "__main__":
     serve(
         DemoSeller(),
         name="demo-seller",
-        port=int(os.environ.get("PORT", 3001)),
+        port=PORT,
         test_controller=DemoStore(),
     )

--- a/scripts/skill-build-setup.sh
+++ b/scripts/skill-build-setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# One-time setup for the skill-build harness. Idempotent.
+# Creates a shared venv, installs the SDK editable, warms npx cache,
+# and checks the skill-build port range (3001-3020).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV="$ROOT/.venv"
+PY="$VENV/bin/python"
+
+echo "[setup] root=$ROOT"
+if [[ ! -x "$PY" ]]; then
+  echo "[setup] creating venv at $VENV"
+  "${PYTHON:-python3}" -m venv "$VENV"
+fi
+
+if ! "$PY" -m pip --version >/dev/null 2>&1; then
+  "$PY" -m ensurepip --upgrade >/dev/null 2>&1 || \
+    curl -sSL https://bootstrap.pypa.io/get-pip.py | "$PY"
+fi
+"$PY" -m pip install --quiet --upgrade pip
+"$PY" -m pip install --quiet -e "$ROOT"
+"$PY" -c "import adcp, adcp.server" >/dev/null
+echo "[setup] adcp installed"
+
+echo "[setup] warming npx cache for @adcp/client"
+npx -y -p @adcp/client adcp storyboard list >/dev/null
+
+busy=()
+for port in $(seq 3001 3020); do
+  lsof -iTCP:"$port" -sTCP:LISTEN -n -P >/dev/null 2>&1 && busy+=("$port")
+done
+(( ${#busy[@]} > 0 )) && echo "[setup] WARN: ports in use: ${busy[*]}"
+
+mkdir -p "$ROOT/.context/dx-runs"
+echo "[setup] done"

--- a/scripts/skill-run.sh
+++ b/scripts/skill-run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Run one skill against one storyboard.
+# Usage: bash scripts/skill-run.sh <skill> <port> <storyboard>
+# Reads .context/dx-runs/<skill>/agent.py, writes <storyboard>.json next to it.
+set -euo pipefail
+
+SKILL="${1:?skill name required}"
+PORT="${2:?port required}"
+STORY="${3:?storyboard id required}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="$ROOT/.venv/bin/python"
+RUN_DIR="$ROOT/.context/dx-runs/$SKILL"
+AGENT="$RUN_DIR/agent.py"
+OUT="$RUN_DIR/$STORY.json"
+LOG="$RUN_DIR/agent.log"
+
+[[ -f "$AGENT" ]] || { echo "[run] missing $AGENT"; exit 2; }
+[[ -x "$PY" ]] || { echo "[run] venv missing — run scripts/skill-build-setup.sh"; exit 2; }
+mkdir -p "$RUN_DIR"
+
+echo "[run] $SKILL :$PORT $STORY"
+# Spawn the venv python directly by absolute path so no shell wrapper sits
+# between us and the child. $! is then the real server PID, killable directly.
+ADCP_PORT="$PORT" "$PY" "$AGENT" >"$LOG" 2>&1 &
+PID=$!
+cleanup() {
+  kill "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+  # Belt-and-suspenders: drop anything still holding the port.
+  lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | xargs -r kill 2>/dev/null || true
+}
+trap cleanup EXIT
+
+URL="http://localhost:$PORT/mcp"
+# Readiness: full MCP initialize. tools/list without a session returns 400,
+# so only a 200 on initialize proves the agent is really serving.
+INIT='{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"skill-run","version":"1"}}}'
+for i in $(seq 1 60); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -d "$INIT" "$URL" 2>/dev/null || echo 000)
+  [[ "$code" == "200" ]] && break
+  kill -0 "$PID" 2>/dev/null || { echo "[run] agent died before ready"; tail -n 40 "$LOG"; exit 3; }
+  sleep 0.5
+  [[ "$i" == 60 ]] && { echo "[run] agent never initialized (last=$code)"; tail -n 40 "$LOG"; exit 3; }
+done
+echo "[run] agent ready"
+
+set +e
+npx -y -p @adcp/client adcp storyboard run "$URL" "$STORY" --json >"$OUT"
+RC=$?
+set -e
+[[ "$RC" == 0 ]] && echo "[run] PASS — $OUT" || echo "[run] FAIL (rc=$RC) — $OUT"
+exit "$RC"

--- a/scripts/skill-run.sh
+++ b/scripts/skill-run.sh
@@ -51,5 +51,59 @@ set +e
 npx -y -p @adcp/client adcp storyboard run "$URL" "$STORY" --json >"$OUT"
 RC=$?
 set -e
-[[ "$RC" == 0 ]] && echo "[run] PASS — $OUT" || echo "[run] FAIL (rc=$RC) — $OUT"
-exit "$RC"
+
+# The storyboard runner exits 0 even on partial/failing overall_status, so
+# the process return code alone is not enough to tell a clean pass from a
+# buried failure. Parse the JSON it writes to distinguish passing / partial
+# / failing, and surface that in the final log line.
+STATUS=""
+if [[ -s "$OUT" ]]; then
+  STATUS=$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        doc = json.load(f)
+except Exception:
+    sys.exit(0)
+overall = doc.get("overall_status") or ""
+summary = doc.get("summary") or {}
+passed = summary.get("tracks_passed", 0)
+partial = summary.get("tracks_partial", 0)
+failed = summary.get("tracks_failed", 0)
+total = passed + partial + failed + summary.get("tracks_skipped", 0)
+headline = summary.get("headline") or ""
+print(f"{overall}\t{passed}\t{partial}\t{failed}\t{total}\t{headline}")
+' "$OUT" 2>/dev/null || echo "")
+fi
+
+if [[ -z "$STATUS" ]]; then
+  echo "[run] FAIL: no storyboard output — $OUT"
+  exit 1
+fi
+
+OVERALL=$(printf '%s' "$STATUS" | cut -f1)
+PASSED=$(printf '%s' "$STATUS" | cut -f2)
+PARTIAL=$(printf '%s' "$STATUS" | cut -f3)
+FAILED=$(printf '%s' "$STATUS" | cut -f4)
+TOTAL=$(printf '%s' "$STATUS" | cut -f5)
+HEADLINE=$(printf '%s' "$STATUS" | cut -f6)
+
+case "$OVERALL" in
+  passing)
+    echo "[run] PASS — $OUT"
+    exit 0
+    ;;
+  partial)
+    echo "[run] WARN: partial — $PASSED of $TOTAL tracks passing ($PARTIAL partial, $FAILED failed) — $OUT"
+    exit 0
+    ;;
+  failing)
+    REASON="${HEADLINE:-overall_status=failing}"
+    echo "[run] FAIL: $REASON — $OUT"
+    exit 1
+    ;;
+  *)
+    echo "[run] FAIL: no storyboard output — $OUT"
+    exit 1
+    ;;
+esac

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -207,7 +207,8 @@ async def build_creative(self, params, context=None):
                 break
 
     if not creative:
-        return adcp_error("CREATIVE_NOT_FOUND", f"No creative found for format {target_format_id}", field="target_format_id")
+        format_label = target_format.get("id", "<none>") if isinstance(target_format, dict) else (target_format or "<none>")
+        return adcp_error("CREATIVE_NOT_FOUND", f"No creative found for format {format_label}", field="target_format_id")
 
     format_id = target_format or (creative or {}).get("format_id", {})
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -80,9 +80,11 @@ async def get_adcp_capabilities(self, params, context=None):
 
 **`list_creative_formats`**
 ```python
+import os
 from adcp.server.responses import creative_formats_response
 
-AGENT_URL = "http://localhost:3001/mcp"
+ADCP_PORT = int(os.environ.get("ADCP_PORT", 3001))
+AGENT_URL = f"http://localhost:{ADCP_PORT}/mcp"
 
 async def list_creative_formats(self, params, context=None):
     return creative_formats_response([

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -50,6 +50,7 @@ One file. Subclass `ADCPHandler`, override the tools you support, call `serve()`
 
 ```python
 from adcp.server import ADCPHandler, serve
+from adcp.server.helpers import adcp_error
 from adcp.server.responses import (
     capabilities_response, creative_formats_response, sync_creatives_response,
     list_creatives_response, preview_creative_response, build_creative_response,
@@ -132,6 +133,7 @@ async def sync_creatives(self, params, context=None):
 
 **`list_creatives`** — query the library. Must include `pagination` and `query_summary` fields. Status must be a valid `CreativeStatus`.
 ```python
+from datetime import datetime, timezone
 from adcp.server.responses import list_creatives_response
 
 async def list_creatives(self, params, context=None):
@@ -143,14 +145,15 @@ async def list_creatives(self, params, context=None):
         format_id_set = {f.get("id", "") if isinstance(f, dict) else str(f) for f in format_ids}
         results = [c for c in results if c.get("format_id", {}).get("id") in format_id_set]
 
+    now = datetime.now(timezone.utc).isoformat()
     serialized = [
         {
             "creative_id": c["creative_id"],
             "name": c.get("name", ""),
             "format_id": c.get("format_id"),
             "status": c.get("status", "approved"),
-            "created_date": "2026-01-01T00:00:00Z",
-            "updated_date": "2026-01-01T00:00:00Z",
+            "created_date": now,
+            "updated_date": now,
         }
         for c in results
     ]
@@ -192,6 +195,7 @@ async def build_creative(self, params, context=None):
     creative = creatives.get(creative_id) if creative_id else None
 
     # Resolve target format
+    # target_format_id is canonical per spec; other names are legacy aliases accepted for compatibility.
     target_format = params.get("target_format_id") or params.get("output_format") or params.get("format_id")
 
     # Find creative by format if not found by ID
@@ -202,9 +206,8 @@ async def build_creative(self, params, context=None):
                 creative = c
                 break
 
-    # Fall back to first available
-    if not creative and creatives:
-        creative = next(iter(creatives.values()))
+    if not creative:
+        return adcp_error("CREATIVE_NOT_FOUND", f"No creative found for format {target_format_id}", field="target_format_id")
 
     format_id = target_format or (creative or {}).get("format_id", {})
 
@@ -242,7 +245,7 @@ Import handlers from `adcp.server`. Import response builders from `adcp.server.r
 
 ```bash
 python agent.py &
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_lifecycle --json
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp creative_lifecycle --json
 ```
 
 **Keep iterating until all steps pass.**

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -151,19 +151,18 @@ from adcp.server.idempotency import IdempotencyStore, MemoryBackend
 
 idempotency = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
 
+@idempotency.wrap
 async def build_creative(self, params, context=None):
-    key = params["idempotency_key"]  # required by schema
-    if cached := await idempotency.get(key):
-        return cached
+    # idempotency_key is required by schema; @idempotency.wrap dedups replays per (caller, key).
     manifest = {
         "promoted_offering": params.get("promoted_offering"),
         "format_id": params["format_id"],
         "assets": [{"asset_id": "image", "url": "https://cdn.example/generated.jpg"}],
     }
-    response = build_creative_response(manifest)
-    await idempotency.put(key, response)
-    return response
+    return build_creative_response(manifest)
 ```
+
+Declare idempotency in your capabilities response so replays are advertised: `capabilities_response(["media_buy"], idempotency=idempotency.capability())`.
 
 **`preview_creative`** — return pre-render previews for a built manifest. Responses wrap a list of `{preview_id, input, renders}`:
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -35,21 +35,24 @@ from adcp.server import ADCPHandler, serve
 from adcp.server.responses import (
     capabilities_response, products_response, media_buy_response,
     delivery_response, creative_formats_response, sync_creatives_response,
+    build_creative_response, preview_creative_response,
 )
 from adcp.server.test_controller import TestControllerStore
+
+AGENT_URL = "http://localhost:3001/mcp"
 
 class MyGenerativeSeller(ADCPHandler):
     # All seller tools (see seller skill) with modified creative handling
     ...
 
-serve(MyGenerativeSeller(), name="my-gen-seller", test_controller=MyStore())
+serve(MyGenerativeSeller(), name="my-gen-seller", port=3001, test_controller=MyStore())
 ```
 
 ## Seller Tools (Required)
 
 Implement all tools from the seller skill. Copy the pattern from `examples/seller_agent.py`:
 
-- `get_adcp_capabilities` → `capabilities_response(["media_buy", "compliance_testing"])`
+- `get_adcp_capabilities` → `capabilities_response(["media_buy"])`
 - `sync_accounts` → `sync_accounts_response(results)`
 - `sync_governance` → `sync_governance_response(results)`
 - `get_products` → `products_response(PRODUCTS)`
@@ -112,9 +115,9 @@ async def sync_creatives(self, params, context=None):
             creatives[creative_id] = {**c, "status": "pending_review"}
             results.append({"creative_id": creative_id, "action": "created", "status": "pending_review"})
         else:
-            # Standard upload: immediate accept
-            creatives[creative_id] = {**c, "status": "accepted"}
-            results.append({"creative_id": creative_id, "action": "created", "status": "accepted"})
+            # Standard upload: immediate approve
+            creatives[creative_id] = {**c, "status": "approved"}
+            results.append({"creative_id": creative_id, "action": "created", "status": "approved"})
 
     return sync_creatives_response(results)
 ```
@@ -124,7 +127,7 @@ async def sync_creatives(self, params, context=None):
 Same as the seller skill. Copy the `TestControllerStore` from `examples/seller_agent.py`:
 
 ```python
-serve(MyGenerativeSeller(), name="my-gen-seller", test_controller=MyStore())
+serve(MyGenerativeSeller(), name="my-gen-seller", port=3001, test_controller=MyStore())
 ```
 
 ## SDK Quick Reference
@@ -136,11 +139,50 @@ All seller response builders apply. The generative delta is in `list_creative_fo
 | `creative_formats_response(formats)` | `list_creative_formats` response |
 | `sync_creatives_response(creatives)` | `sync_creatives` response |
 
+## Generative Tools (Required)
+
+`ADCPHandler` advertises `build_creative` and `preview_creative` by default and returns `not_supported` unless you override them. A generative seller MUST implement both, or the storyboard fails at the generation step.
+
+**`build_creative`** — render a creative manifest from a brief. `idempotency_key` is a REQUIRED request field (pattern `^[A-Za-z0-9_.:-]{16,255}$`, see `src/adcp/types/generated_poc/media_buy/build_creative_request.py:157-165`). Use `adcp.server.idempotency.IdempotencyStore` to dedupe retries:
+
+```python
+from adcp.server.responses import build_creative_response
+from adcp.server.idempotency import IdempotencyStore, MemoryBackend
+
+idempotency = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
+
+async def build_creative(self, params, context=None):
+    key = params["idempotency_key"]  # required by schema
+    if cached := await idempotency.get(key):
+        return cached
+    manifest = {
+        "promoted_offering": params.get("promoted_offering"),
+        "format_id": params["format_id"],
+        "assets": [{"asset_id": "image", "url": "https://cdn.example/generated.jpg"}],
+    }
+    response = build_creative_response(manifest)
+    await idempotency.put(key, response)
+    return response
+```
+
+**`preview_creative`** — return pre-render previews for a built manifest. Responses wrap a list of `{preview_id, input, renders}`:
+
+```python
+from adcp.server.responses import preview_creative_response
+
+async def preview_creative(self, params, context=None):
+    return preview_creative_response([{
+        "preview_id": f"prev-{uuid.uuid4().hex[:8]}",
+        "input": params,
+        "renders": [{"width": 300, "height": 250, "url": "https://cdn.example/preview.png"}],
+    }])
+```
+
 ## Validation
 
 ```bash
 python agent.py &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_seller --json
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp media_buy_generative_seller --json
 ```
 
 ## Common Mistakes

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -39,7 +39,10 @@ from adcp.server.responses import (
 )
 from adcp.server.test_controller import TestControllerStore
 
-AGENT_URL = "http://localhost:3001/mcp"
+import os
+
+ADCP_PORT = int(os.environ.get("ADCP_PORT", 3001))
+AGENT_URL = f"http://localhost:{ADCP_PORT}/mcp"
 
 class MyGenerativeSeller(ADCPHandler):
     # All seller tools (see seller skill) with modified creative handling

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -48,7 +48,7 @@ serve(MyRetailAgent(), name="my-retail-agent", test_controller=MyStore())
 
 Implement all tools from the seller skill. Copy the pattern from `examples/seller_agent.py`:
 
-- `get_adcp_capabilities` → `capabilities_response(["media_buy", "compliance_testing"])`
+- `get_adcp_capabilities` → `capabilities_response(["media_buy"])`
 - `sync_accounts` → `sync_accounts_response(results)`
 - `sync_governance` → `sync_governance_response(results)`
 - `get_products` → `products_response(PRODUCTS)`
@@ -93,6 +93,7 @@ async def log_event(self, params, context=None):
 **`provide_performance_feedback`** — accept buyer metrics
 ```python
 async def provide_performance_feedback(self, params, context=None):
+    # Return shape varies by success/error — consult `ProvidePerformanceFeedbackResponse` in `adcp.types`.
     return {"success": True, "sandbox": True}
 ```
 
@@ -129,8 +130,8 @@ All seller response builders apply, plus:
 
 ```bash
 python agent.py &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_creative --json
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp media_buy_catalog_creative --json
 ```
 
 ## Common Mistakes

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -60,6 +60,8 @@ Implement all tools from the seller skill. Copy the pattern from `examples/selle
 
 See `skills/build-seller-agent/SKILL.md` for the exact response shapes of each.
 
+If your retail platform supports guaranteed deals with negotiation, also implement the proposal workflow from the seller skill. Refined proposals must include `proposal_id`, `name`, and `allocations[]` with `product_id` + `allocation_percentage` (summing to 100) — see "Proposal Workflow (Guaranteed Deals)" in `skills/build-seller-agent/SKILL.md`.
+
 ## Retail-Specific Tools
 
 **`sync_catalogs`** — accept product catalog feeds

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -476,7 +476,20 @@ Pass the store to `serve()`:
 serve(MySeller(), name="my-seller", test_controller=MyStore())
 ```
 
-The SDK's `serve(test_controller=store)` wires up the `compliance_testing` capability block automatically. You do NOT need to add it to `supported_protocols`.
+`compliance_testing` is a separate top-level capability block — not a `supported_protocols` value. `serve(test_controller=store)` registers the `comply_test_controller` tool but does NOT inject the capability block. Declare it yourself via the `compliance_testing=` kwarg on `capabilities_response()`:
+
+```python
+async def get_adcp_capabilities(self, params, context=None):
+    return capabilities_response(
+        ["media_buy"],
+        compliance_testing={"scenarios": [
+            "force_account_status",
+            "force_media_buy_status",
+            "simulate_delivery",
+            "simulate_budget_spend",
+        ]},
+    )
+```
 
 ## Emitting Webhooks
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -162,25 +162,26 @@ class MySeller(ADCPHandler):
 
 ## Emitting Webhooks
 
-Sellers emit webhooks to notify buyers asynchronously — no client library call, just an outbound HTTP POST. Use the SDK helpers instead of hand-rolling payload shape or signature bytes.
+Sellers emit webhooks to notify buyers asynchronously. AdCP 3.0 uses RFC 9421 HTTP Message Signatures as the baseline — use `adcp.webhooks.WebhookSender` (one-liner) or `sign_webhook` for more control.
 
 **When to emit:**
 - Async-approval media buy transitions (e.g., `pending_activation` → `active`, or `→ rejected`)
 - Artifact-ready notifications after long-running operations
 - Delivery reports the buyer subscribed to via `reporting_webhook` on `create_media_buy`
 
-**Build the payload.** Use `create_mcp_webhook_payload(task_id, status, task_type=..., result=..., message=...)` — it matches the `McpWebhookPayload` schema. For A2A transport, use `create_a2a_webhook_payload(...)` instead. There is no dedicated delivery-report helper today; reuse `create_mcp_webhook_payload` with `task_type="get_media_buy_delivery"` and the delivery response as `result`.
-
-**Sign the headers.** Call `get_adcp_signed_headers_for_webhook(headers, secret, timestamp, payload)`. This sets `X-AdCP-Signature` (HMAC-SHA256 over `"{timestamp}.{compact_json_payload}"`) and `X-AdCP-Timestamp`. The signer serializes with compact separators (`","` / `":"`) to match what httpx emits for `json=`, so POST via `client.post(url, json=payload, headers=signed)` — never hand-serialize the body yourself or the signature will mismatch.
-
-**Retry semantics.** Receivers dedupe on `task_id` (or `operation_id` if you set it). A retry is a byte-identical re-POST: same payload, same signed headers, same timestamp. Don't re-sign on retry.
+**Idempotency keys.** Generate one per distinct event with `generate_webhook_idempotency_key()` and reuse the same key on retry — receivers dedupe on it. A retry is a byte-identical re-POST; don't regenerate the key or re-sign.
 
 ```python
-import httpx
 from adcp.types import GeneratedTaskStatus
-from adcp.webhooks import create_mcp_webhook_payload, get_adcp_signed_headers_for_webhook
+from adcp.webhooks import (
+    WebhookSender,
+    create_mcp_webhook_payload,
+    generate_webhook_idempotency_key,
+)
 
-async def notify_media_buy_active(webhook_url: str, secret: str, mb_id: str, mb: dict) -> None:
+sender = WebhookSender(key_id="seller-key-1", private_key_pem=PRIVATE_KEY_PEM)
+
+async def notify_media_buy_active(webhook_url: str, mb_id: str, mb: dict) -> None:
     payload = create_mcp_webhook_payload(
         task_id=mb_id,
         task_type="create_media_buy",
@@ -188,12 +189,13 @@ async def notify_media_buy_active(webhook_url: str, secret: str, mb_id: str, mb:
         result={"media_buy_id": mb_id, "status": "active", "packages": mb["packages"]},
         message="Media buy approved and activated",
     )
-    headers = get_adcp_signed_headers_for_webhook(
-        {"Content-Type": "application/json"}, secret, timestamp=None, payload=payload
-    )
-    async with httpx.AsyncClient() as client:
-        await client.post(webhook_url, json=payload, headers=headers)
+    idem_key = generate_webhook_idempotency_key()  # persist this per-event; reuse on retry
+    await sender.send(webhook_url, payload, idempotency_key=idem_key)
 ```
+
+**Legacy HMAC.** `get_adcp_signed_headers_for_webhook` is 3.x-only and deprecated in 4.0 — use it only when a receiver can't yet verify 9421 signatures. See the `adcp.webhooks` module docstring for the migration path.
+
+**Receiving webhooks.** Sellers that receive webhooks from other agents (audit agents, governance, etc.) should use `adcp.webhooks.WebhookReceiver` — it handles 9421 verification, replay dedup, and legacy HMAC fallback. See the module docstring for a worked example.
 
 ## Proposal Workflow (Guaranteed Deals)
 
@@ -529,20 +531,28 @@ Pass the store to `serve()`:
 serve(MySeller(), name="my-seller", test_controller=MyStore())
 ```
 
-`compliance_testing` is a separate top-level capability block — not a `supported_protocols` value. `serve(test_controller=store)` registers the `comply_test_controller` tool but does NOT inject the capability block. Declare it yourself via the `compliance_testing=` kwarg on `capabilities_response()`:
+`compliance_testing` is a separate top-level capability block — not a `supported_protocols` value. `serve(test_controller=store)` registers the `comply_test_controller` tool but does NOT inject the capability block. Declare it yourself via the `compliance_testing=` kwarg on `capabilities_response()`.
+
+`adcp.idempotency.supported` is REQUIRED in AdCP 3.0 GA — always pass `idempotency=store.capability()` too. Use one shared `IdempotencyStore` per agent and reuse it for `@store.wrap` on mutating tools:
 
 ```python
-async def get_adcp_capabilities(self, params, context=None):
-    return capabilities_response(
-        ["media_buy"],
-        compliance_testing={"scenarios": [
-            "force_account_status",
-            "force_media_buy_status",
-            "force_creative_status",
-            "simulate_delivery",
-            "simulate_budget_spend",
-        ]},
-    )
+from adcp.server.idempotency import IdempotencyStore, MemoryBackend
+
+idempotency = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
+
+class MySeller(ADCPHandler):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(
+            ["media_buy"],
+            idempotency=idempotency.capability(),
+            compliance_testing={"scenarios": [
+                "force_account_status",
+                "force_media_buy_status",
+                "force_creative_status",
+                "simulate_delivery",
+                "simulate_budget_spend",
+            ]},
+        )
 ```
 
 ## Emitting Webhooks

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -79,7 +79,10 @@ serve(MySeller(), name="my-seller", test_controller=MyStore())
 Every product needs `description`, `reporting_capabilities`, and `delivery_measurement` — these are required by the schema and the storyboard validator.
 
 ```python
-AGENT_URL = "http://localhost:3001/mcp"
+import os
+
+ADCP_PORT = int(os.environ.get("ADCP_PORT", 3001))
+AGENT_URL = f"http://localhost:{ADCP_PORT}/mcp"
 
 PRODUCTS = [
     {
@@ -162,40 +165,41 @@ class MySeller(ADCPHandler):
 
 ## Emitting Webhooks
 
-Sellers emit webhooks to notify buyers asynchronously. AdCP 3.0 uses RFC 9421 HTTP Message Signatures as the baseline — use `adcp.webhooks.WebhookSender` (one-liner) or `sign_webhook` for more control.
+Sellers emit webhooks to notify buyers asynchronously. AdCP 3.0 uses RFC 9421 HTTP Message Signatures — use `adcp.webhooks.WebhookSender` (one-call helper) or `sign_webhook` for lower-level control.
 
 **When to emit:**
-- Async-approval media buy transitions (e.g., `pending_activation` → `active`, or `→ rejected`)
+- Async-approval media buy transitions (`pending_activation` → `active`, or `→ rejected`)
 - Artifact-ready notifications after long-running operations
 - Delivery reports the buyer subscribed to via `reporting_webhook` on `create_media_buy`
 
-**Idempotency keys.** Generate one per distinct event with `generate_webhook_idempotency_key()` and reuse the same key on retry — receivers dedupe on it. A retry is a byte-identical re-POST; don't regenerate the key or re-sign.
+**Idempotency keys.** Build with `generate_webhook_idempotency_key()` (or let `send_mcp` mint one via `create_mcp_webhook_payload`). Persist per event and reuse on retry — receivers dedupe on it. Prefer `sender.resend(result)` for retries: it replays the exact signed bytes under a fresh signature.
 
 ```python
 from adcp.types import GeneratedTaskStatus
-from adcp.webhooks import (
-    WebhookSender,
-    create_mcp_webhook_payload,
-    generate_webhook_idempotency_key,
-)
+from adcp.webhooks import WebhookSender, generate_webhook_idempotency_key
 
-sender = WebhookSender(key_id="seller-key-1", private_key_pem=PRIVATE_KEY_PEM)
+# JWK must include the private `d` field and `adcp_use: "webhook-signing"`.
+sender = WebhookSender.from_jwk(WEBHOOK_SIGNING_JWK)
 
 async def notify_media_buy_active(webhook_url: str, mb_id: str, mb: dict) -> None:
-    payload = create_mcp_webhook_payload(
-        task_id=mb_id,
-        task_type="create_media_buy",
-        status=GeneratedTaskStatus.completed,
-        result={"media_buy_id": mb_id, "status": "active", "packages": mb["packages"]},
-        message="Media buy approved and activated",
-    )
-    idem_key = generate_webhook_idempotency_key()  # persist this per-event; reuse on retry
-    await sender.send(webhook_url, payload, idempotency_key=idem_key)
+    idem_key = generate_webhook_idempotency_key()  # persist per-event; reuse on retry
+    async with sender:
+        result = await sender.send_mcp(
+            url=webhook_url,
+            task_id=mb_id,
+            task_type="create_media_buy",
+            status=GeneratedTaskStatus.completed,
+            result={"media_buy_id": mb_id, "status": "active", "packages": mb["packages"]},
+            message="Media buy approved and activated",
+            idempotency_key=idem_key,
+        )
+        if not result.ok:
+            await sender.resend(result)  # replays exact bytes, fresh signature
 ```
 
-**Legacy HMAC.** `get_adcp_signed_headers_for_webhook` is 3.x-only and deprecated in 4.0 — use it only when a receiver can't yet verify 9421 signatures. See the `adcp.webhooks` module docstring for the migration path.
+**Legacy HMAC.** `get_adcp_signed_headers_for_webhook` is 3.x-only and deprecated in 4.0 — use only when a receiver can't yet verify 9421 signatures. See `adcp.webhooks` module docstring for the migration path.
 
-**Receiving webhooks.** Sellers that receive webhooks from other agents (audit agents, governance, etc.) should use `adcp.webhooks.WebhookReceiver` — it handles 9421 verification, replay dedup, and legacy HMAC fallback. See the module docstring for a worked example.
+**Receiving webhooks.** Sellers that receive webhooks from other agents (audit, governance) should use `adcp.webhooks.WebhookReceiver` — it handles 9421 verification, replay dedup, and legacy HMAC fallback.
 
 ## Proposal Workflow (Guaranteed Deals)
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -490,6 +490,7 @@ async def get_adcp_capabilities(self, params, context=None):
         compliance_testing={"scenarios": [
             "force_account_status",
             "force_media_buy_status",
+            "force_creative_status",
             "simulate_delivery",
             "simulate_budget_spend",
         ]},

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -160,6 +160,41 @@ class MySeller(ADCPHandler):
         ...
 ```
 
+## Emitting Webhooks
+
+Sellers emit webhooks to notify buyers asynchronously — no client library call, just an outbound HTTP POST. Use the SDK helpers instead of hand-rolling payload shape or signature bytes.
+
+**When to emit:**
+- Async-approval media buy transitions (e.g., `pending_activation` → `active`, or `→ rejected`)
+- Artifact-ready notifications after long-running operations
+- Delivery reports the buyer subscribed to via `reporting_webhook` on `create_media_buy`
+
+**Build the payload.** Use `create_mcp_webhook_payload(task_id, status, task_type=..., result=..., message=...)` — it matches the `McpWebhookPayload` schema. For A2A transport, use `create_a2a_webhook_payload(...)` instead. There is no dedicated delivery-report helper today; reuse `create_mcp_webhook_payload` with `task_type="get_media_buy_delivery"` and the delivery response as `result`.
+
+**Sign the headers.** Call `get_adcp_signed_headers_for_webhook(headers, secret, timestamp, payload)`. This sets `X-AdCP-Signature` (HMAC-SHA256 over `"{timestamp}.{compact_json_payload}"`) and `X-AdCP-Timestamp`. The signer serializes with compact separators (`","` / `":"`) to match what httpx emits for `json=`, so POST via `client.post(url, json=payload, headers=signed)` — never hand-serialize the body yourself or the signature will mismatch.
+
+**Retry semantics.** Receivers dedupe on `task_id` (or `operation_id` if you set it). A retry is a byte-identical re-POST: same payload, same signed headers, same timestamp. Don't re-sign on retry.
+
+```python
+import httpx
+from adcp.types import GeneratedTaskStatus
+from adcp.webhooks import create_mcp_webhook_payload, get_adcp_signed_headers_for_webhook
+
+async def notify_media_buy_active(webhook_url: str, secret: str, mb_id: str, mb: dict) -> None:
+    payload = create_mcp_webhook_payload(
+        task_id=mb_id,
+        task_type="create_media_buy",
+        status=GeneratedTaskStatus.completed,
+        result={"media_buy_id": mb_id, "status": "active", "packages": mb["packages"]},
+        message="Media buy approved and activated",
+    )
+    headers = get_adcp_signed_headers_for_webhook(
+        {"Content-Type": "application/json"}, secret, timestamp=None, payload=payload
+    )
+    async with httpx.AsyncClient() as client:
+        await client.post(webhook_url, json=payload, headers=headers)
+```
+
 ## Proposal Workflow (Guaranteed Deals)
 
 For premium/guaranteed inventory, buyers negotiate before committing. The flow:
@@ -177,18 +212,31 @@ async def get_products(self, params, context=None):
     if buying_mode == "refine":
         proposal = params.get("proposal", {})
         proposal_id = proposal.get("proposal_id") or f"prop-{uuid.uuid4().hex[:8]}"
+        incoming_packages = proposal.get("packages", [])
         # Store/update the proposal draft
         proposals[proposal_id] = {
             "status": "draft",
-            "packages": proposal.get("packages", []),
+            "packages": incoming_packages,
         }
+        # proposal.json requires: proposal_id, name, allocations (minItems: 1).
+        # Each allocation requires product_id and allocation_percentage (must sum to 100).
+        n = max(len(incoming_packages), 1)
+        even_split = round(100 / n, 2)
         return {**products_response(PRODUCTS), "proposals": [{
             "proposal_id": proposal_id,
             "name": proposal.get("name", "Draft proposal"),
-            "status": "draft",
+            "proposal_status": "draft",
             "allocations": [
-                {"product_id": p["product_id"], "packages": []}
-                for p in proposal.get("packages", [])
+                {
+                    "product_id": p["product_id"],
+                    "allocation_percentage": even_split,
+                }
+                for p in incoming_packages
+            ] or [
+                {
+                    "product_id": PRODUCTS[0]["product_id"],
+                    "allocation_percentage": 100.0,
+                }
             ],
         }]}
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -64,7 +64,7 @@ from adcp.server.test_controller import TestControllerStore
 
 class MySeller(ADCPHandler):
     async def get_adcp_capabilities(self, params, context=None):
-        return capabilities_response(["media_buy", "compliance_testing"])
+        return capabilities_response(["media_buy"])
 
     async def get_products(self, params, context=None):
         return products_response(MY_PRODUCTS)
@@ -79,6 +79,8 @@ serve(MySeller(), name="my-seller", test_controller=MyStore())
 Every product needs `description`, `reporting_capabilities`, and `delivery_measurement` — these are required by the schema and the storyboard validator.
 
 ```python
+AGENT_URL = "http://localhost:3001/mcp"
+
 PRODUCTS = [
     {
         "product_id": "premium-homepage",
@@ -108,8 +110,6 @@ PRODUCTS = [
             "timezone": "UTC",
         },
         "delivery_measurement": {
-            "measurement_type": "server_side",
-            "verification": "internal",
             "provider": "internal",
         },
     },
@@ -182,10 +182,10 @@ async def get_products(self, params, context=None):
             "status": "draft",
             "packages": proposal.get("packages", []),
         }
-        return products_response(PRODUCTS, proposal={
+        return {**products_response(PRODUCTS), "proposals": [{
             "proposal_id": proposal_id,
             "status": "draft",
-        })
+        }]}
 
     # Default brief mode - return all matching products
     return products_response(PRODUCTS)
@@ -219,7 +219,7 @@ Every tool below uses a response builder from `adcp.server.responses`. Use the b
 from adcp.server.responses import capabilities_response
 
 async def get_adcp_capabilities(self, params, context=None):
-    return capabilities_response(["media_buy", "compliance_testing"])
+    return capabilities_response(["media_buy"])
 ```
 
 **`sync_accounts`**
@@ -476,10 +476,7 @@ Pass the store to `serve()`:
 serve(MySeller(), name="my-seller", test_controller=MyStore())
 ```
 
-Declare `compliance_testing` in supported_protocols:
-```python
-return capabilities_response(["media_buy", "compliance_testing"])
-```
+The SDK's `serve(test_controller=store)` wires up the `compliance_testing` capability block automatically. You do NOT need to add it to `supported_protocols`.
 
 ## Emitting Webhooks
 
@@ -548,7 +545,7 @@ Notes:
 | `cancel_media_buy_response(id, "buyer"/"seller")` | Cancellation with auto-defaults |
 | `resolve_account(params, resolver)` | Account resolution with auto-error |
 | `valid_actions_for_status(status)` | Status-to-actions mapping |
-| `serve(handler, transport="a2a"\|"streamable-http", port=3001, test_controller=store)` | Start MCP or A2A server. Context passthrough is automatic. |
+| `serve(handler, *, name=..., port=3001, transport="streamable-http"\|"a2a", test_controller=None)` | Start MCP or A2A server (default transport is `streamable-http`). Context passthrough is automatic. |
 
 Import helpers from `adcp.server`. Import response builders from `adcp.server.responses`. Import types from `adcp.types`.
 
@@ -557,8 +554,9 @@ Import helpers from `adcp.server`. Import response builders from `adcp.server.re
 **After writing the agent, validate it. Fix failures. Repeat.**
 
 ```bash
+# agent.py ends with: serve(handler, port=3001)
 python agent.py &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
 **Keep iterating until all steps pass.**
@@ -571,6 +569,14 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --jso
 | `deterministic_testing` | Test controller state machine validation |
 | `media_buy_non_guaranteed` | Auction flow with bid adjustment |
 | `media_buy_guaranteed_approval` | IO approval workflow |
+
+## Production Deployment
+
+- Publish `.well-known/adagents.json` using the `adcp.adagents` module so buyer agents can discover capabilities.
+- Wrap mutating tools (`create_media_buy`, `update_media_buy`, `sync_creatives`) with `adcp.server.idempotency.IdempotencyStore` to deduplicate retries.
+- Sign outgoing webhooks with `adcp.webhooks` + `adcp.signing` so receivers can verify authenticity.
+- Persist accounts, media buys, and creatives — in-memory dicts are fine for storyboards but lose state on restart.
+- Front `serve()` with a process manager (systemd, Kubernetes) and terminate TLS upstream.
 
 ## Common Mistakes
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -184,7 +184,12 @@ async def get_products(self, params, context=None):
         }
         return {**products_response(PRODUCTS), "proposals": [{
             "proposal_id": proposal_id,
+            "name": proposal.get("name", "Draft proposal"),
             "status": "draft",
+            "allocations": [
+                {"product_id": p["product_id"], "packages": []}
+                for p in proposal.get("packages", [])
+            ],
         }]}
 
     # Default brief mode - return all matching products

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -228,8 +228,11 @@ store = IdempotencyStore()
 async def get_adcp_capabilities(self, params, context=None):
     return capabilities_response(["signals"], idempotency=store.capability())
 
+@store.wrap
 async def activate_signal(self, params, context=None):
-    return await store.wrap(params["idempotency_key"], params, self._do_activate)
+    # idempotency_key is required; @store.wrap dedups replays per (caller, key).
+    # Same key + same payload → cached deployments; different payload → IDEMPOTENCY_CONFLICT.
+    return activate_signal_response(deployments=[...])
 ```
 
 ## Validation

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -96,6 +96,8 @@ async def get_adcp_capabilities(self, params, context=None):
 
 If `signal_spec` doesn't match anything specific, return all signals (discovery query).
 
+**Ordering matters when mixing signal types.** When an agent returns both marketplace and owned signals, return marketplace signals first. Storyboard runners and many buyers chain `signals[0]` into follow-up calls (activation, verification) — if `signals[0]` is an owned signal, it lacks `data_provider_domain` and the downstream call fails.
+
 ```python
 from adcp.server.responses import signals_response
 
@@ -112,10 +114,16 @@ async def get_signals(self, params, context=None):
         if matched:
             results = matched
 
-    # Exact ID lookup
+    # Exact ID lookup — key on (source, scope, id) where scope is agent_url
+    # for source=agent and data_provider_domain for source=catalog.
+    def _signal_key(sid: dict) -> tuple:
+        source = sid["source"]
+        scope = sid["agent_url"] if source == "agent" else sid.get("data_provider_domain", "")
+        return (source, scope, sid["id"])
+
     if signal_ids := params.get("signal_ids"):
-        id_set = {(sid["source"], sid["id"]) for sid in signal_ids}
-        results = [s for s in results if (s["signal_id"]["source"], s["signal_id"]["id"]) in id_set]
+        id_set = {_signal_key(sid) for sid in signal_ids}
+        results = [s for s in results if _signal_key(s["signal_id"]) in id_set]
 
     # CPM filter
     filters = params.get("filters") or {}

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -221,9 +221,9 @@ Import helpers from `adcp.server`. Import response builders from `adcp.server.re
 `idempotency_key` is REQUIRED on `activate_signal` per schema (`schemas/cache/signals/activate-signal-request.json`). Use `adcp.server.idempotency.IdempotencyStore` to dedupe replays: same key + same payload returns the cached deployments; different payload returns an `IDEMPOTENCY_CONFLICT` error. Declare the capability so buyers know replays are safe.
 
 ```python
-from adcp.server.idempotency import IdempotencyStore
+from adcp.server.idempotency import IdempotencyStore, MemoryBackend
 
-store = IdempotencyStore()
+store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)  # 24h per spec minimum
 
 async def get_adcp_capabilities(self, params, context=None):
     return capabilities_response(["signals"], idempotency=store.capability())

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -55,8 +55,12 @@ At least one pricing option per signal:
 One file. Subclass `ADCPHandler`, override the tools you support, call `serve()`.
 
 ```python
+import os
 from adcp.server import ADCPHandler, serve, adcp_error
 from adcp.server.responses import capabilities_response, signals_response, activate_signal_response
+
+ADCP_PORT = int(os.environ.get("ADCP_PORT", 3001))
+AGENT_URL = f"http://localhost:{ADCP_PORT}/mcp"
 
 class MySignalsAgent(ADCPHandler):
     async def get_adcp_capabilities(self, params, context=None):
@@ -154,7 +158,7 @@ Each signal must include:
     }],
     "signal_id": {                               # required — shape depends on type
         "source": "agent",                       # "agent" for owned, "catalog" for marketplace
-        "agent_url": "http://localhost:3001/mcp", # for owned
+        "agent_url": AGENT_URL,                  # for owned
         "id": "seg-001",
     },
     "value_type": "binary",                      # recommended: "binary" | "categorical" | "numeric"
@@ -242,6 +246,26 @@ async def activate_signal(self, params, context=None):
     # Same key + same payload → cached deployments; different payload → IDEMPOTENCY_CONFLICT.
     return activate_signal_response(deployments=[...])
 ```
+
+## Governance Tracks (Optional)
+
+Marketplace signals agents with compliance review flows MUST also implement `sync_accounts` and `sync_governance`. The `signal_marketplace/governance_denied` sub-track exercises both — without them, the storyboard fails before it reaches activation. Skip for pure owned-data agents.
+
+```python
+from adcp.server.responses import sync_accounts_response, sync_governance_response
+
+async def sync_accounts(self, params, context=None):
+    # Echo brand + operator back; assign an account_id, store, return "active".
+    # See examples/seller_agent.py for the full shape.
+    return sync_accounts_response([...])
+
+async def sync_governance(self, params, context=None):
+    # Echo account + governance_agents (url + categories) back as "synced".
+    # See examples/seller_agent.py for the full shape.
+    return sync_governance_response([...])
+```
+
+Required to PASS `signal_marketplace/governance_denied`.
 
 ## Validation
 

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -30,6 +30,8 @@ Determine these four things. Ask the user — don't guess.
 
 **Owned** — first-party data (retailer CDP, publisher contextual, CRM). `signal_id.source: "agent"`.
 
+**Custom** — agent-native segments built on demand from models, composites, or buyer inputs. `signal_id.source: "agent"`, `signal_type: "custom"`.
+
 ### 2. What Segments?
 
 Get specifics: names, definitions, what each represents. Push for 3-5 segments with variety. Each needs:
@@ -70,7 +72,7 @@ class MySignalsAgent(ADCPHandler):
             return adcp_error("SIGNAL_NOT_FOUND", f"Signal {segment_id} not found")
         return activate_signal_response(deployments)
 
-serve(MySignalsAgent(), name="my-signals-agent")
+serve(MySignalsAgent(), name="my-signals-agent", port=3001)
 ```
 
 ## Tools and Required Response Shapes
@@ -89,6 +91,8 @@ async def get_adcp_capabilities(self, params, context=None):
 
 1. `signal_spec` — natural language. Match against segment names and descriptions.
 2. `signal_ids` — exact lookup by ID.
+
+`get_signals` requires anyOf(`signal_spec`, `signal_ids`) per schema — an empty request is invalid.
 
 If `signal_spec` doesn't match anything specific, return all signals (discovery query).
 
@@ -110,8 +114,8 @@ async def get_signals(self, params, context=None):
 
     # Exact ID lookup
     if signal_ids := params.get("signal_ids"):
-        id_set = {sid.get("id") or sid for sid in signal_ids}
-        results = [s for s in results if s["signal_id"]["id"] in id_set]
+        id_set = {(sid["source"], sid["id"]) for sid in signal_ids}
+        results = [s for s in results if (s["signal_id"]["source"], s["signal_id"]["id"]) in id_set]
 
     # CPM filter
     filters = params.get("filters") or {}
@@ -151,6 +155,9 @@ Each signal must include:
 
 **`activate_signal`**
 ```python
+import uuid
+from datetime import datetime, timezone
+
 from adcp.server import adcp_error
 from adcp.server.responses import activate_signal_response
 
@@ -172,7 +179,7 @@ async def activate_signal(self, params, context=None):
                     "type": "segment_id",
                     "segment_id": f"plat-{uuid.uuid4().hex[:8]}",
                 },
-                "deployed_at": "2026-01-01T00:00:00Z",
+                "deployed_at": datetime.now(timezone.utc).isoformat(),
             })
         elif dest.get("type") == "agent":
             deployments.append({
@@ -184,7 +191,7 @@ async def activate_signal(self, params, context=None):
                     "key": "segment",
                     "value": segment_id,
                 },
-                "deployed_at": "2026-01-01T00:00:00Z",
+                "deployed_at": datetime.now(timezone.utc).isoformat(),
             })
 
     return activate_signal_response(deployments)
@@ -209,12 +216,28 @@ async def activate_signal(self, params, context=None):
 
 Import helpers from `adcp.server`. Import response builders from `adcp.server.responses`.
 
+## Idempotency for activate_signal
+
+`idempotency_key` is REQUIRED on `activate_signal` per schema (`schemas/cache/signals/activate-signal-request.json`). Use `adcp.server.idempotency.IdempotencyStore` to dedupe replays: same key + same payload returns the cached deployments; different payload returns an `IDEMPOTENCY_CONFLICT` error. Declare the capability so buyers know replays are safe.
+
+```python
+from adcp.server.idempotency import IdempotencyStore
+
+store = IdempotencyStore()
+
+async def get_adcp_capabilities(self, params, context=None):
+    return capabilities_response(["signals"], idempotency=store.capability())
+
+async def activate_signal(self, params, context=None):
+    return await store.wrap(params["idempotency_key"], params, self._do_activate)
+```
+
 ## Validation
 
 ```bash
 python agent.py &
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_owned --json       # for owned data
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace --json  # for marketplace
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp signal_owned --json       # for owned data
+npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp signal_marketplace --json  # for marketplace
 ```
 
 **Keep iterating until all steps pass.**

--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -415,10 +415,18 @@ from adcp.validation import (
     validate_publisher_properties_item,
 )
 from adcp.webhooks import (
+    LegacyHmacFallback,
+    MemoryBackend,
+    WebhookDedupStore,
+    WebhookReceiver,
+    WebhookReceiverConfig,
+    WebhookVerifyOptions,
     create_a2a_webhook_payload,
     create_mcp_webhook_payload,
     extract_webhook_result_data,
+    generate_webhook_idempotency_key,
     get_adcp_signed_headers_for_webhook,
+    sign_webhook,
 )
 
 __version__ = "3.12.0"
@@ -497,6 +505,14 @@ __all__ = [
     "create_a2a_webhook_payload",
     "get_adcp_signed_headers_for_webhook",
     "extract_webhook_result_data",
+    "generate_webhook_idempotency_key",
+    "sign_webhook",
+    "WebhookReceiver",
+    "WebhookReceiverConfig",
+    "WebhookVerifyOptions",
+    "WebhookDedupStore",
+    "MemoryBackend",
+    "LegacyHmacFallback",
     "McpWebhookPayload",
     # Account operations
     "AccountReference",

--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -426,6 +426,7 @@ from adcp.webhooks import (
     extract_webhook_result_data,
     generate_webhook_idempotency_key,
     get_adcp_signed_headers_for_webhook,
+    sign_legacy_webhook,
     sign_webhook,
 )
 
@@ -506,6 +507,7 @@ __all__ = [
     "get_adcp_signed_headers_for_webhook",
     "extract_webhook_result_data",
     "generate_webhook_idempotency_key",
+    "sign_legacy_webhook",
     "sign_webhook",
     "WebhookReceiver",
     "WebhookReceiverConfig",

--- a/src/adcp/client.py
+++ b/src/adcp/client.py
@@ -3285,26 +3285,54 @@ class ADCPClient:
         Verify HMAC-SHA256 signature of webhook payload.
 
         The verification algorithm matches get_adcp_signed_headers_for_webhook:
-        1. Constructs message as "{timestamp}.{json_payload}"
-        2. Uses raw HTTP body bytes when available (preserves sender's serialization)
-        3. Falls back to json.dumps() if raw_body not provided
-        4. HMAC-SHA256 signs with the shared secret
-        5. Compares against the provided signature (with "sha256=" prefix stripped)
+        1. Constructs message as "{timestamp}.{raw_http_body_bytes}"
+        2. HMAC-SHA256 signs with the shared secret
+        3. Compares against the provided signature (with "sha256=" prefix stripped)
+           using constant-time comparison.
+
+        Per AdCP spec (adcontextprotocol/adcp#2478): verifiers MUST use the raw
+        HTTP body bytes captured before any JSON parse; they SHOULD NOT
+        re-serialize a parsed payload to reconstruct the signed bytes, because
+        re-serialization silently fails against signers whose output differs in
+        separator choice, key order, unicode escapes, or number formatting —
+        masking signer bugs the verifier should surface. Callers that genuinely
+        cannot capture raw bytes MUST fail closed.
+
+        This implementation therefore rejects verification attempts that don't
+        supply ``raw_body``. Capture it from your framework's pre-parse hook
+        (FastAPI ``Request.body()``, Flask ``request.get_data(cache=True)``,
+        aiohttp ``Request.read()``, Express ``express.raw()``).
 
         Args:
-            payload: Webhook payload dict (used as fallback if raw_body not provided)
+            payload: Parsed webhook payload dict (not used for signing; kept
+                for signature parity with callers, but verification derives
+                solely from ``raw_body``).
             signature: Signature to verify (with or without "sha256=" prefix)
             timestamp: Unix timestamp in seconds from X-AdCP-Timestamp header
-            raw_body: Raw HTTP request body bytes. When provided, used directly
-                for signature verification to avoid cross-language serialization
-                mismatches. Strongly recommended for production use.
+            raw_body: Raw HTTP request body bytes as received on the wire,
+                captured before any JSON parse. Required.
 
         Returns:
-            True if signature is valid, False otherwise
+            True if signature is valid, False otherwise (including when
+            ``raw_body`` is missing — fails closed per spec).
         """
         if not self.webhook_secret:
             logger.warning("Webhook signature verification skipped: no webhook_secret configured")
             return True
+
+        # Fail closed per adcontextprotocol/adcp#2478: verifiers that cannot
+        # capture raw bytes MUST reject, surfacing the infrastructure gap
+        # rather than silently reconstructing a signed body that may diverge
+        # from the bytes the signer actually hashed.
+        if raw_body is None:
+            logger.error(
+                "Webhook signature verification failed: raw_body is required. "
+                "Capture the raw HTTP body pre-parse and pass it to "
+                "handle_webhook(raw_body=...). See "
+                "https://adcontextprotocol.org/docs/building/implementation/security"
+                "#legacy-hmac-sha256-fallback-deprecated-removed-in-40"
+            )
+            return False
 
         # Reject stale or future timestamps to prevent replay attacks
         try:
@@ -3319,12 +3347,7 @@ class ADCPClient:
         if signature.startswith("sha256="):
             signature = signature[7:]
 
-        # Use raw body if available (avoids cross-language serialization mismatches),
-        # otherwise fall back to json.dumps() for backward compatibility
-        if raw_body is not None:
-            payload_str = raw_body.decode("utf-8") if isinstance(raw_body, bytes) else raw_body
-        else:
-            payload_str = json.dumps(payload)
+        payload_str = raw_body.decode("utf-8") if isinstance(raw_body, bytes) else raw_body
 
         # Construct signed message: timestamp.payload
         signed_message = f"{timestamp}.{payload_str}"

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -63,10 +63,15 @@ class ADCPAgentExecutor(AgentExecutor):
         self._handler = handler
         self._tool_callers: dict[str, Any] = {}
 
-        # Build tool callers for all tools this handler supports
+        # Build tool callers for all tools this handler supports.
+        # Skip comply_test_controller unless the seller passed a
+        # TestControllerStore; otherwise we would advertise a skill
+        # backed only by the handler's not-supported stub.
         tool_defs = get_tools_for_handler(handler)
         for tool_def in tool_defs:
             name = tool_def["name"]
+            if name == "comply_test_controller" and test_controller is None:
+                continue
             self._tool_callers[name] = create_tool_caller(handler, name)
 
         if test_controller is not None:
@@ -87,22 +92,16 @@ class ADCPAgentExecutor(AgentExecutor):
 
         self._tool_callers["comply_test_controller"] = _call_test_controller
 
-    async def execute(
-        self, context: RequestContext, event_queue: EventQueue
-    ) -> None:
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         """Execute an ADCP skill from an incoming A2A message."""
         skill_name, params = self._parse_request(context)
 
         if skill_name is None:
-            await self._send_error(
-                event_queue, context, "No skill specified in message"
-            )
+            await self._send_error(event_queue, context, "No skill specified in message")
             return
 
         if skill_name not in self._tool_callers:
-            await self._send_error(
-                event_queue, context, f"Unknown skill: {skill_name}"
-            )
+            await self._send_error(event_queue, context, f"Unknown skill: {skill_name}")
             return
 
         tool_context = _tool_context_from_request(context)
@@ -115,19 +114,13 @@ class ADCPAgentExecutor(AgentExecutor):
             # transport-errors.mdx §A2A Binding, plus a human-readable text
             # part. The JSON-RPC channel is reserved for transport-level
             # errors (auth rejected, rate-limited pre-dispatch).
-            logger.info(
-                "AdCP application error for skill %s: %s", skill_name, exc
-            )
+            logger.info("AdCP application error for skill %s: %s", skill_name, exc)
             await self._send_adcp_error(event_queue, context, exc)
         except Exception:
             logger.exception("Error executing skill %s", skill_name)
-            await self._send_error(
-                event_queue, context, f"Skill execution failed: {skill_name}"
-            )
+            await self._send_error(event_queue, context, f"Skill execution failed: {skill_name}")
 
-    async def cancel(
-        self, context: RequestContext, event_queue: EventQueue
-    ) -> None:
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
         """ADCP operations are synchronous; cancellation sets state to canceled."""
         event = _make_task(
             context,
@@ -140,9 +133,7 @@ class ADCPAgentExecutor(AgentExecutor):
     # Message parsing
     # ------------------------------------------------------------------
 
-    def _parse_request(
-        self, context: RequestContext
-    ) -> tuple[str | None, dict[str, Any]]:
+    def _parse_request(self, context: RequestContext) -> tuple[str | None, dict[str, Any]]:
         """Extract skill name and parameters from the A2A message.
 
         Supports two formats:
@@ -173,9 +164,7 @@ class ADCPAgentExecutor(AgentExecutor):
 
         return None, {}
 
-    def _parse_text_request(
-        self, text: str
-    ) -> tuple[str | None, dict[str, Any]]:
+    def _parse_text_request(self, text: str) -> tuple[str | None, dict[str, Any]]:
         """Best-effort parse of a text request for skill + params."""
         try:
             data = json.loads(text)
@@ -354,8 +343,16 @@ def _build_agent_card(
     version: str = "1.0.0",
     extra_skills: list[AgentSkill] | None = None,
 ) -> AgentCard:
-    """Build an A2A AgentCard from an ADCPHandler's tool definitions."""
+    """Build an A2A AgentCard from an ADCPHandler's tool definitions.
+
+    ``comply_test_controller`` is excluded from the card skills list unless
+    the caller supplied it via ``extra_skills`` (which is how
+    :func:`create_a2a_server` opts in when a ``TestControllerStore`` is
+    wired). Extra skills are deduped by id so advertising the test
+    controller never produces two entries.
+    """
     tool_defs = get_tools_for_handler(handler)
+    extra_ids = {s.id for s in extra_skills} if extra_skills else set()
 
     skills = [
         AgentSkill(
@@ -365,6 +362,7 @@ def _build_agent_card(
             tags=["adcp"],
         )
         for td in tool_defs
+        if td["name"] != "comply_test_controller" and td["name"] not in extra_ids
     ]
 
     if extra_skills:

--- a/src/adcp/server/base.py
+++ b/src/adcp/server/base.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
         SyncCatalogsRequest,
         SyncCreativesRequest,
         SyncEventSourcesRequest,
+        SyncGovernanceRequest,
         SyncPlansRequest,
         UpdateCollectionListRequest,
         UpdateContentStandardsRequest,
@@ -152,7 +153,9 @@ class ADCPHandler(ABC):
     # Core Catalog Operations
     # ========================================================================
 
-    async def get_products(self, params: GetProductsRequest | dict[str, Any], context: ToolContext | None = None) -> Any:
+    async def get_products(
+        self, params: GetProductsRequest | dict[str, Any], context: ToolContext | None = None
+    ) -> Any:
         """Get advertising products.
 
         Override this to provide product catalog functionality.
@@ -160,7 +163,9 @@ class ADCPHandler(ABC):
         return self._not_supported("get_products")
 
     async def list_creative_formats(
-        self, params: ListCreativeFormatsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: ListCreativeFormatsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """List supported creative formats.
 
@@ -209,7 +214,9 @@ class ADCPHandler(ABC):
         return self._not_supported("preview_creative")
 
     async def get_creative_delivery(
-        self, params: GetCreativeDeliveryRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetCreativeDeliveryRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Get creative delivery metrics.
 
@@ -240,7 +247,9 @@ class ADCPHandler(ABC):
         return self._not_supported("update_media_buy")
 
     async def get_media_buy_delivery(
-        self, params: GetMediaBuyDeliveryRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetMediaBuyDeliveryRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Get media buy delivery metrics.
 
@@ -261,7 +270,9 @@ class ADCPHandler(ABC):
     # Signal Operations
     # ========================================================================
 
-    async def get_signals(self, params: GetSignalsRequest | dict[str, Any], context: ToolContext | None = None) -> Any:
+    async def get_signals(
+        self, params: GetSignalsRequest | dict[str, Any], context: ToolContext | None = None
+    ) -> Any:
         """Get available signals.
 
         Override this to provide signal catalog.
@@ -282,7 +293,9 @@ class ADCPHandler(ABC):
     # ========================================================================
 
     async def provide_performance_feedback(
-        self, params: ProvidePerformanceFeedbackRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: ProvidePerformanceFeedbackRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Provide performance feedback.
 
@@ -313,7 +326,9 @@ class ADCPHandler(ABC):
         return self._not_supported("sync_accounts")
 
     async def get_account_financials(
-        self, params: GetAccountFinancialsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetAccountFinancialsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Get account financials.
 
@@ -334,7 +349,9 @@ class ADCPHandler(ABC):
     # Event Operations
     # ========================================================================
 
-    async def log_event(self, params: LogEventRequest | dict[str, Any], context: ToolContext | None = None) -> Any:
+    async def log_event(
+        self, params: LogEventRequest | dict[str, Any], context: ToolContext | None = None
+    ) -> Any:
         """Log event.
 
         Override this to provide functionality.
@@ -360,7 +377,7 @@ class ADCPHandler(ABC):
         return self._not_supported("sync_audiences")
 
     async def sync_governance(
-        self, params: dict[str, Any], context: ToolContext | None = None
+        self, params: SyncGovernanceRequest | dict[str, Any], context: ToolContext | None = None
     ) -> Any:
         """Sync governance agents for accounts.
 
@@ -382,7 +399,9 @@ class ADCPHandler(ABC):
     # ========================================================================
 
     async def get_adcp_capabilities(
-        self, params: GetAdcpCapabilitiesRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetAdcpCapabilitiesRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Get ADCP capabilities.
 
@@ -395,7 +414,9 @@ class ADCPHandler(ABC):
     # ========================================================================
 
     async def create_content_standards(
-        self, params: CreateContentStandardsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: CreateContentStandardsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Create content standards configuration.
 
@@ -404,7 +425,9 @@ class ADCPHandler(ABC):
         return self._not_supported("create_content_standards")
 
     async def get_content_standards(
-        self, params: GetContentStandardsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetContentStandardsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Get content standards configuration.
 
@@ -413,7 +436,9 @@ class ADCPHandler(ABC):
         return self._not_supported("get_content_standards")
 
     async def list_content_standards(
-        self, params: ListContentStandardsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: ListContentStandardsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """List content standards configurations.
 
@@ -422,7 +447,9 @@ class ADCPHandler(ABC):
         return self._not_supported("list_content_standards")
 
     async def update_content_standards(
-        self, params: UpdateContentStandardsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: UpdateContentStandardsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Update content standards configuration.
 
@@ -440,7 +467,9 @@ class ADCPHandler(ABC):
         return self._not_supported("calibrate_content")
 
     async def validate_content_delivery(
-        self, params: ValidateContentDeliveryRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: ValidateContentDeliveryRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Validate content delivery against standards.
 
@@ -449,7 +478,9 @@ class ADCPHandler(ABC):
         return self._not_supported("validate_content_delivery")
 
     async def get_media_buy_artifacts(
-        self, params: GetMediaBuyArtifactsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetMediaBuyArtifactsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Get artifacts associated with a media buy.
 
@@ -502,7 +533,9 @@ class ADCPHandler(ABC):
     # ========================================================================
 
     async def get_creative_features(
-        self, params: GetCreativeFeaturesRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: GetCreativeFeaturesRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Evaluate governance features for a creative.
 
@@ -596,7 +629,9 @@ class ADCPHandler(ABC):
     # ========================================================================
 
     async def create_collection_list(
-        self, params: CreateCollectionListRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: CreateCollectionListRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Create a collection list for governance filtering.
 
@@ -614,7 +649,9 @@ class ADCPHandler(ABC):
         return self._not_supported("get_collection_list")
 
     async def list_collection_lists(
-        self, params: ListCollectionListsRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: ListCollectionListsRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """List collection lists.
 
@@ -623,7 +660,9 @@ class ADCPHandler(ABC):
         return self._not_supported("list_collection_lists")
 
     async def update_collection_list(
-        self, params: UpdateCollectionListRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: UpdateCollectionListRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Update a collection list.
 
@@ -632,7 +671,9 @@ class ADCPHandler(ABC):
         return self._not_supported("update_collection_list")
 
     async def delete_collection_list(
-        self, params: DeleteCollectionListRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: DeleteCollectionListRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Delete a collection list.
 
@@ -718,7 +759,9 @@ class ADCPHandler(ABC):
     # ========================================================================
 
     async def comply_test_controller(
-        self, params: ComplyTestControllerRequest | dict[str, Any], context: ToolContext | None = None
+        self,
+        params: ComplyTestControllerRequest | dict[str, Any],
+        context: ToolContext | None = None,
     ) -> Any:
         """Compliance test controller (sandbox only).
 

--- a/src/adcp/server/helpers.py
+++ b/src/adcp/server/helpers.py
@@ -39,7 +39,7 @@ STANDARD_ERROR_CODES: dict[str, dict[str, str]] = {
     "CREATIVE_DEADLINE_EXCEEDED": {
         "recovery": "correctable",
         "message": "Creative deadline passed",
-    },  # noqa: E501
+    },
     "AUDIENCE_TOO_SMALL": {"recovery": "correctable", "message": "Audience too small"},
     "MEDIA_BUY_NOT_FOUND": {"recovery": "correctable", "message": "Media buy not found"},
     "PACKAGE_NOT_FOUND": {"recovery": "correctable", "message": "Package not found"},

--- a/src/adcp/server/helpers.py
+++ b/src/adcp/server/helpers.py
@@ -36,10 +36,14 @@ STANDARD_ERROR_CODES: dict[str, dict[str, str]] = {
     "BUDGET_EXHAUSTED": {"recovery": "correctable", "message": "Budget fully spent"},
     "BUDGET_EXCEEDED": {"recovery": "correctable", "message": "Would exceed budget allocation"},
     "CREATIVE_REJECTED": {"recovery": "correctable", "message": "Creative rejected"},
-    "CREATIVE_DEADLINE_EXCEEDED": {"recovery": "correctable", "message": "Creative deadline passed"},  # noqa: E501
+    "CREATIVE_DEADLINE_EXCEEDED": {
+        "recovery": "correctable",
+        "message": "Creative deadline passed",
+    },  # noqa: E501
     "AUDIENCE_TOO_SMALL": {"recovery": "correctable", "message": "Audience too small"},
     "MEDIA_BUY_NOT_FOUND": {"recovery": "correctable", "message": "Media buy not found"},
     "PACKAGE_NOT_FOUND": {"recovery": "correctable", "message": "Package not found"},
+    "SIGNAL_NOT_FOUND": {"recovery": "correctable", "message": "Signal not found"},
     "CONFLICT": {"recovery": "correctable", "message": "Revision conflict - refetch and retry"},
     "INVALID_STATE": {"recovery": "correctable", "message": "Invalid state for this operation"},
     "NOT_CANCELLABLE": {"recovery": "correctable", "message": "Cannot cancel this media buy"},
@@ -135,12 +139,19 @@ def adcp_error(
 # Public constant — servers can inspect, test against, or extend this.
 MEDIA_BUY_STATE_MACHINE: dict[str, list[str]] = {
     "pending_activation": [
-        "cancel", "update_budget", "update_dates",
-        "update_packages", "add_packages",
+        "cancel",
+        "update_budget",
+        "update_dates",
+        "update_packages",
+        "add_packages",
     ],
     "active": [
-        "pause", "cancel", "update_budget", "update_dates",
-        "update_packages", "add_packages",
+        "pause",
+        "cancel",
+        "update_budget",
+        "update_dates",
+        "update_packages",
+        "add_packages",
     ],
     "paused": ["resume", "cancel", "update_budget", "update_dates"],
     "completed": [],
@@ -286,9 +297,7 @@ def cancel_media_buy_response(
     most commonly forget.
     """
     if canceled_by not in ("buyer", "seller"):
-        raise ValueError(
-            f"canceled_by must be 'buyer' or 'seller', got {canceled_by!r}"
-        )
+        raise ValueError(f"canceled_by must be 'buyer' or 'seller', got {canceled_by!r}")
     resp: dict[str, Any] = {
         "media_buy_id": media_buy_id,
         "status": "canceled",

--- a/src/adcp/server/idempotency/store.py
+++ b/src/adcp/server/idempotency/store.py
@@ -83,9 +83,13 @@ class IdempotencyStore:
         retry-safe windows (AdCP #2315)::
 
             caps.adcp.idempotency = idempotency.capability()
-            # → {"replay_ttl_seconds": 86400}
+            # → {"supported": True, "replay_ttl_seconds": 86400}
+
+        ``supported`` became REQUIRED in AdCP 3.0 GA — agents emitting only
+        ``replay_ttl_seconds`` fail strict schema validation on the new
+        capabilities response.
         """
-        return {"replay_ttl_seconds": self.ttl_seconds}
+        return {"supported": True, "replay_ttl_seconds": self.ttl_seconds}
 
     def wrap(self, handler: HandlerFn) -> HandlerFn:
         """Decorator that adds idempotency semantics to an AdCP handler method.
@@ -179,9 +183,7 @@ class IdempotencyStore:
 
         return _wrapped
 
-    def _prepare(
-        self, params: Any, context: Any
-    ) -> tuple[str | None, str | None, dict[str, Any]]:
+    def _prepare(self, params: Any, context: Any) -> tuple[str | None, str | None, dict[str, Any]]:
         """Normalize inputs and extract the (principal, key, params_dict) tuple.
 
         Returns ``(None, None, params_dict)`` when idempotency doesn't apply
@@ -239,9 +241,7 @@ def _to_dict(value: Any) -> dict[str, Any]:
         return value.model_dump(mode="json", exclude_none=True)  # type: ignore[no-any-return]
     if hasattr(value, "__dict__"):
         return dict(value.__dict__)
-    raise TypeError(
-        f"Cannot coerce {type(value).__name__} to dict for idempotency caching"
-    )
+    raise TypeError(f"Cannot coerce {type(value).__name__} to dict for idempotency caching")
 
 
 def _extract_principal_id(context: Any) -> str | None:

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -821,10 +821,7 @@ ADCP_TOOL_DEFINITIONS: list[dict[str, Any]] = [
     # V3 Compliance
     {
         "name": "comply_test_controller",
-        "description": (
-            "Compliance test controller. Sandbox only,"
-            " not for production use."
-        ),
+        "description": ("Compliance test controller. Sandbox only," " not for production use."),
         "annotations": _MUT,
         "inputSchema": {
             "type": "object",
@@ -914,16 +911,20 @@ for _handler_name, _tools in _HANDLER_TOOLS.items():
 # Pydantic schema generation — spec-accurate input schemas
 # ============================================================================
 
+
 def _generate_pydantic_schemas() -> dict[str, dict[str, Any]]:
     """Generate JSON schemas from Pydantic request models.
 
     Maps tool names to their corresponding request Pydantic types,
-    then generates JSON Schema via model_json_schema(). This produces
+    then generates JSON Schema via ``model_json_schema()``. This produces
     spec-accurate schemas with proper field types, descriptions,
-    required fields, and nested definitions.
+    required fields, and nested ``$defs``.
 
-    Falls back to hand-crafted schemas for tools without a matching
-    Pydantic request type.
+    The result is applied to ``ADCP_TOOL_DEFINITIONS`` at import time
+    by :func:`_apply_pydantic_schemas`. Any tool whose generation
+    fails (or whose request model has no mapping here) silently keeps
+    its hand-crafted stub; ``tests/test_mcp_schema_drift.py`` guards
+    against that regression by asserting every tool has an entry here.
     """
     try:
         from pydantic import TypeAdapter
@@ -978,6 +979,7 @@ def _generate_pydantic_schemas() -> dict[str, dict[str, Any]]:
             SyncCatalogsRequest,
             SyncCreativesRequest,
             SyncEventSourcesRequest,
+            SyncGovernanceRequest,
             SyncPlansRequest,
             UpdateCollectionListRequest,
             UpdateContentStandardsRequest,
@@ -1018,6 +1020,7 @@ def _generate_pydantic_schemas() -> dict[str, dict[str, Any]]:
         "sync_event_sources": SyncEventSourcesRequest,
         "sync_audiences": SyncAudiencesRequest,
         "sync_catalogs": SyncCatalogsRequest,
+        "sync_governance": SyncGovernanceRequest,
         # Feedback
         "provide_performance_feedback": ProvidePerformanceFeedbackRequest,
         # Protocol Discovery
@@ -1165,9 +1168,7 @@ def create_tool_caller(
 
     method = getattr(handler, method_name)
 
-    async def call_tool(
-        params: dict[str, Any], context: ToolContext | None = None
-    ) -> Any:
+    async def call_tool(params: dict[str, Any], context: ToolContext | None = None) -> Any:
         ctx = context if context is not None else ToolContext()
         result = await method(params, ctx)
         # Convert Pydantic models to JSON-safe dicts for MCP serialization

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -821,7 +821,7 @@ ADCP_TOOL_DEFINITIONS: list[dict[str, Any]] = [
     # V3 Compliance
     {
         "name": "comply_test_controller",
-        "description": ("Compliance test controller. Sandbox only," " not for production use."),
+        "description": "Compliance test controller. Sandbox only, not for production use.",
         "annotations": _MUT,
         "inputSchema": {
             "type": "object",

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -53,8 +53,10 @@ def capabilities_response(
     """Build a get_adcp_capabilities response.
 
     Args:
-        supported_protocols: e.g. ["media_buy"], ["media_buy", "signals"],
-            ["media_buy", "compliance_testing"].
+        supported_protocols: e.g. ["media_buy"], ["media_buy", "signals"].
+            Valid values: media_buy, signals, governance, creative, brand,
+            sponsored_intelligence. ``compliance_testing`` is NOT a protocol —
+            pass it via the ``compliance_testing`` kwarg.
         major_versions: AdCP major versions. Defaults to [3].
         sandbox: Whether this is a sandbox agent. Defaults to True.
         features: Additional feature flags.

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -328,10 +328,38 @@ def list_creatives_response(
 
     Each creative should include: creative_id, name, format_id, status.
     Matches ListCreativesResponse schema.
+
+    Timestamp defaults: every Creative item in the spec requires
+    ``created_date`` and ``updated_date`` (ISO 8601 UTC). For any dict
+    item that omits either field, this helper fills it with the current
+    UTC timestamp (``datetime.now(timezone.utc).isoformat()``). Both
+    fields default to the same value when neither is provided, which
+    matches the intuitive meaning for a freshly-listed item. Explicit
+    caller-provided values are always preserved. Pydantic model items
+    are passed through ``_serialize`` unchanged — callers using typed
+    Creative models should set timestamps on the model.
     """
-    count = len(creatives)
+    now = datetime.now(timezone.utc).isoformat()
+    filled: list[Any] = []
+    for item in creatives:
+        if isinstance(item, dict):
+            has_created = "created_date" in item and item["created_date"] is not None
+            has_updated = "updated_date" in item and item["updated_date"] is not None
+            if has_created and has_updated:
+                filled.append(item)
+                continue
+            patched = dict(item)
+            if not has_created:
+                patched["created_date"] = now
+            if not has_updated:
+                patched["updated_date"] = now
+            filled.append(patched)
+        else:
+            filled.append(item)
+
+    count = len(filled)
     return {
-        "creatives": _serialize(creatives),
+        "creatives": _serialize(filled),
         "pagination": pagination or {"total": count, "has_more": False},
         "query_summary": {"total_results": count, "total_matching": count, "returned": count},
         "sandbox": sandbox,

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -48,6 +48,7 @@ def capabilities_response(
     sandbox: bool = True,
     features: dict[str, Any] | None = None,
     idempotency: dict[str, Any] | None = None,
+    compliance_testing: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a get_adcp_capabilities response.
 
@@ -61,6 +62,9 @@ def capabilities_response(
             ``adcp.idempotency`` per AdCP #2315. Pass the output of
             :meth:`adcp.server.idempotency.IdempotencyStore.capability` here
             to declare the seller's ``replay_ttl_seconds``.
+        compliance_testing: Optional top-level ``compliance_testing`` block
+            to advertise compliance-testing capabilities. When provided,
+            emitted as a sibling of ``adcp`` in the response.
 
     Example::
 
@@ -83,6 +87,8 @@ def capabilities_response(
     }
     if features:
         resp["features"] = features
+    if compliance_testing is not None:
+        resp["compliance_testing"] = compliance_testing
     return resp
 
 
@@ -304,7 +310,7 @@ def sync_creatives_response(
     """Build a sync_creatives success response.
 
     Each creative dict should include: creative_id, action ("created"|"updated").
-    Optionally: status ("accepted"|"pending_review"|"rejected").
+    Optionally: status ("processing"|"pending_review"|"approved"|"rejected"|"archived").
     Matches SyncCreativesResponse1 schema (field: "creatives").
     """
     return {"creatives": creatives, "sandbox": sandbox}

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -34,7 +34,6 @@ def serve(
     *,
     name: str = "adcp-agent",
     port: int | None = None,
-    mount: str = "/mcp",
     transport: str = "streamable-http",
     instructions: str | None = None,
     test_controller: TestControllerStore | None = None,
@@ -51,7 +50,6 @@ def serve(
         handler: An ADCPHandler subclass instance with your tool implementations.
         name: Server name shown to clients / in the A2A agent card.
         port: Port to listen on. Defaults to PORT env var, then 3001.
-        mount: URL path to mount MCP endpoint on (MCP only).
         transport: ``"streamable-http"`` (default, MCP) or ``"a2a"``.
         instructions: Optional system instructions for the agent (MCP only).
         test_controller: Optional TestControllerStore instance for storyboard testing.
@@ -143,9 +141,7 @@ def _serve_a2a(
 
     resolved_port = port or int(os.environ.get("PORT", "3001"))
 
-    app = create_a2a_server(
-        handler, name=name, port=resolved_port, test_controller=test_controller
-    )
+    app = create_a2a_server(handler, name=name, port=resolved_port, test_controller=test_controller)
     uvicorn.run(app, host="0.0.0.0", port=resolved_port)
 
 

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -117,7 +117,13 @@ def _serve_mcp(
     test_controller: TestControllerStore | None,
 ) -> None:
     """Start an MCP server."""
-    mcp = create_mcp_server(handler, name=name, port=port, instructions=instructions)
+    mcp = create_mcp_server(
+        handler,
+        name=name,
+        port=port,
+        instructions=instructions,
+        include_test_controller=test_controller is not None,
+    )
 
     if test_controller is not None:
         from adcp.server.test_controller import register_test_controller
@@ -151,6 +157,7 @@ def create_mcp_server(
     name: str = "adcp-agent",
     port: int | None = None,
     instructions: str | None = None,
+    include_test_controller: bool = False,
 ) -> Any:
     """Create a FastMCP server from an ADCP handler without starting it.
 
@@ -162,6 +169,13 @@ def create_mcp_server(
         name: Server name.
         port: Port to listen on.
         instructions: Optional system instructions.
+        include_test_controller: When False (default), skip registering
+            ``comply_test_controller`` as a handler tool. Sellers who want
+            compliance-testing support should pass ``test_controller=`` to
+            :func:`serve`, which registers a store-backed implementation
+            via :func:`register_test_controller` and sets this flag
+            implicitly. Registering the handler stub unconditionally would
+            advertise a tool the seller didn't opt into.
 
     Returns:
         A configured FastMCP server instance. Call mcp.run() to start.
@@ -174,15 +188,22 @@ def create_mcp_server(
 
     resolved_port = port or int(os.environ.get("PORT", "3001"))
     mcp = FastMCP(name, instructions=instructions, port=resolved_port)
-    _register_handler_tools(mcp, handler)
+    _register_handler_tools(mcp, handler, include_test_controller=include_test_controller)
     return mcp
 
 
-def _register_handler_tools(mcp: Any, handler: ADCPHandler) -> None:
+def _register_handler_tools(
+    mcp: Any, handler: ADCPHandler, *, include_test_controller: bool = False
+) -> None:
     """Register all ADCP tools from a handler onto a FastMCP server."""
     tool_defs = get_tools_for_handler(handler)
     for tool_def in tool_defs:
         tool_name = tool_def["name"]
+        # Gate comply_test_controller on explicit opt-in. The handler base
+        # class has a not-supported stub; registering it as an MCP tool
+        # would advertise compliance-testing the seller didn't declare.
+        if tool_name == "comply_test_controller" and not include_test_controller:
+            continue
         description = tool_def.get("description", "")
         input_schema = tool_def.get("inputSchema", {"type": "object", "properties": {}})
         caller = create_tool_caller(handler, tool_name)

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -107,6 +107,43 @@ def serve(
         raise ValueError(f"Unknown transport {transport!r}. Valid: {valid}")
 
 
+def _bind_reusable_socket(host: str, port: int) -> Any:
+    """Create a listening socket with SO_REUSEADDR set.
+
+    Without ``SO_REUSEADDR``, rapid restarts (common during tests and
+    storyboard runs) hit ``TIME_WAIT`` on the prior socket and the new
+    process hangs on bind for up to 2×MSL (roughly a minute on macOS).
+    Setting ``SO_REUSEADDR`` on the listening socket is the standard,
+    portable fix on Linux and macOS; it is safe because listeners are
+    unique by (addr, port) and the kernel still rejects a second live
+    listener on the same tuple.
+
+    On Windows ``SO_REUSEADDR`` has different semantics (it allows
+    hijacking a live listener). FastMCP's streamable-http and uvicorn
+    support Windows, so we guard with ``SO_EXCLUSIVEADDRUSE`` there —
+    but since the ADCP server primarily targets Linux/macOS and the
+    Windows path is rarely exercised, the guard is best-effort.
+    """
+    import socket
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        if os.name == "nt":
+            # Windows: prevent hijacking; don't set SO_REUSEADDR.
+            exclusive = getattr(socket, "SO_EXCLUSIVEADDRUSE", None)
+            if exclusive is not None:
+                sock.setsockopt(socket.SOL_SOCKET, exclusive, 1)
+        else:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        sock.listen(128)
+        sock.set_inheritable(True)
+    except Exception:
+        sock.close()
+        raise
+    return sock
+
+
 def _serve_mcp(
     handler: ADCPHandler,
     *,
@@ -130,7 +167,45 @@ def _serve_mcp(
 
         register_test_controller(mcp, test_controller)
 
-    mcp.run(transport=transport)
+    if transport in ("streamable-http", "sse"):
+        _run_mcp_http(mcp, transport=transport)
+    else:
+        # stdio — no listening socket, nothing to configure.
+        mcp.run(transport=transport)
+
+
+def _run_mcp_http(mcp: Any, *, transport: str) -> None:
+    """Run FastMCP's HTTP transports with a pre-bound SO_REUSEADDR socket.
+
+    FastMCP builds its own ``uvicorn.Server(config).serve()`` inside
+    ``run_*_async`` and does not expose hooks to pass a pre-bound socket,
+    so we reproduce the minimal setup here and hand uvicorn the socket
+    directly via ``Server.serve([sock])``. This keeps the public surface
+    (``serve()``) unchanged while fixing the readiness-flake on reruns.
+    """
+    import anyio
+    import uvicorn
+
+    host = getattr(mcp.settings, "host", "0.0.0.0")
+    port = int(mcp.settings.port)
+    log_level = getattr(mcp.settings, "log_level", "INFO").lower()
+
+    if transport == "streamable-http":
+        app = mcp.streamable_http_app()
+    else:
+        app = mcp.sse_app()
+
+    sock = _bind_reusable_socket(host, port)
+    try:
+        config = uvicorn.Config(app, log_level=log_level)
+        server = uvicorn.Server(config)
+
+        async def _serve() -> None:
+            await server.serve(sockets=[sock])
+
+        anyio.run(_serve)
+    finally:
+        sock.close()
 
 
 def _serve_a2a(
@@ -148,7 +223,18 @@ def _serve_a2a(
     resolved_port = port or int(os.environ.get("PORT", "3001"))
 
     app = create_a2a_server(handler, name=name, port=resolved_port, test_controller=test_controller)
-    uvicorn.run(app, host="0.0.0.0", port=resolved_port)
+    sock = _bind_reusable_socket("0.0.0.0", resolved_port)
+    try:
+        config = uvicorn.Config(app)
+        server = uvicorn.Server(config)
+        import anyio
+
+        async def _serve() -> None:
+            await server.serve(sockets=[sock])
+
+        anyio.run(_serve)
+    finally:
+        sock.close()
 
 
 def create_mcp_server(

--- a/src/adcp/signing/keygen.py
+++ b/src/adcp/signing/keygen.py
@@ -36,7 +36,12 @@ def _encryption_algorithm(
     return serialization.BestAvailableEncryption(passphrase)
 
 
-def generate_ed25519(kid: str, passphrase: bytes | None = None) -> tuple[bytes, dict[str, Any]]:
+_ADCP_USE_VALUES = ("request-signing", "webhook-signing")
+
+
+def generate_ed25519(
+    kid: str, passphrase: bytes | None = None, adcp_use: str = "request-signing"
+) -> tuple[bytes, dict[str, Any]]:
     private = ed25519.Ed25519PrivateKey.generate()
     pem = private.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -54,14 +59,16 @@ def generate_ed25519(kid: str, passphrase: bytes | None = None) -> tuple[bytes, 
         "alg": "EdDSA",
         "use": "sig",
         "key_ops": ["verify"],
-        "adcp_use": "request-signing",
+        "adcp_use": adcp_use,
         "kid": kid,
         "x": b64url_encode(x),
     }
     return pem, jwk
 
 
-def generate_es256(kid: str, passphrase: bytes | None = None) -> tuple[bytes, dict[str, Any]]:
+def generate_es256(
+    kid: str, passphrase: bytes | None = None, adcp_use: str = "request-signing"
+) -> tuple[bytes, dict[str, Any]]:
     private = ec.generate_private_key(ec.SECP256R1())
     pem = private.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -75,7 +82,7 @@ def generate_es256(kid: str, passphrase: bytes | None = None) -> tuple[bytes, di
         "alg": "ES256",
         "use": "sig",
         "key_ops": ["verify"],
-        "adcp_use": "request-signing",
+        "adcp_use": adcp_use,
         "kid": kid,
         "x": b64url_encode(numbers.x.to_bytes(32, "big")),
         "y": b64url_encode(numbers.y.to_bytes(32, "big")),
@@ -134,6 +141,17 @@ def main(argv: list[str] | None = None) -> int:
             "default unencrypted PKCS8 (protected by mode 0600) is usually what you want."
         ),
     )
+    parser.add_argument(
+        "--purpose",
+        choices=list(_ADCP_USE_VALUES),
+        default="request-signing",
+        help=(
+            "Which AdCP signing profile this key is for (sets the JWK `adcp_use` "
+            "claim). `request-signing` for outbound tool calls; `webhook-signing` "
+            "for keys a sender uses to sign outbound webhooks to buyers. Verifiers "
+            "enforce the claim, so mixing the two silently fails at first delivery."
+        ),
+    )
     args = parser.parse_args(argv)
 
     out_path = Path(args.out)
@@ -148,10 +166,10 @@ def main(argv: list[str] | None = None) -> int:
 
     kid = args.kid or f"adcp-{args.alg}-{datetime.now(timezone.utc).strftime('%Y%m%d')}"
     if args.alg == "ed25519":
-        pem, jwk = generate_ed25519(kid, passphrase=passphrase)
+        pem, jwk = generate_ed25519(kid, passphrase=passphrase, adcp_use=args.purpose)
         alg_rfc = ALG_ED25519
     else:
-        pem, jwk = generate_es256(kid, passphrase=passphrase)
+        pem, jwk = generate_es256(kid, passphrase=passphrase, adcp_use=args.purpose)
         alg_rfc = ALG_ES256
 
     # `--force` clobbers in two steps (non-atomic on overwrite), but the

--- a/src/adcp/signing/webhook_hmac.py
+++ b/src/adcp/signing/webhook_hmac.py
@@ -11,10 +11,12 @@ Wire format, matching :func:`adcp.webhooks.get_adcp_signed_headers_for_webhook`:
   f"{timestamp}.{raw_body_bytes.decode()}")``
 * ``X-AdCP-Timestamp`` — Unix epoch seconds, string
 
-The sender serializes the payload via ``json.dumps(payload_dict)`` with default
-separators, so receivers MUST verify against the raw request body bytes, not
-a re-serialized copy — JSON round-trips through a dict reorder keys and break
-the signature. Always call with ``request.body()`` / ``request.get_data()``.
+The sender serializes the payload with compact separators (``","``/``":"``)
+to match what httpx / most HTTP clients put on the wire for ``json=payload``
+(pinned in adcontextprotocol/adcp#2478). Receivers MUST verify against the
+raw request body bytes, not a re-serialized copy — JSON round-trips through
+a dict reorder keys and break the signature. Always call with
+``request.body()`` / ``request.get_data()``.
 
 **Security note — no nonce-based replay cache.** The legacy HMAC scheme binds
 only the timestamp into the signed message; unlike the 9421 profile, it has

--- a/src/adcp/signing/webhook_signer.py
+++ b/src/adcp/signing/webhook_signer.py
@@ -45,6 +45,11 @@ def sign_webhook(
     The ``method`` is normally ``"POST"`` for webhook delivery; passed through
     unchanged so callers signing a retried ``PUT`` or variant delivery verb
     are not forced into an extra translation.
+
+    See also:
+        :class:`adcp.webhooks.WebhookSender` — higher-level one-call helper
+        that builds the payload, signs, and POSTs in a single call. Prefer it
+        unless you need to own the HTTP transport yourself.
     """
     return sign_request(
         method=method,

--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -336,6 +336,8 @@ from adcp.types._generated import (
     SyncCreativesResponse,
     SyncEventSourcesRequest,
     SyncEventSourcesResponse,
+    SyncGovernanceRequest,
+    SyncGovernanceResponse,
     SyncPlansRequest,
     SyncPlansResponse,
     Tags,
@@ -585,8 +587,7 @@ class MediaSubAsset:
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         raise TypeError(
-            "MediaSubAsset was removed from the ADCP schema. "
-            "There is no direct replacement."
+            "MediaSubAsset was removed from the ADCP schema. " "There is no direct replacement."
         )
 
 
@@ -595,8 +596,7 @@ class TextSubAsset:
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         raise TypeError(
-            "TextSubAsset was removed from the ADCP schema. "
-            "There is no direct replacement."
+            "TextSubAsset was removed from the ADCP schema. " "There is no direct replacement."
         )
 
 
@@ -690,6 +690,8 @@ __all__ = [
     "LogEventResponse",
     "SyncEventSourcesRequest",
     "SyncEventSourcesResponse",
+    "SyncGovernanceRequest",
+    "SyncGovernanceResponse",
     "Totals",
     "UpdateMediaBuyRequest",
     "UpdateMediaBuyResponse",

--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -732,6 +732,8 @@ __all__ = [
     "GetPlanAuditLogsResponse",
     "ReportPlanOutcomeRequest",
     "ReportPlanOutcomeResponse",
+    "SyncGovernanceRequest",
+    "SyncGovernanceResponse",
     "SyncPlansRequest",
     "SyncPlansResponse",
     # Forecasting types

--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -690,8 +690,6 @@ __all__ = [
     "LogEventResponse",
     "SyncEventSourcesRequest",
     "SyncEventSourcesResponse",
-    "SyncGovernanceRequest",
-    "SyncGovernanceResponse",
     "Totals",
     "UpdateMediaBuyRequest",
     "UpdateMediaBuyResponse",

--- a/src/adcp/webhook_receiver.py
+++ b/src/adcp/webhook_receiver.py
@@ -49,6 +49,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -295,6 +296,45 @@ class WebhookReceiver:
             payload=parsed,
             duplicate=not is_first_seen,
             idempotency_key=idempotency_key,
+        )
+
+    def receive_sync(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes,
+    ) -> WebhookOutcome:
+        """Synchronous wrapper around :meth:`receive` for WSGI-style frameworks.
+
+        Use this from Flask, Gunicorn sync workers, ``http.server``, or any
+        other sync-only HTTP entry point where wrapping every call in
+        ``asyncio.run(...)`` is just noise::
+
+            @app.post("/webhooks/adcp")
+            def hook():
+                outcome = receiver.receive_sync(
+                    method=request.method,
+                    url=request.url,
+                    headers=dict(request.headers),
+                    body=request.get_data(),
+                )
+                ...
+
+        Raises :class:`RuntimeError` if invoked from a thread that already has
+        a running event loop — the underlying verify / dedup path is async and
+        cannot be driven from inside an active loop without blocking it. From
+        async code, call :meth:`receive` directly.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop in this thread — safe to spin one up.
+            return asyncio.run(self.receive(method=method, url=url, headers=headers, body=body))
+        raise RuntimeError(
+            "WebhookReceiver.receive_sync() cannot be called from a running "
+            "event loop. Use `await receiver.receive(...)` instead."
         )
 
     async def _verify(

--- a/src/adcp/webhook_sender.py
+++ b/src/adcp/webhook_sender.py
@@ -31,11 +31,19 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import httpx
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519
 
-from adcp.signing.crypto import PrivateKey, private_key_from_jwk
+from adcp.signing.crypto import (
+    ALG_ED25519,
+    ALG_ES256,
+    PrivateKey,
+    load_private_key_pem,
+    private_key_from_jwk,
+)
 from adcp.signing.webhook_signer import sign_webhook
 from adcp.types import GeneratedTaskStatus
 from adcp.types.generated_poc.core.async_response_data import AdcpAsyncResponseData
@@ -152,6 +160,82 @@ class WebhookSender:
         return cls(
             private_key=private_key,
             key_id=str(jwk_snapshot["kid"]),
+            alg=alg,
+            client=client,
+            timeout_seconds=timeout_seconds,
+        )
+
+    @classmethod
+    def from_pem(
+        cls,
+        pem_path: str | Path | bytes,
+        *,
+        key_id: str,
+        alg: str = "ed25519",
+        passphrase: bytes | None = None,
+        client: httpx.AsyncClient | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> WebhookSender:
+        """Load a private key from a PEM file and bind it as a webhook sender.
+
+        Companion to ``adcp-keygen --purpose webhook-signing``, which writes
+        the PEM and prints the public JWK. The JWK is published at your
+        ``jwks_uri``; the PEM holds the private key material. ``from_pem``
+        reads the PEM, constructs the right ``PrivateKey`` type for ``alg``,
+        and returns a sender ready to send.
+
+        Args:
+            pem_path: Path to the PKCS#8 PEM, or the PEM bytes directly.
+            key_id: JWK ``kid`` claim — must match the published JWK.
+            alg: Signature algorithm. ``ed25519`` (default) or ``es256``.
+                Also accepts the RFC 9421 form ``ecdsa-p256-sha256``.
+            passphrase: Required if the PEM is encrypted
+                (``adcp-keygen --encrypt``).
+            client: Optional pre-built :class:`httpx.AsyncClient` to share
+                across the SDK; the sender owns its own client when omitted.
+            timeout_seconds: Per-request timeout for the owned client.
+
+        Raises:
+            ValueError: ``alg`` is not ed25519 / es256, or the PEM contains
+                a key whose type doesn't match ``alg``.
+        """
+        if alg in ("es256", "ES256"):
+            alg = ALG_ES256
+        elif alg == "EdDSA":
+            alg = ALG_ED25519
+        if alg not in (ALG_ED25519, ALG_ES256):
+            raise ValueError(
+                f"unsupported alg {alg!r} — use 'ed25519' or 'es256' "
+                f"(the two AdCP webhook-signing algorithms)"
+            )
+
+        if isinstance(pem_path, bytes):
+            pem_bytes = pem_path
+        else:
+            pem_bytes = Path(pem_path).read_bytes()
+
+        private_key = load_private_key_pem(pem_bytes, password=passphrase)
+
+        # The PEM's key type must match the requested alg — mixing them
+        # would produce signatures no verifier can validate, and the
+        # resulting error at delivery time would point at the receiver.
+        # Fail here so the misconfiguration surfaces at construction.
+        if alg == ALG_ED25519 and not isinstance(private_key, ed25519.Ed25519PrivateKey):
+            raise ValueError(
+                f"PEM holds a {type(private_key).__name__} but alg='ed25519' "
+                f"was requested. Re-run adcp-keygen with --alg ed25519, or "
+                f"pass alg='es256' to match the existing PEM."
+            )
+        if alg == ALG_ES256 and not isinstance(private_key, ec.EllipticCurvePrivateKey):
+            raise ValueError(
+                f"PEM holds a {type(private_key).__name__} but alg='es256' "
+                f"was requested. Re-run adcp-keygen with --alg es256, or "
+                f"pass alg='ed25519' to match the existing PEM."
+            )
+
+        return cls(
+            private_key=private_key,
+            key_id=key_id,
             alg=alg,
             client=client,
             timeout_seconds=timeout_seconds,

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -194,6 +194,13 @@ def get_adcp_signed_headers_for_webhook(
     - X-AdCP-Signature: HMAC-SHA256 signature in format "sha256=<hex_digest>"
     - X-AdCP-Timestamp: Unix timestamp in seconds
 
+    See also:
+        :func:`sign_legacy_webhook` — recommended companion that returns
+        ``(headers, body_bytes)`` so callers POST ``content=body_bytes`` and
+        can't accidentally reserialize the payload between signing and
+        transmission. Prefer ``sign_legacy_webhook`` unless you already own
+        the serialization step and need headers only.
+
     The signing algorithm:
     1. Constructs message as "{timestamp}.{json_payload}"
     2. JSON-serializes payload with compact separators (matches the wire
@@ -246,7 +253,28 @@ def get_adcp_signed_headers_for_webhook(
             "X-AdCP-Timestamp": "1773185740"
         }
     """
-    # Default to current Unix time if not provided
+    signature_headers, _body = _compute_legacy_signature(
+        secret=secret,
+        timestamp=timestamp,
+        payload=payload,
+    )
+    headers.update(signature_headers)
+    return headers
+
+
+def _compute_legacy_signature(
+    *,
+    secret: str,
+    timestamp: str | int | None,
+    payload: dict[str, Any] | AdCPBaseModel,
+) -> tuple[dict[str, str], bytes]:
+    """Shared HMAC-SHA256 signing core for the legacy webhook surface.
+
+    Returns the two signature headers and the compact-separator body bytes
+    that were fed into the HMAC. Callers that POST must transmit exactly
+    these bytes (via ``content=body_bytes``, not ``json=payload``) — that's
+    the whole point of exposing the bytes alongside the headers.
+    """
     if timestamp is None:
         import time
 
@@ -268,21 +296,95 @@ def get_adcp_signed_headers_for_webhook(
     # and posted via `client.post(url, json=payload, headers=signed)`.
     # Pinned canonical form per adcontextprotocol/adcp#2478.
     payload_json = json.dumps(payload_dict, separators=(",", ":"))
+    body_bytes = payload_json.encode("utf-8")
 
     # Construct signed message: timestamp.payload
-    # Including timestamp prevents replay attacks
+    # Including timestamp prevents replay attacks.
     signed_message = f"{timestamp}.{payload_json}"
 
-    # Generate HMAC-SHA256 signature over timestamp + payload
     signature_hex = hmac.new(
         secret.encode("utf-8"), signed_message.encode("utf-8"), hashlib.sha256
     ).hexdigest()
 
-    # Add AdCP-compliant signature headers
-    headers["X-AdCP-Signature"] = f"sha256={signature_hex}"
-    headers["X-AdCP-Timestamp"] = timestamp
+    return (
+        {
+            "X-AdCP-Signature": f"sha256={signature_hex}",
+            "X-AdCP-Timestamp": timestamp,
+        },
+        body_bytes,
+    )
 
-    return headers
+
+def sign_legacy_webhook(
+    secret: str,
+    payload: dict[str, Any] | AdCPBaseModel,
+    *,
+    timestamp: str | int | None = None,
+    headers: dict[str, Any] | None = None,
+) -> tuple[dict[str, str], bytes]:
+    """Return ``(signed_headers, body_bytes)`` for a legacy HMAC webhook.
+
+    Byte-equality between signature input and HTTP body is guaranteed —
+    callers POST ``content=body_bytes`` instead of ``json=payload``, so
+    the separator-drift trap that caused silent 401s in every
+    spaced-vs-compact interop is structurally impossible here. This is
+    the 4.x-lifetime replacement for
+    :func:`get_adcp_signed_headers_for_webhook`.
+
+    The returned ``body_bytes`` are produced with compact separators
+    (``","``/``":"``) — matching the canonical on-wire form pinned by
+    adcontextprotocol/adcp#2478.
+
+    Args:
+        secret: Shared HMAC secret, as agreed with the receiver.
+        payload: Webhook payload (dict or Pydantic model). Will be
+            JSON-serialized with compact separators.
+        timestamp: Unix timestamp (string or int). Defaults to current time.
+            Pin a value in tests for determinism.
+        headers: Optional existing headers dict. If provided, the signed
+            headers are merged into it and the merged dict is returned.
+            The caller still must POST ``content=body_bytes``.
+
+    Returns:
+        ``(signed_headers, body_bytes)``. Hand the headers to
+        :meth:`httpx.AsyncClient.post` and the bytes to its ``content=``
+        kwarg — NOT ``json=payload``, which would reserialize and break
+        the signature.
+
+    See also:
+        :func:`get_adcp_signed_headers_for_webhook` — the lower-level
+        headers-only helper. Still useful when the caller owns the
+        serialization step (for example, a framework that emits bytes
+        from a middleware layer).
+
+    Example:
+        >>> import httpx
+        >>> from adcp.webhooks import create_mcp_webhook_payload, sign_legacy_webhook
+        >>>
+        >>> payload = create_mcp_webhook_payload(
+        ...     task_id="task_123",
+        ...     task_type="create_media_buy",
+        ...     status="completed",
+        ...     result={"media_buy_id": "mb_1"},
+        ... )
+        >>> signed_headers, body = sign_legacy_webhook("shared-secret", payload)
+        >>> async with httpx.AsyncClient() as client:
+        ...     response = await client.post(
+        ...         "https://buyer.example.com/webhooks/adcp",
+        ...         content=body,
+        ...         headers={"Content-Type": "application/json", **signed_headers},
+        ...     )
+    """
+    signature_headers, body_bytes = _compute_legacy_signature(
+        secret=secret,
+        timestamp=timestamp,
+        payload=payload,
+    )
+    if headers is not None:
+        merged = {str(k): str(v) for k, v in headers.items()}
+        merged.update(signature_headers)
+        return merged, body_bytes
+    return signature_headers, body_bytes
 
 
 def extract_webhook_result_data(webhook_payload: dict[str, Any]) -> AdcpAsyncResponseData | None:
@@ -583,6 +685,7 @@ __all__ = [
     "create_mcp_webhook_payload",
     "generate_webhook_idempotency_key",
     "get_adcp_signed_headers_for_webhook",
+    "sign_legacy_webhook",
     # Sender — 9421 signing (low-level)
     "sign_webhook",
     # Sender — one-call outbound helper

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -109,8 +109,10 @@ def create_mcp_webhook_payload(
         task_type: Optionally type of AdCP operation (e.g., "get_products", "create_media_buy")
         timestamp: When the webhook was generated (defaults to current UTC time)
         result: Task-specific payload (AdCP response data)
-        operation_id: Publisher-defined operation identifier (deprecated from payload,
-            should be in URL routing, but included for backward compatibility)
+        operation_id: Publisher-defined operation identifier. The AdCP spec
+            recommends carrying this in URL routing rather than the payload
+            body, but the SDK emits it into the payload when provided for
+            compatibility with receivers that still read it there.
         message: Human-readable summary of task state
         context_id: Session/conversation identifier
         domain: AdCP domain this task belongs to
@@ -274,9 +276,12 @@ def get_adcp_signed_headers_for_webhook(
     else:
         payload_dict = payload
 
-    # Serialize payload to JSON with default formatting (matches what json= kwarg sends on the wire)
-    # This aligns with the JS reference implementation's JSON.stringify() behavior
-    payload_json = json.dumps(payload_dict)
+    # Serialize payload with compact separators to match the wire bytes httpx
+    # (and most HTTP clients) produce for `json=payload`. Default json.dumps
+    # output has ", " / ": " separators, which diverges from httpx's compact
+    # form and caused silent 401s when sellers signed with default separators
+    # and posted via `client.post(url, json=payload, headers=signed)`.
+    payload_json = json.dumps(payload_dict, separators=(",", ":"))
 
     # Construct signed message: timestamp.payload
     # Including timestamp prevents replay attacks

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -28,6 +28,8 @@ from a2a.types import (
     TaskStatusUpdateEvent,
 )
 
+from adcp.server.idempotency.backends import MemoryBackend as MemoryBackend
+from adcp.server.idempotency.webhook_dedup import WebhookDedupStore as WebhookDedupStore
 from adcp.signing.webhook_hmac import (
     LegacyWebhookHmacError,
     LegacyWebhookHmacOptions,
@@ -603,6 +605,9 @@ __all__ = [
     "WebhookPayload",
     "WebhookReceiver",
     "WebhookReceiverConfig",
+    # Receiver — dedup store (required by WebhookReceiverConfig)
+    "MemoryBackend",
+    "WebhookDedupStore",
     # Receiver — payload extraction (legacy helper)
     "extract_webhook_result_data",
 ]

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -1,22 +1,10 @@
 """Webhook creation, signing, and reception for AdCP agents.
 
-Single front door for both senders and receivers. Underlying modules in
+Single front door for both senders (``create_mcp_webhook_payload``,
+``sign_webhook``) and receivers (``WebhookReceiver``). Underlying modules in
 ``adcp.signing.webhook_*`` and ``adcp.webhook_receiver`` are implementation
 details kept for internal organization — prefer the re-exports here for
 stability.
-
-**Which sender helper to use**
-
-* :func:`deliver` — one-shot dispatch for legacy ``authentication`` (Bearer
-  or HMAC-SHA256). Collapses the sender's 6-step boilerplate into one call
-  and signs the exact bytes it POSTs. Deprecated with AdCP 4.0; emits a
-  :class:`DeprecationWarning`.
-* :class:`WebhookSender` — the AdCP 4.0 default. RFC 9421 signing, shared
-  connection pool, byte-identical replay via :meth:`WebhookSender.resend`.
-  Use this for any new integration.
-* :func:`create_mcp_webhook_payload` / :func:`create_a2a_webhook_payload`
-  plus :func:`get_adcp_signed_headers_for_webhook` — low-level path for
-  callers who need full control over serialization, headers, or retry logic.
 """
 
 from __future__ import annotations
@@ -24,15 +12,10 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import time
 import uuid
-import warnings
-from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any, cast
-from urllib.parse import urlsplit
 
-import httpx
 from a2a.types import (
     Artifact,
     DataPart,
@@ -109,10 +92,8 @@ def create_mcp_webhook_payload(
         task_type: Optionally type of AdCP operation (e.g., "get_products", "create_media_buy")
         timestamp: When the webhook was generated (defaults to current UTC time)
         result: Task-specific payload (AdCP response data)
-        operation_id: Publisher-defined operation identifier. The AdCP spec
-            recommends carrying this in URL routing rather than the payload
-            body, but the SDK emits it into the payload when provided for
-            compatibility with receivers that still read it there.
+        operation_id: Publisher-defined operation identifier (deprecated from payload,
+            should be in URL routing, but included for backward compatibility)
         message: Human-readable summary of task state
         context_id: Session/conversation identifier
         domain: AdCP domain this task belongs to
@@ -213,7 +194,9 @@ def get_adcp_signed_headers_for_webhook(
 
     The signing algorithm:
     1. Constructs message as "{timestamp}.{json_payload}"
-    2. JSON-serializes payload with default separators (matches wire format from json= kwarg)
+    2. JSON-serializes payload with compact separators (matches the wire
+       bytes httpx and most HTTP clients write for `json=payload`, per
+       adcontextprotocol/adcp#2478)
     3. UTF-8 encodes the message
     4. HMAC-SHA256 signs with the shared secret
     5. Hex-encodes and prefixes with "sha256="
@@ -281,6 +264,7 @@ def get_adcp_signed_headers_for_webhook(
     # output has ", " / ": " separators, which diverges from httpx's compact
     # form and caused silent 401s when sellers signed with default separators
     # and posted via `client.post(url, json=payload, headers=signed)`.
+    # Pinned canonical form per adcontextprotocol/adcp#2478.
     payload_json = json.dumps(payload_dict, separators=(",", ":"))
 
     # Construct signed message: timestamp.payload
@@ -581,388 +565,6 @@ def create_a2a_webhook_payload(
         )
 
 
-_AUTH_DEPRECATION_WARNED = False
-_RESERVED_HEADERS = frozenset(
-    {
-        "authorization",
-        "content-digest",
-        "content-length",
-        "content-type",
-        "host",
-        "signature",
-        "signature-input",
-        "x-adcp-signature",
-        "x-adcp-timestamp",
-    }
-)
-_HEADER_FORBIDDEN_CHARS = ("\r", "\n", "\x00")
-_MAX_HEADER_VALUE_BYTES = 8192
-_DEFAULT_TIMEOUT_SECONDS = 10.0
-# 10MB cap matches typical buyer-side reverse-proxy limits and is ~100×
-# the realistic AdCP payload (biggest seen: get_products with long product
-# lists, rarely over 100KB). Serialized bytes, not dict size — post-
-# serialization check avoids a pre-cap on dict size being meaningless.
-_MAX_BODY_BYTES = 10 * 1024 * 1024
-# Cap extra_headers count so a caller that iterates a large container
-# into the kwarg can't produce an unbounded header block.
-_MAX_EXTRA_HEADERS = 64
-
-
-def _warn_auth_deprecation_once() -> None:
-    global _AUTH_DEPRECATION_WARNED
-    if _AUTH_DEPRECATION_WARNED:
-        return
-    _AUTH_DEPRECATION_WARNED = True
-    warnings.warn(
-        "PushNotificationConfig.authentication (Bearer, HMAC-SHA256) is "
-        "deprecated in AdCP 4.0. Migrate senders to adcp.webhooks.WebhookSender "
-        "(RFC 9421 signing) and receivers to the 9421 webhook profile. This "
-        "warning fires once per process.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
-async def deliver(
-    config: AdCPBaseModel | Mapping[str, Any],
-    payload: AdCPBaseModel | Task | TaskStatusUpdateEvent | Mapping[str, Any],
-    *,
-    client: httpx.AsyncClient | None = None,
-    extra_headers: Mapping[str, str] | None = None,
-    timeout_seconds: float | None = None,
-    token_field: str | None = None,
-) -> httpx.Response:
-    """Dispatch one legacy-auth webhook in a single call.
-
-    Collapses the sender's six-step boilerplate (build envelope, serialize,
-    sign, merge headers, POST, echo token) into one call so the signer and
-    the wire see the *same bytes*. The serialization-format drift that
-    plagued the hand-rolled path — ``json=`` in httpx re-serializes the dict
-    and breaks ``Content-Digest`` — is structurally impossible here: the
-    helper JSON-serializes once, signs those bytes, and POSTs those bytes
-    via ``content=``.
-
-    This helper is for the **legacy** AdCP 3.x authentication schemes
-    (``Bearer`` / ``HMAC-SHA256``) and emits a :class:`DeprecationWarning`
-    on first use. For 4.0+ integrations use :class:`WebhookSender` (RFC 9421).
-
-    Args:
-        config: A :class:`PushNotificationConfig`, :class:`ReportingWebhook`,
-            or equivalent dict. Must carry ``url`` (``https://`` only) and
-            ``authentication.{schemes, credentials}``.
-        payload: The webhook body. Accepts a Pydantic model (e.g. built via
-            :func:`create_mcp_webhook_payload` / :func:`create_a2a_webhook_payload`),
-            an a2a ``Task`` / ``TaskStatusUpdateEvent``, or a plain dict.
-            Models are dumped with ``mode="json", exclude_none=True``.
-        client: Optional shared ``httpx.AsyncClient``. Recommended in
-            production for connection pooling and egress-policy enforcement
-            (a custom ``httpx.BaseTransport`` is the right place to block
-            SSRF to private IPs — the helper validates scheme but cannot
-            see post-DNS resolution without racing TOCTOU).
-        extra_headers: Merged last. May not override any of
-            ``Content-Type``, ``Content-Digest``, ``Content-Length``,
-            ``Host``, ``Authorization``, ``Signature``, ``Signature-Input``,
-            ``X-AdCP-Signature``, or ``X-AdCP-Timestamp``. Auth and
-            signature-binding headers are sender-owned so the signer and
-            the wire cannot disagree.
-        timeout_seconds: Per-request timeout applied only when the helper
-            creates its own client. Raises ``ValueError`` if set alongside
-            ``client=`` — configure the timeout on the shared client instead.
-        token_field: Opt-in field name for echoing ``config.token`` into
-            the payload body (top-level for MCP dicts, under ``metadata``
-            for ``Task`` / ``TaskStatusUpdateEvent``). Default ``None``
-            disables echo; there is no spec-defined field name, so the
-            caller must pick one the receiver agrees to read.
-
-    Returns:
-        The raw ``httpx.Response``. Caller is responsible for
-        ``response.status_code`` inspection and retry scheduling. For retry,
-        pass the *same, unmutated* payload again — serialization is
-        deterministic so retries produce byte-identical bodies (spec-correct
-        receiver dedup via ``idempotency_key``). Mutating the payload dict
-        between attempts breaks byte-identity; callers who need byte-identical
-        HTTP envelopes across retries (including headers) should use
-        :class:`WebhookSender` and :meth:`WebhookSender.resend`. There is
-        intentionally no ``resend()`` here — the retry contract is "call
-        ``deliver`` again with the same inputs".
-
-    Raises:
-        ValueError: missing ``url``, non-HTTPS URL, control characters in
-            header values, missing / unknown ``authentication`` (use
-            :class:`WebhookSender` for RFC 9421), overriding a reserved
-            header, or setting ``timeout_seconds`` alongside ``client``.
-        DeprecationWarning (fires once): ``authentication`` is a 3.x fallback.
-
-    Security notes:
-        * ``config.url`` is buyer-controlled. The helper enforces HTTPS and
-          rejects control characters but does NOT block private / link-local
-          destinations — wire an egress policy via ``client.transport`` to
-          stop SSRF into your VPC or cloud metadata service.
-        * ``config.token`` sits in the request body, so any receiver that
-          logs bodies retains it indefinitely. Treat the token as a
-          medium-sensitivity correlator, not a long-lived secret.
-        * At ``httpx`` DEBUG log level, ``Authorization`` and
-          ``X-AdCP-Signature`` appear in logs — gate DEBUG in production.
-    """
-    if client is not None and timeout_seconds is not None:
-        raise ValueError(
-            "timeout_seconds cannot be set when client= is provided; "
-            "configure the timeout on your shared httpx.AsyncClient instead."
-        )
-
-    url, token, auth_scheme, credentials = _extract_config_fields(config)
-
-    if auth_scheme is None:
-        raise ValueError(
-            "config.authentication is required for deliver(). "
-            "For RFC 9421 signing (the AdCP 4.0 default), use "
-            "adcp.webhooks.WebhookSender — no helper for unsigned webhooks "
-            "is provided because the spec requires signing."
-        )
-    if auth_scheme not in ("Bearer", "HMAC-SHA256"):
-        raise ValueError(
-            f"unknown authentication scheme {auth_scheme!r}; "
-            "supported legacy schemes are 'Bearer' and 'HMAC-SHA256'. "
-            "For RFC 9421 use adcp.webhooks.WebhookSender."
-        )
-
-    _warn_auth_deprecation_once()
-
-    body_dict = _payload_to_dict(payload)
-    if token is not None and token_field is not None:
-        _validate_header_value("config.token", token)
-        _inject_push_token(body_dict, token, payload, token_field)
-
-    body_bytes = json.dumps(body_dict).encode("utf-8")
-    if len(body_bytes) > _MAX_BODY_BYTES:
-        raise ValueError(
-            f"serialized webhook body is {len(body_bytes):,} bytes, over the "
-            f"{_MAX_BODY_BYTES:,}-byte cap. Split into smaller webhooks or use "
-            "the batch-reporting endpoints — most receivers reject bodies over "
-            "10MB at the reverse proxy anyway."
-        )
-
-    headers: dict[str, str] = {"Content-Type": "application/json"}
-
-    if auth_scheme == "Bearer":
-        if not credentials:
-            raise ValueError(
-                "config.authentication.schemes=['Bearer'] requires "
-                "authentication.credentials (min 32 characters — token "
-                "exchanged out-of-band with the receiver)."
-            )
-        _validate_header_value("authentication.credentials", credentials)
-        headers["Authorization"] = f"Bearer {credentials}"
-    else:  # HMAC-SHA256
-        if not credentials:
-            raise ValueError(
-                "config.authentication.schemes=['HMAC-SHA256'] requires "
-                "authentication.credentials (min 32 characters — shared "
-                "secret exchanged out-of-band with the receiver)."
-            )
-        _validate_header_value("authentication.credentials", credentials)
-        get_adcp_signed_headers_for_webhook(
-            headers,
-            secret=credentials,
-            timestamp=str(int(time.time())),
-            payload=body_dict,
-        )
-
-    if extra_headers:
-        if len(extra_headers) > _MAX_EXTRA_HEADERS:
-            raise ValueError(
-                f"extra_headers has {len(extra_headers)} entries; "
-                f"helper caps at {_MAX_EXTRA_HEADERS}. Pass only the custom "
-                "headers you actually need (trace IDs, correlation IDs)."
-            )
-        for key in extra_headers:
-            normalized = str(key).lower()
-            if normalized in _RESERVED_HEADERS or normalized.startswith(":"):
-                raise ValueError(_reserved_header_message(normalized, key))
-        for key, value in extra_headers.items():
-            _validate_header_value(f"extra_headers[{key!r}]", value)
-            headers[key] = value
-
-    owns_client = client is None
-    effective_timeout = timeout_seconds if timeout_seconds is not None else _DEFAULT_TIMEOUT_SECONDS
-    http_client = client or httpx.AsyncClient(timeout=effective_timeout)
-    try:
-        return await http_client.post(url, content=body_bytes, headers=headers)
-    finally:
-        if owns_client:
-            await http_client.aclose()
-
-
-def _extract_config_fields(
-    config: AdCPBaseModel | Mapping[str, Any],
-) -> tuple[str, str | None, str | None, str | None]:
-    """Pull ``url``, ``token``, auth scheme, and credentials out of a webhook config.
-
-    Accepts either a ``PushNotificationConfig`` / ``ReportingWebhook`` model
-    or an equivalent dict — sellers often receive these as plain dicts from
-    an incoming AdCP request and shouldn't have to round-trip through the
-    Pydantic model just to dispatch a webhook.
-
-    Validates the URL at the boundary: HTTPS only, no control characters.
-    """
-    if hasattr(config, "model_dump"):
-        cfg = cast(AdCPBaseModel, config).model_dump(mode="json", exclude_none=True)
-    else:
-        cfg = dict(config)
-
-    url_value = cfg.get("url")
-    if not url_value:
-        raise ValueError(
-            "webhook config is missing required 'url' field. Pass a "
-            "PushNotificationConfig, ReportingWebhook, or dict with an "
-            "https:// 'url'."
-        )
-    url = str(url_value)
-    if any(c in url for c in _HEADER_FORBIDDEN_CHARS):
-        raise ValueError(
-            "webhook config 'url' contains control characters "
-            "(newline, carriage return, or NUL are not allowed in URLs)"
-        )
-    lower = url.lower()
-    if not lower.startswith("https://"):
-        scheme_end = lower.find("://")
-        shown_scheme = lower[:scheme_end] if scheme_end >= 0 else "<no scheme>"
-        raise ValueError(
-            f"webhook config 'url' must use https:// (got scheme {shown_scheme!r}). "
-            "HTTP and other schemes are rejected because they expose the "
-            "webhook body, token, and Authorization header in transit."
-        )
-    parsed = urlsplit(url)
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError(
-            "webhook config 'url' must not embed userinfo (user:pass@host). "
-            "Pass credentials via config.authentication.credentials instead — "
-            "URLs get logged by proxies, load balancers, and httpx DEBUG."
-        )
-
-    token = cfg.get("token")
-
-    auth_raw = cfg.get("authentication")
-    if auth_raw is not None and not isinstance(auth_raw, Mapping):
-        raise ValueError(
-            f"config.authentication must be an object with 'schemes' + "
-            f"'credentials', got {type(auth_raw).__name__}"
-        )
-    auth: Mapping[str, Any] = auth_raw or {}
-    schemes_raw = auth.get("schemes")
-    if schemes_raw is not None and not isinstance(schemes_raw, (list, tuple)):
-        raise ValueError(
-            "config.authentication.schemes must be a list, got " f"{type(schemes_raw).__name__}"
-        )
-    schemes = list(schemes_raw or [])
-    if len(schemes) > 1:
-        raise ValueError(
-            f"config.authentication.schemes has {len(schemes)} entries; "
-            "the AdCP legacy auth schema allows exactly one scheme per config."
-        )
-    scheme = schemes[0] if schemes else None
-    credentials = auth.get("credentials")
-
-    return url, token, scheme, credentials
-
-
-def _reserved_header_message(normalized: str, original_key: Any) -> str:
-    """Build a fix-the-error message tailored to the reserved header class.
-
-    The mistake category differs sharply by header: a caller passing
-    ``Authorization`` usually doesn't know about ``config.authentication``;
-    a caller passing ``Content-Type`` is probably debugging and reached for
-    the override by reflex. Give each the right nudge."""
-    if normalized == "authorization":
-        return (
-            f"extra_headers may not override {original_key!r} — set "
-            "config.authentication.schemes=['Bearer'] + credentials instead. "
-            "The helper derives Authorization from config so the signer and "
-            "the wire cannot disagree."
-        )
-    if normalized in ("signature", "signature-input", "content-digest"):
-        return (
-            f"extra_headers may not override {original_key!r} — RFC 9421 "
-            "signing headers are produced by adcp.webhooks.WebhookSender, "
-            "not injected. Switch helpers if you need 9421."
-        )
-    if normalized in ("x-adcp-signature", "x-adcp-timestamp"):
-        return (
-            f"extra_headers may not override {original_key!r} — these are "
-            "the HMAC-SHA256 signature headers the helper produces from "
-            "config.authentication.credentials."
-        )
-    if normalized == "content-type":
-        return (
-            f"extra_headers may not override {original_key!r}; "
-            "the helper always sends 'application/json'."
-        )
-    return (
-        f"extra_headers may not override {original_key!r}; "
-        "this header is sender-owned and managed by the helper."
-    )
-
-
-def _payload_to_dict(
-    payload: AdCPBaseModel | Task | TaskStatusUpdateEvent | Mapping[str, Any],
-) -> dict[str, Any]:
-    """Normalize a webhook payload to a JSON-ready dict.
-
-    a2a-sdk ``Task`` / ``TaskStatusUpdateEvent`` serialize with ``by_alias=True``
-    so ``artifact_id`` → ``artifactId`` matches what external A2A receivers
-    expect. MCP-shape dicts / AdCP models are dumped with camelCase-off defaults.
-    """
-    if isinstance(payload, (Task, TaskStatusUpdateEvent)):
-        return payload.model_dump(mode="json", by_alias=True, exclude_none=True)
-    if hasattr(payload, "model_dump"):
-        model = cast(AdCPBaseModel, payload)
-        return model.model_dump(mode="json", exclude_none=True)
-    return dict(payload)
-
-
-def _inject_push_token(
-    body: dict[str, Any],
-    token: str,
-    original_payload: AdCPBaseModel | Task | TaskStatusUpdateEvent | Mapping[str, Any],
-    token_field: str,
-) -> None:
-    """Echo ``PushNotificationConfig.token`` into the body for buyer-side auth.
-
-    AdCP 3.x says the token is "echoed back in webhook payload" but doesn't
-    name the field. The caller picks ``token_field`` to match whatever the
-    receiver is configured to read. A2A ``Task`` / ``TaskStatusUpdateEvent``
-    carry a ``metadata`` object — the token lands there so the top-level
-    shape stays a valid A2A entity. MCP-shape webhooks and plain dicts get
-    the token at top-level (``additionalProperties`` is permitted by the
-    MCP webhook payload schema).
-    """
-    is_a2a = isinstance(original_payload, (Task, TaskStatusUpdateEvent))
-    if is_a2a:
-        metadata = body.get("metadata")
-        if not isinstance(metadata, dict):
-            metadata = {}
-            body["metadata"] = metadata
-        metadata.setdefault(token_field, token)
-    else:
-        body.setdefault(token_field, token)
-
-
-def _validate_header_value(name: str, value: Any) -> None:
-    """Reject control characters and oversize values at the helper boundary.
-
-    httpx rejects bare CRLF at send time, but relying on that is
-    defense-in-absentia — a later swap of the HTTP client, or a caller that
-    logs the value before sending, would re-open header injection. Enforce
-    here so the boundary contract is explicit.
-    """
-    if not isinstance(value, str):
-        raise ValueError(f"{name} must be a string, got {type(value).__name__}")
-    if any(c in value for c in _HEADER_FORBIDDEN_CHARS):
-        raise ValueError(f"{name} contains control characters")
-    if len(value.encode("utf-8")) > _MAX_HEADER_VALUE_BYTES:
-        raise ValueError(f"{name} exceeds {_MAX_HEADER_VALUE_BYTES}-byte limit")
-
-
 # Sender import is at the bottom to resolve a circular dependency:
 # WebhookSender uses create_mcp_webhook_payload / generate_webhook_idempotency_key
 # which are defined above. Importing it at the top would try to resolve those
@@ -981,8 +583,7 @@ __all__ = [
     "get_adcp_signed_headers_for_webhook",
     # Sender — 9421 signing (low-level)
     "sign_webhook",
-    # Sender — one-call outbound helpers
-    "deliver",
+    # Sender — one-call outbound helper
     "WebhookDeliveryResult",
     "WebhookSender",
     # Receiver — 9421 verification (low-level)

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -335,7 +335,8 @@ def sign_legacy_webhook(
 
     Example:
         >>> signed, body = sign_legacy_webhook("shared-secret", payload)
-        >>> await client.post(url, content=body, headers={**signed, "Content-Type": "application/json"})
+        >>> headers = {**signed, "Content-Type": "application/json"}
+        >>> await client.post(url, content=body, headers=headers)
     """
     signature_headers, body_bytes = _compute_legacy_signature(
         secret=secret, timestamp=timestamp, payload=payload

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -1,10 +1,22 @@
 """Webhook creation, signing, and reception for AdCP agents.
 
-Single front door for both senders (``create_mcp_webhook_payload``,
-``sign_webhook``) and receivers (``WebhookReceiver``). Underlying modules in
+Single front door for both senders and receivers. Underlying modules in
 ``adcp.signing.webhook_*`` and ``adcp.webhook_receiver`` are implementation
 details kept for internal organization — prefer the re-exports here for
 stability.
+
+**Which sender helper to use**
+
+* :func:`deliver` — one-shot dispatch for legacy ``authentication`` (Bearer
+  or HMAC-SHA256). Collapses the sender's 6-step boilerplate into one call
+  and signs the exact bytes it POSTs. Deprecated with AdCP 4.0; emits a
+  :class:`DeprecationWarning`.
+* :class:`WebhookSender` — the AdCP 4.0 default. RFC 9421 signing, shared
+  connection pool, byte-identical replay via :meth:`WebhookSender.resend`.
+  Use this for any new integration.
+* :func:`create_mcp_webhook_payload` / :func:`create_a2a_webhook_payload`
+  plus :func:`get_adcp_signed_headers_for_webhook` — low-level path for
+  callers who need full control over serialization, headers, or retry logic.
 """
 
 from __future__ import annotations
@@ -12,10 +24,15 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import time
 import uuid
+import warnings
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any, cast
+from urllib.parse import urlsplit
 
+import httpx
 from a2a.types import (
     Artifact,
     DataPart,
@@ -194,18 +211,9 @@ def get_adcp_signed_headers_for_webhook(
     - X-AdCP-Signature: HMAC-SHA256 signature in format "sha256=<hex_digest>"
     - X-AdCP-Timestamp: Unix timestamp in seconds
 
-    See also:
-        :func:`sign_legacy_webhook` — recommended companion that returns
-        ``(headers, body_bytes)`` so callers POST ``content=body_bytes`` and
-        can't accidentally reserialize the payload between signing and
-        transmission. Prefer ``sign_legacy_webhook`` unless you already own
-        the serialization step and need headers only.
-
     The signing algorithm:
     1. Constructs message as "{timestamp}.{json_payload}"
-    2. JSON-serializes payload with compact separators (matches the wire
-       bytes httpx and most HTTP clients write for `json=payload`, per
-       adcontextprotocol/adcp#2478)
+    2. JSON-serializes payload with default separators (matches wire format from json= kwarg)
     3. UTF-8 encodes the message
     4. HMAC-SHA256 signs with the shared secret
     5. Hex-encodes and prefixes with "sha256="
@@ -253,10 +261,8 @@ def get_adcp_signed_headers_for_webhook(
             "X-AdCP-Timestamp": "1773185740"
         }
     """
-    signature_headers, _body = _compute_legacy_signature(
-        secret=secret,
-        timestamp=timestamp,
-        payload=payload,
+    signature_headers, _body_bytes = _compute_legacy_signature(
+        secret=secret, timestamp=timestamp, payload=payload
     )
     headers.update(signature_headers)
     return headers
@@ -270,9 +276,9 @@ def _compute_legacy_signature(
 ) -> tuple[dict[str, str], bytes]:
     """Shared HMAC-SHA256 signing core for the legacy webhook surface.
 
-    Returns the two signature headers and the compact-separator body bytes
-    that were fed into the HMAC. Callers that POST must transmit exactly
-    these bytes (via ``content=body_bytes``, not ``json=payload``) — that's
+    Returns ``(signature_headers, body_bytes)`` where ``body_bytes`` is the
+    compact-separator JSON the HMAC was computed over. Callers that POST
+    must transmit exactly these bytes via ``content=body_bytes`` — that's
     the whole point of exposing the bytes alongside the headers.
     """
     if timestamp is None:
@@ -282,26 +288,16 @@ def _compute_legacy_signature(
     else:
         timestamp = str(timestamp)
 
-    # Convert Pydantic model to dict if needed
-    # All AdCP types inherit from AdCPBaseModel (Pydantic BaseModel)
     if hasattr(payload, "model_dump"):
         payload_dict = payload.model_dump(mode="json")
     else:
         payload_dict = payload
 
-    # Serialize payload with compact separators to match the wire bytes httpx
-    # (and most HTTP clients) produce for `json=payload`. Default json.dumps
-    # output has ", " / ": " separators, which diverges from httpx's compact
-    # form and caused silent 401s when sellers signed with default separators
-    # and posted via `client.post(url, json=payload, headers=signed)`.
-    # Pinned canonical form per adcontextprotocol/adcp#2478.
+    # Compact separators per adcontextprotocol/adcp#2478 canonical form.
     payload_json = json.dumps(payload_dict, separators=(",", ":"))
     body_bytes = payload_json.encode("utf-8")
 
-    # Construct signed message: timestamp.payload
-    # Including timestamp prevents replay attacks.
     signed_message = f"{timestamp}.{payload_json}"
-
     signature_hex = hmac.new(
         secret.encode("utf-8"), signed_message.encode("utf-8"), hashlib.sha256
     ).hexdigest()
@@ -325,60 +321,24 @@ def sign_legacy_webhook(
     """Return ``(signed_headers, body_bytes)`` for a legacy HMAC webhook.
 
     Byte-equality between signature input and HTTP body is guaranteed —
-    callers POST ``content=body_bytes`` instead of ``json=payload``, so
-    the separator-drift trap that caused silent 401s in every
-    spaced-vs-compact interop is structurally impossible here. This is
-    the 4.x-lifetime replacement for
-    :func:`get_adcp_signed_headers_for_webhook`.
+    callers POST ``content=body_bytes`` instead of ``json=payload``, so the
+    separator-drift trap that caused silent 401s in every spaced-vs-compact
+    interop is structurally impossible here.
 
-    The returned ``body_bytes`` are produced with compact separators
-    (``","``/``":"``) — matching the canonical on-wire form pinned by
-    adcontextprotocol/adcp#2478.
+    This is a lower-level companion to :func:`deliver` for callers who need
+    to own the HTTP transport themselves (custom auth, pre-configured
+    ``httpx.AsyncClient``, non-httpx clients). For the one-shot "send a
+    webhook" path, prefer :func:`deliver`.
 
-    Args:
-        secret: Shared HMAC secret, as agreed with the receiver.
-        payload: Webhook payload (dict or Pydantic model). Will be
-            JSON-serialized with compact separators.
-        timestamp: Unix timestamp (string or int). Defaults to current time.
-            Pin a value in tests for determinism.
-        headers: Optional existing headers dict. If provided, the signed
-            headers are merged into it and the merged dict is returned.
-            The caller still must POST ``content=body_bytes``.
-
-    Returns:
-        ``(signed_headers, body_bytes)``. Hand the headers to
-        :meth:`httpx.AsyncClient.post` and the bytes to its ``content=``
-        kwarg — NOT ``json=payload``, which would reserialize and break
-        the signature.
-
-    See also:
-        :func:`get_adcp_signed_headers_for_webhook` — the lower-level
-        headers-only helper. Still useful when the caller owns the
-        serialization step (for example, a framework that emits bytes
-        from a middleware layer).
+    The returned ``body_bytes`` use compact separators (``","``/``":"``)
+    matching the canonical on-wire form pinned by adcontextprotocol/adcp#2478.
 
     Example:
-        >>> import httpx
-        >>> from adcp.webhooks import create_mcp_webhook_payload, sign_legacy_webhook
-        >>>
-        >>> payload = create_mcp_webhook_payload(
-        ...     task_id="task_123",
-        ...     task_type="create_media_buy",
-        ...     status="completed",
-        ...     result={"media_buy_id": "mb_1"},
-        ... )
-        >>> signed_headers, body = sign_legacy_webhook("shared-secret", payload)
-        >>> async with httpx.AsyncClient() as client:
-        ...     response = await client.post(
-        ...         "https://buyer.example.com/webhooks/adcp",
-        ...         content=body,
-        ...         headers={"Content-Type": "application/json", **signed_headers},
-        ...     )
+        >>> signed, body = sign_legacy_webhook("shared-secret", payload)
+        >>> await client.post(url, content=body, headers={**signed, "Content-Type": "application/json"})
     """
     signature_headers, body_bytes = _compute_legacy_signature(
-        secret=secret,
-        timestamp=timestamp,
-        payload=payload,
+        secret=secret, timestamp=timestamp, payload=payload
     )
     if headers is not None:
         merged = {str(k): str(v) for k, v in headers.items()}
@@ -669,6 +629,393 @@ def create_a2a_webhook_payload(
         )
 
 
+_AUTH_DEPRECATION_WARNED = False
+_RESERVED_HEADERS = frozenset(
+    {
+        "authorization",
+        "content-digest",
+        "content-length",
+        "content-type",
+        "host",
+        "signature",
+        "signature-input",
+        "x-adcp-signature",
+        "x-adcp-timestamp",
+    }
+)
+_HEADER_FORBIDDEN_CHARS = ("\r", "\n", "\x00")
+_MAX_HEADER_VALUE_BYTES = 8192
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+# 10MB cap matches typical buyer-side reverse-proxy limits and is ~100×
+# the realistic AdCP payload (biggest seen: get_products with long product
+# lists, rarely over 100KB). Serialized bytes, not dict size — post-
+# serialization check avoids a pre-cap on dict size being meaningless.
+_MAX_BODY_BYTES = 10 * 1024 * 1024
+# Cap extra_headers count so a caller that iterates a large container
+# into the kwarg can't produce an unbounded header block.
+_MAX_EXTRA_HEADERS = 64
+
+
+def _warn_auth_deprecation_once() -> None:
+    global _AUTH_DEPRECATION_WARNED
+    if _AUTH_DEPRECATION_WARNED:
+        return
+    _AUTH_DEPRECATION_WARNED = True
+    warnings.warn(
+        "PushNotificationConfig.authentication (Bearer, HMAC-SHA256) is "
+        "deprecated in AdCP 4.0. Migrate senders to adcp.webhooks.WebhookSender "
+        "(RFC 9421 signing) and receivers to the 9421 webhook profile. This "
+        "warning fires once per process.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+async def deliver(
+    config: AdCPBaseModel | Mapping[str, Any],
+    payload: AdCPBaseModel | Task | TaskStatusUpdateEvent | Mapping[str, Any],
+    *,
+    client: httpx.AsyncClient | None = None,
+    extra_headers: Mapping[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    token_field: str | None = None,
+) -> httpx.Response:
+    """Dispatch one legacy-auth webhook in a single call.
+
+    Collapses the sender's six-step boilerplate (build envelope, serialize,
+    sign, merge headers, POST, echo token) into one call so the signer and
+    the wire see the *same bytes*. The serialization-format drift that
+    plagued the hand-rolled path — ``json=`` in httpx re-serializes the dict
+    and breaks ``Content-Digest`` — is structurally impossible here: the
+    helper JSON-serializes once, signs those bytes, and POSTs those bytes
+    via ``content=``.
+
+    This helper is for the **legacy** AdCP 3.x authentication schemes
+    (``Bearer`` / ``HMAC-SHA256``) and emits a :class:`DeprecationWarning`
+    on first use. For 4.0+ integrations use :class:`WebhookSender` (RFC 9421).
+
+    Args:
+        config: A :class:`PushNotificationConfig`, :class:`ReportingWebhook`,
+            or equivalent dict. Must carry ``url`` (``https://`` only) and
+            ``authentication.{schemes, credentials}``.
+        payload: The webhook body. Accepts a Pydantic model (e.g. built via
+            :func:`create_mcp_webhook_payload` / :func:`create_a2a_webhook_payload`),
+            an a2a ``Task`` / ``TaskStatusUpdateEvent``, or a plain dict.
+            Models are dumped with ``mode="json", exclude_none=True``.
+        client: Optional shared ``httpx.AsyncClient``. Recommended in
+            production for connection pooling and egress-policy enforcement
+            (a custom ``httpx.BaseTransport`` is the right place to block
+            SSRF to private IPs — the helper validates scheme but cannot
+            see post-DNS resolution without racing TOCTOU).
+        extra_headers: Merged last. May not override any of
+            ``Content-Type``, ``Content-Digest``, ``Content-Length``,
+            ``Host``, ``Authorization``, ``Signature``, ``Signature-Input``,
+            ``X-AdCP-Signature``, or ``X-AdCP-Timestamp``. Auth and
+            signature-binding headers are sender-owned so the signer and
+            the wire cannot disagree.
+        timeout_seconds: Per-request timeout applied only when the helper
+            creates its own client. Raises ``ValueError`` if set alongside
+            ``client=`` — configure the timeout on the shared client instead.
+        token_field: Opt-in field name for echoing ``config.token`` into
+            the payload body (top-level for MCP dicts, under ``metadata``
+            for ``Task`` / ``TaskStatusUpdateEvent``). Default ``None``
+            disables echo; there is no spec-defined field name, so the
+            caller must pick one the receiver agrees to read.
+
+    Returns:
+        The raw ``httpx.Response``. Caller is responsible for
+        ``response.status_code`` inspection and retry scheduling. For retry,
+        pass the *same, unmutated* payload again — serialization is
+        deterministic so retries produce byte-identical bodies (spec-correct
+        receiver dedup via ``idempotency_key``). Mutating the payload dict
+        between attempts breaks byte-identity; callers who need byte-identical
+        HTTP envelopes across retries (including headers) should use
+        :class:`WebhookSender` and :meth:`WebhookSender.resend`. There is
+        intentionally no ``resend()`` here — the retry contract is "call
+        ``deliver`` again with the same inputs".
+
+    Raises:
+        ValueError: missing ``url``, non-HTTPS URL, control characters in
+            header values, missing / unknown ``authentication`` (use
+            :class:`WebhookSender` for RFC 9421), overriding a reserved
+            header, or setting ``timeout_seconds`` alongside ``client``.
+        DeprecationWarning (fires once): ``authentication`` is a 3.x fallback.
+
+    Security notes:
+        * ``config.url`` is buyer-controlled. The helper enforces HTTPS and
+          rejects control characters but does NOT block private / link-local
+          destinations — wire an egress policy via ``client.transport`` to
+          stop SSRF into your VPC or cloud metadata service.
+        * ``config.token`` sits in the request body, so any receiver that
+          logs bodies retains it indefinitely. Treat the token as a
+          medium-sensitivity correlator, not a long-lived secret.
+        * At ``httpx`` DEBUG log level, ``Authorization`` and
+          ``X-AdCP-Signature`` appear in logs — gate DEBUG in production.
+    """
+    if client is not None and timeout_seconds is not None:
+        raise ValueError(
+            "timeout_seconds cannot be set when client= is provided; "
+            "configure the timeout on your shared httpx.AsyncClient instead."
+        )
+
+    url, token, auth_scheme, credentials = _extract_config_fields(config)
+
+    if auth_scheme is None:
+        raise ValueError(
+            "config.authentication is required for deliver(). "
+            "For RFC 9421 signing (the AdCP 4.0 default), use "
+            "adcp.webhooks.WebhookSender — no helper for unsigned webhooks "
+            "is provided because the spec requires signing."
+        )
+    if auth_scheme not in ("Bearer", "HMAC-SHA256"):
+        raise ValueError(
+            f"unknown authentication scheme {auth_scheme!r}; "
+            "supported legacy schemes are 'Bearer' and 'HMAC-SHA256'. "
+            "For RFC 9421 use adcp.webhooks.WebhookSender."
+        )
+
+    _warn_auth_deprecation_once()
+
+    body_dict = _payload_to_dict(payload)
+    if token is not None and token_field is not None:
+        _validate_header_value("config.token", token)
+        _inject_push_token(body_dict, token, payload, token_field)
+
+    # Compact separators so the signer and the wire see byte-identical
+    # payloads, matching the canonical on-wire form pinned by
+    # adcontextprotocol/adcp#2478. ``_compute_legacy_signature`` returns the
+    # same compact body bytes below — we serialize here for the size check
+    # and Bearer path, which both operate on the final transmitted bytes.
+    body_bytes = json.dumps(body_dict, separators=(",", ":")).encode("utf-8")
+    if len(body_bytes) > _MAX_BODY_BYTES:
+        raise ValueError(
+            f"serialized webhook body is {len(body_bytes):,} bytes, over the "
+            f"{_MAX_BODY_BYTES:,}-byte cap. Split into smaller webhooks or use "
+            "the batch-reporting endpoints — most receivers reject bodies over "
+            "10MB at the reverse proxy anyway."
+        )
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+
+    if auth_scheme == "Bearer":
+        if not credentials:
+            raise ValueError(
+                "config.authentication.schemes=['Bearer'] requires "
+                "authentication.credentials (min 32 characters — token "
+                "exchanged out-of-band with the receiver)."
+            )
+        _validate_header_value("authentication.credentials", credentials)
+        headers["Authorization"] = f"Bearer {credentials}"
+    else:  # HMAC-SHA256
+        if not credentials:
+            raise ValueError(
+                "config.authentication.schemes=['HMAC-SHA256'] requires "
+                "authentication.credentials (min 32 characters — shared "
+                "secret exchanged out-of-band with the receiver)."
+            )
+        _validate_header_value("authentication.credentials", credentials)
+        get_adcp_signed_headers_for_webhook(
+            headers,
+            secret=credentials,
+            timestamp=str(int(time.time())),
+            payload=body_dict,
+        )
+
+    if extra_headers:
+        if len(extra_headers) > _MAX_EXTRA_HEADERS:
+            raise ValueError(
+                f"extra_headers has {len(extra_headers)} entries; "
+                f"helper caps at {_MAX_EXTRA_HEADERS}. Pass only the custom "
+                "headers you actually need (trace IDs, correlation IDs)."
+            )
+        for key in extra_headers:
+            normalized = str(key).lower()
+            if normalized in _RESERVED_HEADERS or normalized.startswith(":"):
+                raise ValueError(_reserved_header_message(normalized, key))
+        for key, value in extra_headers.items():
+            _validate_header_value(f"extra_headers[{key!r}]", value)
+            headers[key] = value
+
+    owns_client = client is None
+    effective_timeout = timeout_seconds if timeout_seconds is not None else _DEFAULT_TIMEOUT_SECONDS
+    http_client = client or httpx.AsyncClient(timeout=effective_timeout)
+    try:
+        return await http_client.post(url, content=body_bytes, headers=headers)
+    finally:
+        if owns_client:
+            await http_client.aclose()
+
+
+def _extract_config_fields(
+    config: AdCPBaseModel | Mapping[str, Any],
+) -> tuple[str, str | None, str | None, str | None]:
+    """Pull ``url``, ``token``, auth scheme, and credentials out of a webhook config.
+
+    Accepts either a ``PushNotificationConfig`` / ``ReportingWebhook`` model
+    or an equivalent dict — sellers often receive these as plain dicts from
+    an incoming AdCP request and shouldn't have to round-trip through the
+    Pydantic model just to dispatch a webhook.
+
+    Validates the URL at the boundary: HTTPS only, no control characters.
+    """
+    if hasattr(config, "model_dump"):
+        cfg = cast(AdCPBaseModel, config).model_dump(mode="json", exclude_none=True)
+    else:
+        cfg = dict(config)
+
+    url_value = cfg.get("url")
+    if not url_value:
+        raise ValueError(
+            "webhook config is missing required 'url' field. Pass a "
+            "PushNotificationConfig, ReportingWebhook, or dict with an "
+            "https:// 'url'."
+        )
+    url = str(url_value)
+    if any(c in url for c in _HEADER_FORBIDDEN_CHARS):
+        raise ValueError(
+            "webhook config 'url' contains control characters "
+            "(newline, carriage return, or NUL are not allowed in URLs)"
+        )
+    lower = url.lower()
+    if not lower.startswith("https://"):
+        scheme_end = lower.find("://")
+        shown_scheme = lower[:scheme_end] if scheme_end >= 0 else "<no scheme>"
+        raise ValueError(
+            f"webhook config 'url' must use https:// (got scheme {shown_scheme!r}). "
+            "HTTP and other schemes are rejected because they expose the "
+            "webhook body, token, and Authorization header in transit."
+        )
+    parsed = urlsplit(url)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(
+            "webhook config 'url' must not embed userinfo (user:pass@host). "
+            "Pass credentials via config.authentication.credentials instead — "
+            "URLs get logged by proxies, load balancers, and httpx DEBUG."
+        )
+
+    token = cfg.get("token")
+
+    auth_raw = cfg.get("authentication")
+    if auth_raw is not None and not isinstance(auth_raw, Mapping):
+        raise ValueError(
+            f"config.authentication must be an object with 'schemes' + "
+            f"'credentials', got {type(auth_raw).__name__}"
+        )
+    auth: Mapping[str, Any] = auth_raw or {}
+    schemes_raw = auth.get("schemes")
+    if schemes_raw is not None and not isinstance(schemes_raw, (list, tuple)):
+        raise ValueError(
+            "config.authentication.schemes must be a list, got " f"{type(schemes_raw).__name__}"
+        )
+    schemes = list(schemes_raw or [])
+    if len(schemes) > 1:
+        raise ValueError(
+            f"config.authentication.schemes has {len(schemes)} entries; "
+            "the AdCP legacy auth schema allows exactly one scheme per config."
+        )
+    scheme = schemes[0] if schemes else None
+    credentials = auth.get("credentials")
+
+    return url, token, scheme, credentials
+
+
+def _reserved_header_message(normalized: str, original_key: Any) -> str:
+    """Build a fix-the-error message tailored to the reserved header class.
+
+    The mistake category differs sharply by header: a caller passing
+    ``Authorization`` usually doesn't know about ``config.authentication``;
+    a caller passing ``Content-Type`` is probably debugging and reached for
+    the override by reflex. Give each the right nudge."""
+    if normalized == "authorization":
+        return (
+            f"extra_headers may not override {original_key!r} — set "
+            "config.authentication.schemes=['Bearer'] + credentials instead. "
+            "The helper derives Authorization from config so the signer and "
+            "the wire cannot disagree."
+        )
+    if normalized in ("signature", "signature-input", "content-digest"):
+        return (
+            f"extra_headers may not override {original_key!r} — RFC 9421 "
+            "signing headers are produced by adcp.webhooks.WebhookSender, "
+            "not injected. Switch helpers if you need 9421."
+        )
+    if normalized in ("x-adcp-signature", "x-adcp-timestamp"):
+        return (
+            f"extra_headers may not override {original_key!r} — these are "
+            "the HMAC-SHA256 signature headers the helper produces from "
+            "config.authentication.credentials."
+        )
+    if normalized == "content-type":
+        return (
+            f"extra_headers may not override {original_key!r}; "
+            "the helper always sends 'application/json'."
+        )
+    return (
+        f"extra_headers may not override {original_key!r}; "
+        "this header is sender-owned and managed by the helper."
+    )
+
+
+def _payload_to_dict(
+    payload: AdCPBaseModel | Task | TaskStatusUpdateEvent | Mapping[str, Any],
+) -> dict[str, Any]:
+    """Normalize a webhook payload to a JSON-ready dict.
+
+    a2a-sdk ``Task`` / ``TaskStatusUpdateEvent`` serialize with ``by_alias=True``
+    so ``artifact_id`` → ``artifactId`` matches what external A2A receivers
+    expect. MCP-shape dicts / AdCP models are dumped with camelCase-off defaults.
+    """
+    if isinstance(payload, (Task, TaskStatusUpdateEvent)):
+        return payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if hasattr(payload, "model_dump"):
+        model = cast(AdCPBaseModel, payload)
+        return model.model_dump(mode="json", exclude_none=True)
+    return dict(payload)
+
+
+def _inject_push_token(
+    body: dict[str, Any],
+    token: str,
+    original_payload: AdCPBaseModel | Task | TaskStatusUpdateEvent | Mapping[str, Any],
+    token_field: str,
+) -> None:
+    """Echo ``PushNotificationConfig.token`` into the body for buyer-side auth.
+
+    AdCP 3.x says the token is "echoed back in webhook payload" but doesn't
+    name the field. The caller picks ``token_field`` to match whatever the
+    receiver is configured to read. A2A ``Task`` / ``TaskStatusUpdateEvent``
+    carry a ``metadata`` object — the token lands there so the top-level
+    shape stays a valid A2A entity. MCP-shape webhooks and plain dicts get
+    the token at top-level (``additionalProperties`` is permitted by the
+    MCP webhook payload schema).
+    """
+    is_a2a = isinstance(original_payload, (Task, TaskStatusUpdateEvent))
+    if is_a2a:
+        metadata = body.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+            body["metadata"] = metadata
+        metadata.setdefault(token_field, token)
+    else:
+        body.setdefault(token_field, token)
+
+
+def _validate_header_value(name: str, value: Any) -> None:
+    """Reject control characters and oversize values at the helper boundary.
+
+    httpx rejects bare CRLF at send time, but relying on that is
+    defense-in-absentia — a later swap of the HTTP client, or a caller that
+    logs the value before sending, would re-open header injection. Enforce
+    here so the boundary contract is explicit.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string, got {type(value).__name__}")
+    if any(c in value for c in _HEADER_FORBIDDEN_CHARS):
+        raise ValueError(f"{name} contains control characters")
+    if len(value.encode("utf-8")) > _MAX_HEADER_VALUE_BYTES:
+        raise ValueError(f"{name} exceeds {_MAX_HEADER_VALUE_BYTES}-byte limit")
+
+
 # Sender import is at the bottom to resolve a circular dependency:
 # WebhookSender uses create_mcp_webhook_payload / generate_webhook_idempotency_key
 # which are defined above. Importing it at the top would try to resolve those
@@ -688,7 +1035,8 @@ __all__ = [
     "sign_legacy_webhook",
     # Sender — 9421 signing (low-level)
     "sign_webhook",
-    # Sender — one-call outbound helper
+    # Sender — one-call outbound helpers
+    "deliver",
     "WebhookDeliveryResult",
     "WebhookSender",
     # Receiver — 9421 verification (low-level)
@@ -708,9 +1056,9 @@ __all__ = [
     "WebhookPayload",
     "WebhookReceiver",
     "WebhookReceiverConfig",
-    # Receiver — dedup store (required by WebhookReceiverConfig)
-    "MemoryBackend",
-    "WebhookDedupStore",
     # Receiver — payload extraction (legacy helper)
     "extract_webhook_result_data",
+    # Dedup / idempotency backends (re-exported so one import root suffices)
+    "MemoryBackend",
+    "WebhookDedupStore",
 ]

--- a/tests/conformance/signing/test_sign_legacy_webhook.py
+++ b/tests/conformance/signing/test_sign_legacy_webhook.py
@@ -1,0 +1,122 @@
+"""Tests for :func:`sign_legacy_webhook` — the tuple-returning companion.
+
+The whole point is byte-equality between signed input and HTTP body, so the
+tests here exercise that invariant against real httpx serialization and
+against the receiver (:func:`verify_webhook_hmac`) that relies on it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import httpx
+
+from adcp.webhooks import (
+    LegacyWebhookHmacOptions,
+    create_mcp_webhook_payload,
+    sign_legacy_webhook,
+    verify_webhook_hmac,
+)
+
+
+def test_sign_legacy_webhook_round_trip_verifies() -> None:
+    secret = "s" * 32
+    ts = str(int(time.time()))
+    payload = create_mcp_webhook_payload(
+        task_id="t1",
+        task_type="create_media_buy",
+        status="completed",
+        result={"media_buy_id": "mb_1"},
+    )
+    signed_headers, body = sign_legacy_webhook(secret, payload, timestamp=ts)
+
+    # The tuple contract: headers ready to attach, bytes ready to POST.
+    assert signed_headers["X-AdCP-Signature"].startswith("sha256=")
+    assert signed_headers["X-AdCP-Timestamp"] == ts
+    assert isinstance(body, bytes)
+
+    verified = verify_webhook_hmac(
+        headers=signed_headers,
+        body=body,
+        options=LegacyWebhookHmacOptions(
+            secret=secret.encode(),
+            sender_identity="test-sender",
+            now=float(int(ts)),
+        ),
+    )
+    assert verified.as_sender_identity() == "test-sender"
+
+
+def test_sign_legacy_webhook_timestamp_pinned_across_calls() -> None:
+    """Pinning timestamp produces reproducible headers/body — useful in
+    deterministic tests and when regenerating a signature for a replay."""
+    secret = "abc123"
+    payload = {"idempotency_key": "whk_x", "task_id": "t"}
+    ts = "1773185740"
+    first_headers, first_body = sign_legacy_webhook(secret, payload, timestamp=ts)
+    second_headers, second_body = sign_legacy_webhook(secret, payload, timestamp=ts)
+    assert first_headers == second_headers
+    assert first_body == second_body
+
+
+def test_sign_legacy_webhook_body_matches_httpx_content_bytes() -> None:
+    """The DX claim: passing ``content=body_bytes`` to httpx transmits the
+    exact same bytes that were signed. If httpx ever re-serialized ``content``
+    or the SDK stopped pinning compact separators, this test catches it.
+    The check is structural — compare our bytes to what httpx produces from
+    the same payload under ``json=`` with compact separators enforced."""
+    payload = {"idempotency_key": "whk_1", "task_id": "t", "status": "completed"}
+    _headers, body = sign_legacy_webhook("secret", payload, timestamp="100")
+
+    # httpx's default json= path uses compact separators, same as us.
+    httpx_request = httpx.Request("POST", "http://example.com/hook", json=payload)
+    assert body == httpx_request.content
+
+
+def test_sign_legacy_webhook_merges_into_existing_headers() -> None:
+    """When ``headers`` is passed, the returned dict includes the caller's
+    headers plus the two signature headers. Byte-equality still holds."""
+    secret = "s" * 32
+    payload = {"idempotency_key": "whk_2", "task_id": "t"}
+    base = {"Content-Type": "application/json", "X-Request-Id": "r1"}
+    merged, body = sign_legacy_webhook(secret, payload, headers=base, timestamp="123")
+
+    assert merged["Content-Type"] == "application/json"
+    assert merged["X-Request-Id"] == "r1"
+    assert merged["X-AdCP-Signature"].startswith("sha256=")
+    assert merged["X-AdCP-Timestamp"] == "123"
+    # The caller's dict is NOT mutated — merging returns a fresh dict.
+    assert "X-AdCP-Signature" not in base
+
+    verified = verify_webhook_hmac(
+        headers=merged,
+        body=body,
+        options=LegacyWebhookHmacOptions(
+            secret=secret.encode(),
+            sender_identity="sender",
+            now=123.0,
+        ),
+    )
+    assert verified.as_sender_identity() == "sender"
+
+
+def test_sign_legacy_webhook_accepts_pydantic_model() -> None:
+    """Payload may be a Pydantic model (AdCPBaseModel) — it's model_dumped
+    with mode=json before serialization, matching the existing behavior of
+    :func:`get_adcp_signed_headers_for_webhook`."""
+    from adcp.types.base import AdCPBaseModel
+
+    class _Payload(AdCPBaseModel):
+        idempotency_key: str
+        task_id: str
+        status: str
+
+    payload = _Payload(idempotency_key="whk_3", task_id="t", status="completed")
+    headers, body = sign_legacy_webhook("secret", payload, timestamp="1")
+
+    # Bytes are the compact-separator serialization of the model's JSON form.
+    assert body == json.dumps(payload.model_dump(mode="json"), separators=(",", ":")).encode(
+        "utf-8"
+    )
+    assert headers["X-AdCP-Signature"].startswith("sha256=")

--- a/tests/conformance/signing/test_webhook_e2e_fastapi.py
+++ b/tests/conformance/signing/test_webhook_e2e_fastapi.py
@@ -30,7 +30,7 @@ from adcp.webhooks import (
     WebhookReceiverConfig,
     WebhookVerifyOptions,
     create_mcp_webhook_payload,
-    get_adcp_signed_headers_for_webhook,
+    sign_legacy_webhook,
     sign_webhook,
 )
 
@@ -275,11 +275,11 @@ async def test_legacy_hmac_e2e_over_http() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_e2e_hmaclegacyaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
-    headers = {"Content-Type": "application/json"}
-    get_adcp_signed_headers_for_webhook(
-        headers=headers, secret=secret.decode(), timestamp=ts, payload=payload
-    )
+    # Use sign_legacy_webhook so body and signed bytes are guaranteed to match
+    # (avoids the spaced-vs-compact json.dumps separator drift that was the
+    # whole reason we added the paired-return helper in R8).
+    signed_headers, body = sign_legacy_webhook(secret.decode(), payload, timestamp=ts)
+    headers = {"Content-Type": "application/json", **signed_headers}
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/conformance/signing/test_webhook_hmac.py
+++ b/tests/conformance/signing/test_webhook_hmac.py
@@ -33,7 +33,7 @@ def _sign_body(
     # The existing sender uses json.dumps(payload_dict) without sort_keys —
     # receiver MUST verify against the raw bytes the sender emitted, which
     # means we serialize once here and use the same bytes on both sides.
-    raw = json.dumps(payload).encode("utf-8")
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     return raw, headers, timestamp
 
 

--- a/tests/conformance/signing/test_webhook_receiver.py
+++ b/tests/conformance/signing/test_webhook_receiver.py
@@ -79,7 +79,7 @@ async def test_happy_path_9421() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_aaaaaaaaaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver()
@@ -101,7 +101,7 @@ async def test_duplicate_detected() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_dupeaaaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -145,7 +145,7 @@ async def test_tampered_body_rejected() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_tamperaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -163,7 +163,7 @@ async def test_missing_idempotency_key_rejected() -> None:
         "status": "completed",
         "timestamp": "2026-04-19T00:00:00Z",
     }
-    body = json.dumps(body_dict).encode("utf-8")
+    body = json.dumps(body_dict, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -183,7 +183,7 @@ async def test_legacy_hmac_fallback_when_9421_absent() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_hmaclegacyaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -215,7 +215,7 @@ async def test_from_shared_secret_shortcut() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_sharedshortcutaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -306,7 +306,7 @@ async def test_accepts_content_type_with_charset() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_charsetaaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     # Sign with plain content-type (what sign_webhook emits) then mutate the
     # header on the wire to include a charset parameter. The 9421 signature
     # covers content-type; this test asserts the receiver's content-type
@@ -339,7 +339,7 @@ async def test_rejects_malformed_idempotency_key() -> None:
         "status": "completed",
         "timestamp": "2026-04-19T00:00:00Z",
     }
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -362,7 +362,7 @@ async def test_only_signature_input_header_falls_through_to_hmac_when_configured
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_onlyfallbackaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -418,7 +418,7 @@ async def test_hmac_fallback_accepts_invalid_9421_when_opted_in() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_optinfallbackaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -457,7 +457,7 @@ async def test_receives_revocation_notification() -> None:
         "reason": "Rights revoked",
         "effective_at": "2026-04-19T00:00:00Z",
     }
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="revocation_notification")
@@ -476,7 +476,7 @@ async def test_receives_artifact_webhook() -> None:
         "timestamp": "2026-04-19T00:00:00Z",
         "artifacts": [],
     }
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="artifact")
@@ -494,7 +494,7 @@ async def test_receives_collection_list_changed() -> None:
         "resolved_at": "2026-04-19T00:00:00Z",
         "signature": "sig",
     }
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="collection_list_changed")
@@ -512,7 +512,7 @@ async def test_receives_property_list_changed() -> None:
         "resolved_at": "2026-04-19T00:00:00Z",
         "signature": "sig",
     }
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="property_list_changed")

--- a/tests/conformance/signing/test_webhook_sender_from_pem.py
+++ b/tests/conformance/signing/test_webhook_sender_from_pem.py
@@ -1,0 +1,199 @@
+"""Round-trip: adcp-keygen-produced PEM + public JWK glue together via from_pem.
+
+The DX contract this closes: ``adcp-keygen --purpose webhook-signing`` writes
+a PEM and prints the PUBLIC JWK. The PEM has the private key material but no
+``d`` scalar for :meth:`WebhookSender.from_jwk`. ``from_pem`` is the companion
+that takes the same PEM, binds the kid, and returns a sender whose signatures
+verify against the printed JWK.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+FastAPI = fastapi.FastAPI
+Request = fastapi.Request
+from fastapi.responses import JSONResponse  # noqa: E402
+
+from adcp.server.idempotency import MemoryBackend, WebhookDedupStore
+from adcp.signing import StaticJwksResolver
+from adcp.signing.keygen import generate_ed25519, generate_es256
+from adcp.webhooks import (
+    WebhookReceiver,
+    WebhookReceiverConfig,
+    WebhookSender,
+    WebhookVerifyOptions,
+)
+
+
+def _build_receiver_app(jwk: dict[str, Any]) -> FastAPI:
+    receiver = WebhookReceiver(
+        config=WebhookReceiverConfig(
+            verify_options=WebhookVerifyOptions(
+                jwks_resolver=StaticJwksResolver({"keys": [jwk]}),
+            ),
+            dedup=WebhookDedupStore(MemoryBackend(), ttl_seconds=86400),
+            kind="mcp",
+        ),
+    )
+    app = FastAPI()
+
+    @app.post("/webhooks/adcp")
+    async def endpoint(request: Request) -> JSONResponse:
+        outcome = await receiver.receive(
+            method=request.method,
+            url=str(request.url),
+            headers=dict(request.headers),
+            body=await request.body(),
+        )
+        if outcome.rejected:
+            return JSONResponse(
+                {"error": outcome.rejection_reason},
+                status_code=401,
+            )
+        return JSONResponse(
+            {
+                "duplicate": outcome.duplicate,
+                "sender": outcome.sender_identity,
+            },
+            status_code=200,
+        )
+
+    return app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generator", "alg"),
+    [(generate_ed25519, "ed25519"), (generate_es256, "es256")],
+)
+async def test_from_pem_signatures_verify_against_public_jwk(
+    tmp_path: Path, generator: Any, alg: str
+) -> None:
+    """The core DX loop: keygen writes a PEM, publishes the JWK, from_pem
+    rehydrates the PEM into a sender, and the sender's signatures verify
+    against that same JWK. No private-key-material-in-JWK roundabout."""
+    kid = f"webhook-{alg}-kid"
+    pem_bytes, public_jwk = generator(kid=kid, adcp_use="webhook-signing")
+    pem_path = tmp_path / "webhook-key.pem"
+    pem_path.write_bytes(pem_bytes)
+
+    app = _build_receiver_app(public_jwk)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        sender = WebhookSender.from_pem(pem_path, key_id=kid, alg=alg, client=client)
+        result = await sender.send_mcp(
+            url="http://test/webhooks/adcp",
+            task_id="task_from_pem",
+            task_type="create_media_buy",
+            status="completed",
+            result={"media_buy_id": "mb_1"},
+        )
+
+    assert result.ok, result.response_body
+    body = json.loads(result.response_body)
+    assert body["sender"] == kid
+    assert body["duplicate"] is False
+
+
+@pytest.mark.asyncio
+async def test_from_pem_accepts_raw_bytes() -> None:
+    """The pem_path kwarg accepts bytes directly — useful for callers who
+    load the PEM from a secrets store (Vault, AWS Secrets Manager) and
+    never touch the filesystem."""
+    kid = "webhook-bytes-kid"
+    pem_bytes, public_jwk = generate_ed25519(kid=kid, adcp_use="webhook-signing")
+
+    app = _build_receiver_app(public_jwk)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        sender = WebhookSender.from_pem(pem_bytes, key_id=kid, client=client)
+        result = await sender.send_mcp(
+            url="http://test/webhooks/adcp",
+            task_id="task_bytes",
+            task_type="create_media_buy",
+            status="completed",
+        )
+    assert result.ok, result.response_body
+
+
+@pytest.mark.asyncio
+async def test_from_pem_encrypted_pem_with_passphrase(tmp_path: Path) -> None:
+    """Round-trip the ``adcp-keygen --encrypt`` output: an encrypted PEM,
+    loaded by from_pem with the matching passphrase, signs webhooks the
+    published JWK verifies."""
+    kid = "webhook-enc-kid"
+    passphrase = b"correct horse battery staple"
+    pem_bytes, public_jwk = generate_ed25519(
+        kid=kid, passphrase=passphrase, adcp_use="webhook-signing"
+    )
+    assert b"ENCRYPTED" in pem_bytes
+    pem_path = tmp_path / "enc.pem"
+    pem_path.write_bytes(pem_bytes)
+
+    app = _build_receiver_app(public_jwk)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        sender = WebhookSender.from_pem(pem_path, key_id=kid, passphrase=passphrase, client=client)
+        result = await sender.send_mcp(
+            url="http://test/webhooks/adcp",
+            task_id="task_enc",
+            task_type="create_media_buy",
+            status="completed",
+        )
+    assert result.ok, result.response_body
+
+
+def test_from_pem_wrong_passphrase_raises_clear_error(tmp_path: Path) -> None:
+    """Passing the wrong passphrase must surface an error at construction
+    time rather than producing a silently-broken sender."""
+    pem_bytes, _ = generate_ed25519(kid="kid", passphrase=b"right", adcp_use="webhook-signing")
+    pem_path = tmp_path / "enc.pem"
+    pem_path.write_bytes(pem_bytes)
+
+    with pytest.raises(ValueError):
+        WebhookSender.from_pem(pem_path, key_id="kid", passphrase=b"wrong")
+
+
+def test_from_pem_missing_passphrase_on_encrypted_pem(tmp_path: Path) -> None:
+    """Cryptography raises TypeError when we omit the passphrase on an
+    encrypted PEM — surfaced unmodified so the caller sees exactly what
+    went wrong."""
+    pem_bytes, _ = generate_ed25519(kid="kid", passphrase=b"phrase", adcp_use="webhook-signing")
+    pem_path = tmp_path / "enc.pem"
+    pem_path.write_bytes(pem_bytes)
+
+    with pytest.raises(TypeError):
+        WebhookSender.from_pem(pem_path, key_id="kid")
+
+
+def test_from_pem_rejects_unsupported_alg(tmp_path: Path) -> None:
+    pem_bytes, _ = generate_ed25519(kid="kid", adcp_use="webhook-signing")
+    pem_path = tmp_path / "k.pem"
+    pem_path.write_bytes(pem_bytes)
+
+    with pytest.raises(ValueError, match="unsupported alg"):
+        WebhookSender.from_pem(pem_path, key_id="kid", alg="rsa")
+
+
+def test_from_pem_detects_alg_pem_mismatch(tmp_path: Path) -> None:
+    """An ed25519 PEM declared as es256 (or vice versa) would produce
+    signatures no verifier can validate. from_pem detects the mismatch
+    at construction and raises with a remediation hint."""
+    ed_pem, _ = generate_ed25519(kid="kid", adcp_use="webhook-signing")
+    ed_path = tmp_path / "ed.pem"
+    ed_path.write_bytes(ed_pem)
+    with pytest.raises(ValueError, match="PEM holds"):
+        WebhookSender.from_pem(ed_path, key_id="kid", alg="es256")
+
+    es_pem, _ = generate_es256(kid="kid", adcp_use="webhook-signing")
+    es_path = tmp_path / "es.pem"
+    es_path.write_bytes(es_pem)
+    with pytest.raises(ValueError, match="PEM holds"):
+        WebhookSender.from_pem(es_path, key_id="kid", alg="ed25519")

--- a/tests/fixtures/webhook-hmac-sha256.json
+++ b/tests/fixtures/webhook-hmac-sha256.json
@@ -2,7 +2,10 @@
   "version": 1,
   "algorithm": "HMAC-SHA256",
   "secret": "test-secret-key-minimum-32-characters-long",
-  "description": "Test vectors from adcontextprotocol/adcp PR #1383",
+  "specification": "https://adcontextprotocol.org/docs/building/implementation/webhooks",
+  "status": "legacy",
+  "deprecation": "AdCP 3.0 unifies webhook signing on the RFC 9421 webhook profile (see docs/building/implementation/security.mdx#webhook-callbacks). This HMAC-SHA256 path is the legacy fallback selected when a buyer populates push_notification_config.authentication.credentials; it is deprecated and removed in AdCP 4.0. Conformance vectors for the 9421 webhook profile will ship alongside the request-signing vectors.",
+  "description": "Test vectors for AdCP webhook HMAC-SHA256 signature verification (legacy / deprecated path). Each vector contains a raw_body (the exact bytes on the wire), a timestamp (Unix seconds), and the expected signature. Implementations supporting the legacy path MUST produce matching signatures for every vector and MUST use constant-time comparison when verifying signatures in production. Sign the raw_body as-is — never re-serialize it. When constructing a body from a JSON value, use compact separators (',' and ':', no whitespace between tokens) so the signed bytes match the bytes on the wire.",
   "vectors": [
     {
       "description": "compact JSON (JS-style JSON.stringify)",
@@ -63,6 +66,104 @@
       "timestamp": 2208988800,
       "raw_body": "{\"event\":\"test\"}",
       "expected_signature": "sha256=a0fdee5e93b2ac2efdf8d3d22b7a03ae8e6df157b493d0140f7902ef32f6be60"
+    },
+    {
+      "description": "null bytes in body",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\u0000null\"}",
+      "expected_signature": "sha256=7672d4251c1bc327b8c4cbb0e0d4d93a062db44810663f46bcabdd7d3736e9fc"
+    },
+    {
+      "description": "trailing newline in body",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\"}\n",
+      "expected_signature": "sha256=bc9597756458e0349125bcb50b828271adadc9ed1282e91a5b0c79dbf0864fc8"
+    },
+    {
+      "description": "compact separators with whitespace-sensitive keys and nested objects/arrays — canonical on-wire form",
+      "timestamp": 1700000000,
+      "raw_body": "{\"key with spaces\":1,\"nested\":{\"inner key\":[1,2,{\"deep key\":\"v\"}],\"flag\":true}}",
+      "expected_signature": "sha256=df7036a04cf825c30ef6bdc020c98fcdcc7429c99e8178c17188912757860f97"
+    },
+    {
+      "description": "ascii-escaped unicode (\\u00e9, \\u65e5) — produces a different signature than the raw-UTF-8 vector above; unicode-escape policy is not canonicalized, so signers and verifiers MUST compare bytes",
+      "timestamp": 1700000000,
+      "raw_body": "{\"name\":\"caf\\u00e9\",\"region\":\"\\u65e5\\u672c\"}",
+      "expected_signature": "sha256=572cfc7fa6ed58d2154bdbfff6ee1a2107a4d60adb60709d0c3e065972a01114"
+    }
+  ],
+  "rejection_vectors": [
+    {
+      "description": "truncated signature",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "sha256=c4faf8",
+      "reason": "Signature length mismatch — MUST reject before HMAC comparison"
+    },
+    {
+      "description": "wrong algorithm prefix",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "sha512=0ae7bf3ebd08098a9bec251fd1405a852dfbe3f75f5f19d9aa3e81af0f2617ca",
+      "reason": "Only sha256= prefix is valid"
+    },
+    {
+      "description": "empty signature header",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "",
+      "reason": "Missing or empty signature MUST be rejected"
+    },
+    {
+      "description": "missing signature header",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": null,
+      "reason": "Null signature MUST be rejected"
+    },
+    {
+      "description": "timestamp outside window (5 minutes in the past)",
+      "timestamp": 1699999399,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "sha256=valid_but_irrelevant",
+      "current_time": 1700000000,
+      "reason": "Timestamp 601 seconds old — exceeds 300-second window"
+    },
+    {
+      "description": "timestamp outside window (5 minutes in the future)",
+      "timestamp": 1700000401,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "sha256=valid_but_irrelevant",
+      "current_time": 1700000000,
+      "reason": "Timestamp 401 seconds in the future — exceeds 300-second window"
+    },
+    {
+      "description": "non-numeric timestamp",
+      "timestamp": "not-a-number",
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "sha256=anything",
+      "reason": "Non-numeric timestamp MUST be rejected before HMAC computation"
+    },
+    {
+      "description": "body modified after signing",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"hacked\"}",
+      "signature": "sha256=0ae7bf3ebd08098a9bec251fd1405a852dfbe3f75f5f19d9aa3e81af0f2617ca",
+      "reason": "Signature was computed over {\"event\":\"test\"} — modified body MUST not verify"
+    },
+    {
+      "description": "double prefix",
+      "timestamp": 1700000000,
+      "raw_body": "{\"event\":\"test\"}",
+      "signature": "sha256=sha256=0ae7bf3ebd08098a9bec251fd1405a852dfbe3f75f5f19d9aa3e81af0f2617ca",
+      "reason": "Double sha256= prefix produces wrong length and MUST be rejected"
+    },
+    {
+      "description": "signer used Python-default spaced separators but client wrote compact bytes on the wire",
+      "timestamp": 1700000000,
+      "raw_body": "{\"key with spaces\":1,\"nested\":{\"inner key\":[1,2,{\"deep key\":\"v\"}],\"flag\":true}}",
+      "signature": "sha256=fdbde186af151dc1430f33fd9c70a0b5455b02d95a675d24bc85f60f3e05ffb5",
+      "reason": "Signature was computed over the spaced-separator form '{\"key with spaces\": 1, ...}' while the wire carries the compact form — the canonical on-wire form is compact (','/':') so this MUST NOT verify. This is the exact cross-SDK bug that motivated pinning compact separators in the legacy scheme."
     }
   ]
 }

--- a/tests/test_mcp_schema_drift.py
+++ b/tests/test_mcp_schema_drift.py
@@ -1,0 +1,142 @@
+"""Drift tests for MCP tool inputSchema generation.
+
+The MCP tool registry exposes ``inputSchema`` for every ADCP tool via
+``tools/list``. These schemas are auto-generated from the corresponding
+Pydantic request models in ``adcp.types`` at import time
+(:func:`adcp.server.mcp_tools._generate_pydantic_schemas`).
+
+This module protects the generation path from regressions:
+
+1. Every tool must resolve to a Pydantic-generated schema. If a new tool
+   is added to ``ADCP_TOOL_DEFINITIONS`` without a mapping in
+   ``_tool_to_request``, the tool would silently ship a hand-crafted
+   stub schema again — the drift this whole mechanism exists to prevent.
+2. Each tool's ``inputSchema`` must match the ``model_json_schema()``
+   output of its request model (modulo the ``title`` strip and the
+   conditional ``$defs`` drop). If Pydantic changes its schema output,
+   or a model gains/drops a field, this test fails on the affected tool.
+3. The schema must advertise the model's required fields so agents
+   constructing payloads via ``tools/list`` see accurate constraints.
+"""
+
+from __future__ import annotations
+
+import json
+
+from adcp.server.mcp_tools import (
+    _PYDANTIC_SCHEMAS,
+    ADCP_TOOL_DEFINITIONS,
+    _generate_pydantic_schemas,
+)
+
+
+def test_every_tool_has_pydantic_generated_schema() -> None:
+    """Every ADCP tool must map to a Pydantic request model."""
+    tool_names = {t["name"] for t in ADCP_TOOL_DEFINITIONS}
+    missing = tool_names - set(_PYDANTIC_SCHEMAS.keys())
+    assert not missing, (
+        "Tools missing from Pydantic schema generator — they would ship "
+        "stub inputSchemas that drift from the real request model:\n"
+        + "\n".join(f"  - {name}" for name in sorted(missing))
+        + "\n\nAdd each tool to ``_tool_to_request`` in "
+        "``adcp/server/mcp_tools.py``, mapped to its ``<ToolName>Request`` model."
+    )
+
+
+def test_input_schemas_match_pydantic_generation() -> None:
+    """tools/list schemas must byte-match fresh generation — no silent drift."""
+    fresh = _generate_pydantic_schemas()
+    mismatches: list[str] = []
+    for tool in ADCP_TOOL_DEFINITIONS:
+        name = tool["name"]
+        if name not in fresh:
+            continue
+        expected = fresh[name]
+        actual = tool["inputSchema"]
+        if json.dumps(actual, sort_keys=True) != json.dumps(expected, sort_keys=True):
+            mismatches.append(name)
+
+    assert not mismatches, (
+        "ADCP_TOOL_DEFINITIONS has stale inputSchemas — "
+        "`_apply_pydantic_schemas()` must run at import time:\n"
+        + "\n".join(f"  - {name}" for name in mismatches)
+    )
+
+
+def test_required_fields_advertised() -> None:
+    """Required fields on each model must appear in the tool's inputSchema.
+
+    Agents building payloads from ``tools/list`` rely on the ``required``
+    array to know which fields cannot be omitted. If a model marks a
+    field as required but the advertised schema doesn't, the agent will
+    happily send a malformed request.
+    """
+    from pydantic import TypeAdapter
+
+    from adcp.types import (
+        AcquireRightsRequest,
+        BuildCreativeRequest,
+        CheckGovernanceRequest,
+        ContextMatchRequest,
+        CreateMediaBuyRequest,
+        GetProductsRequest,
+        IdentityMatchRequest,
+        ReportPlanOutcomeRequest,
+        SyncGovernanceRequest,
+        UpdateRightsRequest,
+    )
+
+    # Spot-check a representative slice: a mix of simple GETs, mutating
+    # writes, and schemas that include nested $refs. If the required
+    # fields drift for any of these, the rest probably drifted too.
+    checks = {
+        "get_products": GetProductsRequest,
+        "build_creative": BuildCreativeRequest,
+        "create_media_buy": CreateMediaBuyRequest,
+        "check_governance": CheckGovernanceRequest,
+        "report_plan_outcome": ReportPlanOutcomeRequest,
+        "acquire_rights": AcquireRightsRequest,
+        "update_rights": UpdateRightsRequest,
+        "sync_governance": SyncGovernanceRequest,
+        "context_match": ContextMatchRequest,
+        "identity_match": IdentityMatchRequest,
+    }
+
+    tool_schemas = {t["name"]: t["inputSchema"] for t in ADCP_TOOL_DEFINITIONS}
+    errors: list[str] = []
+
+    for tool_name, model in checks.items():
+        expected_required = set(TypeAdapter(model).json_schema().get("required", []))
+        advertised_required = set(tool_schemas[tool_name].get("required", []))
+        missing = expected_required - advertised_required
+        if missing:
+            errors.append(
+                f"{tool_name}: model requires {sorted(missing)} " f"but inputSchema does not"
+            )
+
+    assert not errors, "Required-field drift:\n" + "\n".join(errors)
+
+
+def test_spot_check_real_fields_reach_clients() -> None:
+    """The three tools that previously had the worst drift must now
+    advertise the real required fields from their request models.
+    """
+    tool_schemas = {t["name"]: t["inputSchema"] for t in ADCP_TOOL_DEFINITIONS}
+
+    get_products = tool_schemas["get_products"]
+    assert "brief" in get_products["properties"]
+    assert "buying_mode" in get_products["properties"]
+    assert "buying_mode" in get_products.get("required", [])
+
+    build_creative = tool_schemas["build_creative"]
+    assert "target_format_id" in build_creative["properties"]
+    assert "creative_manifest" in build_creative["properties"]
+    assert "idempotency_key" in build_creative.get("required", [])
+
+    create_media_buy = tool_schemas["create_media_buy"]
+    for field in ("account", "brand", "start_time", "end_time", "packages"):
+        assert field in create_media_buy["properties"], f"create_media_buy missing field {field!r}"
+    for req in ("account", "brand", "start_time", "end_time", "idempotency_key"):
+        assert req in create_media_buy.get(
+            "required", []
+        ), f"create_media_buy should require {req!r}"

--- a/tests/test_server_dx.py
+++ b/tests/test_server_dx.py
@@ -22,9 +22,9 @@ from adcp.server.responses import (
     products_response,
     signals_response,
     sync_accounts_response,
-    sync_governance_response,
     sync_catalogs_response,
     sync_creatives_response,
+    sync_governance_response,
     update_media_buy_response,
 )
 from adcp.server.test_controller import (
@@ -33,7 +33,6 @@ from adcp.server.test_controller import (
     _handle_test_controller,
     _list_scenarios,
 )
-
 
 # ============================================================================
 # Response builder tests — match actual AdCP spec schemas
@@ -153,7 +152,9 @@ class TestDeliveryResponse:
 
 class TestCreativeFormatsResponse:
     def test_basic(self):
-        formats = [{"format_id": {"agent_url": "http://localhost", "id": "d300"}, "name": "Display"}]
+        formats = [
+            {"format_id": {"agent_url": "http://localhost", "id": "d300"}, "name": "Display"}
+        ]
         result = creative_formats_response(formats)
         assert result["formats"] == formats
         assert result["sandbox"] is True
@@ -173,9 +174,46 @@ class TestListCreativesResponse:
     def test_basic(self):
         creatives = [{"creative_id": "c1", "name": "Test", "status": "accepted"}]
         result = list_creatives_response(creatives)
-        assert result["creatives"] == creatives
+        # Helper injects timestamps when caller omits them; identity compare
+        # no longer holds, but payload shape and original fields do.
+        assert len(result["creatives"]) == 1
+        assert result["creatives"][0]["creative_id"] == "c1"
         assert result["pagination"]["total"] == 1
         assert result["query_summary"]["total_results"] == 1
+
+    def test_fills_missing_timestamps(self):
+        """Caller omits created_date/updated_date — helper fills both with now()."""
+        import re
+
+        creatives = [{"creative_id": "c1", "name": "Test", "status": "accepted"}]
+        result = list_creatives_response(creatives)
+        item = result["creatives"][0]
+        assert "created_date" in item
+        assert "updated_date" in item
+        # ISO 8601 with timezone offset.
+        iso_re = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(\+\d{2}:\d{2}|Z)$")
+        assert iso_re.match(item["created_date"]), item["created_date"]
+        assert iso_re.match(item["updated_date"]), item["updated_date"]
+        # When both are defaulted in a single call, they share the same value.
+        assert item["created_date"] == item["updated_date"]
+
+    def test_preserves_caller_provided_timestamps(self):
+        """Explicit timestamps are preserved verbatim."""
+        created = "2024-01-15T10:00:00+00:00"
+        updated = "2024-02-20T15:30:00+00:00"
+        creatives = [
+            {
+                "creative_id": "c1",
+                "name": "Test",
+                "status": "accepted",
+                "created_date": created,
+                "updated_date": updated,
+            }
+        ]
+        result = list_creatives_response(creatives)
+        item = result["creatives"][0]
+        assert item["created_date"] == created
+        assert item["updated_date"] == updated
 
 
 class TestPreviewCreativeResponse:
@@ -284,7 +322,8 @@ class TestTestControllerError:
 
         store = ErrorStore()
         result = await _handle_test_controller(
-            store, {"scenario": "force_account_status", "params": {"account_id": "x", "status": "active"}}
+            store,
+            {"scenario": "force_account_status", "params": {"account_id": "x", "status": "active"}},
         )
         assert result["success"] is False
         assert result["error"] == "NOT_FOUND"
@@ -296,12 +335,17 @@ class TestTestControllerError:
             async def force_media_buy_status(
                 self, media_buy_id: str, status: str, rejection_reason: str | None = None
             ) -> dict[str, Any]:
-                raise TestControllerError("INVALID_TRANSITION", "Cannot transition", current_state="completed")
+                raise TestControllerError(
+                    "INVALID_TRANSITION", "Cannot transition", current_state="completed"
+                )
 
         store = ErrorStore()
         result = await _handle_test_controller(
             store,
-            {"scenario": "force_media_buy_status", "params": {"media_buy_id": "mb-1", "status": "active"}},
+            {
+                "scenario": "force_media_buy_status",
+                "params": {"media_buy_id": "mb-1", "status": "active"},
+            },
         )
         assert result["error"] == "INVALID_TRANSITION"
         assert result["current_state"] == "completed"
@@ -321,7 +365,10 @@ class TestHandleTestController:
         store = MinimalStore()
         result = await _handle_test_controller(
             store,
-            {"scenario": "force_account_status", "params": {"account_id": "acct-1", "status": "suspended"}},
+            {
+                "scenario": "force_account_status",
+                "params": {"account_id": "acct-1", "status": "suspended"},
+            },
         )
         assert result["success"] is True
         assert result["current_state"] == "suspended"
@@ -388,9 +435,8 @@ class TestRegisterTestController:
 class TestServeWithTestController:
     def test_serve_accepts_test_controller(self):
         """Verify serve() signature accepts test_controller kwarg."""
-        from adcp.server.serve import create_mcp_server
-
         from adcp.server import ADCPHandler
+        from adcp.server.serve import create_mcp_server
 
         class TestHandler(ADCPHandler):
             async def get_adcp_capabilities(self, params, context=None):
@@ -400,6 +446,7 @@ class TestServeWithTestController:
         mcp = create_mcp_server(TestHandler(), name="test")
         store = MinimalStore()
         from adcp.server.test_controller import register_test_controller
+
         register_test_controller(mcp, store)
 
         tool_names = [t.name for t in mcp._tool_manager.list_tools()]
@@ -435,5 +482,11 @@ class TestPydanticSchemas:
     def test_key_tools_have_pydantic_schemas(self):
         from adcp.server.mcp_tools import _PYDANTIC_SCHEMAS
 
-        for tool in ["get_products", "create_media_buy", "sync_accounts", "get_signals", "activate_signal"]:
+        for tool in [
+            "get_products",
+            "create_media_buy",
+            "sync_accounts",
+            "get_signals",
+            "activate_signal",
+        ]:
             assert tool in _PYDANTIC_SCHEMAS, f"{tool} missing Pydantic schema"

--- a/tests/test_server_idempotency.py
+++ b/tests/test_server_idempotency.py
@@ -42,9 +42,7 @@ class TestCanonicalize:
         assert a != b
 
     def test_strip_idempotency_key(self) -> None:
-        stripped = strip_excluded_fields(
-            {"idempotency_key": "abc123def456ghi7", "brand": "acme"}
-        )
+        stripped = strip_excluded_fields({"idempotency_key": "abc123def456ghi7", "brand": "acme"})
         assert stripped == {"brand": "acme"}
 
     def test_strip_context(self) -> None:
@@ -100,9 +98,7 @@ class TestCanonicalize:
         # Regression guard — if a maintainer adds fields to EXCLUDED_FIELDS
         # without updating the spec, the test surfaces it. This test locks the
         # closed set to what's actually in the spec.
-        assert EXCLUDED_FIELDS == frozenset(
-            {"idempotency_key", "context", "governance_context"}
-        )
+        assert EXCLUDED_FIELDS == frozenset({"idempotency_key", "context", "governance_context"})
 
 
 class TestMemoryBackend:
@@ -129,9 +125,7 @@ class TestMemoryBackend:
     @pytest.mark.asyncio
     async def test_expired_entry_returns_none_and_evicts(self) -> None:
         backend = MemoryBackend()
-        entry = CachedResponse(
-            payload_hash="abc", response={}, expires_at_epoch=time.time() - 1
-        )
+        entry = CachedResponse(payload_hash="abc", response={}, expires_at_epoch=time.time() - 1)
         await backend.put("principal-a", "key-1", entry)
         assert await backend.get("principal-a", "key-1") is None
         # Lazy eviction should have removed it.
@@ -160,12 +154,8 @@ class TestMemoryBackend:
     async def test_delete_expired_sweeps(self) -> None:
         backend = MemoryBackend()
         now = time.time()
-        await backend.put(
-            "principal-a", "fresh", CachedResponse("h", {}, now + 60)
-        )
-        await backend.put(
-            "principal-a", "stale", CachedResponse("h", {}, now - 1)
-        )
+        await backend.put("principal-a", "fresh", CachedResponse("h", {}, now + 60))
+        await backend.put("principal-a", "stale", CachedResponse("h", {}, now - 1))
         removed = await backend.delete_expired(now)
         assert removed == 1
         assert await backend._size() == 1
@@ -183,9 +173,7 @@ class TestMemoryBackend:
             )
 
         await asyncio.gather(*[writer(i) for i in range(50)])
-        hits = await asyncio.gather(
-            *[backend.get("principal", f"key-{i}") for i in range(50)]
-        )
+        hits = await asyncio.gather(*[backend.get("principal", f"key-{i}") for i in range(50)])
         assert all(h is not None for h in hits)
         assert all(h.response["i"] == i for i, h in enumerate(hits))  # type: ignore[union-attr]
 
@@ -272,12 +260,8 @@ class TestIdempotencyStoreWrap:
         wrapped = store.wrap(_FakeHandler.create_media_buy)
         key = str(uuid.uuid4())
         ctx = ToolContext(caller_identity="principal-a")
-        r1 = await wrapped(
-            handler, {"idempotency_key": key, "brand": "A", "context": "ctx1"}, ctx
-        )
-        r2 = await wrapped(
-            handler, {"idempotency_key": key, "brand": "A", "context": "ctx2"}, ctx
-        )
+        r1 = await wrapped(handler, {"idempotency_key": key, "brand": "A", "context": "ctx1"}, ctx)
+        r2 = await wrapped(handler, {"idempotency_key": key, "brand": "A", "context": "ctx2"}, ctx)
         assert r1 == r2
         assert handler.call_count == 1
 
@@ -430,9 +414,7 @@ class TestCachedResponseImmutability:
 
 class TestBackendPutFailure:
     @pytest.mark.asyncio
-    async def test_put_failure_logs_warning_and_returns_handler_result(
-        self, caplog: Any
-    ) -> None:
+    async def test_put_failure_logs_warning_and_returns_handler_result(self, caplog: Any) -> None:
         import logging as _logging
 
         class BrokenBackend(MemoryBackend):
@@ -444,9 +426,7 @@ class TestBackendPutFailure:
         wrapped = store.wrap(_FakeHandler.create_media_buy)
         ctx = ToolContext(caller_identity="principal-a")
         with caplog.at_level(_logging.WARNING, logger="adcp.server.idempotency.store"):
-            result = await wrapped(
-                handler, {"idempotency_key": str(uuid.uuid4()), "b": 1}, ctx
-            )
+            result = await wrapped(handler, {"idempotency_key": str(uuid.uuid4()), "b": 1}, ctx)
         assert result["media_buy_id"] == "mb_1"  # handler ran, result returned
         assert any("cache put failed" in rec.message for rec in caplog.records)
 
@@ -523,9 +503,7 @@ class TestWireTranslation:
         task = captured[0]
         assert task.status.state == TaskState.failed
         assert task.artifacts, "failed task missing artifacts"
-        data_parts = [
-            p.root for p in task.artifacts[0].parts if isinstance(p.root, DataPart)
-        ]
+        data_parts = [p.root for p in task.artifacts[0].parts if isinstance(p.root, DataPart)]
         assert data_parts, "failed task missing DataPart"
         adcp_error = data_parts[0].data.get("adcp_error")
         assert adcp_error is not None
@@ -543,14 +521,18 @@ def _make_context_shim() -> Any:
 class TestCapability:
     def test_capability_fragment(self) -> None:
         store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
-        assert store.capability() == {"replay_ttl_seconds": 86400}
+        # ``supported`` became REQUIRED on adcp.idempotency in 3.0 GA.
+        assert store.capability() == {"supported": True, "replay_ttl_seconds": 86400}
 
     def test_capabilities_response_accepts_idempotency(self) -> None:
         from adcp.server.responses import capabilities_response
 
         store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=86400)
         resp = capabilities_response(["media_buy"], idempotency=store.capability())
-        assert resp["adcp"]["idempotency"] == {"replay_ttl_seconds": 86400}
+        assert resp["adcp"]["idempotency"] == {
+            "supported": True,
+            "replay_ttl_seconds": 86400,
+        }
 
     def test_capabilities_response_idempotency_omitted_when_none(self) -> None:
         from adcp.server.responses import capabilities_response
@@ -575,11 +557,11 @@ class TestCapability:
 
     def test_ttl_minimum_accepted(self) -> None:
         store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=3600)
-        assert store.capability() == {"replay_ttl_seconds": 3600}
+        assert store.capability() == {"supported": True, "replay_ttl_seconds": 3600}
 
     def test_ttl_maximum_accepted(self) -> None:
         store = IdempotencyStore(backend=MemoryBackend(), ttl_seconds=604800)
-        assert store.capability() == {"replay_ttl_seconds": 604800}
+        assert store.capability() == {"supported": True, "replay_ttl_seconds": 604800}
 
 
 class TestTTLExpiry:

--- a/tests/test_spec_coverage.py
+++ b/tests/test_spec_coverage.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
 
 def _schema_task_names() -> set[str]:
@@ -83,9 +82,7 @@ def test_feature_and_domain_maps_cover_brand_tasks() -> None:
     from adcp.capabilities import TASK_FEATURE_MAP
     from adcp.server.builder import HANDLER_TO_DOMAIN
 
-    brand_tasks = {
-        name for name, domain in HANDLER_TO_DOMAIN.items() if domain == "brand"
-    }
+    brand_tasks = {name for name, domain in HANDLER_TO_DOMAIN.items() if domain == "brand"}
     missing = sorted(t for t in brand_tasks if t not in TASK_FEATURE_MAP)
     assert missing == [], (
         f"brand tasks present in HANDLER_TO_DOMAIN but missing from "
@@ -107,21 +104,33 @@ def test_tool_filtering_by_handler_type():
 
     gov_tools = {t["name"] for t in get_tools_for_handler(GovernanceHandler)}
     assert gov_tools == {
-        "get_creative_features", "sync_plans", "check_governance",
-        "report_plan_outcome", "get_plan_audit_logs",
-        "create_property_list", "get_property_list", "list_property_lists",
-        "update_property_list", "delete_property_list",
-        "create_collection_list", "get_collection_list", "list_collection_lists",
-        "update_collection_list", "delete_collection_list",
+        "get_creative_features",
+        "sync_plans",
+        "check_governance",
+        "report_plan_outcome",
+        "get_plan_audit_logs",
+        "create_property_list",
+        "get_property_list",
+        "list_property_lists",
+        "update_property_list",
+        "delete_property_list",
+        "create_collection_list",
+        "get_collection_list",
+        "list_collection_lists",
+        "update_collection_list",
+        "delete_collection_list",
         "get_adcp_capabilities",
     }
 
     # ContentStandardsHandler: content standards tools + protocol discovery
     cs_tools = {t["name"] for t in get_tools_for_handler(ContentStandardsHandler)}
     assert cs_tools == {
-        "create_content_standards", "get_content_standards",
-        "list_content_standards", "update_content_standards",
-        "calibrate_content", "validate_content_delivery",
+        "create_content_standards",
+        "get_content_standards",
+        "list_content_standards",
+        "update_content_standards",
+        "calibrate_content",
+        "validate_content_delivery",
         "get_media_buy_artifacts",
         "get_adcp_capabilities",
     }
@@ -129,8 +138,10 @@ def test_tool_filtering_by_handler_type():
     # SponsoredIntelligenceHandler: SI tools + protocol discovery
     si_tools = {t["name"] for t in get_tools_for_handler(SponsoredIntelligenceHandler)}
     assert si_tools == {
-        "si_get_offering", "si_initiate_session",
-        "si_send_message", "si_terminate_session",
+        "si_get_offering",
+        "si_initiate_session",
+        "si_send_message",
+        "si_terminate_session",
         "get_adcp_capabilities",
     }
 
@@ -146,51 +157,19 @@ def test_tool_filtering_by_handler_type():
     assert subclass_tools == gov_tools
 
 
-def _collect_all_properties(schema: dict[str, Any]) -> set[str]:
-    """Extract all top-level property names from a JSON schema.
-
-    Handles plain objects, oneOf/anyOf union schemas, and $defs references.
-    """
-    defs = schema.get("$defs", {})
-
-    def _props_from_subschema(sub: dict[str, Any]) -> set[str]:
-        if "properties" in sub:
-            return set(sub["properties"].keys())
-        if "$ref" in sub:
-            ref_name = sub["$ref"].rsplit("/", 1)[-1]
-            ref_schema = defs.get(ref_name, {})
-            return set(ref_schema.get("properties", {}).keys())
-        return set()
-
-    # Direct properties on the schema
-    if "properties" in schema:
-        return set(schema["properties"].keys())
-
-    # Union types produce oneOf or anyOf at top level
-    for key in ("oneOf", "anyOf"):
-        if key in schema:
-            props: set[str] = set()
-            for variant in schema[key]:
-                props |= _props_from_subschema(variant)
-            return props
-
-    return set()
-
-
 def test_mcp_tool_input_schema_matches_pydantic_models():
-    """MCP tool inputSchema properties stay in sync with Pydantic request models.
+    """MCP tool inputSchemas are generated from Pydantic request models.
 
-    For each MCP tool that has a corresponding Pydantic request model, verify
-    that no *new* fields have appeared on the model without being reflected in
-    the hand-written MCP inputSchema.
-
-    Known gaps (fields the MCP schema intentionally omits) are recorded below.
-    If a Pydantic model gains a field that is not in the MCP inputSchema AND
-    not in the known-gaps set, this test fails -- signaling that the MCP tool
-    definition needs updating.
+    The ``ADCP_TOOL_DEFINITIONS[*].inputSchema`` is overwritten at import
+    time by ``_apply_pydantic_schemas()`` with the output of
+    ``model_json_schema()`` on the corresponding ``<ToolName>Request``
+    model. This test is a coarse guard that every tool with a mapped
+    request model carries a schema advertising every field of that
+    model. For byte-level drift enforcement, see
+    ``tests/test_mcp_schema_drift.py``.
     """
     from adcp.__main__ import _get_dispatch_table
-    from adcp.server.mcp_tools import ADCP_TOOL_DEFINITIONS
+    from adcp.server.mcp_tools import _PYDANTIC_SCHEMAS, ADCP_TOOL_DEFINITIONS
 
     dispatch_table = _get_dispatch_table()
     tool_schemas = {
@@ -199,194 +178,30 @@ def test_mcp_tool_input_schema_matches_pydantic_models():
     }
 
     # Tools with no request type or that intentionally diverge
-    SKIP_TOOLS = {"list_tools", "get_info"}
-
-    # Fields the MCP inputSchema intentionally omits per tool.
-    # When adding a field to a Pydantic model, either add it to the MCP
-    # inputSchema in mcp_tools.py or add it here with a comment explaining why.
-    KNOWN_GAPS: dict[str, set[str]] = {
-        "get_products": {
-            "account", "brand", "brief", "buyer_campaign_ref", "buying_mode",
-            "catalog", "ext", "preferred_delivery_types", "property_list",
-            "refine", "required_policies", "time_budget",
-        },
-        "list_creative_formats": {
-            "asset_types", "context", "disclosure_persistence",
-            "disclosure_positions", "ext", "format_ids", "input_format_ids",
-            "is_responsive", "max_height", "max_width", "min_height",
-            "min_width", "name_search", "output_format_ids", "wcag_level",
-        },
-        "preview_creative": {
-            "context", "creative_id", "ext", "inputs", "item_limit", "quality",
-            "request_type", "requests", "template_id", "variant_id",
-        },
-        "build_creative": {
-            "brand", "concept_id", "context", "creative_id",
-            "creative_manifest", "ext", "idempotency_key", "include_preview",
-            "item_limit", "macro_values", "media_buy_id", "message",
-            "package_id", "preview_inputs", "preview_output_format",
-            "preview_quality", "quality", "target_format_id",
-            "target_format_ids",
-        },
-        "sync_creatives": {
-            "account", "assignments", "context", "creative_ids",
-            "delete_missing", "dry_run", "ext", "idempotency_key",
-            "push_notification_config", "validation_mode",
-        },
-        "list_creatives": {
-            "context", "ext", "include_assignments", "include_items",
-            "include_snapshot", "include_variables", "sort",
-        },
-        "create_media_buy": {
-            "account", "advertiser_industry", "artifact_webhook", "brand",
-            "buyer_campaign_ref", "buyer_ref", "context", "end_time", "ext",
-            "idempotency_key", "invoice_recipient", "io_acceptance",
-            "plan_id", "po_number", "push_notification_config",
-            "reporting_webhook", "start_time", "total_budget",
-        },
-        "update_media_buy": {
-            "buyer_ref", "canceled", "cancellation_reason", "context",
-            "end_time", "ext", "idempotency_key", "invoice_recipient",
-            "new_packages", "paused", "push_notification_config",
-            "reporting_webhook", "revision", "start_time", "status_filter",
-            "total_budget",
-        },
-        "get_media_buy_delivery": {
-            "account", "attribution_window", "buyer_refs", "context",
-            "end_date", "ext", "fields", "include_creative_breakdown",
-            "include_package_daily_breakdown", "media_buy_ids",
-            "metrics_granularity", "package_ids", "pagination",
-            "reporting_dimensions", "start_date", "status_filter",
-        },
-        "get_media_buys": {
-            "context", "ext", "fields", "include_delivery_snapshot",
-            "include_history", "include_packages", "include_snapshot",
-            "status_filter",
-        },
-        "get_signals": {
-            "account", "buyer_campaign_ref", "context", "countries",
-            "destinations", "ext", "max_results", "signal_ids", "signal_spec",
-        },
-        "activate_signal": {
-            "account", "action", "buyer_campaign_ref", "context",
-            "destinations", "ext", "idempotency_key", "pricing_option_id",
-            "signal_agent_segment_id",
-        },
-        "provide_performance_feedback": {
-            "buyer_ref", "context", "creative_id", "ext", "feedback_source",
-            "idempotency_key", "measurement_period", "metric_type",
-            "package_id", "performance_index",
-        },
-        "list_accounts": {"context", "ext", "sandbox", "status"},
-        "sync_accounts": {
-            "context", "delete_missing", "dry_run", "ext",
-            "push_notification_config",
-        },
-        "get_account_financials": {"context", "ext", "period"},
-        "report_usage": {"context", "ext", "idempotency_key", "reporting_period"},
-        "log_event": {"context", "event_source_id", "ext", "idempotency_key", "test_event_code"},
-        "sync_event_sources": {"account", "context", "delete_missing", "ext"},
-        "sync_audiences": {"context", "delete_missing", "ext"},
-        "sync_catalogs": {
-            "catalog_ids", "context", "delete_missing", "dry_run", "ext",
-            "push_notification_config", "validation_mode",
-        },
-        "get_creative_delivery": {
-            "account", "context", "end_date", "ext", "max_variants",
-            "media_buy_buyer_refs", "pagination", "start_date",
-        },
-        "get_adcp_capabilities": {"context", "ext", "protocols"},
-        "create_content_standards": {
-            "calibration_exemplars", "context", "ext", "idempotency_key",
-            "policy", "registry_policy_ids", "scope",
-        },
-        "get_content_standards": {"context", "ext", "standards_id"},
-        "list_content_standards": {
-            "channels", "context", "countries", "ext", "languages",
-        },
-        "update_content_standards": {
-            "calibration_exemplars", "context", "ext", "idempotency_key",
-            "policy", "registry_policy_ids", "scope", "standards_id",
-        },
-        "calibrate_content": {"artifact", "idempotency_key", "standards_id"},
-        "validate_content_delivery": {
-            "context", "ext", "feature_ids", "include_passed", "records",
-            "standards_id",
-        },
-        "get_media_buy_artifacts": {
-            "account", "context", "ext", "failures_only", "package_ids",
-            "pagination", "sampling", "time_range",
-        },
-        "get_creative_features": {"ext", "feature_ids"},
-        "check_governance": {
-            "buyer_ref", "delivery_metrics", "invoice_recipient",
-            "media_buy_id", "modification_summary", "phase",
-            "planned_delivery",
-        },
-        "si_get_offering": {
-            "context", "ext", "include_products", "offering_id",
-            "product_limit",
-        },
-        "report_plan_outcome": {
-            "governance_context", "idempotency_key",
-        },
-        "si_initiate_session": {
-            "context", "ext", "idempotency_key", "identity", "media_buy_id",
-            "offering_id", "offering_token", "placement",
-            "supported_capabilities",
-        },
-        "si_send_message": {"action_response", "ext"},
-        "si_terminate_session": {"ext", "reason", "termination_context"},
-        "create_property_list": {"brand", "context", "ext", "idempotency_key"},
-        "get_property_list": {"context", "ext"},
-        "list_property_lists": {"context", "ext", "name_contains"},
-        "update_property_list": {
-            "base_properties", "brand", "context", "ext", "idempotency_key",
-            "webhook_url",
-        },
-        "delete_property_list": {"context", "ext", "idempotency_key"},
-        # Collection Lists + sync_governance: envelope fields
-        "create_collection_list": {"context", "ext", "idempotency_key"},
-        "get_collection_list": {"context", "ext"},
-        "list_collection_lists": {"context", "ext"},
-        "update_collection_list": {"context", "ext", "idempotency_key"},
-        "delete_collection_list": {"context", "ext", "idempotency_key"},
-        "sync_governance": {
-            "adcp_major_version", "context", "ext", "idempotency_key",
-        },
-        # TMP: envelope fields optional for agents
-        "context_match": {
-            "$schema", "artifact", "property_id", "protocol_version",
-        },
-        "identity_match": {"$schema", "protocol_version"},
-        # Brand Rights: envelope fields
-        "get_brand_identity": {"context", "ext"},
-        "get_rights": {"buyer_brand", "context", "ext"},
-        "acquire_rights": {"context", "ext", "push_notification_config"},
-        # Compliance: envelope field
-        "comply_test_controller": {"ext"},
-    }
+    skip_tools = {"list_tools", "get_info"}
 
     drift: list[str] = []
-
     for tool_name, (_, type_adapter) in dispatch_table.items():
-        if tool_name in SKIP_TOOLS or type_adapter is None:
+        if tool_name in skip_tools or type_adapter is None:
             continue
         if tool_name not in tool_schemas:
             continue
+        # If generation failed for this tool, the inputSchema is the
+        # hand-crafted stub — covered by tests/test_mcp_schema_drift.py's
+        # test_every_tool_has_pydantic_generated_schema.
+        if tool_name not in _PYDANTIC_SCHEMAS:
+            continue
 
-        model_schema = type_adapter.json_schema()
-        model_props = _collect_all_properties(model_schema)
+        model_props = set(type_adapter.json_schema().get("properties", {}).keys())
         mcp_props = tool_schemas[tool_name]
-        known = KNOWN_GAPS.get(tool_name, set())
-
-        missing = sorted(model_props - mcp_props - known)
+        missing = sorted(model_props - mcp_props)
         if missing:
-            drift.append(f"{tool_name}: model has {missing} not in MCP inputSchema")
+            drift.append(f"{tool_name}: model has {missing} not in inputSchema")
 
     assert drift == [], (
         "MCP tool inputSchema fields have drifted from Pydantic models.\n"
-        "Either add the field to ADCP_TOOL_DEFINITIONS in mcp_tools.py,\n"
-        "or add it to KNOWN_GAPS in this test with a comment explaining why.\n"
+        "The inputSchema is auto-generated from the request model at\n"
+        "import time; this drift shouldn't be possible unless schema\n"
+        "generation is broken. See tests/test_mcp_schema_drift.py.\n"
         + "\n".join(f"  - {d}" for d in drift)
     )

--- a/tests/test_webhook_handling.py
+++ b/tests/test_webhook_handling.py
@@ -1247,11 +1247,12 @@ class TestHMACTestVectors:
             pytest.skip("non-JSON raw_body")
             return
 
-        # If json.dumps(payload_dict) reproduces the raw_body exactly,
-        # then get_adcp_signed_headers_for_webhook should match
-        reserialized = json.dumps(payload_dict)
+        # The signer writes compact-separator bytes (matching httpx json=),
+        # so the test vector only round-trips cleanly when its raw_body was
+        # captured in the same form. Skip vectors that used spaced/pretty JSON.
+        reserialized = json.dumps(payload_dict, separators=(",", ":"))
         if reserialized != raw_body:
-            pytest.skip("raw_body uses different serialization than json.dumps default")
+            pytest.skip("raw_body uses different serialization than compact json.dumps")
             return
 
         headers = get_adcp_signed_headers_for_webhook(
@@ -1263,6 +1264,45 @@ class TestHMACTestVectors:
 
         assert headers["X-AdCP-Signature"] == expected
         assert headers["X-AdCP-Timestamp"] == str(timestamp)
+
+    def test_signer_matches_httpx_json_wire_form(self):
+        """Signer must produce the same bytes httpx writes for `json=payload`.
+
+        Regression guard for the round-4 blocker: default json.dumps uses
+        ", "/": " separators while httpx writes compact ","/":" — sellers
+        using the documented ``client.post(url, json=payload, headers=signed)``
+        pattern got silent 401s. Verifying directly against httpx's wire
+        bytes means any future drift fails loudly in CI.
+        """
+        import hashlib
+        import hmac
+
+        import httpx
+
+        payload = {
+            "task_id": "task_123",
+            "status": "completed",
+            "result": {"products": [{"id": "p1", "price": 12.5}]},
+            "nested": {"a": 1, "b": None, "c": [1, 2, 3]},
+        }
+        timestamp = "1700000000"
+        secret = "test_secret"
+
+        headers = get_adcp_signed_headers_for_webhook(
+            headers={},
+            secret=secret,
+            timestamp=timestamp,
+            payload=payload,
+        )
+
+        # The bytes httpx actually sends on the wire for json=
+        httpx_wire = httpx.Request("POST", "http://localhost/", json=payload).content
+        signed_message = f"{timestamp}.{httpx_wire.decode()}"
+        expected_sig = hmac.new(
+            secret.encode("utf-8"), signed_message.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+        assert headers["X-AdCP-Signature"] == f"sha256={expected_sig}"
 
     @pytest.mark.parametrize(
         "vector",

--- a/tests/test_webhook_handling.py
+++ b/tests/test_webhook_handling.py
@@ -202,6 +202,7 @@ class TestMCPWebhooks:
             operation_id="op_333",
             signature=signature,
             timestamp=header_timestamp,
+            raw_body=payload_json.encode("utf-8"),
         )
 
         assert result.status == TaskStatus.COMPLETED
@@ -292,6 +293,7 @@ class TestMCPWebhooks:
             operation_id="op_ts1",
             signature=signature,
             timestamp=header_timestamp,
+            raw_body=payload_json.encode("utf-8"),
         )
 
         assert result.status == TaskStatus.COMPLETED
@@ -1269,6 +1271,65 @@ class TestHMACTestVectors:
 
         assert headers["X-AdCP-Signature"] == expected
         assert headers["X-AdCP-Timestamp"] == str(timestamp)
+
+    @pytest.mark.asyncio
+    async def test_verify_fails_closed_when_raw_body_missing(self):
+        """Per adcontextprotocol/adcp#2478, verifiers MUST fail closed when
+        they cannot capture raw body bytes. Re-serializing a parsed payload
+        to reconstruct the signed bytes silently fails against signers whose
+        output differs in separator choice, key order, unicode escape policy,
+        or number formatting — masking the signer bugs the verifier should
+        surface.
+        """
+        config = AgentConfig(
+            id="test_agent",
+            agent_uri="https://test.example.com",
+            protocol=Protocol.MCP,
+        )
+        client = ADCPClient(config, webhook_secret="test_secret")
+
+        import hashlib
+        import hmac
+
+        valid_payload = {
+            "task_id": "t1",
+            "task_type": "create_media_buy",
+            "status": "completed",
+            "timestamp": "2025-01-15T10:00:00Z",
+            "result": {"media_buy_id": "mb_1", "buyer_ref": "ref_1", "packages": []},
+        }
+        # Compute what would have been a valid signature under the old
+        # re-serialize-from-payload fallback. Under the fail-closed rule,
+        # this must no longer verify — even with a real HMAC over a real
+        # serialization, if raw_body isn't captured, reject.
+        timestamp = str(int(time.time()))
+        body_bytes = json.dumps(valid_payload, separators=(",", ":")).encode("utf-8")
+        signed_message = f"{timestamp}.{body_bytes.decode('utf-8')}"
+        signature = hmac.new(
+            b"test_secret", signed_message.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+        with pytest.raises(ADCPWebhookSignatureError):
+            await client.handle_webhook(
+                valid_payload,
+                task_type="create_media_buy",
+                operation_id="op_fail_closed",
+                signature=f"sha256={signature}",
+                timestamp=timestamp,
+                # raw_body intentionally omitted — MUST reject
+            )
+
+        # Same call WITH raw_body must succeed, proving the rejection is
+        # specifically about the missing raw_body, not the signature itself.
+        result = await client.handle_webhook(
+            valid_payload,
+            task_type="create_media_buy",
+            operation_id="op_fail_closed_ok",
+            signature=f"sha256={signature}",
+            timestamp=timestamp,
+            raw_body=body_bytes,
+        )
+        assert result.status == TaskStatus.COMPLETED
 
     def test_signer_matches_httpx_json_wire_form(self):
         """Signer must produce the same bytes httpx writes for `json=payload`.

--- a/tests/test_webhook_handling.py
+++ b/tests/test_webhook_handling.py
@@ -26,13 +26,8 @@ from a2a.types import (
 
 from adcp.client import ADCPClient
 from adcp.exceptions import ADCPWebhookSignatureError
-from adcp.types import GeneratedTaskStatus
 from adcp.types.core import AgentConfig, Protocol, TaskStatus
-from adcp.webhooks import (
-    create_mcp_webhook_payload,
-    extract_webhook_result_data,
-    get_adcp_signed_headers_for_webhook,
-)
+from adcp.webhooks import extract_webhook_result_data, get_adcp_signed_headers_for_webhook
 
 
 class TestMCPWebhooks:
@@ -1297,6 +1292,7 @@ class TestHMACTestVectors:
         import hmac
 
         valid_payload = {
+            "idempotency_key": "whk_fail_closed_test",
             "task_id": "t1",
             "task_type": "create_media_buy",
             "status": "completed",
@@ -1526,5 +1522,3 @@ class TestHMACTestVectors:
             raw_body=raw_body,
         )
         assert result is False, f"Verifier accepted rejection vector {vector['description']!r}"
-
-

--- a/tests/test_webhook_handling.py
+++ b/tests/test_webhook_handling.py
@@ -25,8 +25,13 @@ from a2a.types import (
 
 from adcp.client import ADCPClient
 from adcp.exceptions import ADCPWebhookSignatureError
+from adcp.types import GeneratedTaskStatus
 from adcp.types.core import AgentConfig, Protocol, TaskStatus
-from adcp.webhooks import extract_webhook_result_data, get_adcp_signed_headers_for_webhook
+from adcp.webhooks import (
+    create_mcp_webhook_payload,
+    extract_webhook_result_data,
+    get_adcp_signed_headers_for_webhook,
+)
 
 
 class TestMCPWebhooks:
@@ -1369,3 +1374,5 @@ class TestHMACTestVectors:
         )
 
         assert result is False
+
+

--- a/tests/test_webhook_handling.py
+++ b/tests/test_webhook_handling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re as _re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1197,12 +1198,16 @@ class TestExtractWebhookResultData:
         assert result["errors"][0]["code"] == "INTERNAL_ERROR"
 
 
-# Load official AdCP HMAC test vectors from fixtures
-# Source: adcontextprotocol/adcp PR #1383
+# Load official AdCP HMAC test vectors from fixtures.
+# Source: adcontextprotocol/adcp PR #2478 (merged 2026-04-20), which pins the
+# canonical on-wire JSON form (compact separators) and adds rejection vectors
+# including the signer/serialization-mismatch case. Upstream file:
+# https://github.com/adcontextprotocol/adcp/blob/main/static/test-vectors/webhook-hmac-sha256.json
 _VECTORS_PATH = Path(__file__).parent / "fixtures" / "webhook-hmac-sha256.json"
 _VECTORS_DATA = json.loads(_VECTORS_PATH.read_text())
 HMAC_TEST_VECTORS_SECRET = _VECTORS_DATA["secret"]
 HMAC_TEST_VECTORS = _VECTORS_DATA["vectors"]
+HMAC_REJECTION_VECTORS = _VECTORS_DATA.get("rejection_vectors", [])
 
 
 class TestHMACTestVectors:
@@ -1435,5 +1440,91 @@ class TestHMACTestVectors:
         )
 
         assert result is False
+
+    @pytest.mark.parametrize(
+        "vector",
+        HMAC_REJECTION_VECTORS,
+        ids=[v["description"] for v in HMAC_REJECTION_VECTORS],
+    )
+    def test_rejection_vectors_do_not_collapse_to_positive(self, vector):
+        """Mirrors the upstream adcp#2478 CI: for each rejection vector whose
+        claimed signature has a well-formed `sha256=<hex>` shape, verify that
+        a correctly-computed HMAC over the claimed raw_body does NOT match
+        the claimed signature — otherwise the rejection vector silently
+        collapses into a positive case and stops catching what it claims to.
+        """
+        import hashlib
+        import hmac as _hmac
+
+        sig = vector.get("signature")
+        raw_body = vector.get("raw_body")
+        timestamp = vector.get("timestamp")
+
+        # Skip structural-rejection cases where the signature is empty, None,
+        # has prefix mismatches, or isn't a numeric HMAC (e.g. the
+        # "sha256=valid_but_irrelevant" or "Double sha256= prefix" vectors).
+        # Those are documented for verifier implementers but not computable.
+        if not isinstance(sig, str) or not sig:
+            pytest.skip("non-computable rejection shape")
+        if not _re.fullmatch(r"sha(256|512)=[0-9a-f]+", sig):
+            pytest.skip("malformed rejection signature — structural, not computational")
+        if not isinstance(timestamp, int) or raw_body is None:
+            pytest.skip("missing raw_body or timestamp")
+
+        message = f"{timestamp}.{raw_body}"
+        computed = (
+            "sha256="
+            + _hmac.new(
+                HMAC_TEST_VECTORS_SECRET.encode("utf-8"),
+                message.encode("utf-8"),
+                hashlib.sha256,
+            ).hexdigest()
+        )
+
+        assert computed != sig, (
+            f"Rejection vector {vector['description']!r} collapses into a "
+            "positive case — the claimed signature is a correct HMAC over "
+            "the claimed raw_body. Fix the vector upstream."
+        )
+
+    @pytest.mark.parametrize(
+        "vector",
+        HMAC_REJECTION_VECTORS,
+        ids=[v["description"] for v in HMAC_REJECTION_VECTORS],
+    )
+    @pytest.mark.asyncio
+    async def test_verifier_rejects_upstream_rejection_vectors(self, vector):
+        """The verifier MUST reject every upstream rejection vector that
+        provides enough context to run end-to-end (signature + raw_body +
+        numeric timestamp). This is the behavioral mirror of the
+        computational check above: not just "the claimed sig doesn't match"
+        but "our verifier returns False."
+        """
+        sig = vector.get("signature")
+        raw_body = vector.get("raw_body")
+        timestamp = vector.get("timestamp")
+
+        if not isinstance(sig, str) or not sig:
+            pytest.skip("non-computable rejection shape")
+        if raw_body is None or not isinstance(timestamp, int):
+            pytest.skip("vector missing raw_body or timestamp")
+
+        config = AgentConfig(
+            id="test_agent",
+            agent_uri="https://test.example.com",
+            protocol=Protocol.MCP,
+        )
+        client = ADCPClient(
+            config,
+            webhook_secret=HMAC_TEST_VECTORS_SECRET,
+            webhook_timestamp_tolerance=10**10,
+        )
+        result = client._verify_webhook_signature(
+            payload={},
+            signature=sig,
+            timestamp=str(timestamp),
+            raw_body=raw_body,
+        )
+        assert result is False, f"Verifier accepted rejection vector {vector['description']!r}"
 
 

--- a/tests/test_webhooks_deliver.py
+++ b/tests/test_webhooks_deliver.py
@@ -455,7 +455,9 @@ async def test_signed_bytes_match_posted_bytes() -> None:
     async with client:
         await deliver(config, payload, client=client)
 
-    expected_body = json.dumps(payload).encode("utf-8")
+    # Compact separators — deliver() pins the canonical on-wire form from
+    # adcontextprotocol/adcp#2478 so signer and wire bytes can never drift.
+    expected_body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     assert captured[0].content == expected_body
 
 


### PR DESCRIPTION
## Summary

Pre-4.0 DX sweep driven by a skill-based validation gate: have Claude follow each `build-*` skill literally against its primary storyboard, capture friction, fix the cheap findings. This PR lands the fixes in atomic commits so review is per-finding.

The new harness (`scripts/skill-build-setup.sh` + `scripts/skill-run.sh`) makes this loop repeatable — one-line rerun of any skill against its storyboard. Verified end-to-end: `creative_lifecycle` passes via the harness.

Two rounds of expert review + re-validation landed additional fixes (see expanded Commits below). One surprise worth flagging: the original "59 drifted MCP inputSchemas" claim was wrong — `_generate_pydantic_schemas()` at `server/mcp_tools.py:915` was already auto-generating them at import time. Only `sync_governance` was still on a hand-crafted stub. That's now fixed + drift-guarded.

## Commits

**Round 1 — Skill doc fixes** (5 commits, one per skill):
- `docs(seller)` — drops invalid `compliance_testing` SupportedProtocol claim, strips invalid `delivery_measurement` keys, fixes `products_response(proposal=)` crash, corrects `serve()` Quick Ref.
- `docs(generative-seller)` — same enum fix, corrects `"accepted"` → `"approved"` status, adds required `build_creative`/`preview_creative` handler section with `idempotency_key`.
- `docs(retail)` — enum fix, validation command.
- `docs(creative)` — kills silent fallback anti-pattern (now `adcp_error("CREATIVE_NOT_FOUND")`), replaces hardcoded timestamps, adds missing `adcp_error` import.
- `docs(signals)` — fixes `signal_ids` filter to tuple-key `(source, id)` discrimination, adds Custom-source bullet, new idempotency subsection.

**Round 1 — SDK fixes** (1 commit):
- `fix(sdk)` — adds `SIGNAL_NOT_FOUND` to `STANDARD_ERROR_CODES`, types `sync_governance` param, re-exports `SyncGovernanceRequest`/`Response`, fixes `CreativeStatus` docstring, drops unwired `mount` kwarg, adds optional `compliance_testing=` kwarg to `capabilities_response()`.

**Round 1 — Example + harness** (2 commits):
- `feat(examples): add seller_agent.py reference impl` — 409-line runnable seller referenced 11× by other skills.
- `chore(dx): skill-build harness for 4.1 iteration` — shared-workspace pattern + two scripts, verified on `creative_lifecycle`.

**Round 2 — Validator + reviewer findings** (5 commits):
- `fix(example): derive port and AGENT_URL from ADCP_PORT env` — blocked every harness run in round-1 validation.
- `docs(creative): fix NameError in build_creative fallback` — f-string referenced undefined `target_format_id`.
- `docs(signals,generative): correct idempotency.wrap decorator usage` — both skills invented non-existent APIs (`store.wrap(key, params, handler)`, `idempotency.get/put`).
- `docs(seller): replace false compliance_testing auto-wire with explicit kwarg` — `serve(test_controller=store)` doesn't auto-inject the block; skill now uses the new `capabilities_response(compliance_testing=)` kwarg from the SDK fixes.
- `fix(sdk): remove stray noqa, correct capabilities_response docstring` — two small cleanups.
- `docs(signals,seller): round-2 validator findings`.

**Round 3 — MCP inputSchema** (2 commits):
- `feat(mcp): auto-generate sync_governance inputSchema from Pydantic` — the one tool still on a hand-crafted stub (`{accounts: array}`). Now mapped to `SyncGovernanceRequest`; all 57 tools advertise schemas derived from their Pydantic models.
- `test(mcp): drift guard for Pydantic-generated inputSchemas` — 4 new tests prevent regression. Pruned ~190 lines of obsolete `KNOWN_GAPS` scaffolding.

## Test plan

- [x] `ruff check src/ examples/seller_agent.py` — clean
- [x] `mypy src/adcp/` — 664 files, no issues
- [x] `pytest tests/ -q` — 1641 passed, 11 skipped (post round-3)
- [x] `bash scripts/skill-build-setup.sh && bash scripts/skill-run.sh creative 3014 creative_lifecycle` — passing
- [x] 3 expert reviews (code / protocol / DX) — findings addressed in round 2
- [x] Live `mcp.list_tools()` spot-check on `get_products`, `build_creative`, `create_media_buy` — all three advertise correct required fields (`buying_mode`, `idempotency_key`, `account`/`brand`/`start_time`/`end_time`)
- [ ] Full CI on this branch
- [ ] Human spot-check of the skill diffs

## Filed upstream against adcontextprotocol/adcp

- #2428 — Schema: clarify whether `sync_creatives` response items carry `status`
- #2429 — Schema: `adcp.idempotency.replay_ttl_seconds` required-when-present creates an ergonomic trap
- (third issue on `CREATIVE_NOT_FOUND` / `SIGNAL_NOT_FOUND` enum additions hit an intermittent gh API error; will retry)

## Out of scope — deferred to 4.1

- Auto-inject `compliance_testing` capability block when `serve(test_controller=store)` is used (closes the auto-wire loop for real; today skills use the explicit kwarg)
- A2A `comply_test_controller` response missing `result.artifacts` (moves seller-family partials to clean passes)
- Seller-family storyboard coverage: governance flows (denied / conditions / approved), invalid-transitions, `pending_creatives → pending_start`, `inventory_list_targeting`, retail `packages[].catalogs[].type`
- Harness papercuts from DX review: CI timeout, port-range collision with Next.js, offline-npx handling, Alpine/`lsof`, readiness-loop duration, platform pin
- Typed `ComplianceTesting | dict` for the `compliance_testing=` kwarg
- Test coverage for the new kwarg and `sync_governance` typed-param round-trip

## Release coordination

Release-please PR #177 (`chore(main): release 4.0.0`) is queued. Merging this PR into `main` first lets release-please regenerate its release PR to include these fixes in the 4.0.0 tag.