### PR TITLE
fix(adcp): skip eager httpx.AsyncClient alloc in WebhookSender.__aenter__ on owned-client path

### DIFF
--- a/src/adcp/webhook_sender.py
+++ b/src/adcp/webhook_sender.py
@@ -253,7 +253,8 @@ class WebhookSender:
             self._client = None
 
     async def __aenter__(self) -> WebhookSender:
-        await self._get_client()
+        if not self._owns_client:
+            await self._get_client()
         return self
 
     async def __aexit__(self, *args: Any) -> None:


### PR DESCRIPTION
Closes #300

When `WebhookSender` owns its client (`_owns_client=True`, i.e. no caller-supplied `client=`), `__aenter__` was unconditionally calling `_get_client()`, which allocated an `httpx.AsyncClient` that sat idle until `__aexit__`. On the owned-client path, `_send_bytes` calls `_get_client()` lazily at first use anyway, so the eager allocation in `__aenter__` was wasted. The fix skips it; the operator-supplied-client branch (`_owns_client=False`) still calls `_get_client()` for symmetry, though that call is a no-op since `self._client` is already set.

## What was tested

- `pytest tests/ -k "webhook_sender or webhook"` — 182 passed, 0 failed
- `ruff check src/` — clean
- `mypy src/adcp/webhook_sender.py` — no new errors (pre-existing errors are in unrelated files)

## Pre-PR review

- code-reviewer: approved — fix correct and non-breaking; nit: `_get_client()` call on `_owns_client=False` branch is a harmless no-op but could be removed for clarity.
- dx-expert: approved — both `async with WebhookSender(...)` paths (owned and operator-supplied) preserve their existing contract; no docstring update needed.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXvZUh1KahNgiZUTTdS7qQ)_