### PR TITLE
chore(release): pre-stage spec-version pinning for major releases

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,80 @@
 
 This project uses [Release Please](https://github.com/googleapis/release-please) for automated versioning and releases. It's the Python equivalent of Changesets but works per-PR instead of per-commit.
 
+## Spec-version pinning for major releases
+
+**Read this before cutting any major SDK version (e.g. 3.x → 4.x, 4.x → 5.x).**
+
+The SDK's generated Pydantic types in `src/adcp/types/generated_poc/` are built from the AdCP spec bundle fetched at build time. Which bundle gets fetched is pinned by `src/adcp/ADCP_VERSION`:
+
+- **`latest`** (default on `main`): tracks spec HEAD. Types drift between regens. Safe for rolling development; **never** safe for a stable release — buyers on that version would see types mutate under them at the next regen.
+- **`3.0.0`** (or any semver tag): pinned to a specific spec release. Stable. What you want to ship.
+
+### Release-day checklist
+
+Execute in this order. All commands run from repo root.
+
+1. **Confirm upstream spec is tagged.** The spec repo publishes a bundle at `https://adcontextprotocol.org/protocol/{version}.tgz`. Check it returns 200:
+
+   ```bash
+   curl -sI "https://adcontextprotocol.org/protocol/3.0.0.tgz" | head -1
+   # Expected: HTTP/2 200
+   ```
+
+   If 404, the spec isn't tagged yet — abort the release.
+
+2. **Pin `ADCP_VERSION`:**
+
+   ```bash
+   echo "3.0.0" > src/adcp/ADCP_VERSION
+   ```
+
+3. **Regenerate schemas + types:**
+
+   ```bash
+   make regenerate-schemas
+   ```
+
+   This fetches the pinned bundle, rewrites `schemas/cache/`, regenerates `src/adcp/types/generated_poc/` + `_generated.py` + `_ergonomic.py`, and updates `schemas/cache/index.json.adcp_version` to match `ADCP_VERSION`.
+
+4. **Run the full pre-push check:**
+
+   ```bash
+   make pre-push
+   ```
+
+   Includes `tests/test_schemas_version_pin.py` — a paranoia check that `ADCP_VERSION` matches `schemas/cache/index.json.adcp_version`. If you skipped step 3, this fires.
+
+5. **Review the diff.** Expect `schemas/cache/*`, `src/adcp/types/generated_poc/*`, `_generated.py`, `_ergonomic.py`, and `src/adcp/ADCP_VERSION` to change. Anything else means a regen script mutated source — investigate.
+
+6. **Commit + open PR:**
+
+   ```bash
+   git checkout -b bokelley/pin-spec-X.Y.Z
+   git add -A
+   git commit -m "chore(types): pin AdCP spec to X.Y.Z and regenerate"
+   gh pr create --title "chore(types): pin AdCP spec to X.Y.Z"
+   ```
+
+7. **Merge the spec-pin PR.** Release Please's open release PR (`chore(main): release X.Y.Z`) will pick up the new commit; review the updated changelog.
+
+8. **Merge the release PR** (`chore(main): release X.Y.Z`). PyPI publish + GitHub release + tag happen automatically.
+
+### Reverting to `latest`
+
+After a stable release ships, `main` typically stays pinned until the next spec drop. To resume tracking HEAD:
+
+```bash
+echo "latest" > src/adcp/ADCP_VERSION
+make regenerate-schemas
+```
+
+Commit as `chore(types): resume tracking spec HEAD after X.Y.Z release`.
+
+### Drift protection
+
+`tests/test_schemas_version_pin.py` cross-checks `ADCP_VERSION` against `schemas/cache/index.json.adcp_version` on every CI run. You cannot merge a PR where the two drift — which means you cannot accidentally ship stable types generated from `latest` or vice versa.
+
 ## How It Works
 
 1. **Write Conventional Commits**: Use conventional commit messages in your PRs

--- a/tests/test_schemas_version_pin.py
+++ b/tests/test_schemas_version_pin.py
@@ -1,0 +1,99 @@
+"""CI gate: ``src/adcp/ADCP_VERSION`` and ``schemas/cache/index.json``
+must pin the same AdCP spec version.
+
+Without this test, a seller can bump ``ADCP_VERSION`` from ``"latest"``
+to ``"3.0.0"`` (or vice versa) and forget to re-run
+``make regenerate-schemas``. The package then ships with generated
+Pydantic types from the *wrong* spec version — validation passes
+locally because nothing cross-checks, but downstream consumers hit
+subtle schema mismatches in production.
+
+Failure mode this test prevents:
+
+1. Developer edits ``ADCP_VERSION`` (e.g. pinning for a stable
+   release).
+2. CI green — nothing ran the regen.
+3. Release ships.
+4. Clients upgrade to the new SDK version, hit types missing fields
+   or flagged as unexpected because the schemas were generated
+   against a different spec revision.
+
+The check is cheap (two file reads, one string comparison) and
+catches the exact release-day footgun:
+``git log --oneline src/adcp/ADCP_VERSION`` shows a bump;
+``git log --oneline schemas/cache/`` doesn't. Test fails → regen
+was skipped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ADCP_VERSION_FILE = _REPO_ROOT / "src" / "adcp" / "ADCP_VERSION"
+_CACHE_INDEX = _REPO_ROOT / "schemas" / "cache" / "index.json"
+
+
+def test_adcp_version_file_exists() -> None:
+    """Paranoia: the pinning file must exist. A missing file is the
+    same drift class — the SDK doesn't know what spec it targets."""
+    assert _ADCP_VERSION_FILE.exists(), (
+        f"Missing {_ADCP_VERSION_FILE.relative_to(_REPO_ROOT)}. "
+        f"This file pins the AdCP spec version the SDK was generated "
+        f"against; its absence means nothing downstream can verify spec "
+        f"alignment."
+    )
+
+
+def test_schemas_cache_index_exists() -> None:
+    """Paranoia: the schema cache index must exist. Same drift class —
+    without the index, we can't verify what spec the types were
+    generated from."""
+    assert _CACHE_INDEX.exists(), (
+        f"Missing {_CACHE_INDEX.relative_to(_REPO_ROOT)}. "
+        f"This file is written by ``make regenerate-schemas`` and records "
+        f"the spec version the generated types were built against."
+    )
+
+
+def test_adcp_version_matches_schemas_cache() -> None:
+    """The pinned spec version must match what the generated schemas
+    were built against. If this test fails, someone changed
+    ``ADCP_VERSION`` without running ``make regenerate-schemas``
+    (or vice versa).
+
+    Fix: run ``make regenerate-schemas`` at the repo root, then commit
+    the updated ``schemas/cache/`` + ``src/adcp/types/generated_poc/``.
+    """
+    pinned = _ADCP_VERSION_FILE.read_text().strip()
+    cache_data = json.loads(_CACHE_INDEX.read_text())
+    cache_version = cache_data.get("adcp_version", "<missing>")
+
+    assert pinned == cache_version, (
+        f"Spec version drift:\n"
+        f"  {_ADCP_VERSION_FILE.relative_to(_REPO_ROOT)}: {pinned!r}\n"
+        f"  {_CACHE_INDEX.relative_to(_REPO_ROOT)}.adcp_version: "
+        f"{cache_version!r}\n"
+        f"\n"
+        f"These must agree. If you bumped ADCP_VERSION intentionally, "
+        f"run `make regenerate-schemas` to refresh the generated types "
+        f"and commit the result."
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["", " ", "\n", "\t"],
+)
+def test_adcp_version_file_not_blank(bad_value: str) -> None:
+    """Pinning to a blank string would make the check pass trivially
+    (empty == empty). Guard against that class of regression at the
+    file-read level."""
+    pinned = _ADCP_VERSION_FILE.read_text().strip()
+    assert pinned != bad_value.strip(), (
+        f"{_ADCP_VERSION_FILE.relative_to(_REPO_ROOT)} is blank. "
+        f"Set it to a concrete version like 'latest' or '3.0.0'."
+    )


### PR DESCRIPTION
## Summary

Prep work so the eventual AdCP spec 3.0 tag → SDK 4.0.0 stable cut is mechanical on the day. Two pieces, no behavior change for anyone running `main`.

### 1. Drift-check CI gate — `tests/test_schemas_version_pin.py`

Cross-checks `src/adcp/ADCP_VERSION` against `schemas/cache/index.json.adcp_version` on every test run. Prevents the release-day footgun:

1. Someone bumps `ADCP_VERSION` from `"latest"` to `"3.0.0"` in a PR.
2. Forgets to run `make regenerate-schemas`.
3. CI green — nothing cross-checks.
4. Release ships with types generated from the wrong spec version.
5. Downstream clients hit "field X missing / unexpected" in production.

With this test, step 3 fails on the PR. Message points at the fix (`make regenerate-schemas`).

+7 tests total: main drift check, file-exists paranoia guards, blank-value guard (parametrized).

### 2. Release-day runbook — new section at the top of `RELEASING.md`

One-page checklist:

1. Confirm `curl -sI https://adcontextprotocol.org/protocol/X.Y.Z.tgz` returns 200 (abort if not tagged).
2. `echo "X.Y.Z" > src/adcp/ADCP_VERSION`
3. `make regenerate-schemas`
4. `make pre-push` (drift check from #1 lives inside this).
5. Review diff.
6. Commit + open PR.
7. Merge spec-pin PR → Release Please picks up the commit on its open release PR.
8. Merge Release Please's release PR → PyPI publish + GitHub release + tag.

Also documents the "revert to latest after release" workflow for resuming spec-HEAD tracking on `main`.

## Tested

- `test_schemas_version_pin.py` locally: 7 passed.
- Full suite: `2086 passed, 22 skipped`.
- `ruff`, `mypy` clean across 678 files.

## Test plan

- [ ] CI green across Python 3.10–3.13
- [ ] Review the release-day runbook for anything missing — anyone run a major SDK cut recently and remember a step I didn't capture?
- [ ] Optional: move the drift check from `tests/` to a dedicated CI step earlier in the pipeline (fail fast before running the 60-second test suite). Current placement is fine if the test suite is the gate everyone waits on anyway.

## Not in this PR (deferred)

- Pre-staged `bokelley/pin-spec-3.0` branch — can't exist until the bundle URL returns 200 on `3.0.0.tgz`. On tag day: create, pin, regen, PR, merge. ~5 minutes of mechanical work per the runbook.
- Salesagent notification draft — queued for tag day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)