### PR TITLE
fix(examples): seller_agent.py AdCP 3.0.1 storyboard compliance (items 1-6 of #304)

### DIFF
--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -107,6 +107,7 @@ class DemoSeller(ADCPHandler):
     ) -> dict[str, Any]:
         return capabilities_response(
             ["media_buy"],
+            idempotency={"supported": False},
             compliance_testing={
                 "scenarios": [
                     "force_account_status",
@@ -223,14 +224,20 @@ class DemoSeller(ADCPHandler):
                 }
             )
 
+        has_creatives = any(
+            pkg.get("creative_assignments") or pkg.get("creatives")
+            for pkg in params["packages"]
+        )
+        status = "active" if has_creatives else "pending_creatives"
+
         mb_id = f"mb-{uuid.uuid4().hex[:8]}"
         media_buys[mb_id] = {
-            "status": "active",
+            "status": status,
             "currency": "USD",
             "packages": packages,
             "revision": 1,
         }
-        return media_buy_response(mb_id, packages, status="active")
+        return media_buy_response(mb_id, packages, status=status)
 
     async def get_media_buys(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         requested_ids = params.get("media_buy_ids")
@@ -238,12 +245,14 @@ class DemoSeller(ADCPHandler):
         for mb_id, mb in media_buys.items():
             if requested_ids and mb_id not in requested_ids:
                 continue
+            total_budget = sum((pkg.get("budget") or 0) for pkg in mb.get("packages", []))
             results.append(
                 {
                     "media_buy_id": mb_id,
                     "status": mb["status"],
                     "currency": mb.get("currency", "USD"),
                     "packages": mb.get("packages", []),
+                    "total_budget": total_budget,
                 }
             )
         return media_buys_response(results)
@@ -257,7 +266,25 @@ class DemoSeller(ADCPHandler):
         if params.get("revision") and params["revision"] != mb.get("revision", 1):
             return adcp_error("CONFLICT", "Revision mismatch - refetch and retry")
 
+        if params.get("packages"):
+            existing_pkg_ids = {p["package_id"] for p in mb.get("packages", [])}
+            for pkg_update in params["packages"]:
+                pkg_id = pkg_update.get("package_id")
+                if pkg_id and pkg_id not in existing_pkg_ids:
+                    return adcp_error(
+                        "PACKAGE_NOT_FOUND",
+                        f"Package '{pkg_id}' not found in media buy {mb_id}",
+                        field="package_id",
+                    )
+
         status = mb["status"]
+        if status == "pending_creatives" and params.get("packages"):
+            if any(
+                pkg.get("creative_assignments") or pkg.get("creatives")
+                for pkg in params["packages"]
+            ):
+                mb["status"] = "active"
+                status = "active"
         if params.get("paused") is True and status == "active":
             mb["status"] = "paused"
         elif params.get("paused") is False and status == "paused":
@@ -274,50 +301,59 @@ class DemoSeller(ADCPHandler):
     async def list_creative_formats(
         self, params: dict[str, Any], context: Any = None
     ) -> dict[str, Any]:
-        return creative_formats_response(
-            [
-                {
-                    "format_id": {
-                        "agent_url": AGENT_URL,
-                        "id": "display_300x250",
-                    },
-                    "name": "Display 300x250",
-                    "renders": [{"width": 300, "height": 250}],
-                    "assets": [
-                        {
-                            "item_type": "individual",
-                            "asset_id": "image",
-                            "asset_type": "image",
-                            "required": True,
-                            "accepted_media_types": [
-                                "image/png",
-                                "image/jpeg",
-                            ],
-                        }
-                    ],
+        all_formats: list[dict[str, Any]] = [
+            {
+                "format_id": {
+                    "agent_url": AGENT_URL,
+                    "id": "display_300x250",
                 },
-                {
-                    "format_id": {
-                        "agent_url": AGENT_URL,
-                        "id": "display_970x250",
-                    },
-                    "name": "Display 970x250",
-                    "renders": [{"width": 970, "height": 250}],
-                    "assets": [
-                        {
-                            "item_type": "individual",
-                            "asset_id": "image",
-                            "asset_type": "image",
-                            "required": True,
-                            "accepted_media_types": [
-                                "image/png",
-                                "image/jpeg",
-                            ],
-                        }
-                    ],
+                "name": "Display 300x250",
+                "renders": [{"role": "primary", "dimensions": {"width": 300, "height": 250}}],
+                "assets": [
+                    {
+                        "item_type": "individual",
+                        "asset_id": "image",
+                        "asset_type": "image",
+                        "required": True,
+                        "accepted_media_types": [
+                            "image/png",
+                            "image/jpeg",
+                        ],
+                    }
+                ],
+            },
+            {
+                "format_id": {
+                    "agent_url": AGENT_URL,
+                    "id": "display_970x250",
                 },
+                "name": "Display 970x250",
+                "renders": [{"role": "primary", "dimensions": {"width": 970, "height": 250}}],
+                "assets": [
+                    {
+                        "item_type": "individual",
+                        "asset_id": "image",
+                        "asset_type": "image",
+                        "required": True,
+                        "accepted_media_types": [
+                            "image/png",
+                            "image/jpeg",
+                        ],
+                    }
+                ],
+            },
+        ]
+        filter_ids = params.get("format_ids")
+        if filter_ids:
+            wanted = {(fid.get("agent_url"), fid["id"]) for fid in filter_ids if "id" in fid}
+            formats = [
+                f
+                for f in all_formats
+                if (f["format_id"].get("agent_url"), f["format_id"]["id"]) in wanted
             ]
-        )
+        else:
+            formats = all_formats
+        return creative_formats_response(formats)
 
     async def sync_creatives(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         results = []

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -450,7 +450,7 @@ class DemoStore(TestControllerStore):
         impressions: int | None = None,
         clicks: int | None = None,
         conversions: int | None = None,
-        reported_spend: float | None = None,
+        reported_spend: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if media_buy_id not in media_buys:
             raise TestControllerError("NOT_FOUND", f"Media buy {media_buy_id} not found")

--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -237,7 +237,12 @@ class DemoSeller(ADCPHandler):
             "packages": packages,
             "revision": 1,
         }
-        return media_buy_response(mb_id, packages, status=status)
+        pending_actions = ["sync_creatives", "cancel", "update_budget", "update_dates",
+                           "update_packages", "add_packages"]
+        return media_buy_response(
+            mb_id, packages, status=status,
+            valid_actions=pending_actions if status == "pending_creatives" else None,
+        )
 
     async def get_media_buys(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         requested_ids = params.get("media_buy_ids")
@@ -296,7 +301,14 @@ class DemoSeller(ADCPHandler):
             return cancel_media_buy_response(mb_id, "buyer")
 
         mb["revision"] = mb.get("revision", 1) + 1
-        return update_media_buy_response(mb_id, status=mb["status"], revision=mb["revision"])
+        pending_actions = ["sync_creatives", "cancel", "update_budget", "update_dates",
+                           "update_packages", "add_packages"]
+        return update_media_buy_response(
+            mb_id,
+            status=mb["status"],
+            revision=mb["revision"],
+            valid_actions=pending_actions if mb["status"] == "pending_creatives" else None,
+        )
 
     async def list_creative_formats(
         self, params: dict[str, Any], context: Any = None


### PR DESCRIPTION
Refs #304

Fixes 6 content-side storyboard failures in `examples/seller_agent.py` (the SDK's reference seller for the `media_buy_seller` compliance suite). All changes are examples-only — no SDK source modifications. Item 7 (`seed_product` / `controller_detected`) remains blocked on #282.

## Changes

1. **`adcp.idempotency` not declared** — add `idempotency={"supported": False}` to `capabilities_response()`. Without this, the AdCP 3.0.1 storyboard runner downgrades to v2 mode.

2. **`get_media_buys` missing `total_budget`** — schema requires this field; added as `sum(pkg budgets)` per media buy entry.

3. **`create_media_buy` returns `active` without creatives** — now returns `pending_creatives` when no `creative_assignments`/`creatives` are in the request packages. `update_media_buy` transitions `pending_creatives → active` when creatives are attached. Also passes explicit `valid_actions` for `pending_creatives` status because `MEDIA_BUY_STATE_MACHINE` on main does not yet include this key (it lands with #296).

4. **`list_creative_formats` renders missing `role`** — `{"width":300,"height":250}` → `{"role":"primary","dimensions":{"width":300,"height":250}}` per schema.

5. **`list_creative_formats` filter ignored** — now honours `format_ids` filter from request, matching on compound `(agent_url, id)` key.

6. **`update_media_buy` with bogus `package_id`** — validates package IDs exist before processing; returns `PACKAGE_NOT_FOUND` if not.

**Also fixed during expert review:**
- `DemoStore.simulate_delivery` had `reported_spend: float | None` instead of `dict[str, Any] | None`, mismatching the base class and the ReportedSpend schema.

## What was tested

- `pytest tests/ -q --ignore=tests/conformance/signing/test_ip_pinned_transport.py` — 2223 passed, 22 skipped (run before dev-dep install; examples/ has no unit tests, so all SDK tests remain unaffected)
- `ruff check src/` — clean (examples/ excluded per pyproject.toml)
- `python3 -c "import ast; ast.parse(...)"` — syntax OK on final diff

## Pre-PR review

- **code-reviewer:** approved — confirmed no blockers after valid_actions fix; nit: silent empty-list for cross-agent agent_url mismatches in format filter (noted below)
- **dx-expert:** approved — all 6 compliance fixes correct; flagged `pending_creatives` valid_actions gap (fixed in commit 3) and `simulate_delivery` type mismatch (fixed in commit 2)

**Nits surfaced (not fixed — follow-up candidates):**
- `list_creative_formats` filter silently returns empty list when `agent_url` doesn't match this seller's URL; a comment explaining the match semantics would help readers
- `get_media_buy_delivery` returns hardcoded numbers that don't reflect `simulate_delivery` state (pre-existing gap, out of scope for #304)
- `inject_context` is never called in handlers (pre-existing)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01HAP5upax2a7FrcrmgVwTX2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAP5upax2a7FrcrmgVwTX2)_