### PR TITLE
ci(adcp): add storyboard CI job for seller_agent.py compliance checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,3 +330,82 @@ jobs:
             echo "  Numbered-variant class-name churn is expected; the semantic"
             echo "  alias tests and drift-version-pin test guard the real surface."
           fi
+
+  storyboard:
+    name: AdCP storyboard runner — examples/seller_agent.py
+    runs-on: ubuntu-latest
+    # Non-blocking until seller-agent content gaps in #304 are resolved.
+    # Promote to required once overall_status: pass and controller_detected: true.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Start seller agent
+        run: |
+          ADCP_PORT=3001 python examples/seller_agent.py &
+          AGENT_PID=$!
+          for i in $(seq 1 60); do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
+              http://localhost:3001/mcp 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" != "000" ]; then
+              echo "Seller agent ready (HTTP ${HTTP_CODE}, pid ${AGENT_PID})"
+              break
+            fi
+            if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+              echo "Seller agent process died during startup"
+              exit 1
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Seller agent failed to start within 30s"
+              kill "$AGENT_PID" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+
+      - name: Run storyboard suite
+        timeout-minutes: 5
+        run: |
+          npx -y -p @adcp/client@latest adcp storyboard run \
+            http://localhost:3001/mcp media_buy_seller \
+            --json --allow-http \
+            > storyboard-result.json
+
+      - name: Assert pass
+        run: |
+          python -c "
+          import json, sys, pathlib
+          p = pathlib.Path('storyboard-result.json')
+          if not p.exists() or p.stat().st_size == 0:
+              print('storyboard-result.json missing or empty — runner produced no output')
+              sys.exit(1)
+          d = json.load(p.open())
+          if d.get('overall_status') != 'pass':
+              print(json.dumps({k: d[k] for k in ('overall_status', 'summary', 'failures')}, indent=2))
+              sys.exit(1)
+          if not d.get('controller_detected'):
+              print('controller_detected was false; check DemoStore overrides (see #304)')
+              sys.exit(1)
+          "
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storyboard-result
+          path: storyboard-result.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
             # Any HTTP response (including 405 on GET to a POST-only endpoint)
             # means the server is up and accepting connections.
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
-              http://localhost:3001/mcp 2>/dev/null || echo "000")
+              http://127.0.0.1:3001/mcp 2>/dev/null || echo "000")
             if [ "$HTTP_CODE" != "000" ]; then
               echo "Seller agent ready (HTTP ${HTTP_CODE}, pid ${AGENT_PID})"
               break
@@ -388,7 +388,7 @@ jobs:
         # drift as soon as it ships, which is the point of this job.
         run: |
           npx -y -p @adcp/client@latest adcp storyboard run \
-            http://localhost:3001/mcp media_buy_seller \
+            http://127.0.0.1:3001/mcp media_buy_seller \
             --json --allow-http \
             > storyboard-result.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
     name: AdCP storyboard runner — examples/seller_agent.py
     runs-on: ubuntu-latest
     # Non-blocking until seller-agent content gaps in #304 are resolved.
-    # Promote to required once overall_status: pass and controller_detected: true.
+    # Promote to required once overall_status: passing and controller_detected: true.
     continue-on-error: true
 
     steps:
@@ -361,6 +361,8 @@ jobs:
           ADCP_PORT=3001 python examples/seller_agent.py &
           AGENT_PID=$!
           for i in $(seq 1 60); do
+            # Any HTTP response (including 405 on GET to a POST-only endpoint)
+            # means the server is up and accepting connections.
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
               http://localhost:3001/mcp 2>/dev/null || echo "000")
             if [ "$HTTP_CODE" != "000" ]; then
@@ -381,6 +383,9 @@ jobs:
 
       - name: Run storyboard suite
         timeout-minutes: 5
+        # @adcp/client@latest is intentionally unpinned — this is AdCP's own CI
+        # running AdCP's own canonical runner. Tracking latest surfaces protocol
+        # drift as soon as it ships, which is the point of this job.
         run: |
           npx -y -p @adcp/client@latest adcp storyboard run \
             http://localhost:3001/mcp media_buy_seller \
@@ -395,9 +400,10 @@ jobs:
           if not p.exists() or p.stat().st_size == 0:
               print('storyboard-result.json missing or empty — runner produced no output')
               sys.exit(1)
-          d = json.load(p.open())
-          if d.get('overall_status') != 'pass':
-              print(json.dumps({k: d[k] for k in ('overall_status', 'summary', 'failures')}, indent=2))
+          with p.open() as f:
+              d = json.load(f)
+          if d.get('overall_status') != 'passing':
+              print(json.dumps(d, indent=2))
               sys.exit(1)
           if not d.get('controller_detected'):
               print('controller_detected was false; check DemoStore overrides (see #304)')
@@ -407,5 +413,6 @@ jobs:
       - if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: storyboard-result
+          name: storyboard-result-${{ github.run_attempt }}
           path: storyboard-result.json
+          if-no-files-found: warn


### PR DESCRIPTION
Closes #305

Adds a `storyboard` CI job that boots `examples/seller_agent.py` on port 3001 and runs the `@adcp/client` storyboard suite against it on every PR. The job catches end-to-end response-shape, status-enum, and capability-declaration regressions that unit tests and import smoke checks cannot see — exactly the class of breakage that silently broke `#295`/`#296`.

The job is `continue-on-error: true` (informational, non-blocking) because `examples/seller_agent.py` on current `main` has known content gaps (#304) that produce partial results. Once those are fixed and the job goes green, remove `continue-on-error` to promote it to a required check.

## What's tested

- YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(...)"` ✓
- No Python source changes; `pytest`, `mypy`, `ruff` not applicable to this diff

## Implementation notes

- **Readiness check:** curl polls `http://localhost:3001/mcp` (any non-`000` HTTP code means uvicorn is accepting HTTP); 30s timeout with PID-alive-check to fail fast if the agent crashes on startup
- **`@adcp/client@latest`:** intentionally unpinned — this is AdCP's own CI running AdCP's own canonical storyboard runner. Tracking latest surfaces protocol drift immediately, which is the purpose of this job. (The supply-chain risk vs. `npx playwright` treatment question was the only blocker/nit split in the prior triage; `/triage execute` resolved it.)
- **Artifact:** always uploaded as `storyboard-result-${{ github.run_attempt }}` (suffixed to avoid v4 conflict on re-runs), with `if-no-files-found: warn` so a startup failure doesn't add a second noisy annotation

## Pre-PR review

- code-reviewer: approved after fixes — caught `'pass'` → `'passing'` enum mismatch (would have made the job permanently red) and `d[k]` KeyError in diagnostic print; both fixed
- dx-expert: approved after fixes — caught `upload-artifact@v4` hard-error on missing file; fixed with `if-no-files-found: warn`; noted `run_attempt` suffix for re-run safety; applied

**Nits noted (not fixed):**
- Agent process not explicitly torn down between steps (fine for single-scenario job; AGENT_PID is process-local to the step, VM exits clean it up)
- Timeout message "30s" is technically ~29.5s; not operationally significant

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 306` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01SSje6ebBHD85TWdQbEig9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSje6ebBHD85TWdQbEig9m)_