### PR TITLE
feat(server): request-body size cap middleware (closes #239)

### DIFF
--- a/docs/handler-authoring.md
+++ b/docs/handler-authoring.md
@@ -242,6 +242,46 @@ locks the default posture with a positive assertion that `tools/list`
 returns 200 without credentials and a negative control that the gate
 still lets it through when an invalid bearer is present.
 
+## Request-body size cap
+
+`serve()` installs an ASGI middleware that caps incoming request
+bodies at **10 MB by default**. Bodies above the cap are rejected with
+HTTP 413 at the ASGI boundary — before FastMCP or a2a-sdk parses the
+JSON, and before typed-dispatch runs `model_validate`. This is the
+only guard against adversarial callers exhausting validation CPU or
+memory with arbitrarily large payloads.
+
+Two layers of enforcement:
+
+1. **Content-Length fast-fail.** If the client advertises a body size
+   over the cap, the middleware rejects immediately without reading a
+   byte.
+2. **Streaming accounting.** For chunked transfers (no
+   Content-Length), the middleware totals bytes as they arrive and
+   rejects the moment the total crosses the cap.
+
+`GET`, `HEAD`, `OPTIONS` bypass the check (no request body).
+
+Tune via `serve(..., max_request_size=N)`:
+
+```python
+# Legitimate multi-package media buys with embedded creative assets
+# can run over 10 MB. Bump the cap for those deployments.
+serve(MyAgent(), max_request_size=50 * 1024 * 1024)
+
+# Public-facing deployments that only accept small payloads can
+# tighten the cap.
+serve(MyAgent(), max_request_size=256 * 1024)
+
+# Sellers with genuinely unbounded payloads (not recommended) can
+# opt out entirely. You become responsible for enforcing bounds at
+# a different layer — usually your reverse proxy or WAF.
+serve(MyAgent(), max_request_size=0)
+```
+
+Applies to both MCP (streamable-http, sse) and A2A transports. stdio
+transport skips the cap since there's no HTTP body to police.
+
 ## Idempotency
 
 The SDK ships an `IdempotencyStore` middleware that honors the

--- a/docs/handler-authoring.md
+++ b/docs/handler-authoring.md
@@ -282,6 +282,24 @@ serve(MyAgent(), max_request_size=0)
 Applies to both MCP (streamable-http, sse) and A2A transports. stdio
 transport skips the cap since there's no HTTP body to police.
 
+**What this cap does NOT bound.** The middleware caps **bytes** per
+request, not **duration**. A slow-loris caller sending 1 byte every
+30 seconds stays under the cap forever while tying up a worker. Bound
+duration at the layer above:
+
+- `uvicorn --timeout-keep-alive N` caps keep-alive connection idle
+  time (but doesn't cover request-body reads).
+- Reverse-proxy read timeouts do: nginx `client_body_timeout`, Envoy
+  `request_timeout`, Caddy `timeouts.read`.
+- Under serverless / platform-managed runtimes (Fly.io, Cloud Run),
+  the platform's per-request timeout is the effective upper bound.
+
+For adversarial-tenant deployments, also budget memory: the middleware
+buffers the full body up to the cap before replaying to the handler,
+so worst-case RSS runs `workers × concurrency × max_request_size`. An
+upstream reverse proxy enforcing a smaller per-connection cap is the
+right lever if this is too generous.
+
 ## Idempotency
 
 The SDK ships an `IdempotencyStore` middleware that honors the

--- a/src/adcp/server/_size_limit.py
+++ b/src/adcp/server/_size_limit.py
@@ -10,11 +10,31 @@ typed-dispatch made per-request validation unconditional.)
 Installed once at server bind time — before FastMCP or the a2a-sdk
 ``Starlette`` app handle the request — so oversized bodies are cut
 off at the ASGI boundary, well before any parser allocates for them.
+
+.. note::
+   **What this guard does NOT bound.** The middleware caps bytes per
+   request, not duration. A slow-loris caller sending 1 byte every 30
+   seconds stays under the cap forever while tying up a worker.
+   Bound duration at the layer above — uvicorn ``--timeout-keep-alive``
+   and a reverse-proxy read timeout (nginx ``client_body_timeout``,
+   Envoy ``request_timeout``) are the standard levers. Docs at
+   ``docs/handler-authoring.md`` spell this out alongside the size cap.
+
+   **Memory budgeting.** The middleware buffers the full body up to
+   the cap before replaying to the inner app (simpler than streaming
+   passthrough, and the cap bounds the allocation). Operators sizing
+   worker counts should budget roughly ``workers × concurrency ×
+   max_request_size`` of RSS. Upstream proxies enforcing a smaller
+   per-connection cap reduce this ceiling for hostile-tenant
+   deployments.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # 10 MB — generous enough for realistic AdCP payloads (multi-package
 # create_media_buy with embedded creatives/assets can run ~1–2 MB) but
@@ -65,10 +85,17 @@ class RequestSizeLimitMiddleware:
                 try:
                     declared = int(value)
                 except ValueError:
-                    # Malformed header; fall through to streaming check.
+                    # Malformed header; fall through to the streaming
+                    # check. RFC 9110 §8.6 allows rejecting with 400,
+                    # but the cap governs regardless of how the client
+                    # framed the request.
+                    logger.debug(
+                        "malformed Content-Length header (%r); falling through to streaming check",
+                        value,
+                    )
                     break
                 if declared > self.max_bytes:
-                    await self._send_413(send)
+                    await self._send_413(send, self.max_bytes)
                     return
                 break
 
@@ -85,19 +112,27 @@ class RequestSizeLimitMiddleware:
             msg = await receive()
             msg_type = msg.get("type")
             if msg_type == "http.disconnect":
-                # Client gave up before sending the full body. Pass
-                # through — nothing to do.
+                # Client gave up before sending the full body. The
+                # inner app hasn't been invoked yet, so there's nothing
+                # to unwind — just drop the request on the floor
+                # silently. If the app were invoked earlier, we'd need
+                # to propagate the disconnect; it isn't, so we don't.
                 return
             if msg_type != "http.request":
-                # Unexpected message type; forward verbatim via a fresh
-                # receive loop by replaying what we have and letting the
-                # app handle the rest.
-                chunks.append(b"")
-                break
+                # ASGI http scope only defines http.request and
+                # http.disconnect (spec §HTTP). Anything else is a
+                # protocol bug upstream. Skip defensively — don't
+                # truncate the body to an empty chunk as a silent
+                # fallback.
+                logger.debug(
+                    "unexpected ASGI message type %r in http scope; skipping",
+                    msg_type,
+                )
+                continue
             body = msg.get("body", b"")
             total += len(body)
             if total > self.max_bytes:
-                await self._send_413(send)
+                await self._send_413(send, self.max_bytes)
                 return
             chunks.append(body)
             more_body = bool(msg.get("more_body", False))
@@ -123,9 +158,15 @@ class RequestSizeLimitMiddleware:
         await self.app(scope, replay_receive, send)
 
     @staticmethod
-    async def _send_413(send: Any) -> None:
-        """Emit a minimal HTTP 413 Payload Too Large response."""
-        body = b"Payload too large.\n"
+    async def _send_413(send: Any, max_bytes: int) -> None:
+        """Emit an HTTP 413 Payload Too Large response.
+
+        Includes the cap in the body so legitimate clients know the
+        limit they hit — the cap isn't a secret (documented SDK
+        default + deployment config), and a bare "too large" without
+        a number forces adopters to grep the source or docs.
+        """
+        body = f"Payload too large. Maximum request body size is {max_bytes} bytes.\n".encode()
         await send(
             {
                 "type": "http.response.start",

--- a/src/adcp/server/_size_limit.py
+++ b/src/adcp/server/_size_limit.py
@@ -1,0 +1,145 @@
+"""Request-body size cap middleware — closes #239.
+
+ASGI middleware that rejects HTTP requests whose body exceeds a
+configurable byte cap. Without this guard, every MCP/A2A tool call
+reaches ``Pydantic.model_validate`` with no input size bound, letting
+a single attacker send arbitrarily large JSON and exhaust CPU/memory
+at the validation step. (PR #238 security review flagged this when
+typed-dispatch made per-request validation unconditional.)
+
+Installed once at server bind time — before FastMCP or the a2a-sdk
+``Starlette`` app handle the request — so oversized bodies are cut
+off at the ASGI boundary, well before any parser allocates for them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# 10 MB — generous enough for realistic AdCP payloads (multi-package
+# create_media_buy with embedded creatives/assets can run ~1–2 MB) but
+# small enough that adversarial traffic can't trivially exhaust a
+# single-worker server. Sellers who legitimately need more override via
+# ``serve(..., max_request_size=N)``.
+DEFAULT_MAX_REQUEST_BYTES: int = 10 * 1024 * 1024
+
+
+class RequestSizeLimitMiddleware:
+    """Reject HTTP requests whose body exceeds ``max_bytes``.
+
+    Two layers:
+
+    1. **Content-Length fast-fail.** If the client advertises a body
+       bigger than the cap, we reject before reading a single byte.
+    2. **Streaming accounting.** For chunked transfers (``Transfer-
+       Encoding: chunked`` with no Content-Length) the middleware
+       buffers and counts bytes as they arrive; when the total crosses
+       the cap it stops reading and returns ``413 Payload Too Large``.
+
+    GET / HEAD / OPTIONS bypass both — they don't carry request bodies
+    in any spec we talk to.
+
+    The response payload is deliberately minimal. AdCP has no transport
+    error shape for oversized requests (errors/recovery are for
+    application-layer failures), so we return a plain HTTP 413 —
+    the standard shape every HTTP client understands.
+    """
+
+    def __init__(self, app: Any, max_bytes: int = DEFAULT_MAX_REQUEST_BYTES) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "GET").upper()
+        if method in ("GET", "HEAD", "OPTIONS"):
+            await self.app(scope, receive, send)
+            return
+
+        # Pattern 1 — Content-Length fast-fail.
+        for key, value in scope.get("headers", []):
+            if key == b"content-length":
+                try:
+                    declared = int(value)
+                except ValueError:
+                    # Malformed header; fall through to streaming check.
+                    break
+                if declared > self.max_bytes:
+                    await self._send_413(send)
+                    return
+                break
+
+        # Pattern 2 — buffer + count. We read the whole body (up to the
+        # cap) before handing it to the inner app. Buffering is fine
+        # because (a) we're bounding the buffer size by the cap, and
+        # (b) ASGI apps downstream (FastMCP, a2a-sdk) already read the
+        # full body into memory before parsing — we're not adding a new
+        # RAM cost, we're enforcing one that already exists.
+        chunks: list[bytes] = []
+        total = 0
+        more_body = True
+        while more_body:
+            msg = await receive()
+            msg_type = msg.get("type")
+            if msg_type == "http.disconnect":
+                # Client gave up before sending the full body. Pass
+                # through — nothing to do.
+                return
+            if msg_type != "http.request":
+                # Unexpected message type; forward verbatim via a fresh
+                # receive loop by replaying what we have and letting the
+                # app handle the rest.
+                chunks.append(b"")
+                break
+            body = msg.get("body", b"")
+            total += len(body)
+            if total > self.max_bytes:
+                await self._send_413(send)
+                return
+            chunks.append(body)
+            more_body = bool(msg.get("more_body", False))
+
+        # Body fit within the cap — replay to the app.
+        index = 0
+        chunks_count = len(chunks)
+
+        async def replay_receive() -> dict[str, Any]:
+            nonlocal index
+            if index < chunks_count:
+                body = chunks[index]
+                index += 1
+                return {
+                    "type": "http.request",
+                    "body": body,
+                    "more_body": index < chunks_count,
+                }
+            # App asked for more after we replayed everything — the
+            # spec says http.disconnect once the body is drained.
+            return {"type": "http.disconnect"}
+
+        await self.app(scope, replay_receive, send)
+
+    @staticmethod
+    async def _send_413(send: Any) -> None:
+        """Emit a minimal HTTP 413 Payload Too Large response."""
+        body = b"Payload too large.\n"
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": body,
+                "more_body": False,
+            }
+        )

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -351,13 +351,35 @@ def _wrap_with_size_limit(app: Any, max_request_size: int | None) -> Any:
     ``None`` = use the module default (10 MB). ``0`` = disable — skip
     the middleware entirely so sellers who genuinely need unlimited
     bodies can opt out. Any positive int overrides the default.
+
+    Negative values raise ``ValueError`` — they have no meaningful
+    interpretation and almost certainly indicate a typo (e.g. the
+    author meant ``0`` for "disable" or a positive cap for "N bytes").
+    Failing loudly at configure time beats a silent opt-out that only
+    surfaces when an attacker finds it.
     """
+    import logging
+
     from adcp.server._size_limit import (
         DEFAULT_MAX_REQUEST_BYTES,
         RequestSizeLimitMiddleware,
     )
 
-    if max_request_size is not None and max_request_size <= 0:
+    if max_request_size is not None and max_request_size < 0:
+        raise ValueError(
+            f"max_request_size must be >= 0 (got {max_request_size}). "
+            "Use 0 to disable the cap entirely, or a positive int in bytes."
+        )
+    if max_request_size == 0:
+        # Load-bearing warning — 0 disables the only Pydantic-validation
+        # DoS guard. Operators should know, and a typo that lands on 0
+        # should leave a breadcrumb in the startup log rather than
+        # silently opt out.
+        logging.getLogger("adcp.server").warning(
+            "max_request_size=0 disables ASGI body cap; relying on upstream "
+            "proxy or WAF to bound request size. This is a security-relevant "
+            "configuration choice."
+        )
         return app
     cap = max_request_size if max_request_size is not None else DEFAULT_MAX_REQUEST_BYTES
     return RequestSizeLimitMiddleware(app, max_bytes=cap)

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -228,6 +228,7 @@ def serve(
     push_config_store: PushNotificationConfigStore | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
     advertise_all: bool = False,
+    max_request_size: int | None = None,
 ) -> None:
     """Start an MCP or A2A server from an ADCP handler or server builder.
 
@@ -269,6 +270,13 @@ def serve(
             advertised surface. Turn on for spec-compliance storyboards
             or when you want to signal ``not_supported`` on a specific
             tool to clients.
+        max_request_size: Maximum request body size in bytes. Defaults
+            to 10 MB. Set higher for sellers that legitimately transmit
+            very large creative asset payloads; set lower for stricter
+            public-facing deployments. Set to ``0`` to disable the cap
+            entirely (not recommended — the cap is the only guard
+            against adversarial payloads exhausting Pydantic validation
+            CPU/memory). See :mod:`adcp.server._size_limit`.
 
     Security:
         This function does NOT configure authentication. In production,
@@ -318,6 +326,7 @@ def serve(
             push_config_store=push_config_store,
             middleware=middleware,
             advertise_all=advertise_all,
+            max_request_size=max_request_size,
         )
     elif transport in ("streamable-http", "sse", "stdio"):
         _serve_mcp(
@@ -329,10 +338,29 @@ def serve(
             test_controller=test_controller,
             context_factory=context_factory,
             advertise_all=advertise_all,
+            max_request_size=max_request_size,
         )
     else:
         valid = ", ".join(sorted(("a2a", "streamable-http", "sse", "stdio")))
         raise ValueError(f"Unknown transport {transport!r}. Valid: {valid}")
+
+
+def _wrap_with_size_limit(app: Any, max_request_size: int | None) -> Any:
+    """Wrap an ASGI app with the request-body size cap.
+
+    ``None`` = use the module default (10 MB). ``0`` = disable — skip
+    the middleware entirely so sellers who genuinely need unlimited
+    bodies can opt out. Any positive int overrides the default.
+    """
+    from adcp.server._size_limit import (
+        DEFAULT_MAX_REQUEST_BYTES,
+        RequestSizeLimitMiddleware,
+    )
+
+    if max_request_size is not None and max_request_size <= 0:
+        return app
+    cap = max_request_size if max_request_size is not None else DEFAULT_MAX_REQUEST_BYTES
+    return RequestSizeLimitMiddleware(app, max_bytes=cap)
 
 
 def _bind_reusable_socket(host: str, port: int) -> Any:
@@ -382,6 +410,7 @@ def _serve_mcp(
     test_controller: TestControllerStore | None,
     context_factory: ContextFactory | None = None,
     advertise_all: bool = False,
+    max_request_size: int | None = None,
 ) -> None:
     """Start an MCP server."""
     mcp = create_mcp_server(
@@ -400,13 +429,13 @@ def _serve_mcp(
         register_test_controller(mcp, test_controller, context_factory=context_factory)
 
     if transport in ("streamable-http", "sse"):
-        _run_mcp_http(mcp, transport=transport)
+        _run_mcp_http(mcp, transport=transport, max_request_size=max_request_size)
     else:
         # stdio — no listening socket, nothing to configure.
         mcp.run(transport=transport)
 
 
-def _run_mcp_http(mcp: Any, *, transport: str) -> None:
+def _run_mcp_http(mcp: Any, *, transport: str, max_request_size: int | None = None) -> None:
     """Run FastMCP's HTTP transports with a pre-bound SO_REUSEADDR socket.
 
     FastMCP builds its own ``uvicorn.Server(config).serve()`` inside
@@ -426,6 +455,8 @@ def _run_mcp_http(mcp: Any, *, transport: str) -> None:
         app = mcp.streamable_http_app()
     else:
         app = mcp.sse_app()
+
+    app = _wrap_with_size_limit(app, max_request_size)
 
     sock = _bind_reusable_socket(host, port)
     try:
@@ -451,6 +482,7 @@ def _serve_a2a(
     push_config_store: PushNotificationConfigStore | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
     advertise_all: bool = False,
+    max_request_size: int | None = None,
 ) -> None:
     """Start an A2A server using uvicorn."""
     import uvicorn
@@ -470,6 +502,7 @@ def _serve_a2a(
         middleware=middleware,
         advertise_all=advertise_all,
     )
+    app = _wrap_with_size_limit(app, max_request_size)
     sock = _bind_reusable_socket("0.0.0.0", resolved_port)
     try:
         config = uvicorn.Config(app)

--- a/tests/test_request_size_limit.py
+++ b/tests/test_request_size_limit.py
@@ -1,0 +1,333 @@
+"""RequestSizeLimitMiddleware — closes #239.
+
+Security review of PR #238 (typed-handler dispatch) flagged that every
+tool call now runs ``model_validate`` unconditionally, with no input
+size bound. A hostile caller can submit arbitrarily large JSON and
+exhaust CPU / memory at the validation step.
+
+This middleware caps request body size at the ASGI boundary — before
+FastMCP or a2a-sdk parses the JSON. Two patterns:
+
+- **Content-Length fast-fail**. Client advertises a body bigger than
+  the cap; reject with 413 before reading a byte.
+- **Streaming accounting**. Chunked transfers (no Content-Length) are
+  buffered and counted; 413 the moment the total crosses the cap.
+
+These tests exercise the middleware directly via the ASGI protocol
+(no HTTP socket, no httpx) so they're fast and deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from adcp.server._size_limit import (
+    DEFAULT_MAX_REQUEST_BYTES,
+    RequestSizeLimitMiddleware,
+)
+
+# ---------------------------------------------------------------------------
+# ASGI test harness — minimal async scope/receive/send plumbing
+# ---------------------------------------------------------------------------
+
+
+def _scope(method: str, headers: Iterable[tuple[bytes, bytes]] = ()) -> dict[str, Any]:
+    return {
+        "type": "http",
+        "method": method,
+        "path": "/mcp",
+        "headers": list(headers),
+    }
+
+
+def _body_messages(body: bytes, chunk_size: int = 0) -> list[dict[str, Any]]:
+    """Produce http.request messages that carry ``body`` as one chunk
+    (``chunk_size=0``) or multiple (``chunk_size=N``)."""
+    if chunk_size <= 0:
+        return [{"type": "http.request", "body": body, "more_body": False}]
+    chunks = [body[i : i + chunk_size] for i in range(0, len(body), chunk_size)] or [b""]
+    return [
+        {"type": "http.request", "body": chunk, "more_body": i < len(chunks) - 1}
+        for i, chunk in enumerate(chunks)
+    ]
+
+
+class _MockApp:
+    """Records what the middleware forwarded."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        received_body = b""
+        while True:
+            msg = await receive()
+            if msg["type"] == "http.disconnect":
+                break
+            if msg["type"] == "http.request":
+                received_body += msg.get("body", b"")
+                if not msg.get("more_body", False):
+                    break
+        self.calls.append({"scope": scope, "body": received_body})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b'{"ok": true}',
+                "more_body": False,
+            }
+        )
+
+
+async def _run(
+    middleware: RequestSizeLimitMiddleware,
+    scope: dict[str, Any],
+    body_messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Drive the middleware once. Returns {status, body, app_saw}."""
+    received = iter(body_messages)
+    sent_start: dict[str, Any] | None = None
+    sent_body = bytearray()
+
+    async def receive() -> dict[str, Any]:
+        try:
+            return next(received)
+        except StopIteration:
+            return {"type": "http.disconnect"}
+
+    async def send(msg: dict[str, Any]) -> None:
+        nonlocal sent_start
+        if msg["type"] == "http.response.start":
+            sent_start = msg
+        elif msg["type"] == "http.response.body":
+            sent_body.extend(msg.get("body", b""))
+
+    await middleware(scope, receive, send)
+    return {
+        "status": sent_start["status"] if sent_start else None,
+        "body": bytes(sent_body),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Content-Length fast-fail
+# ---------------------------------------------------------------------------
+
+
+async def test_content_length_over_cap_rejects_with_413_before_reading_body():
+    """**Primary guard.** A client advertising Content-Length bigger
+    than the cap is rejected immediately — the middleware doesn't even
+    receive the body."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=1024)
+
+    result = await _run(
+        mw,
+        _scope("POST", headers=[(b"content-length", b"999999")]),
+        # Body messages are provided but should never be read.
+        _body_messages(b"x" * 999999),
+    )
+
+    assert result["status"] == 413
+    assert b"Payload too large" in result["body"]
+    assert app.calls == [], "inner app must not be invoked on oversized request"
+
+
+async def test_content_length_at_cap_passes_through():
+    """Boundary case. Exactly equal to the cap is allowed."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=10)
+
+    result = await _run(
+        mw,
+        _scope("POST", headers=[(b"content-length", b"10")]),
+        _body_messages(b"x" * 10),
+    )
+
+    assert result["status"] == 200
+    assert len(app.calls) == 1
+    assert app.calls[0]["body"] == b"x" * 10
+
+
+async def test_malformed_content_length_falls_through_to_streaming_check():
+    """A non-numeric Content-Length header shouldn't crash the
+    middleware — it falls through to the streaming body check."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=100)
+
+    result = await _run(
+        mw,
+        _scope("POST", headers=[(b"content-length", b"not-a-number")]),
+        _body_messages(b"x" * 50),
+    )
+
+    # Body was 50 bytes, under the 100-byte cap — request succeeds.
+    assert result["status"] == 200
+    assert app.calls[0]["body"] == b"x" * 50
+
+
+# ---------------------------------------------------------------------------
+# Streaming accounting (chunked / no Content-Length)
+# ---------------------------------------------------------------------------
+
+
+async def test_chunked_body_exceeding_cap_mid_stream_rejects():
+    """Defense-in-depth. No Content-Length header, body streamed across
+    multiple chunks. Middleware totals bytes as they arrive and 413s
+    the moment the total crosses the cap. The inner app must never
+    see a chunk from a request that blew the budget."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=100)
+
+    # 5 × 50 = 250 bytes total, no Content-Length.
+    result = await _run(
+        mw,
+        _scope("POST"),
+        _body_messages(b"x" * 250, chunk_size=50),
+    )
+
+    assert result["status"] == 413
+    assert app.calls == []
+
+
+async def test_chunked_body_under_cap_passes_through():
+    """Chunked body totalling less than the cap is forwarded to the
+    app verbatim — inner app sees the full body reassembled."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=1000)
+
+    payload = b"hello-world-" * 10  # 120 bytes
+    result = await _run(
+        mw,
+        _scope("POST"),
+        _body_messages(payload, chunk_size=25),
+    )
+
+    assert result["status"] == 200
+    assert app.calls[0]["body"] == payload
+
+
+# ---------------------------------------------------------------------------
+# Bypasses — methods without bodies
+# ---------------------------------------------------------------------------
+
+
+async def test_get_bypasses_body_check():
+    """GET requests skip the size check entirely — they don't have
+    request bodies in any protocol we serve. A GET to /.well-known/
+    agent.json or an MCP notifications stream must not be gated on
+    Content-Length."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=1)
+
+    # Content-Length would blow the 1-byte cap, but GET bypasses.
+    result = await _run(
+        mw,
+        _scope("GET", headers=[(b"content-length", b"999")]),
+        _body_messages(b""),
+    )
+
+    assert result["status"] == 200
+    assert len(app.calls) == 1
+
+
+async def test_head_and_options_bypass_body_check():
+    """Same bypass for HEAD and OPTIONS — preflight and health-check
+    methods never have bodies."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=1)
+
+    for method in ("HEAD", "OPTIONS"):
+        result = await _run(
+            mw,
+            _scope(method, headers=[(b"content-length", b"999")]),
+            _body_messages(b""),
+        )
+        assert result["status"] == 200, f"{method} should bypass"
+
+
+# ---------------------------------------------------------------------------
+# Non-HTTP scopes pass through (WebSocket, lifespan)
+# ---------------------------------------------------------------------------
+
+
+async def test_lifespan_scope_passes_through_untouched():
+    """ASGI lifespan messages (startup/shutdown) must not be touched
+    by the HTTP-body middleware — otherwise the app's startup hook
+    never runs."""
+    received: list[dict[str, Any]] = []
+
+    async def lifespan_app(scope: Any, receive: Any, send: Any) -> None:
+        msg = await receive()
+        received.append(msg)
+        await send({"type": "lifespan.startup.complete"})
+
+    mw = RequestSizeLimitMiddleware(lifespan_app, max_bytes=10)
+
+    scope = {"type": "lifespan"}
+    messages = iter([{"type": "lifespan.startup"}])
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return next(messages)
+
+    async def send(msg: dict[str, Any]) -> None:
+        sent.append(msg)
+
+    await mw(scope, receive, send)
+
+    assert received == [{"type": "lifespan.startup"}]
+    assert sent == [{"type": "lifespan.startup.complete"}]
+
+
+# ---------------------------------------------------------------------------
+# Default cap + opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_default_cap_is_ten_megabytes():
+    """The default should be big enough for realistic AdCP payloads
+    (multi-package create_media_buy with creative assets) but small
+    enough that adversarial traffic can't trivially exhaust validation
+    CPU. 10 MB is the documented default. Regression here needs a
+    deliberate doc update."""
+    assert DEFAULT_MAX_REQUEST_BYTES == 10 * 1024 * 1024
+
+
+async def test_zero_cap_in_wrapper_disables_middleware():
+    """``serve(..., max_request_size=0)`` should skip middleware
+    installation entirely — the escape hatch for sellers with
+    legitimate multi-hundred-megabyte payloads. Tested at the
+    wrapper layer (serve.py._wrap_with_size_limit) because the
+    middleware class itself doesn't accept 0 as an opt-out."""
+    from adcp.server.serve import _wrap_with_size_limit
+
+    async def inner(scope: Any, receive: Any, send: Any) -> None:
+        return None
+
+    wrapped_none = _wrap_with_size_limit(inner, None)
+    wrapped_zero = _wrap_with_size_limit(inner, 0)
+
+    # None → wrapped with middleware (10 MB default).
+    assert isinstance(wrapped_none, RequestSizeLimitMiddleware)
+    # 0 → opt-out, returns the original app.
+    assert wrapped_zero is inner
+
+
+async def test_explicit_cap_in_wrapper_overrides_default():
+    """A non-zero int overrides the 10 MB default."""
+    from adcp.server.serve import _wrap_with_size_limit
+
+    async def inner(scope: Any, receive: Any, send: Any) -> None:
+        return None
+
+    wrapped = _wrap_with_size_limit(inner, 5_000_000)
+    assert isinstance(wrapped, RequestSizeLimitMiddleware)
+    assert wrapped.max_bytes == 5_000_000

--- a/tests/test_request_size_limit.py
+++ b/tests/test_request_size_limit.py
@@ -197,6 +197,43 @@ async def test_chunked_body_exceeding_cap_mid_stream_rejects():
     assert app.calls == []
 
 
+async def test_single_chunk_exceeding_cap_rejects():
+    """**Regression guard**: a single ``http.request`` message whose
+    body alone exceeds the cap must still be rejected. No Content-
+    Length, one giant chunk — the streaming accounting check fires
+    on iteration 1. Easy to regress with a naive "read at least one
+    chunk" refactor."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=100)
+
+    result = await _run(
+        mw,
+        _scope("POST"),
+        [{"type": "http.request", "body": b"x" * 10_000, "more_body": False}],
+    )
+
+    assert result["status"] == 413
+    assert app.calls == []
+
+
+async def test_413_body_includes_cap_value():
+    """Legitimate clients need to know the limit they hit — the cap
+    isn't a secret, and a bare "too large" forces adopters to grep
+    docs. Include the number."""
+    app = _MockApp()
+    mw = RequestSizeLimitMiddleware(app, max_bytes=1024)
+
+    result = await _run(
+        mw,
+        _scope("POST", headers=[(b"content-length", b"9999")]),
+        _body_messages(b""),
+    )
+
+    assert result["status"] == 413
+    assert b"1024" in result["body"]
+    assert b"bytes" in result["body"]
+
+
 async def test_chunked_body_under_cap_passes_through():
     """Chunked body totalling less than the cap is forwarded to the
     app verbatim — inner app sees the full body reassembled."""
@@ -331,3 +368,40 @@ async def test_explicit_cap_in_wrapper_overrides_default():
     wrapped = _wrap_with_size_limit(inner, 5_000_000)
     assert isinstance(wrapped, RequestSizeLimitMiddleware)
     assert wrapped.max_bytes == 5_000_000
+
+
+def test_negative_cap_raises_value_error():
+    """Negative values don't have a meaningful interpretation —
+    probably a typo. Fail loud at configure time instead of silently
+    opting out."""
+    import pytest
+
+    from adcp.server.serve import _wrap_with_size_limit
+
+    async def inner(scope: Any, receive: Any, send: Any) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="max_request_size must be >= 0"):
+        _wrap_with_size_limit(inner, -1)
+
+
+async def test_zero_cap_emits_warning_log(caplog):
+    """**Load-bearing breadcrumb**: a seller who configures
+    ``max_request_size=0`` (typo or intentional) should see a warning
+    in the startup log so they know the only Pydantic-validation DoS
+    guard is disabled. A silent opt-out that only surfaces when an
+    attacker finds it is the failure mode we're preventing."""
+    import logging
+
+    from adcp.server.serve import _wrap_with_size_limit
+
+    async def inner(scope: Any, receive: Any, send: Any) -> None:
+        return None
+
+    with caplog.at_level(logging.WARNING, logger="adcp.server"):
+        _wrap_with_size_limit(inner, 0)
+
+    assert any(
+        "max_request_size=0" in record.message and "disables" in record.message
+        for record in caplog.records
+    ), "warning log must fire when size cap is disabled"


### PR DESCRIPTION
## Summary

Closes #239 — the Medium security finding deferred from PR #238. Every tool call runs Pydantic \`model_validate\` unconditionally now that typed-dispatch is live; without an input-size bound, adversarial callers can exhaust validation CPU/memory with arbitrarily large JSON.

Adds an ASGI middleware installed at the \`serve()\` bind point — caps HTTP request bodies at 10 MB by default, rejects oversized bodies with HTTP 413 **before** FastMCP or a2a-sdk parse a byte.

## Two enforcement layers

- **Content-Length fast-fail.** Advertised body over the cap → reject without reading.
- **Streaming accounting.** No Content-Length (chunked transfers) → middleware buffers + counts, 413s the moment the total crosses the cap.

GET / HEAD / OPTIONS bypass (no request body). Lifespan + WebSocket scopes pass through untouched.

## API

\`\`\`python
# Default: 10 MB
serve(MyAgent())

# Sellers with legitimately large creative asset payloads:
serve(MyAgent(), max_request_size=50 * 1024 * 1024)

# Public-facing deployments that only accept small payloads:
serve(MyAgent(), max_request_size=256 * 1024)

# Escape hatch — enforce elsewhere (reverse proxy / WAF):
serve(MyAgent(), max_request_size=0)
\`\`\`

Covers both transports (MCP streamable-http + SSE, A2A). stdio skips since there's no HTTP body to police.

## Test plan

- [x] 11 ASGI-level tests, all passing
- [x] Content-Length reject (over cap), accept (at cap), accept (under cap)
- [x] Malformed Content-Length falls through to streaming check
- [x] Chunked body exceeding cap mid-stream rejects; inner app never invoked
- [x] Chunked body under cap passes through verbatim
- [x] GET/HEAD/OPTIONS bypass
- [x] Lifespan scope passes through untouched
- [x] \`max_request_size=0\` opt-out returns app unwrapped
- [x] Explicit int overrides default
- [x] Full suite: 1876/1876 pass
- [x] mypy clean (673 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)