### PR TITLE
ci(ipr): use adcp's reusable callable workflow + GitHub App

### DIFF
--- a/.github/workflows/ipr-agreement.yml
+++ b/.github/workflows/ipr-agreement.yml
@@ -1,57 +1,23 @@
 name: IPR Agreement
 
+# Delegates to the reusable workflow in adcontextprotocol/adcp. Signatures
+# land in the central ledger at adcontextprotocol/adcp:signatures/ipr-signatures.json.
+# See https://github.com/adcontextprotocol/adcp/blob/main/governance/ipr-bot-setup.md
+# for the GitHub App configuration and how to rotate / revoke credentials.
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize, reopened]
 
 permissions:
-  actions: write
-  contents: read
   pull-requests: write
   statuses: write
 
 jobs:
-  ipr-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: CLA Assistant
-        if: (github.event.comment.body == 'I have read the IPR Policy' || github.event_name == 'pull_request_target')
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.IPR_PAT }}
-        with:
-          path-to-signatures: 'signatures/ipr-signatures.json'
-          path-to-document: 'https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md'
-          branch: 'ipr-signatures'
-          remote-organization-name: 'adcontextprotocol'
-          remote-repository-name: 'adcp'
-          allowlist: 'bot*,dependabot*,renovate*,github-actions*'
-
-          custom-notsigned-prcomment: |
-            ## IPR Policy Agreement Required
-
-            Thank you for your contribution! Before we can accept your pull request, you must agree to our [Intellectual Property Rights Policy](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md).
-
-            By making a Contribution, you agree that:
-            - You grant the Foundation a perpetual, irrevocable, worldwide, non-exclusive, royalty-free copyright license to your Contribution
-            - You grant a patent license under any Necessary Claims
-            - You represent that you own or have sufficient rights to grant these licenses
-
-            **To agree, please comment below with the exact phrase:**
-
-            ```
-            I have read the IPR Policy
-            ```
-
-            You can read the full [IPR Policy here](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md).
-
-          custom-pr-sign-comment: 'I have read the IPR Policy'
-
-          custom-allsigned-prcomment: |
-            All contributors have agreed to the [IPR Policy](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md). Thank you!
-
-          lock-pullrequest-aftermerge: false
-          use-dco-flag: false
+  check:
+    uses: adcontextprotocol/adcp/.github/workflows/ipr-check-callable.yml@main
+    secrets:
+      IPR_APP_ID: ${{ secrets.IPR_APP_ID }}
+      IPR_APP_PRIVATE_KEY: ${{ secrets.IPR_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Replaces the IPR signing workflow with a delegation to the reusable workflow at [adcontextprotocol/adcp/.github/workflows/ipr-check-callable.yml](https://github.com/adcontextprotocol/adcp/blob/main/.github/workflows/ipr-check-callable.yml) (landed via [adcontextprotocol/adcp#3134](https://github.com/adcontextprotocol/adcp/pull/3134)).

Same change as [adcp-client#985](https://github.com/adcontextprotocol/adcp-client/pull/985), already merged + canary-verified.

## What changes

- Cross-repo signature writes use a **GitHub App installation token** (short-lived, org-scoped to adcontextprotocol/adcp only) instead of a long-lived PAT
- PR author's GitHub identity is the signing fact, not commit-author email — same fix from [adcontextprotocol/adcp#3011](https://github.com/adcontextprotocol/adcp/pull/3011)
- Workflow shrinks to a 22-line caller stub

## Pre-requisites

- [x] AAO IPR Bot installed on this repo
- [x] `IPR_APP_ID` and `IPR_APP_PRIVATE_KEY` org secrets accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)