### PR TITLE
fix(handlers): sync MEDIA_BUY_STATE_MACHINE with spec v3 enum

### DIFF
--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -168,7 +168,7 @@ class MySeller(ADCPHandler):
 Sellers emit webhooks to notify buyers asynchronously. AdCP 3.0 uses RFC 9421 HTTP Message Signatures — use `adcp.webhooks.WebhookSender` (one-call helper) or `sign_webhook` for lower-level control.
 
 **When to emit:**
-- Async-approval media buy transitions (`pending_activation` → `active`, or `→ rejected`)
+- Async-approval media buy transitions (`pending_creatives` → `pending_start` → `active`, or `→ rejected`)
 - Artifact-ready notifications after long-running operations
 - Delivery reports the buyer subscribed to via `reporting_webhook` on `create_media_buy`
 

--- a/src/adcp/server/helpers.py
+++ b/src/adcp/server/helpers.py
@@ -141,7 +141,15 @@ def adcp_error(
 # Actions are operations available via update_media_buy for each status.
 # Public constant — servers can inspect, test against, or extend this.
 MEDIA_BUY_STATE_MACHINE: dict[str, list[str]] = {
-    "pending_activation": [
+    "pending_creatives": [
+        "cancel",
+        "update_budget",
+        "update_dates",
+        "update_packages",
+        "add_packages",
+        "sync_creatives",
+    ],
+    "pending_start": [
         "cancel",
         "update_budget",
         "update_dates",
@@ -164,7 +172,18 @@ MEDIA_BUY_STATE_MACHINE: dict[str, list[str]] = {
 
 
 def valid_actions_for_status(status: str) -> list[str]:
-    """Get valid buyer actions for a media buy status."""
+    """Get valid buyer actions for a media buy status.
+
+    Returns the list of ``update_media_buy`` actions available to a buyer for
+    the given status string. Returns ``[]`` for terminal statuses and for any
+    unrecognized status string.
+
+    Valid statuses per ``enums/media-buy-status.json``:
+    ``pending_creatives``, ``pending_start``, ``active``, ``paused``,
+    ``completed``, ``rejected``, ``canceled``.
+
+    Inspect or extend :data:`MEDIA_BUY_STATE_MACHINE` to add custom actions.
+    """
     return list(MEDIA_BUY_STATE_MACHINE.get(status, []))
 
 

--- a/tests/test_server_helpers.py
+++ b/tests/test_server_helpers.py
@@ -85,10 +85,15 @@ class TestValidActionsForStatus:
         for status in ("completed", "rejected", "canceled"):
             assert valid_actions_for_status(status) == []
 
-    def test_pending_activation_allows_cancel(self) -> None:
-        actions = valid_actions_for_status("pending_activation")
+    def test_pending_start_allows_cancel(self) -> None:
+        actions = valid_actions_for_status("pending_start")
         assert "cancel" in actions
         assert "update_packages" in actions
+
+    def test_pending_creatives_allows_sync_creatives(self) -> None:
+        actions = valid_actions_for_status("pending_creatives")
+        assert "sync_creatives" in actions
+        assert "cancel" in actions
 
     def test_unknown_status_empty(self) -> None:
         assert valid_actions_for_status("nonexistent") == []

--- a/tests/test_server_helpers.py
+++ b/tests/test_server_helpers.py
@@ -95,6 +95,31 @@ class TestValidActionsForStatus:
         assert "sync_creatives" in actions
         assert "cancel" in actions
 
+    def test_pending_activation_is_not_recognized(self) -> None:
+        # AdCP v3 renamed pending_activation to pending_creatives + pending_start.
+        # Lock the rename so a copy-paste from old docs / old SDK code returns
+        # an empty action list rather than silently matching a stale entry.
+        from adcp.server.helpers import MEDIA_BUY_STATE_MACHINE
+
+        assert valid_actions_for_status("pending_activation") == []
+        assert "pending_activation" not in MEDIA_BUY_STATE_MACHINE
+
+    def test_state_machine_keys_match_spec_enum(self) -> None:
+        # Keys must exactly match enums/media-buy-status.json. Terminal
+        # statuses are present with empty action lists. Guards against
+        # future silent drift between the spec enum and the dispatcher.
+        from adcp.server.helpers import MEDIA_BUY_STATE_MACHINE
+
+        assert set(MEDIA_BUY_STATE_MACHINE) == {
+            "pending_creatives",
+            "pending_start",
+            "active",
+            "paused",
+            "completed",
+            "rejected",
+            "canceled",
+        }
+
     def test_unknown_status_empty(self) -> None:
         assert valid_actions_for_status("nonexistent") == []
 


### PR DESCRIPTION
Closes #288

## Summary

Issue #288 identified schema drift between the SDK and AdCP v3 spec. Most reported drift was already resolved in v4.0.0 (the `MediaBuyStatus` generated enum and `AggregatedTotals` fields are correct). One residual bug remained: `MEDIA_BUY_STATE_MACHINE` in `src/adcp/server/helpers.py` still had `"pending_activation"` as its pre-flight key — a status that no longer exists in `enums/media-buy-status.json`. This caused `valid_actions_for_status("pending_start")` to return `[]` instead of the correct pre-flight action list, and `valid_actions_for_status("pending_activation")` to return a non-empty list for a spec-invalid status.

Changes:
- Replace `"pending_activation"` key with `"pending_start"` (same pre-flight actions) and `"pending_creatives"` (adds `sync_creatives` — the buyer must attach creatives before the buy can serve)
- Expand `valid_actions_for_status` docstring to enumerate all valid status strings and document the `[]` fallback
- Update `tests/test_server_helpers.py`: rename `test_pending_activation_allows_cancel` → `test_pending_start_allows_cancel`, add `test_pending_creatives_allows_sync_creatives`
- Fix stale `pending_activation → active` webhook transition example in `skills/build-seller-agent/SKILL.md` → `pending_creatives → pending_start → active`

## What was tested

- `pytest tests/test_server_helpers.py` — 43 passed
- `ruff check src/adcp/server/helpers.py` — clean
- `mypy src/adcp/server/helpers.py` — no issues

## Pre-PR review

- **code-reviewer:** approved — no blockers; nit: `is_terminal_status` hard-codes its terminal set independently of `MEDIA_BUY_STATE_MACHINE` (same drift risk pattern, currently consistent); nit: `test_pending_start_allows_cancel` could add `assert "sync_creatives" not in actions` negative assertion
- **dx-expert:** approved — no blockers; nit: add intent comment in `pending_start` explaining `sync_creatives` is intentionally absent (creatives locked once flight-date-pending); same negative assertion nit as above

## Nits surfaced (not fixed — reviewer discretion)

- `is_terminal_status` hard-codes `("completed", "rejected", "canceled")` separately from the state machine; currently consistent but divergence risk on future spec updates
- `test_pending_start_allows_cancel` could assert `"sync_creatives" not in actions` to make the `pending_creatives` vs `pending_start` distinction explicit
- `pending_start` action block could carry a one-line comment: `# sync_creatives intentionally absent — creatives are locked once flight-date-pending`

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Q4gEoNmiYsfqnfFSR71JLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4gEoNmiYsfqnfFSR71JLg)_