### PR TITLE
docs(readme): note AAO IPR Policy requirement for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,7 +1371,7 @@ ruff check src/ tests/
 
 ## Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. All contributors must agree to the [AgenticAdvertising.Org IPR Policy](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md) — the bot prompts new contributors on their first PR and a single signature covers all AAO repositories.
 
 ## License
 


### PR DESCRIPTION
Tiny doc PR. Two purposes:

1. Real content: surface the IPR Policy expectation to anyone reading the README.
2. Seeds the \`IPR Policy / Signature\` status check name in this repo's branch-protection autocomplete so the ruleset can require it.

Once the IPR check posts on this PR, you can finish setting up branch protection and either merge or close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)