### PR TITLE
fix(examples): fix 6 storyboard compliance gaps in seller_agent.py

### DIFF
--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -225,7 +225,10 @@ class DemoSeller(ADCPHandler):
                 }
             )
 
-        has_creatives = any(pkg.get("creatives") for pkg in params["packages"])
+        has_creatives = any(
+            pkg.get("creatives") or pkg.get("creative_assignments")
+            for pkg in params["packages"]
+        )
         status = "active" if has_creatives else "pending_creatives"
         mb_id = f"mb-{uuid.uuid4().hex[:8]}"
         media_buys[mb_id] = {

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -116,6 +116,8 @@ class DemoSeller(ADCPHandler):
                     "simulate_budget_spend",
                 ],
             },
+            # adcp.idempotency is required by spec (get-adcp-capabilities-response.json)
+            idempotency={"supported": False},
         )
 
     async def sync_accounts(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
@@ -223,14 +225,16 @@ class DemoSeller(ADCPHandler):
                 }
             )
 
+        has_creatives = any(pkg.get("creatives") for pkg in params["packages"])
+        status = "active" if has_creatives else "pending_creatives"
         mb_id = f"mb-{uuid.uuid4().hex[:8]}"
         media_buys[mb_id] = {
-            "status": "active",
+            "status": status,
             "currency": "USD",
             "packages": packages,
             "revision": 1,
         }
