### PR TITLE
chore(sync-schemas): allow cosign verify against refs/tags/* for forward-compat

### DIFF
--- a/scripts/sync_schemas.py
+++ b/scripts/sync_schemas.py
@@ -61,10 +61,15 @@ BUNDLE_BASE_URL = _ADCP_BASE + "/protocol"
 USER_AGENT = "adcp-python-sdk/3.0"
 
 # Sigstore keyless verification identity. Must match the upstream release
-# workflow — see adcontextprotocol/adcp#2273.
+# workflow — see adcontextprotocol/adcp#2273. Accepts any branch or tag ref;
+# the trust gate is upstream `release.yml`'s `on.push.branches` allowlist
+# (currently main, 3.0.x, 2.6.x), which is what determines which refs can
+# produce a signature in the first place. `refs/tags/*` is forward-compat
+# for any future post-tag re-signing flow. Aligned with adcp-client (TS) and
+# adcp-go, which both use the same `refs/(heads|tags)/.*` pattern.
 COSIGN_IDENTITY_REGEX = (
     r"^https://github\.com/adcontextprotocol/adcp/"
-    r"\.github/workflows/release\.yml@refs/heads/.*$"
+    r"\.github/workflows/release\.yml@refs/(heads|tags)/.*$"
 )
 COSIGN_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 


### PR DESCRIPTION
## Summary

Small consistency change: \`scripts/sync_schemas.py\`'s \`COSIGN_IDENTITY_REGEX\` already accepts any branch ref (\`refs/heads/.*\`); this PR also accepts tag refs (\`refs/tags/.*\`) for forward-compat with any future post-tag re-signing flow.

\`\`\`diff
- r"\\.github/workflows/release\\.yml@refs/heads/.*$"
+ r"\\.github/workflows/release\\.yml@refs/(heads|tags)/.*$"
\`\`\`

## Why

Aligns with the other two SDKs:

| SDK | Pattern |
|---|---|
| **adcp-client-python (this PR)** | \`refs/(heads\|tags)/.*\` |
| adcp-client (TS) | \`refs/(heads\|tags)/.*\` (see adcontextprotocol/adcp-client#1243) |
| adcp-go | \`refs/(heads\|tags)/.*\` (already in place) |

Branch refs are what's used by the AdCP release workflow today (cosign signs during the push-triggered run, so the OIDC subject is \`release.yml@refs/heads/<branch>\`). Tag refs are forward-compat — if upstream ever adds a post-tag re-signing flow (so the cert subject becomes \`release.yml@refs/tags/v3.0.X\`), no SDK bump needed.

## No behavior change for current v3.0.x adopters

\`refs/heads/.*\` already accepts \`refs/heads/3.0.x\`, so this SDK has been verifying v3.0.1, v3.0.2, v3.0.3 correctly. The TS SDK has been broken for those releases (PR #1243 fixes that); this PR just rounds out the consistency story.

## Test plan

- [ ] CI green
- [ ] \`sync_schemas.py\` continues to verify v3.0.3 cleanly (smoke test)
- [ ] Future tag-ref signature (when/if upstream adds it) verifies without another SDK bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)