### PR TITLE
fix(a2a): Checkpoint export + TaskState enum cleanup, pin release as 4.0.1

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -27,7 +27,7 @@ from adcp.capabilities import (  # noqa: F401
     build_synthetic_capabilities,
     validate_capabilities,
 )
-from adcp.client import ADCPClient, ADCPMultiAgentClient
+from adcp.client import ADCPClient, ADCPMultiAgentClient, Checkpoint
 from adcp.exceptions import (  # noqa: F401
     AdagentsNotFoundError,
     AdagentsTimeoutError,
@@ -566,6 +566,7 @@ __all__ = [
     # Client classes
     "ADCPClient",
     "ADCPMultiAgentClient",
+    "Checkpoint",
     "RegistryClient",
     "PropertyRegistry",
     "RegistrySync",

--- a/src/adcp/protocols/a2a.py
+++ b/src/adcp/protocols/a2a.py
@@ -523,7 +523,7 @@ class A2AAdapter(ProtocolAdapter):
         """Process a Task response from A2A into our TaskResult format."""
         task_state = task.status.state
 
-        if task_state == "completed":
+        if task_state == TaskState.completed:
             # Extract the result from the artifacts array
             result_data = self._extract_result_from_task(task)
 
@@ -542,7 +542,7 @@ class A2AAdapter(ProtocolAdapter):
                 },
                 debug_info=debug_info,
             )
-        elif task_state == "failed":
+        elif task_state == TaskState.failed:
             # Protocol-level failure - extract error message from TextPart
             error_msg = self._extract_text_from_task(task) or "Task failed"
             return TaskResult[Any](

--- a/tests/fixtures/public_api_snapshot.json
+++ b/tests/fixtures/public_api_snapshot.json
@@ -72,6 +72,7 @@
     "ChangeHandler",
     "CheckGovernanceRequest",
     "CheckGovernanceResponse",
+    "Checkpoint",
     "ComplyTestControllerRequest",
     "ComplyTestControllerResponse",
     "ConsentBasis",


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #258, plus a \`Release-As: 4.0.1\` footer to override the pending 5.0.0 release PR (#257).

### Code changes

- **Export \`Checkpoint\` from top-level \`adcp\`** — callers can now \`from adcp import Checkpoint\` instead of \`from adcp.client import Checkpoint\`, which matters because it's the type used as a persistence-key dict.
- **Enum comparisons in \`_process_task_response\`** — \`task_state == TaskState.completed\` / \`TaskState.failed\` matches the enum-based frozenset used for non-terminal states. An upstream rename in a2a-sdk now becomes a type error instead of a silent classification drift.

### Release positioning: 4.0.1 not 5.0.0

PR #258 landed with \`feat(a2a)!:\` + \`BREAKING CHANGE:\` footer, so release-please opened #257 for 5.0.0. The breaking bits were:

- \`pending_task_id\` → \`active_task_id\` (public property rename)
- \`ValueError\` → \`TypeError\` on non-A2A \`context_id=\` / \`reset_context()\`

4.0.0 shipped <48h before #258 landed. Per the salesagent roadmap, MCP is the critical path; A2A adoption is deferred behind pluggable TaskStore / push-notification work that isn't merged yet. Treating these as pre-adoption corrections rather than a major bump.

## What happens after merge

Once this lands on main, release-please will regenerate #257 at **4.0.1** instead of 5.0.0. Merge that and PyPI publishes 4.0.1.

## Test plan

- [x] \`ruff check src/\` — clean
- [x] \`mypy src/adcp/\` — 684 files, clean
- [x] \`pytest tests/test_protocols.py tests/integration/test_a2a_context_id.py\` — 70/70 pass

## Heads-up, not blocking 4.0.1

- **a2a-sdk 1.0.1 is out** (our pin is \`<1.0\`). Not backward-compatible — types moved, \`DefaultRequestHandler\` renamed, \`ServerError\` removed, \`Part\`/\`Message\` construction changed. Repo already tracks this as a separate compat PR (see pyproject.toml comment at a2a-sdk line). The \`A2AClient is deprecated\` warnings in our test output are the 0.3.x line signalling the 1.0 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)