-        return media_buy_response(mb_id, packages, status="active")
+        return media_buy_response(mb_id, packages, status=status)
 
     async def get_media_buys(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         requested_ids = params.get("media_buy_ids")
@@ -238,12 +242,14 @@ class DemoSeller(ADCPHandler):
         for mb_id, mb in media_buys.items():
             if requested_ids and mb_id not in requested_ids:
                 continue
+            pkgs = mb.get("packages", [])
             results.append(
                 {
                     "media_buy_id": mb_id,
                     "status": mb["status"],
                     "currency": mb.get("currency", "USD"),
-                    "packages": mb.get("packages", []),
+                    "total_budget": sum(pkg.get("budget") or 0 for pkg in pkgs),  # None for flat-rate pkgs
+                    "packages": pkgs,
                 }
             )
         return media_buys_response(results)
@@ -256,6 +262,16 @@ class DemoSeller(ADCPHandler):
 
         if params.get("revision") and params["revision"] != mb.get("revision", 1):
             return adcp_error("CONFLICT", "Revision mismatch - refetch and retry")
+
+        if params.get("packages"):
+            existing_pkg_ids = {pkg["package_id"] for pkg in mb.get("packages", [])}
+            for pkg_update in params["packages"]:
+                if pkg_update.get("package_id") not in existing_pkg_ids:
+                    return adcp_error(
+                        "PACKAGE_NOT_FOUND",
+                        f"Package {pkg_update.get('package_id')!r} not found in media buy {mb_id}",
+                        field="packages",
+                    )
 
         status = mb["status"]
         if params.get("paused") is True and status == "active":
@@ -274,50 +290,60 @@ class DemoSeller(ADCPHandler):
     async def list_creative_formats(
         self, params: dict[str, Any], context: Any = None
     ) -> dict[str, Any]:
-        return creative_formats_response(
-            [
-                {
-                    "format_id": {
-                        "agent_url": AGENT_URL,
-                        "id": "display_300x250",
-                    },
-                    "name": "Display 300x250",
-                    "renders": [{"width": 300, "height": 250}],
-                    "assets": [
-                        {
-                            "item_type": "individual",
-                            "asset_id": "image",
-                            "asset_type": "image",
-                            "required": True,
-                            "accepted_media_types": [
-                                "image/png",
-                                "image/jpeg",
-                            ],
-                        }
-                    ],
+        all_formats: list[dict[str, Any]] = [
+            {
+                "format_id": {
+                    "agent_url": AGENT_URL,
+                    "id": "display_300x250",
                 },
-                {
-                    "format_id": {
-                        "agent_url": AGENT_URL,
-                        "id": "display_970x250",
-                    },
-                    "name": "Display 970x250",
-                    "renders": [{"width": 970, "height": 250}],
-                    "assets": [
-                        {
-                            "item_type": "individual",
-                            "asset_id": "image",
-                            "asset_type": "image",
-                            "required": True,
-                            "accepted_media_types": [
-                                "image/png",
-                                "image/jpeg",
-                            ],
-                        }
-                    ],
+                "name": "Display 300x250",
+                # role is required; width/height must be nested under dimensions
+                "renders": [{"role": "primary", "dimensions": {"width": 300, "height": 250}}],
+                "assets": [
+                    {
+                        "item_type": "individual",
+                        "asset_id": "image",
+                        "asset_type": "image",
+                        "required": True,
+                        "accepted_media_types": [
+                            "image/png",
+                            "image/jpeg",
+                        ],
+                    }
+                ],
+            },
+            {
+                "format_id": {
+                    "agent_url": AGENT_URL,
+                    "id": "display_970x250",
                 },
+                "name": "Display 970x250",
+                # role is required; width/height must be nested under dimensions
+                "renders": [{"role": "primary", "dimensions": {"width": 970, "height": 250}}],
+                "assets": [
+                    {
+                        "item_type": "individual",
+                        "asset_id": "image",
+                        "asset_type": "image",
+                        "required": True,
+                        "accepted_media_types": [
+                            "image/png",
+                            "image/jpeg",
+                        ],
+                    }
+                ],
+            },
+        ]
+        # format_ids is optional per spec: absent means return all formats
+        # match on compound (agent_url, id) key — correct for multi-agent deployments
+        requested = params.get("format_ids")
+        if requested:
+            keys = {(r["agent_url"], r["id"]) for r in requested}
+            all_formats = [
+                fmt for fmt in all_formats
+                if (fmt["format_id"]["agent_url"], fmt["format_id"]["id"]) in keys
             ]
-        )
+        return creative_formats_response(all_formats)
 
     async def sync_creatives(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         results = []

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -225,6 +225,7 @@ class DemoSeller(ADCPHandler):
                 }
             )
 
+        # check input packages (not the built output) — creatives live on the request pkg
         has_creatives = any(
             pkg.get("creatives") or pkg.get("creative_assignments")
             for pkg in params["packages"]
@@ -272,9 +273,12 @@ class DemoSeller(ADCPHandler):
                 if pkg_update.get("package_id") not in existing_pkg_ids:
                     return adcp_error(
                         "PACKAGE_NOT_FOUND",
-                        f"Package {pkg_update.get('package_id')!r} not found in media buy {mb_id}",
+                        "Package not found in this media buy",
                         field="packages",
                     )
+            # Note: this reference implementation validates package IDs but does not
+            # apply budget/targeting updates. A production seller should merge pkg_update
+            # fields back into mb["packages"] here.
 
         status = mb["status"]
         if params.get("paused") is True and status == "active":
@@ -341,7 +345,7 @@ class DemoSeller(ADCPHandler):
         # match on compound (agent_url, id) key — correct for multi-agent deployments
         requested = params.get("format_ids")
         if requested:
-            keys = {(r["agent_url"], r["id"]) for r in requested}
+            keys = {(r.get("agent_url"), r.get("id")) for r in requested}
             all_formats = [
                 fmt for fmt in all_formats
                 if (fmt["format_id"]["agent_url"], fmt["format_id"]["id"]) in keys


### PR DESCRIPTION
Refs #304

Fixes items 1–6 from the issue punch list. Item 7 (`seed_product` controller stub) is deferred pending #296, which adds the `seed_*` dispatcher to `TestControllerStore`. The `controller_detected: true` target also depends on #282 landing.

**What changed in `examples/seller_agent.py`:**

1. **Idempotency capability** — `adcp.idempotency` is required by the capabilities schema; added `idempotency={"supported": False}` to `capabilities_response()`. Without it the runner silently downgrades to v2 mode.
2. **`get_media_buys` missing `total_budget`** — schema `required: ["total_budget"]`; added sum of package budgets (or 0 for flat-rate packages).
3. **`create_media_buy` status lifecycle** — return `pending_creatives` when no per-package `creatives` or `creative_assignments` are supplied at create time; `active` otherwise. Checks both creative-attachment paths on the input request packages.
4. **`list_creative_formats` renders schema** — `role` is required; `width`/`height` must be nested under `dimensions`. Changed bare `{"width": W, "height": H}` to `{"role": "primary", "dimensions": {"width": W, "height": H}}`.
5. **`list_creative_formats` filter ignored** — honor `format_ids` request parameter; filter on compound `(agent_url, id)` key per `format-id.json` schema; absent means return all.
6. **`update_media_buy` missing `PACKAGE_NOT_FOUND`** — validate `package_id` existence when a `packages` update is requested; return `PACKAGE_NOT_FOUND` for unknown IDs (per `error-code.json` canonical code). Note: this reference implementation validates but does not apply budget/targeting writes back — a production seller should merge update fields into the stored package.

## What was tested

- `pytest tests/ -q --ignore=tests/conformance/signing/test_ip_pinned_transport.py --ignore=tests/integration` — **2132 passed, 0 failures** (no tests touch `examples/`, suite clean)
- `python -c "import ast; ast.parse(open('examples/seller_agent.py').read())"` — syntax OK
- `examples/` is excluded from `ruff` and `mypy` per `pyproject.toml`

## Pre-PR review

- **code-reviewer:** approved — no CI-blocking issues; two fixes applied from review (static error message in `PACKAGE_NOT_FOUND` to avoid user-data in LLM-visible error context per `adcp_error` docstring; `.get()` in `format_ids` filter to avoid `KeyError` on malformed input)
- **ad-tech-protocol-expert:** approved — all 6 items schema-sound; blocker fixed (`creative_assignments` path now covered alongside `creatives` in `has_creatives` check; confirmed exhaustive per `package-request.json` schema)

## Nits surfaced (not fixed — follow-up candidates)

- `update_media_buy` silently accepts valid `packages` update payloads but discards the field writes; a production seller should merge `pkg_update` fields back into stored packages (comment added in-code)
- `total_budget: 0.0` is schema-valid (`minimum: 0`) for flat-rate-only catalogs but may surprise implementors — inline comment added

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01GDFGtecoKD34z3KmZ4GuML

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDFGtecoKD34z3KmZ4GuML)_