### PR TITLE
fix(agents): triage already-engaged + ship-more (missed in #259)

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -33,11 +33,20 @@ quoting only.
 
 ## Four outcomes
 
+Default: **execute when the outcome is clear.** Ship work, don't
+narrate it. Flag only for genuine ambiguity or breaking changes.
+
 1. **Clarify** — ask 1–3 concrete questions
-2. **Flag for human review** — synthesis + ask for `@bokelley`
-3. **Execute PR** — experts agree, scope small, draft PR
+2. **Flag for human review** — experts formed an opinion but the
+   change is breaking, architectural, security-sensitive, or
+   experts disagreed. Synthesis + ask for `@bokelley`.
+3. **Execute PR** — experts agree, change is **non-breaking**.
+   Draft PR. No scope cap, no classification gate, no author gate.
 4. **Defer** — post-cycle / blocked — label-only (short ack for
    NONE / FIRST_TIME authors)
+
+**When in doubt: Execute.** Draft PRs are reversible; unshipped
+good changes rarely get revisited.
 
 ## Concurrency check — first thing
 
@@ -172,21 +181,46 @@ Apply only when the issue text names a target version, a linked PR
 is milestoned, or a version-shaped label is present. Otherwise omit.
 Never create new milestones.
 
-## PR criteria — all must be true
+## Non-breaking vs. breaking — the central question
 
-- Outcome is Execute after expert consultation
-- Classification is Bug or Usage where a doc fix suffices
-- Not RFC / epic / tracking / child-of-open-parent / deferred
+**Non-breaking — Execute:**
+
+- New optional params / methods / handler methods / Pydantic fields
+  (optional with default)
+- New examples, docstrings, doc pages
+- New tests for existing behavior
+- Typo / link / import-path fixes
+- Clarifying wording, error-message improvements
+
+**Breaking — Flag:**
+
+- Removing or renaming public symbols (ADCPClient, ADCPHandler
+  methods, exported types)
+- Changing function signatures (new required params, changed types)
+- Changing Pydantic field requirements (optional → required)
+- Changing default values
+- Changing error classes or raising different exceptions
+- Dep version bumps, especially for the pinned ones (`a2a-sdk`,
+  `httpcore`, `datamodel-code-generator`)
+
+## PR criteria — execute when outcome is clear
+
+All must be true:
+
+- Experts converge
+- Change is **non-breaking** (definition above)
 - Not security-sensitive (always Flag)
-- Scope small: 1–2 files, <150 lines
-- Success testable with `pytest`
+- Not RFC / epic / tracking / child-of-open-parent / deferred
 - Duplicate + open-PR checks clean
-- No bumps to pinned deps without explicit issue authorization
-  (especially `a2a-sdk`, `httpcore`, `datamodel-code-generator` —
-  the pins have comments explaining why)
+- Success testable with `pytest`
+- No bumps to pinned deps (`a2a-sdk`, `httpcore`,
+  `datamodel-code-generator`) without explicit issue authorization
 - No edits to generated code under `src/adcp/generated/` (if present)
 
-Author association is NOT a gate.
+**Scope NOT a gate.** **Author NOT a gate.** CODEOWNERS + human
+review gate merge.
+
+**When in doubt: Execute.**
 
 ## PR constraints
 

--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -49,6 +49,22 @@ gh api repos/adcontextprotocol/adcp-client-python/issues/<N>/comments \
 
 If > 0, skip — another session beat you to it.
 
+## Already-engaged check — before any expert work
+
+Silent-defer (apply `claude-triaged`, no comment) if any of these:
+
+1. **Assigned to a repo member** — any assignee is
+   `OWNER | MEMBER | COLLABORATOR`.
+2. **Open PR references it** —
+   `gh pr list --repo adcontextprotocol/adcp-client-python --search "in:body #<N>" --state open`
+   returns anything.
+3. **Recent repo-member comment** — any comment from
+   `OWNER | MEMBER | COLLABORATOR` (non-bot) in the last 7 days.
+   Exception: the comment explicitly asks for triage help.
+
+Don't post a competing analysis on work a human is already engaged
+on.
+
 ## Decision order
 
 ### Step 1 — Pre-classification
@@ -76,7 +92,17 @@ Classifications:
   issue. Verify against `pyproject.toml`.
 - **needs-info** (tiebreaker)
 
-Scope buckets (`gh label list` first, never invent):
+Scope buckets — **label application is strictly gated**:
+
+1. Run `gh label list --repo adcontextprotocol/adcp-client-python --limit 200 --json name,description` **first**.
+2. Apply only labels whose exact `name` is in that list and is a
+   clear, direct match.
+3. **Never create new labels.** Never POST to `/labels`. If a bucket
+   has no matching label, put the bucket name in the comment body
+   and flag the gap in the run summary.
+4. Default to not applying when uncertain.
+
+Common buckets (verify every time):
 
 - **client** — `src/adcp/` core client / ADCPClient surface
 - **handlers** — `ADCPHandler` server-side subclass surface


### PR DESCRIPTION
## Summary

Two commits intended for #259 that landed on the branch after the merge button was clicked — carrying them forward here as a follow-up.

### 1. Already-engaged check (mirror of `adcontextprotocol/adcp#2957`)

Silent-defer when the issue is assigned to a repo member, has an open PR referencing it, or has a repo-member comment in the last 7 days. Prevents competing analysis on work a human is already engaged on (the bot can't see Conductor workspaces / local drafts / Slack).

### 2. Ship-more default (mirror of `adcontextprotocol/adcp#2958`)

Default flipped: Execute when outcome is clear; Flag only for genuine ambiguity or breaking changes. Drops <150 line scope cap + classification-only-Bug-or-Doc gate. Adds non-breaking-vs-breaking as the primary binary.

For this repo specifically:
- **Non-breaking (Execute):** new optional params / methods / handler methods / Pydantic fields, new examples / docs / tests, typo / link fixes, wording clarifications
- **Breaking (Flag):** removing/renaming public symbols, signature changes, Pydantic required flips, default changes, dep bumps on pinned deps (`a2a-sdk`, `httpcore`, `datamodel-code-generator`)

Scope and author association are NOT gates. CODEOWNERS + human review still gate merge.

## Test plan

- [ ] Merge
- [ ] Fire the adcp-client-python routine when it's set up; confirm new mix (more Execute, less Flag on non-breaking issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)