### PR TITLE
docs(skills): round-8 DX polish — scope seller, self-contain signals

### DIFF
--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -640,13 +640,37 @@ python agent.py &
 npx -y -p @adcp/client adcp storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
-**Keep iterating until all steps pass.**
+### What this skill covers (and what it doesn't)
+
+This skill teaches the **9 core lifecycle scenarios** on the
+`media_buy_seller` storyboard — the happy-path buyer journey from
+discovery to delivery. Following the skill end-to-end produces an
+agent that passes those 9 steps cleanly.
+
+The full `media_buy_seller` storyboard runs ~40 scenarios across
+multiple tracks. Expect `WARN: partial — 0 of 2 tracks passing`
+against your skill-built agent: ~13 advanced scenarios require
+stubs this skill doesn't teach. That's not a skill bug; it's a
+scope choice. Add these independently when you need them:
+
+| Track | Scenarios | What to add |
+|---|---|---|
+| Governance | `governance_denied`, `governance_override` | Wire a `GovernanceHandler` subclass (see `docs/handler-authoring.md`) |
+| Creative lifecycle | `pending_creatives_to_start`, `pending_creatives_to_reject` | Extend your `sync_creatives` to return `status="pending"`, then flip via a `force_creative_status` test-controller scenario |
+| Measurement | `measurement_terms_mismatch` | Validate `delivery_measurement` on `create_media_buy`; reject mismatched terms with `INVALID_REQUEST` |
+| Targeting persistence | `inventory_list_targeting` | Persist targeting lists across `sync_creatives` / `get_media_buy_delivery` calls |
+| State machine | `invalid_transition_*` | Return `INVALID_TRANSITION` from `update_media_buy` for disallowed state moves (e.g. `completed → paused`) |
+| Delivery | `delivery_reporting/simulate_and_verify` | Wire `simulate_delivery` + `simulate_budget_spend` on your `TestControllerStore` |
+
+**Keep iterating until the 9 core steps pass.** Advanced tracks are
+additive — tackle them when your deployment actually needs the
+behavior they validate.
 
 ## Storyboards
 
 | Storyboard | Use case |
 |-----------|----------|
-| `media_buy_seller` | Full lifecycle — every seller should pass this (9 steps) |
+| `media_buy_seller` | Full lifecycle — this skill teaches the 9 core steps; advanced tracks are optional additions above |
 | `deterministic_testing` | Test controller state machine validation |
 | `media_buy_non_guaranteed` | Auction flow with bid adjustment |
 | `media_buy_guaranteed_approval` | IO approval workflow |

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -251,18 +251,45 @@ async def activate_signal(self, params, context=None):
 
 Marketplace signals agents with compliance review flows MUST also implement `sync_accounts` and `sync_governance`. The `signal_marketplace/governance_denied` sub-track exercises both — without them, the storyboard fails before it reaches activation. Skip for pure owned-data agents.
 
+Minimal stub bodies — paste into your handler class. The `accounts` dict is whatever in-memory store your agent already uses.
+
 ```python
+import uuid
+
 from adcp.server.responses import sync_accounts_response, sync_governance_response
 
 async def sync_accounts(self, params, context=None):
-    # Echo brand + operator back; assign an account_id, store, return "active".
-    # See examples/seller_agent.py for the full shape.
-    return sync_accounts_response([...])
+    results = []
+    for acct in params.get("accounts", []):
+        account_id = f"acct-{uuid.uuid4().hex[:8]}"
+        accounts[account_id] = {
+            "status": "active",
+            "brand": acct.get("brand"),
+            "operator": acct.get("operator"),
+        }
+        results.append({
+            "account_id": account_id,
+            "brand": acct.get("brand"),
+            "operator": acct.get("operator"),
+            "action": "created",
+            "status": "active",
+            "account_scope": "operator_brand",
+        })
+    return sync_accounts_response(results)
 
 async def sync_governance(self, params, context=None):
-    # Echo account + governance_agents (url + categories) back as "synced".
-    # See examples/seller_agent.py for the full shape.
-    return sync_governance_response([...])
+    results = []
+    for entry in params.get("accounts", []):
+        agents = entry.get("governance_agents", [])
+        results.append({
+            "account": entry.get("account", {}),
+            "status": "synced",
+            "governance_agents": [
+                {"url": a.get("url"), "categories": a.get("categories", [])}
+                for a in agents
+            ],
+        })
+    return sync_governance_response(results)
 ```
 
 Required to PASS `signal_marketplace/governance_denied`.


### PR DESCRIPTION
## Summary

Bundles two round-8 validation findings into one docs-only PR. Closes #215 and #216.

### #215 — seller skill scoping (Option A)

Rewrite the Validation section of \`build-seller-agent/SKILL.md\` to explicitly scope the skill to the **9 core** \`media_buy_seller\` scenarios. Round-8 observed fresh users seeing \`WARN: partial\` on the full storyboard and doubting the skill. Adds a track-by-track breakdown of the ~13 advanced scenarios the skill deliberately doesn't teach, with pointers for wiring them up independently (governance, creative lifecycle, measurement, targeting persistence, state machine, delivery).

### #216 — signals skill self-containment

Inline minimal \`sync_accounts\` + \`sync_governance\` bodies into \`build-signals-agent/SKILL.md\`'s Governance Tracks section (~25 lines). Drops the \"see \`examples/seller_agent.py\`\" cross-reference — the last external jump in an otherwise self-contained skill.

## Why bundle

Both findings come from the same round-8 validation report, both are skill-polish docs, both touch \`skills/*/SKILL.md\` — zero risk of merge conflicts, identical review context, and one PR is less process than two for ~55 lines of docs.

## Test plan

- [x] No code changes — docs only
- [x] Pre-commit passes (trim whitespace, end-of-files, merge-conflict check)
- [ ] Visual review: seller skill's new Validation subsection reads cleanly
- [ ] Visual review: signals skill Governance section is now self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)