### PR TITLE
feat(agents): triage defer subtypes + partial-rollout linkage rule

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -42,8 +42,17 @@ narrate it. Flag only for genuine ambiguity or breaking changes.
    experts disagreed. Synthesis + ask for `@bokelley`.
 3. **Execute PR** — experts agree, change is **non-breaking**.
    Draft PR. No scope cap, no classification gate, no author gate.
-4. **Defer** — post-cycle / blocked — label-only (short ack for
-   NONE / FIRST_TIME authors)
+4. **Defer** — three flavors:
+   - **Out of cycle (no blocker).** Silent for MEMBER+; ack for
+     NONE / FIRST_TIME_CONTRIBUTOR.
+   - **Blocked on open PR/issue.** Always post `Blocked-on: #N —
+     resurfaces on merge`, any author tier — the comment is the
+     audit trail and the resurfacing trigger.
+   - **Fold candidate.** Same as Blocked-on, plus also comment on
+     the parent PR suggesting scope be folded before merge (only
+     when parent is same-author / active contributor, still
+     iterating, and overlaps file scope). Skip if parent is
+     approved/awaiting-merge.
 
 **When in doubt: Execute.** Draft PRs are reversible; unshipped
 good changes rarely get revisited.
@@ -89,8 +98,17 @@ on.
 
 ### Step 1 — Pre-classification
 
-Skip auto-PR for: RFC/proposal, epic, tracking/meta,
-child-of-open-parent. These proceed to relevance check.
+Skip auto-PR for:
+
+- RFC / proposal, epic, tracking/meta
+- **child-of-open-parent** — any of: `Fixes #N`/`Closes #N` to an
+  open issue/PR; body text references an open PR as prereq ("after
+  #N", "follow-up to #N", "depends on #N", "extends #N");
+  acceptance criteria reference files that exist in an open PR's
+  diff but not on `main` (`gh pr view <N> --json files` to confirm).
+
+These proceed to relevance check, then to the **Defer** outcome
+(typically *Fold candidate* or *Blocked-on*) rather than Execute.
 
 ### Step 2 — Relevance check: in-cycle?
 
@@ -252,6 +270,22 @@ related fixes, or "items 1-5 after PR #N" — decide:
 
 A single cohesive PR is easier to review than three PRs with
 dependencies. The bot reduces maintainer clicks, not multiplies them.
+
+### Linkage rule for partial-rollout PRs
+
+When the issue proposes multiple items and you're shipping a subset,
+the PR body uses `Refs #N`, **not** `Closes #N`. `Closes` is reserved
+for PRs that fulfill the entire issue scope (even if delivered
+incrementally — only the *last* PR in the sequence carries `Closes`).
+
+Applies to multi-item issues (numbered lists, taxonomies with multiple
+`kind`s, follow-up bundles), issues with explicit "ship X first, then
+Y" guidance, or any case where PR scope is narrower than issue scope.
+
+In addition to using `Refs`, post a status comment on the parent issue
+listing what shipped and what remains, so a future triage sweep can
+find queued work. `Closes` here would be a quiet bug — the issue
+auto-closes on merge and remaining items lose their tracking surface.
 
 ## Pre-PR build + test gate — mandatory before expert review
 


### PR DESCRIPTION
Aligns this repo's triage prompt with the canonical change in adcontextprotocol/adcp: broader detection of child-of-open-parent issues, a three-flavor split of the **Defer** outcome, and an explicit linkage rule for partial-rollout PRs.

## What changes

**Step 1 — broader child-of-open-parent detection.** Now triggers on:
- `Fixes #N` / `Closes #N` references (existing)
- Body text references like "after #N", "follow-up to #N", "depends on #N", "extends #N"
- Acceptance criteria referencing files that exist in an open PR's diff but not on `main`

**Outcome 4 — Defer split into three flavors:**
- **Out of cycle (no specific blocker)** — silent for MEMBER+; ack for NONE / FIRST_TIME_CONTRIBUTOR. (Unchanged behavior.)
- **Blocked on a specific open PR/issue** — always posts `Blocked-on: #N — resurfaces on merge` regardless of author tier. The comment is the audit trail and the resurfacing trigger.
- **Fold candidate** — same as Blocked-on, plus comments on the parent PR suggesting scope be folded before merge (when same-author / active-contributor / still-iterating / file-overlap). Skip if parent is approved/awaiting-merge.

**Linkage rule for partial-rollout PRs.** When the issue proposes multiple items and the PR ships a subset, the body uses `Refs #N`, not `Closes #N`. `Closes` is reserved for PRs that fulfill the entire issue scope. Motivated by adcp-client#937, which closed #935 despite shipping only 1 of 5 proposed `StoryboardStepHint` kinds — the Bundling spirit said "leave the parent open," but the PR-drafting step emitted `Closes #N` by reflex. The new rule makes it explicit.

## Why now

The motivating gap: triage runs that defer an issue blocked on an open PR currently apply `claude-triaged` and go silent for repo members. The dependency disappears — when the parent PR merges, nothing resurfaces the child issue. Same shape as the linkage bug, just on the opposite side: bot's intent ("track this work") and bot's wire-output ("close it / silently defer") were misaligned.

No PR-creation logic changes. No expert cycles burned on deferred issues. Just better dependency tracking and clearer linkage discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
