### PR TITLE
fix(server): comply_test_controller returns dict to fix controller_detected: false

### DIFF
--- a/src/adcp/server/test_controller.py
+++ b/src/adcp/server/test_controller.py
@@ -683,7 +683,7 @@ def register_test_controller(
     from adcp.server.base import ToolContext as _ToolContext
     from adcp.server.serve import RequestMetadata as _RequestMetadata
 
-    async def comply_test_controller(**kwargs: Any) -> str:
+    async def comply_test_controller(**kwargs: Any) -> dict[str, Any]:
         context: _ToolContext | None = None
         if context_factory is not None:
             meta = _RequestMetadata(tool_name="comply_test_controller", transport="mcp")
@@ -693,8 +693,7 @@ def register_test_controller(
                     "context_factory for comply_test_controller returned "
                     f"{type(context).__name__}, not a ToolContext instance"
                 )
-        result = await _handle_test_controller(store, kwargs, context=context)
-        return json.dumps(result)
+        return await _handle_test_controller(store, kwargs, context=context)
 
     tool = Tool.from_function(
         comply_test_controller,

--- a/tests/test_test_controller_context.py
+++ b/tests/test_test_controller_context.py
@@ -337,6 +337,27 @@ async def test_register_test_controller_threads_context_factory():
     assert received[0].metadata["tool_name"] == "comply_test_controller"
 
 
+async def test_register_test_controller_list_scenarios_returns_dict():
+    """Regression for #314 — comply_test_controller must return a dict (not a
+    JSON string) through the FastMCP registration path so the JS runner's
+    structuredContent unwrapper can read data.success and data.scenarios."""
+
+    class _Store(TestControllerStore):
+        async def force_account_status(self, account_id: str, status: str) -> dict[str, Any]:
+            return {"previous_state": "active", "current_state": status}
+
+    mcp = create_mcp_server(_MinimalHandler(), name="test-agent")
+    register_test_controller(mcp, _Store())
+
+    tool = mcp._tool_manager._tools["comply_test_controller"]
+    fn = tool.fn  # type: ignore[attr-defined]
+    result = await fn(scenario="list_scenarios")
+
+    assert isinstance(result, dict), "must be a dict, not a JSON string"
+    assert result["success"] is True
+    assert "force_account_status" in result["scenarios"]
+
+
 async def test_register_test_controller_rejects_non_toolcontext_from_factory():
     """Guard rail — a factory that returns a dict instead of a
     ToolContext fails loudly at call time, not deep inside the store."""

--- a/tests/test_test_controller_context.py
+++ b/tests/test_test_controller_context.py
@@ -318,14 +318,11 @@ async def test_register_test_controller_threads_context_factory():
     tool = mcp._tool_manager._tools["comply_test_controller"]
     # FastMCP's tool wrapper takes the function args as kwargs.
     fn = tool.fn  # type: ignore[attr-defined]
-    result_json = await fn(
+    result = await fn(
         scenario="force_account_status",
         params={"account_id": "acc-1", "status": "suspended"},
     )
 
-    import json
-
-    result = json.loads(result_json)
     assert result["success"] is True
     assert result["current_state"] == "suspended"
     # The factory ran, built a ToolContext, and the store saw the header-


### PR DESCRIPTION
Closes #314

## Root Cause

The JS storyboard runner (`@adcp/sdk`) detects the test controller by calling `comply_test_controller(scenario='list_scenarios')` and checking the response shape. Its `detectController` function:

```javascript
const data = result.data;
if (data.success && data.scenarios) {
    return { detected: true, scenarios };
}
return { detected: false };
```

Previously, `comply_test_controller` returned `json.dumps(result)` — a **string**. FastMCP wraps string-returning tools as `structuredContent: {result: "<json string>"}`. The runner's `unwrapProtocolResponse` extracts that as `data = {result: "<string>"}`, so `data.success` and `data.scenarios` are both `undefined` → `controller_detected: false`.

Returning the result **dict directly** causes FastMCP to emit the fields at the top level (`structuredContent: {success: true, scenarios: [...]}` or via `content[0].text`). Either path gives the runner `data.success = true` and `data.scenarios = [...]` → `controller_detected: true`.

**Confirmed locally:** before the fix, the live MCP response was:
```json
"structuredContent": {"result": "{\"success\": true, \"scenarios\": [...]}"}
```
After the fix:
```json
"structuredContent": {"success": true, "scenarios": ["force_creative_status", ...]}
```

## What Changed

- `src/adcp/server/test_controller.py`: `comply_test_controller` closure in `register_test_controller` changed from `-> str` + `json.dumps(result)` to `-> dict[str, Any]` returning the result directly. The `json` import is still live (used for the 256 KB payload size check in `_handle_test_controller`).
- `tests/test_test_controller_context.py`: removed the `json.loads()` call in the one test that was calling `tool.fn` directly; added a regression test that calls `fn(scenario='list_scenarios')` through the FastMCP registration path and asserts the result is a `dict` (not a string).

## What Tested

- `pytest tests/test_test_controller_context.py tests/test_force_create_media_buy_arm_and_force_task_completion.py tests/test_server_dx.py` — 75 passed
- `pytest tests/` (full suite, excluding pre-existing TLS conformance failure unrelated to this change) — 2312 passed, 0 new failures
- `ruff check src/` — passed
- Live MCP wire test: `tools/call comply_test_controller scenario=list_scenarios` confirmed `structuredContent` now contains the parsed dict

**Pre-PR review:**
- code-reviewer: approved — no blockers; flagged missing regression test (now added), nit on fn_metadata comment
- dx-expert: approved — no blockers; clarified that detection works via the text-content fallback path when FastMCP omits structuredContent for dict returns; all four backward-compat questions resolved (no breaking callers, json import remains live, no guide update needed)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01LuThNVrmmHfVvPbfrbWsvy

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuThNVrmmHfVvPbfrbWsvy)_