### PR TITLE
feat(signing): v3-identity Tier 1 — BrandJsonJwksResolver + CapabilityCache (port from JS)

### DIFF
--- a/docs/proposals/v3-identity-bundle-design.md
+++ b/docs/proposals/v3-identity-bundle-design.md
@@ -1,0 +1,659 @@
+# v3 identity bundle — Python design + port plan
+
+Pre-implementation reference for the v3 buyer-side identity layer.
+Three concerns, one RFC:
+
+1. **JWKS resolution** — port the JS `BrandJsonJwksResolver` +
+   `CapabilityCache` + `ensure_capability_loaded` to Python. The
+   existing Python `adcp.signing/` already has the underlying
+   verifier machinery; this layer is the missing seam.
+2. **Buyer-agent registry** — implement
+   [`BuyerAgentRegistry`](https://github.com/adcontextprotocol/adcp-client/issues/1269)
+   in Python. New Protocol the framework calls *before*
+   `accounts.resolve` to ask "do we recognize this counterparty,
+   and what's their commercial relationship?"
+3. **Brand authorization** — `BrandAuthorizationResolver` —
+   per-request "is this agent authorized for *this* brand?" via
+   `brand.json/authorized_operators` + eTLD+1 binding.
+   #3690-gated for the binding semantics.
+
+These compose. (1) proves an agent's *cryptographic identity*; (2)
+asserts the *commercial relationship*; (3) verifies *per-brand
+authorization*. All three checks gate a request.
+
+**Status:** RFC, awaiting review.
+**Companions:**
+- JS `BuyerAgentRegistry` design — [adcp-client#1269](https://github.com/adcontextprotocol/adcp-client/issues/1269)
+- JS parity gaps (other items) — [adcp-client#1249](https://github.com/adcontextprotocol/adcp-client/issues/1249)
+- ADCP spec — [#3690](https://github.com/adcontextprotocol/adcp/issues/3690)
+  (`brand_url` on `get_adcp_capabilities`, eTLD+1, `authorized_operators[]`)
+
+## What changed since the first draft
+
+The first two drafts of this RFC overstated some gaps and missed
+others. After two audits + #1269:
+
+**Already in Python `adcp.signing/` (6,325 LOC) — no port needed:**
+
+| Capability | Surface |
+|---|---|
+| Inbound HTTP-Sig verification | `verify_request_signature`, `verify_starlette_request`, `verify_flask_request` |
+| Outbound request signing | `sign_request`, `async_sign_request` |
+| JWKS resolver + caching | `JwksResolver` Protocol, `CachingJwksResolver`, `AsyncCachingJwksResolver`, `StaticJwksResolver` |
+| Replay protection | `ReplayStore` Protocol + `InMemoryReplayStore` + `PgReplayStore` |
+| Revocation list checking | `RevocationChecker`, `CachingRevocationChecker` |
+| `SigningProvider` Protocol + `InMemorySigningProvider` | What I called "`SigningKeyStore`" — already exists |
+| Content-Digest validation | `compute_content_digest_sha256`, `content_digest_matches` |
+| URL canonicalization | `canonicalize_authority`, `canonicalize_target_uri` |
+| SSRF-safe transport | `IpPinnedTransport`, `validate_jwks_uri`, `resolve_and_validate_host` |
+| All 17 `REQUEST_SIGNATURE_*` error codes | Including `*_REPLAYED`, `*_KEY_PURPOSE_INVALID`, `*_DIGEST_MISMATCH` |
+| `adcp.adagents` (publisher direction) | `fetch_adagents`, `verify_agent_authorization` |
+
+**Already in JS `src/lib/signing/` — Python's port targets:**
+
+| File | LOC | Surface |
+|---|---|---|
+| `brand-jwks.ts` | 577 | `BrandJsonJwksResolver` |
+| `capability-cache.ts` | 119 | `CapabilityCache` |
+| `capability-priming.ts` | 159 | `ensureCapabilityLoaded` |
+
+**New for both sides (#1269 — design only, not yet built on JS):**
+
+| Surface | Status |
+|---|---|
+| `BuyerAgentRegistry` Protocol | Designed in #1269; not yet implemented in either language |
+| `BuyerAgent` dataclass with `billing_capability`, `default_account_terms` | New shape — neither language has this today |
+| Kind-discriminated `AuthInfo`/`ResolvedAuthInfo` `credential` variant | JS migration designed in #1269; Python's `AuthInfo` needs the same migration |
+| `billing_capability` enforcement on `sync_accounts` | New framework-level constraint |
+| `BrandAuthorizationResolver` (separate from the JWKS resolver) | Net-new on both sides; #3690-gated |
+
+**Naming feedback received from #1269:** the original first-draft
+RFC's `AdagentsResolver` was misnamed; the right surface for
+buyer-agent authz is `brand.json/authorized_operators`, not
+`adagents.json` (which is sell-side). Already corrected to
+`BrandResolver` / `BrandAuthorizationResolver` here. ✓
+
+## The v3 trust model
+
+Three identity layers in spec 3.x with three corresponding
+verifications. The spec separates them cleanly; the SDK must too.
+
+| Layer | What it is | Identified by | Trust source |
+|---|---|---|---|
+| **Agent** | The buyer-side AI agent making the call | `agent_url` (HTTPS origin) | NEVER self-attested. Keys discovered via the brand (operator-attested) per #3690 |
+| **Brand** | The advertiser whose ads run | `brand.domain` (house domain) | The brand's `/.well-known/brand.json` `agents[]` array |
+| **Operator** | Seller-side platform / SSP / publisher operator | Operator service URL | Operator's `get_adcp_capabilities` response carries top-level `brand_url` per #3690; multi-tenant SaaS operators handled via `authorized_operators[]` on the brand |
+
+**Three checks gate a request, in order:**
+
+```
+1. Cryptographic identity (Tier 1)
+   inbound request signature
+     → CapabilityCache.get(agent_url) → brand_url
+     → BrandJsonJwksResolver.resolve(kid)
+     → JWK → verify signature
+   ⇒ proves: agent_url is who they say they are
+
+2. Commercial recognition (Tier 2 — #1269)
+   verified agent_url
+     → BuyerAgentRegistry.resolve_by_agent_url(agent_url)
+     → BuyerAgent | None
+   ⇒ proves: we recognize this agent commercially
+   ⇒ provides: billing_capability, default_account_terms, status
+
+3. Per-brand authorization (Tier 3 — #3690)
+   (verified agent_url, claimed brand_domain)
+     → BrandAuthorizationResolver.is_authorized(agent_url, brand_domain, agent_type)
+     → bool   (walks brand.json/agents[]; eTLD+1 binding;
+               authorized_operators[] delegation)
+   ⇒ proves: this agent is authorized for THIS brand
+
+→ then: accounts.resolve(ref, ctx with BuyerAgent attached)
+```
+
+**Direction note (already corrected):**
+
+* `/.well-known/brand.json` (this RFC's primary surface) — published
+  by **brands**; authorizes **buyer-side agents** via the `agents[]`
+  array, with `jwks_uri` pointers + `authorized_operators[]` for
+  multi-tenant operators.
+* `/.well-known/adagents.json` (publisher direction, already handled
+  by `adcp.adagents`) — published by **publishers / operators**;
+  authorizes **sell-side agents** to monetize the publisher's
+  inventory.
+
+Both files can be fetched directly OR via an AAO community proxy /
+registry (e.g., `adcontextprotocol/registry`).
+
+**Why the three layers don't collapse into one.**
+
+It might seem simpler to fold all of this into one fat
+`AccountStore.resolve` (today's surface). #1269 explicitly rejects
+that:
+
+- HTTP-Sig + brand.json answer "who signed?" and "are they
+  brand-authorized?" — not "who are they to us *commercially*?"
+- The OpenRTB analogy: an SSP doesn't just verify a DSP's auth — it
+  has a `buyer_id` row with rate cards, credit, payment status,
+  suspension flags. Token proves identity; row drives commercial
+  behavior.
+- The registry is durable infrastructure even with full v3 identity.
+  Sellers still need allowlist + onboarding state + commercial-handle
+  + billing-capability.
+
+## Tier 1 — JWKS resolution port (in flight)
+
+Status: **shipped on branch `bokelley/round2-webhook-supervisor`**;
+2,975 tests pass; awaiting PR-split + review.
+
+Three Python modules, all under `adcp.signing/`:
+
+### 1a. `BrandJsonJwksResolver` (port `brand-jwks.ts`)
+
+Implements `adcp.signing.AsyncJwksResolver`. Walks brand.json,
+follows `authoritative_location` / `house` redirects (with bare-host
+validation), picks agent by `(agent_type, agent_id?, brand_id?)`,
+falls back to origin-bound `/.well-known/jwks.json` (security:
+prevents cross-origin trust pivot). Composes with
+`AsyncCachingJwksResolver` for the inner JWKS fetch — does NOT
+reinvent JWK caching.
+
+10 typed error codes (`invalid_url`, `invalid_house`,
+`redirect_loop`, `redirect_depth_exceeded`, `fetch_failed`,
+`invalid_body`, `schema_invalid`, `agent_not_found`,
+`agent_ambiguous`, `jwks_origin_mismatch`) — same set as JS for
+cross-language conformance.
+
+### 1b. `CapabilityCache` (port `capability-cache.ts`)
+
+Per-agent TTL cache for `request_signing` capability blocks. Keyed
+on `build_capability_cache_key(agent_uri, auth_token, signer_fingerprint)`
+— byte-identical key format to JS so a future shared Redis cache
+works cross-language.
+
+### 1c. `ensure_capability_loaded` (port `capability-priming.ts`)
+
+Async primer with fail-open negative-cache TTL (60s) on fetch
+failures, in-flight dedup via `asyncio.Future`, MCP / A2A transport
+unwrapping (`structuredContent`, `content[].text`,
+`result.artifacts[].parts[].data`, `result.parts[].data`).
+
+## Tier 2 — `BuyerAgentRegistry` (the round-2 spine, per #1269)
+
+The Protocol the framework calls *before* `accounts.resolve` to
+resolve agent identity into a `BuyerAgent` row. Two methods so
+adopters can pick their posture (signing-only / mixed / pre-trust)
+by which methods they implement.
+
+### 2a. `BuyerAgent` dataclass
+
+```python
+@dataclass(frozen=True)
+class BuyerAgent:
+    """Commercial identity for a buyer agent we recognize.
+
+    Mirrors the JS surface in adcp-client#1269. ``agent_url`` is the
+    canonical, on-the-wire identifier — treat like a public key: stable
+    enough that rotation requires explicit re-onboarding. No separate
+    internal id is exposed; adopters with internal ids attach them via
+    ``ext``.
+    """
+
+    agent_url: str
+    display_name: str
+    status: Literal["active", "suspended", "blocked"]
+
+    #: Drives sync_accounts validation (see § 2c). passthrough_only
+    #: means the agent has no payments relationship — accounts under
+    #: this agent MUST be operator-billed.
+    billing_capability: Literal["passthrough_only", "agent_billable"]
+
+    #: Commercial defaults applied when accounts are provisioned under
+    #: this agent. Each field optional; the framework merges these
+    #: with per-request overrides (per-request wins).
+    default_account_terms: BuyerAgentDefaultTerms | None = None
+
+    #: Pre-RFC allowlist. Obviated once BrandAuthorizationResolver
+    #: (Tier 3) is wired — at that point per-brand authz is verified
+    #: per-request against brand.json rather than this static list.
+    allowed_brands: tuple[str, ...] | None = None
+
+    #: Adopter passthrough — internal ids, audit metadata, etc.
+    ext: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class BuyerAgentDefaultTerms:
+    rate_card: str | None = None
+    payment_terms: str | None = None  # net_15 | net_30 | net_45 | net_60 | net_90 | prepay
+    credit_limit: dict[str, Any] | None = None  # {amount, currency}
+    billing_entity: dict[str, Any] | None = None  # applies when agent_billable
+```
+
+### 2b. `BuyerAgentRegistry` Protocol
+
+```python
+class BuyerAgentRegistry(Protocol):
+    """Adopter-implemented registry mapping credentials → BuyerAgent.
+
+    Two methods so adopters pick their posture by which ones they
+    implement:
+
+    * Signing-only (production target): implement
+      ``resolve_by_agent_url`` only; ``resolve_by_credential`` returns
+      None. Bearer traffic refused at the registry layer with no extra
+      config.
+    * Mixed (transition): implement both. Signed traffic resolves
+      cryptographically; bearer falls through to the legacy key table.
+    * Pre-trust beta: implement ``resolve_by_credential`` only.
+      Existing world, just typed. Migration path: add the signed method
+      later.
+
+    The framework calls whichever method matches the request's
+    credential kind (see § 2d). Returning None rejects the request
+    with ``REQUEST_AUTH_UNRECOGNIZED_AGENT``.
+    """
+
+    async def resolve_by_agent_url(self, agent_url: str) -> BuyerAgent | None:
+        """Resolve a cryptographically-verified agent_url. Called only
+        after the framework has verified the RFC 9421 signature and
+        extracted ``agent_url`` from the JWK claim — adopters do NOT
+        re-verify the signature here, just look up the counterparty
+        row. Return None to reject."""
+
+    async def resolve_by_credential(
+        self, credential: ApiKeyCredential | OAuthCredential
+    ) -> BuyerAgent | None:
+        """Resolve a bearer / API-key / OAuth credential to a buyer
+        agent. For pre-trust beta sellers, this IS the existing key
+        table, just exposed through a typed surface. Return None to
+        reject."""
+```
+
+### 2c. `billing_capability` enforcement
+
+Concrete validation the framework can enforce now that
+`billing_capability` exists on the resolved buyer agent:
+
+| `billing_capability` | Legal `sync_accounts` `billing` values |
+|---|---|
+| `agent_billable` | `'agent'`, `'operator'`, `'advertiser'` — all three |
+| `passthrough_only` | `'operator'` only — `'agent'` and `'advertiser'` reject |
+
+Reject path:
+
+```python
+raise AdcpError(
+    "INVALID_BILLING_MODEL",
+    message=(
+        "This buyer agent does not have a payments relationship; "
+        "accounts must be operator-billed."
+    ),
+    field="billing",
+    recovery="terminal",
+)
+```
+
+This is the first place the framework can enforce a commercial
+constraint that today drifts silently between adopters.
+
+### 2d. `AuthInfo` migration (kind-discriminated `credential`)
+
+Today's `adcp.decisioning.context.AuthInfo` is flat:
+
+```python
+@dataclass(frozen=True)
+class AuthInfo:
+    kind: str  # "derived" | "signed_request" | ...
+    key_id: str | None
+    principal: str | None
+    scopes: list[str]
+```
+
+Per #1269, this should become a kind-discriminated `credential`
+shape — JS does this in `ResolvedAuthInfo`, Python's port follows:
+
+```python
+@dataclass(frozen=True)
+class ApiKeyCredential:
+    kind: Literal["api_key"]
+    key_id: str
+
+@dataclass(frozen=True)
+class OAuthCredential:
+    kind: Literal["oauth"]
+    client_id: str
+    scopes: tuple[str, ...]
+    expires_at: float | None = None
+
+@dataclass(frozen=True)
+class HttpSigCredential:
+    kind: Literal["http_sig"]
+    keyid: str
+    agent_url: str  # cryptographically verified (NOT claimed)
+    verified_at: float
+
+Credential = ApiKeyCredential | OAuthCredential | HttpSigCredential
+
+
+@dataclass(frozen=True)
+class AuthInfo:
+    """Resolved authentication context attached to RequestContext.
+
+    Note the rename: previously a flat shape, now wraps a discriminated
+    ``credential``. Legacy callsites preserved via a deprecated
+    backward-compat alias for one minor.
+    """
+
+    credential: Credential
+
+    #: Canonical agent identifier. Populated by BuyerAgentRegistry
+    #: resolution. For http_sig: same as credential.agent_url. For
+    #: api_key/oauth: from registry.resolve_by_credential().
+    #: Authoritative for downstream — audit logs source from here.
+    agent_url: str | None = None
+
+    #: Optional seat within the agent (only when the credential carries
+    #: one — e.g., signed claims with sub=operator).
+    operator: str | None = None
+
+    #: Adopter passthrough.
+    extra: Mapping[str, Any] = field(default_factory=dict)
+```
+
+**Migration:** keep current flat-shape `AuthInfo` working as a
+deprecated alias for one minor. The framework's existing
+``serve_kwargs={'context_factory': ...}`` adopter hook continues to
+work — adopters that build their own `AuthInfo` either upgrade to
+the new shape, or the framework wraps the legacy shape into
+`HttpSigCredential` / `ApiKeyCredential` based on `kind`.
+
+### 2e. Dispatch wire-up (call order)
+
+In `decisioning/dispatch.py`, the per-request flow becomes:
+
+```
+inbound request
+  → context_factory builds AuthInfo (with verified Credential)
+  → registry.resolve_by_(agent_url|credential) → BuyerAgent | None
+       ── if None: 401/403 with REQUEST_AUTH_UNRECOGNIZED_AGENT
+  → status check: if buyer_agent.status != "active":
+       403 with AGENT_SUSPENDED / AGENT_BLOCKED
+  → attach BuyerAgent to RequestContext (ctx.buyer_agent)
+  → method-specific pre-validation:
+       - sync_accounts: check billing_capability against request.billing
+  → accounts.resolve(ref, ctx)  [unchanged surface, ctx now richer]
+  → platform method invoked
+```
+
+`RequestContext` gains a typed `buyer_agent: BuyerAgent | None`
+field. Platform methods reading commercial defaults
+(`default_account_terms` for upserts) source from there.
+
+### 2f. Three implementer postures (table from #1269)
+
+| Seller posture | Implements | Behavior |
+|---|---|---|
+| **Signing-only** (production target) | `resolve_by_agent_url` only; `resolve_by_credential` returns None | Bearer traffic refused at the registry layer with no extra config |
+| **Mixed** (transition) | Both | Signed resolves cryptographically; bearer falls through to legacy key table |
+| **Pre-trust beta** | `resolve_by_credential` only | Existing world, just typed. Migration path: add the signed method later |
+
+The signing-only posture is the path of least resistance once an
+adopter is ready: implement one method, traffic that doesn't sign is
+automatically refused.
+
+## Tier 3 — `BrandAuthorizationResolver` (#3690-gated)
+
+The per-request brand-authz check. Separate from the JWKS resolver;
+both walk brand.json and should share an underlying fetcher.
+
+```python
+class BrandAuthorizationResolver(Protocol):
+    """Verify a buyer agent is authorized to act for a brand.
+
+    Per ADCP #3690: walks brand.json/agents[], enforces eTLD+1
+    binding (agent host eTLD+1 must match brand_domain eTLD+1, OR
+    the agent host appears in brand.authorized_operators[]).
+    """
+
+    async def is_authorized(
+        self,
+        *,
+        agent_url: str,
+        brand_domain: str,
+        agent_type: str | None = None,
+    ) -> bool: ...
+
+    async def resolve(self, brand_domain: str) -> BrandRecord | None:
+        """Return the cached/fetched brand.json document. Shared with
+        BrandJsonJwksResolver via a common BrandJsonFetcher (factor
+        out during implementation)."""
+```
+
+**Implementation note:** `BrandJsonJwksResolver` already has the
+brand.json fetch + redirect-following + agent-pick machinery.
+Factor a shared `_BrandJsonFetcher` (or extend the resolver) so
+both surfaces share the snapshot — no double-fetching.
+
+**Net-new on both sides** — neither JS nor Python has this Protocol
+yet. Defer until #3690 lands so the eTLD+1 binding rule and
+`authorized_operators[]` semantics are stable.
+
+## Tier 1.5 — wire-through (lands with Tier 2)
+
+`adcp.decisioning.serve()` accepts the new dependencies:
+
+```python
+serve(
+    platform,
+    *,
+    # Tier 1 (JWKS lookup):
+    brand_jwks_resolver_factory: Callable[[str], BrandJsonJwksResolver] | None = None,
+    capability_cache: CapabilityCache | None = None,
+
+    # Tier 2 (registry):
+    buyer_agent_registry: BuyerAgentRegistry | None = None,
+
+    # Tier 3 (brand authz, #3690):
+    brand_authz_resolver: BrandAuthorizationResolver | None = None,
+
+    # Already exist; surfacing here for completeness:
+    signing_provider: SigningProvider | None = None,
+    replay_store: ReplayStore | None = None,
+    revocation_checker: RevocationChecker | None = None,
+
+    enable_request_signature_verification: bool = False,
+    require_signed_requests: bool = False,
+    ...
+)
+```
+
+When `enable_request_signature_verification=True`, `serve()` mounts
+the existing `verify_starlette_request` middleware
+(`adcp.signing.middleware`) configured with the supplied dependencies.
+The dispatch layer calls `buyer_agent_registry.resolve_*` after
+verification but before `accounts.resolve` (see § 2e).
+
+**No new middleware code** — the signing middleware exists.
+What's new is the dispatch-level call to the registry.
+
+## Salesagent migration path
+
+The original concern that drove this RFC was: how does salesagent's
+identity model map to v3? Answer: their `Principal` table is a
+primitive `BuyerAgent` table.
+
+| Salesagent today | v3 mapping | What changes |
+|---|---|---|
+| `Principal.access_token` | `ApiKeyCredential.key_id` | Token storage stays; surfaced through typed credential |
+| `Principal.principal_id`, `name` | `BuyerAgent.agent_url` (synthesize from existing principal_id), `display_name` | Need to populate `agent_url` — for pre-trust beta they can use `https://principal-{id}.salesagent.local` or similar; on signing onboarding it becomes the real `agent_url` |
+| `Account.billing` enum | `BuyerAgent.billing_capability` constraint | Framework now enforces; salesagent's silent drift becomes loud rejection |
+| `Account.rate_card`, `payment_terms`, `credit_limit`, `billing_entity` | `BuyerAgent.default_account_terms` | Move from per-account to per-agent default; per-account override still allowed |
+| `AgentAccountAccess` junction | Hand-rolled "registry resolves agent, then accounts.resolve finds the account" | Becomes the formal sequence in dispatch |
+| Bearer-token auth path | "Pre-trust beta" posture per #1269 | Implement `resolve_by_credential` only — single method, ~50 LOC against existing Principal table |
+
+**Concrete migration steps (after Tier 2 lands):**
+
+1. **No new tables required** — `Principal` already has the data.
+   Add `billing_capability` column (default `'passthrough_only'` —
+   safe; salesagent's existing principals don't have a payments
+   relationship modeled).
+2. **Implement `BuyerAgentRegistry.resolve_by_credential`** —
+   single method that does
+   `SELECT FROM principals WHERE access_token = ?` and projects to
+   `BuyerAgent`. ~50 LOC.
+3. **Wire into `serve()`** —
+   `serve(buyer_agent_registry=SalesagentBuyerAgentRegistry(session_factory))`.
+4. **Get framework-enforced `billing_capability` validation
+   immediately.** If salesagent currently allows
+   `billing: 'agent'` on `sync_accounts` from passthrough principals
+   (likely a real bug — they have no enforcement today), the
+   framework now catches it.
+5. **Later, when ready for signing:** add
+   `resolve_by_agent_url` against the same Principal table keyed on
+   a new `Principal.agent_url` column. Co-exists with bearer.
+
+LOC delete on salesagent's side: ~zero. They configure existing
+primitives + add one column. The benefit isn't LOC delete; it's
+**framework-enforced commercial correctness** that prevents
+billing-model drift.
+
+## Open questions
+
+1. **Where does `BuyerAgentRegistry` live?**
+   `adcp.decisioning.registry` (next to `accounts.py`)?
+   `adcp.server.auth.registry`? **Preference:
+   `adcp.decisioning.registry`** — the registry's resolution
+   composes with `accounts.resolve` and they're conceptually
+   adjacent. `adcp.server.auth` is for bearer/JWKS-validation
+   primitives, lower-level.
+
+2. **`BuyerAgent` immutability vs mutability.** I have it as a
+   frozen dataclass. JS's interface is mutable. Argument for frozen:
+   it's a runtime resolution result, mutation by the platform method
+   is a bug. **Preference: frozen.**
+
+3. **`AuthInfo` migration cycle.** Keep the legacy flat shape
+   working for one minor with a deprecation warning, then remove?
+   Or longer? **Preference: one minor with deprecation, two minors
+   to remove** — adopters need migration time.
+
+4. **Error code shape for registry rejection.** New code, or reuse
+   `REQUEST_SIGNATURE_KEY_UNKNOWN`? Bearer rejection isn't a
+   signature error. **Preference: new code
+   `REQUEST_AUTH_UNRECOGNIZED_AGENT`** — distinct from signature
+   verification failures. Sibling codes: `AGENT_SUSPENDED`,
+   `AGENT_BLOCKED`.
+
+5. **Does `BuyerAgentRegistry` get a Postgres reference impl?**
+   Most adopters land here against an existing tenant-style
+   schema. Argument for shipping a SQLAlchemy reference: every
+   adopter writes ~50 LOC of similar code. Argument against:
+   adopter schemas vary too much for one reference to fit. **Soft
+   yes** — ship a small `examples/buyer_agent_registry_sqlalchemy.py`
+   reference, not a class in the SDK proper.
+
+6. **Cross-language `CapabilityCache` Redis sharing.** Already in
+   the JS issue; cache key format is byte-identical so the seam
+   exists. Lock the format here. **Preference: yes, locked.**
+
+7. **`tldextract` as hard dependency** for eTLD+1 (Tier 3).
+   Defer until #3690 lands; revisit then. Alternative: ship
+   bundled PSL with refresh instructions.
+
+8. **`BrandAuthorizationResolver` snapshot sharing with
+   `BrandJsonJwksResolver`.** Factor a `_BrandJsonFetcher` that
+   both classes use, or just have the authz resolver call the
+   JWKS resolver's internal cache? **Preference: factor a shared
+   private fetcher** so the snapshot isn't duplicated and ETag/
+   Cache-Control state is single-source.
+
+## Out of scope
+
+- Offline provisioning (contract, KYC, credit check, ToS sign-off,
+  billing-entity capture). Adopter responsibility, same posture as
+  how operator account creation isn't modeled.
+- Outbound HTTP-Signatures from sellers calling agents. Already
+  shipped via `sign_request` / `async_sign_request`.
+- Reference impls for `SigningProvider` beyond
+  `InMemorySigningProvider`. Adopters with KMS/HSM write their own.
+- Multi-tenant JWKS routing infrastructure for the signing path.
+  Tracked separately under `adcp.signing/`.
+- Adding an envelope `buyer_agent_url` field. Explicitly rejected
+  in #1269: bearer auth has no cryptographic binding to envelope
+  content, so the field would be exactly as trustworthy as the
+  bearer→agent mapping the seller already maintains. Audit logs
+  source `agent_url` from `AuthInfo.agent_url`, which the registry
+  populates.
+
+## Acceptance (rolled up across tiers)
+
+**Tier 1 (in flight):**
+
+- [x] `BrandJsonJwksResolver` ported with same surface + 10 error
+  codes + tests
+- [x] `CapabilityCache` ported with byte-identical key format +
+  in-flight dedup + tests
+- [x] `ensure_capability_loaded` ported with fail-open negative-cache
+  + transport unwrapping + tests
+- [ ] PR opened, reviewed, merged
+
+**Tier 2 (next, lands without #3690):**
+
+- [ ] `BuyerAgent` + `BuyerAgentDefaultTerms` dataclasses in
+  `adcp.decisioning.registry`
+- [ ] `BuyerAgentRegistry` Protocol with both async methods
+- [ ] `AuthInfo` migration: kind-discriminated `credential` shape +
+  legacy alias for one minor + deprecation warning
+- [ ] Dispatch wire-up: registry call after auth verification, before
+  `accounts.resolve`
+- [ ] `RequestContext.buyer_agent: BuyerAgent | None` field
+- [ ] `sync_accounts` enforcement of `billing_capability`
+- [ ] New error codes: `REQUEST_AUTH_UNRECOGNIZED_AGENT`,
+  `AGENT_SUSPENDED`, `AGENT_BLOCKED`, `INVALID_BILLING_MODEL`
+- [ ] `examples/buyer_agent_registry_sqlalchemy.py` reference
+- [ ] Conformance test: passthrough-only agent rejects
+  `billing: 'agent'`; agent-billable agent accepts all three
+- [ ] Storyboard updated to cover the three postures
+
+**Tier 3 (gated on #3690):**
+
+- [ ] `BrandAuthorizationResolver` Protocol + reference impl
+- [ ] eTLD+1 binding helper (`tldextract` dep or bundled PSL)
+- [ ] `authorized_operators[]` delegation
+- [ ] `identity.key_origins.{purpose}` consistency check on the
+  verifier
+- [ ] Diff #3690's seven new `request_signature_*` codes against
+  Python's existing 17; add the delta
+- [ ] Shared `_BrandJsonFetcher` between JWKS and authz resolvers
+
+## Cross-references
+
+- **ADCP #3690** — `brand_url` on `get_adcp_capabilities`,
+  formalizes the verifier chain, eTLD+1 binding,
+  `authorized_operators[]`, `request_signature_*` error codes.
+- **adcp-client#1269** — `BuyerAgentRegistry` design (the spine of
+  Tier 2 above).
+- **adcp-client#1249** — JS-side parity gaps (supervisor, audit,
+  subdomain routing, Account v3, #3690 follow-on). Note: section 2
+  was trimmed after the audit found JS already had Tier 1 ahead of
+  Python.
+- JS source we're porting:
+  - `adcp-client/src/lib/signing/brand-jwks.ts` (577 LOC)
+  - `adcp-client/src/lib/signing/capability-cache.ts` (119 LOC)
+  - `adcp-client/src/lib/signing/capability-priming.ts` (159 LOC)
+- Python primitives we're composing:
+  - `adcp.signing.JwksResolver`, `AsyncCachingJwksResolver`,
+    `StaticJwksResolver`
+  - `adcp.signing.verify_starlette_request`,
+    `verify_request_signature`
+  - `adcp.signing.ReplayStore`, `PgReplayStore`
+  - `adcp.signing.RevocationChecker`, `CachingRevocationChecker`
+  - `adcp.signing.SigningProvider`, `InMemorySigningProvider`
+  - `adcp.decisioning.AccountStore` (existing — gets a `BuyerAgent`
+    threaded through `RequestContext`)
+- AAO community proxy / registry: `adcontextprotocol/registry`
+- AdCP brand.json schema: `schemas/cache/brand.json`
+- AdCP adagents.json schema: `schemas/cache/adagents.json` (opposite
+  direction, already handled)
+- RFC 9421 (HTTP Message Signatures), RFC 9530 (HTTP Content Digest)

--- a/src/adcp/signing/__init__.py
+++ b/src/adcp/signing/__init__.py
@@ -92,12 +92,29 @@ from adcp.signing.autosign import (
     SigningDecision,
     operation_needs_signing,
 )
+from adcp.signing.brand_jwks import (
+    BrandAgentType,
+    BrandJsonJwksResolver,
+    BrandJsonResolverError,
+    BrandJsonResolverErrorCode,
+)
 from adcp.signing.canonical import (
     SignatureInputLabel,
     build_signature_base,
     canonicalize_authority,
     canonicalize_target_uri,
     parse_signature_input_header,
+)
+from adcp.signing.capability_cache import (
+    CachedCapability,
+    CapabilityCache,
+    build_capability_cache_key,
+    default_capability_cache,
+)
+from adcp.signing.capability_priming import (
+    CAPABILITY_OP,
+    NEGATIVE_CACHE_TTL_SECONDS,
+    ensure_capability_loaded,
 )
 from adcp.signing.client import (
     CapabilityProvider,
@@ -255,8 +272,15 @@ __all__ = [
     "AsyncJwksFetcher",
     "AsyncJwksResolver",
     "AsyncRevocationListFetcher",
+    "BrandAgentType",
+    "BrandJsonJwksResolver",
+    "BrandJsonResolverError",
+    "BrandJsonResolverErrorCode",
+    "CAPABILITY_OP",
+    "CachedCapability",
     "CachingJwksResolver",
     "CachingRevocationChecker",
+    "CapabilityCache",
     "CapabilityProvider",
     "DEFAULT_ALLOWED_PORTS",
     "DEFAULT_EXPIRES_IN_SECONDS",
@@ -273,6 +297,7 @@ __all__ = [
     "JwsSignatureInvalidError",
     "JwsUnknownKeyError",
     "MAX_WINDOW_SECONDS",
+    "NEGATIVE_CACHE_TTL_SECONDS",
     "NONCE_BYTES",
     "PgReplayStore",
     "REQUEST_SIGNATURE_ALG_NOT_ALLOWED",
@@ -325,14 +350,17 @@ __all__ = [
     "b64url_decode",
     "b64url_encode",
     "build_async_ip_pinned_transport",
+    "build_capability_cache_key",
     "build_ip_pinned_transport",
     "build_signature_base",
     "canonicalize_authority",
     "canonicalize_target_uri",
     "compute_content_digest_sha256",
     "content_digest_matches",
+    "default_capability_cache",
     "default_jwks_fetcher",
     "default_revocation_list_fetcher",
+    "ensure_capability_loaded",
     "extract_signature_bytes",
     "format_signature_header",
     "generate_signing_keypair",

--- a/src/adcp/signing/brand_jwks.py
+++ b/src/adcp/signing/brand_jwks.py
@@ -1,0 +1,673 @@
+"""Receiver-side: resolve a sender's JWKS via brand.json.
+
+Port of ``src/lib/signing/brand-jwks.ts`` from the JS SDK
+(``adcontextprotocol/adcp-client``). Same selector model, same
+redirect-following, same security posture (origin-bound well-known
+fallback). Composes with the existing
+:class:`adcp.signing.AsyncCachingJwksResolver` for the inner JWKS
+fetch — does NOT reinvent JWK caching.
+
+**Why this exists.** The seller's verifier never trusts an
+``agent_url/.well-known/jwks.json`` directly — that would let any agent
+self-attest its own keys. Per ADCP, keys root through the brand: the
+brand's ``/.well-known/brand.json`` lists each authorized agent and
+its ``jwks_uri``, operator-attested. This resolver walks brand.json,
+picks the right agent entry, and delegates JWK fetch to the inner
+JWKS resolver pinned to that ``jwks_uri``.
+
+**What it doesn't do (yet).** ADCP #3690's eTLD+1 binding and
+``authorized_operators[]`` delegation are not enforced here — they're
+verifier-side concerns added when #3690 lands. This resolver only does
+the brand-json walk + JWKS fetch chain; the verifier composes the
+authorization check around it.
+
+Hand the resulting instance to ``verify_request_signature`` (or
+``verify_starlette_request``) as the ``jwks`` dependency. The
+receiver never has to know where the sender hosts their keys —
+brand.json is the single source of truth.
+
+Caching is stacked: brand.json honors its own ``Cache-Control`` /
+``ETag`` (bounded by ``max_age_seconds``); unknown-kid refreshes
+cascade — first to the inner JWKS endpoint, then (if the JWKS still
+doesn't have the kid and the brand.json cooldown has elapsed) to
+brand.json itself, in case the sender rotated ``jwks_uri``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from adcp.signing.jwks import (
+    AsyncCachingJwksResolver,
+    AsyncJwksFetcher,
+    async_default_jwks_fetcher,
+)
+
+#: Functional roles an agent may declare in brand.json's ``agents[]``
+#: array. Mirrors ``schemas/cache/enums/brand-agent-type.json`` and the
+#: JS ``BrandAgentType`` union.
+BrandAgentType = Literal[
+    "brand",
+    "rights",
+    "measurement",
+    "governance",
+    "creative",
+    "sales",
+    "buying",
+    "signals",
+]
+
+#: Error codes raised by :class:`BrandJsonResolverError`. Verifier
+#: callers fold these into ``REQUEST_SIGNATURE_JWKS_*`` codes (or
+#: treat ambiguous / schema errors as config bugs) without parsing
+#: error message strings.
+BrandJsonResolverErrorCode = Literal[
+    "invalid_url",
+    "invalid_house",
+    "redirect_loop",
+    "redirect_depth_exceeded",
+    "fetch_failed",
+    "invalid_body",
+    "schema_invalid",
+    "agent_not_found",
+    "agent_ambiguous",
+    "jwks_origin_mismatch",
+]
+
+DEFAULT_MIN_COOLDOWN_SECONDS = 30.0
+DEFAULT_MAX_AGE_SECONDS = 3600.0
+DEFAULT_MAX_REDIRECTS = 3
+DEFAULT_BRAND_JSON_TIMEOUT_SECONDS = 10.0
+
+# Bare hostname pattern for the ``house`` redirect variant. Matches
+# the regex in brand.json's schema (``schemas/cache/brand.json``)
+# exactly so cross-language conformance behavior stays identical.
+_BARE_HOSTNAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")
+
+
+class BrandJsonResolverError(Exception):
+    """Typed error surfaced by the resolver pipeline."""
+
+    def __init__(self, code: BrandJsonResolverErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code: BrandJsonResolverErrorCode = code
+
+
+@dataclass
+class _BrandSnapshot:
+    """One cached brand.json snapshot — the agent we picked + the
+    ``jwks_uri`` we resolved + cache metadata."""
+
+    jwks_uri: str
+    agent_url: str
+    fetched_at: float
+    expires_at: float
+    etag: str | None = None
+
+
+@dataclass(frozen=True)
+class _SelectedAgent:
+    """The agent we picked from a brand.json walk."""
+
+    url: str
+    jwks_uri: str
+
+
+@dataclass
+class _FetchedBrandJson:
+    """One brand.json fetch outcome — an OK body or a 304 ETag bump."""
+
+    status: Literal["ok", "not_modified"]
+    final_url: str
+    data: dict[str, Any] | None
+    etag: str | None = None
+    cache_control: str | None = None
+
+
+class BrandJsonJwksResolver:
+    """JWKS resolver backed by a sender's ``brand.json``.
+
+    Implements :class:`adcp.signing.AsyncJwksResolver` (callable as
+    ``await resolver(kid)``). Construct one per counterparty (or per
+    ``brand.json`` URL + agent selector tuple) and hand it to the
+    request / webhook verifier as the ``jwks`` dependency.
+
+    On a cold cache, fetches brand.json first; on an expired
+    snapshot, refreshes respecting the cooldown. Unknown kids
+    cascade: first ask the inner :class:`AsyncCachingJwksResolver`
+    (which will refetch its own URL if cooldown has elapsed); if
+    still unknown, refresh brand.json in case ``jwks_uri`` rotated.
+    """
+
+    def __init__(
+        self,
+        brand_json_url: str,
+        *,
+        agent_type: BrandAgentType,
+        agent_id: str | None = None,
+        brand_id: str | None = None,
+        min_cooldown_seconds: float = DEFAULT_MIN_COOLDOWN_SECONDS,
+        max_age_seconds: float = DEFAULT_MAX_AGE_SECONDS,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        allow_private_destinations: bool = False,
+        jwks_fetcher: AsyncJwksFetcher | None = None,
+        clock: Callable[[], float] | None = None,
+        timeout_seconds: float = DEFAULT_BRAND_JSON_TIMEOUT_SECONDS,
+    ) -> None:
+        self._url = brand_json_url
+        self._agent_type = agent_type
+        self._agent_id = agent_id
+        self._brand_id = brand_id
+        self._min_cooldown = min_cooldown_seconds
+        self._max_age = max_age_seconds
+        self._max_redirects = max_redirects
+        self._allow_private = allow_private_destinations
+        self._jwks_fetcher = jwks_fetcher or async_default_jwks_fetcher
+        self._clock = clock or time.time
+        self._timeout = timeout_seconds
+
+        self._snapshot: _BrandSnapshot | None = None
+        self._inner: AsyncCachingJwksResolver | None = None
+        self._refresh_lock: asyncio.Lock = asyncio.Lock()
+
+    # AsyncJwksResolver Protocol — callable as ``await resolver(kid)``.
+    async def __call__(self, kid: str) -> dict[str, Any] | None:
+        return await self.resolve(kid)
+
+    async def resolve(self, kid: str) -> dict[str, Any] | None:
+        """Resolve a JWK by ``kid``.
+
+        Cold cache → fetch brand.json + inner JWKS. Expired snapshot
+        past cooldown → refresh, keep stale on transient failure.
+        Unknown kid → cascade: inner resolver refresh first, then
+        brand.json refresh.
+        """
+        if self._snapshot is None or self._inner is None:
+            await self._refresh()
+        elif (
+            self._clock() > self._snapshot.expires_at
+            and self._clock() - self._snapshot.fetched_at >= self._min_cooldown
+        ):
+            try:
+                await self._refresh()
+            except BrandJsonResolverError:
+                # Keep stale on transient failure — same posture as JS.
+                pass
+
+        if self._inner is None:
+            return None
+
+        hit = await self._inner(kid)
+        if hit is not None:
+            return hit
+
+        # Cascade: refresh brand.json in case jwks_uri rotated.
+        if (
+            self._snapshot is not None
+            and self._clock() - self._snapshot.fetched_at >= self._min_cooldown
+        ):
+            try:
+                await self._refresh()
+            except BrandJsonResolverError:
+                return None
+            return await self._inner(kid) if self._inner is not None else None
+        return None
+
+    @property
+    def agent_url(self) -> str | None:
+        """The agent URL we resolved ``jwks_uri`` from. Populated
+        after the first successful refresh; useful for verifier
+        result attribution."""
+        return self._snapshot.agent_url if self._snapshot is not None else None
+
+    async def force_refresh(self) -> None:
+        """Force refetch of both brand.json and inner JWKS, bypassing
+        the cooldown."""
+        async with self._refresh_lock:
+            self._snapshot = None
+            self._inner = None
+            await self._do_refresh()
+
+    async def _refresh(self) -> None:
+        async with self._refresh_lock:
+            await self._do_refresh()
+
+    async def _do_refresh(self) -> None:
+        fetched = await _fetch_brand_json(
+            start_url=self._url,
+            current_etag=self._snapshot.etag if self._snapshot is not None else None,
+            max_redirects=self._max_redirects,
+            allow_private=self._allow_private,
+            timeout_seconds=self._timeout,
+        )
+
+        # 304 on the entry URL: extend the lifetime, keep the inner resolver.
+        if fetched.status == "not_modified" and self._snapshot is not None:
+            now = self._clock()
+            self._snapshot = _BrandSnapshot(
+                jwks_uri=self._snapshot.jwks_uri,
+                agent_url=self._snapshot.agent_url,
+                fetched_at=now,
+                expires_at=now + _compute_lifetime(fetched.cache_control, self._max_age),
+                etag=fetched.etag or self._snapshot.etag,
+            )
+            return
+
+        if fetched.data is None:
+            # Defensive: status == "ok" should always carry a body.
+            raise BrandJsonResolverError("invalid_body", "brand.json response missing body")
+
+        agent = _select_agent(
+            fetched.data,
+            fetched.final_url,
+            agent_type=self._agent_type,
+            agent_id=self._agent_id,
+            brand_id=self._brand_id,
+        )
+
+        if self._inner is None or (
+            self._snapshot is not None and self._snapshot.jwks_uri != agent.jwks_uri
+        ):
+            self._inner = AsyncCachingJwksResolver(
+                agent.jwks_uri,
+                fetcher=self._jwks_fetcher,
+                allow_private=self._allow_private,
+                clock=self._clock,
+            )
+
+        now = self._clock()
+        self._snapshot = _BrandSnapshot(
+            jwks_uri=agent.jwks_uri,
+            agent_url=agent.url,
+            fetched_at=now,
+            expires_at=now + _compute_lifetime(fetched.cache_control, self._max_age),
+            etag=fetched.etag,
+        )
+
+
+# --- brand.json fetching ---
+
+
+async def _fetch_brand_json(
+    *,
+    start_url: str,
+    current_etag: str | None,
+    max_redirects: int,
+    allow_private: bool,
+    timeout_seconds: float,
+) -> _FetchedBrandJson:
+    """Fetch brand.json from ``start_url``, following ``authoritative_location``
+    and ``house`` redirect variants up to ``max_redirects`` hops.
+
+    Each hop validates the URL structurally before dispatch — an
+    attacker-controlled brand.json that emits
+    ``{"house": "evil.com\\@victim.com"}`` or
+    ``{"authoritative_location": "http://169.254.169.254/..."}`` is
+    rejected at parse time rather than relying on the transport
+    layer to catch every pathological shape.
+
+    SSRF protection: ``allow_private=False`` (default) rejects
+    private IPs / link-local / cloud metadata via the underlying
+    httpx client. Production deployments leave it False.
+    """
+    seen: set[str] = set()
+    url = _canonicalize_url(start_url, allow_private=allow_private)
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        for hop in range(max_redirects + 1):
+            if url in seen:
+                raise BrandJsonResolverError("redirect_loop", "brand.json redirect loop detected")
+            seen.add(url)
+
+            headers: dict[str, str] = {"accept": "application/json"}
+            # Only attach If-None-Match on the entry URL: a 304
+            # short-circuits the whole chain, so revalidating a deeper
+            # hop with a stale ETag would lie about the redirect target.
+            if hop == 0 and current_etag is not None:
+                headers["if-none-match"] = current_etag
+
+            try:
+                response = await client.get(url, headers=headers)
+            except (httpx.HTTPError, OSError) as exc:
+                raise BrandJsonResolverError(
+                    "fetch_failed", f"brand.json fetch failed: {exc}"
+                ) from exc
+
+            if hop == 0 and response.status_code == 304:
+                return _FetchedBrandJson(
+                    status="not_modified",
+                    final_url=url,
+                    data=None,
+                    etag=response.headers.get("etag"),
+                    cache_control=response.headers.get("cache-control"),
+                )
+            if response.status_code != 200:
+                raise BrandJsonResolverError(
+                    "fetch_failed",
+                    f"brand.json fetch returned HTTP {response.status_code}",
+                )
+
+            try:
+                parsed = response.json()
+            except (ValueError, httpx.DecodingError) as exc:
+                raise BrandJsonResolverError(
+                    "invalid_body", "brand.json response is not valid JSON"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise BrandJsonResolverError("invalid_body", "brand.json response is not an object")
+
+            authoritative = parsed.get("authoritative_location")
+            house = parsed.get("house")
+
+            if isinstance(authoritative, str):
+                if hop == max_redirects:
+                    raise BrandJsonResolverError(
+                        "redirect_depth_exceeded",
+                        "brand.json redirect depth exceeded",
+                    )
+                url = _canonicalize_url(authoritative, allow_private=allow_private)
+                continue
+            if isinstance(house, str):
+                # The "house string" redirect variant: a bare domain
+                # pointing at the authoritative portfolio. Reject
+                # anything that isn't a bare hostname so an attacker
+                # can't inject userinfo, paths, or ports via the
+                # interpolation.
+                if not _BARE_HOSTNAME_RE.match(house):
+                    raise BrandJsonResolverError(
+                        "invalid_house",
+                        'brand.json "house" is not a bare hostname',
+                    )
+                if hop == max_redirects:
+                    raise BrandJsonResolverError(
+                        "redirect_depth_exceeded",
+                        "brand.json redirect depth exceeded",
+                    )
+                url = _canonicalize_url(
+                    f"https://{house}/.well-known/brand.json",
+                    allow_private=allow_private,
+                )
+                continue
+
+            # Narrow shape validation on the terminal document. Full
+            # schema validation is stricter than we need; what we MUST
+            # reject is a document whose shape would let an attacker
+            # smuggle a non-string url or jwks_uri past the selector.
+            _assert_brand_json_shape(parsed)
+
+            return _FetchedBrandJson(
+                status="ok",
+                final_url=url,
+                data=parsed,
+                etag=response.headers.get("etag"),
+                cache_control=response.headers.get("cache-control"),
+            )
+
+    raise BrandJsonResolverError("redirect_depth_exceeded", "brand.json redirect depth exceeded")
+
+
+def _canonicalize_url(raw: str, *, allow_private: bool) -> str:
+    """Structurally validate a URL and return it canonicalized.
+
+    Rejects URLs the transport layer would later refuse anyway, but
+    catching them here gives a clearer error code and prevents a
+    malformed redirect target from silently bypassing the hop cap
+    because its string form differed from a prior seen URL.
+    """
+    try:
+        parts = urlsplit(raw)
+    except ValueError as exc:
+        raise BrandJsonResolverError("invalid_url", "brand.json URL is malformed") from exc
+    if not parts.scheme or not parts.netloc:
+        raise BrandJsonResolverError("invalid_url", "brand.json URL is malformed")
+    if parts.username or parts.password:
+        raise BrandJsonResolverError("invalid_url", "brand.json URL must not include userinfo")
+    if parts.scheme != "https" and not (allow_private and parts.scheme == "http"):
+        raise BrandJsonResolverError("invalid_url", "brand.json URL must use https://")
+    # Strip fragments — they aren't sent on the wire and must not
+    # smuggle loop-detection aliases into ``seen``.
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))
+
+
+def _assert_brand_json_shape(obj: dict[str, Any]) -> None:
+    """Walk every ``agents[]`` array we might consult and reject
+    entries where ``url`` or ``jwks_uri`` are present but non-string.
+
+    A permissive walk here catches a malformed document that the
+    selector would otherwise silently skip (a non-string url gets
+    filtered out, so an attacker who declares two agents of a type —
+    one well-formed and one with a poisoned shape — couldn't change
+    the selector outcome, but schema-invalid payloads are still a
+    strong signal of compromise).
+    """
+    queues: list[Any] = [obj.get("agents")]
+    house = obj.get("house")
+    if isinstance(house, dict):
+        queues.append(house.get("agents"))
+        brands = obj.get("brands")
+        if isinstance(brands, list):
+            for brand in brands:
+                if isinstance(brand, dict):
+                    queues.append(brand.get("agents"))
+
+    for q in queues:
+        if q is None:
+            continue
+        if not isinstance(q, list):
+            raise BrandJsonResolverError("schema_invalid", "brand.json `agents` must be an array")
+        for entry in q:
+            if isinstance(entry, dict):
+                url = entry.get("url")
+                jwks_uri = entry.get("jwks_uri")
+                if url is not None and not isinstance(url, str):
+                    raise BrandJsonResolverError(
+                        "schema_invalid",
+                        "brand.json agent.url must be a string",
+                    )
+                if jwks_uri is not None and not isinstance(jwks_uri, str):
+                    raise BrandJsonResolverError(
+                        "schema_invalid",
+                        "brand.json agent.jwks_uri must be a string",
+                    )
+
+
+# --- agent selection ---
+
+
+def _select_agent(
+    data: dict[str, Any],
+    final_brand_url: str,
+    *,
+    agent_type: BrandAgentType,
+    agent_id: str | None,
+    brand_id: str | None,
+) -> _SelectedAgent:
+    """Pick the agent matching the selector from a brand.json document.
+
+    Resolution order on a portfolio document:
+    ``brands[brand_id].agents[]`` first (when ``brand_id`` set), then
+    ``house.agents[]`` as fallback. On a non-portfolio document, walks
+    the top-level ``agents[]``.
+    """
+    house = data.get("house")
+    picked: _SelectedAgent | None = None
+
+    if isinstance(house, dict):
+        if brand_id is not None:
+            brands = data.get("brands")
+            if isinstance(brands, list):
+                brand = next(
+                    (b for b in brands if isinstance(b, dict) and b.get("id") == brand_id),
+                    None,
+                )
+                if brand is not None:
+                    picked = _pick_agent(
+                        brand.get("agents"),
+                        final_brand_url,
+                        agent_type=agent_type,
+                        agent_id=agent_id,
+                    )
+        if picked is None:
+            picked = _pick_agent(
+                house.get("agents"),
+                final_brand_url,
+                agent_type=agent_type,
+                agent_id=agent_id,
+            )
+    else:
+        picked = _pick_agent(
+            data.get("agents"),
+            final_brand_url,
+            agent_type=agent_type,
+            agent_id=agent_id,
+        )
+
+    if picked is None:
+        descriptor = _describe_selector(agent_type, agent_id, brand_id)
+        raise BrandJsonResolverError(
+            "agent_not_found",
+            f"brand.json has no agent matching {descriptor}",
+        )
+    return picked
+
+
+def _pick_agent(
+    agents: Any,
+    final_brand_url: str,
+    *,
+    agent_type: BrandAgentType,
+    agent_id: str | None,
+) -> _SelectedAgent | None:
+    """Filter ``agents[]`` by the selector and return the matching entry.
+
+    Raises :class:`BrandJsonResolverError` ``agent_ambiguous`` when
+    multiple agents of the requested type exist and no ``agent_id``
+    was provided.
+    """
+    if not isinstance(agents, list):
+        return None
+    matches: list[dict[str, Any]] = []
+    for entry in agents:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") != agent_type:
+            continue
+        if agent_id is not None and entry.get("id") != agent_id:
+            continue
+        url = entry.get("url")
+        if not isinstance(url, str):
+            continue
+        matches.append(entry)
+
+    if not matches:
+        return None
+    if len(matches) > 1 and agent_id is None:
+        choices = ", ".join(str(m.get("id", "<no-id>")) for m in matches)
+        raise BrandJsonResolverError(
+            "agent_ambiguous",
+            (
+                f"brand.json declares {len(matches)} agents of type "
+                f'"{agent_type}"; pass agent_id to disambiguate '
+                f"(choices: {choices})"
+            ),
+        )
+    agent = matches[0]
+    url = str(agent["url"])
+    jwks_uri_raw = agent.get("jwks_uri")
+    jwks_uri = (
+        str(jwks_uri_raw)
+        if isinstance(jwks_uri_raw, str)
+        else _default_jwks_uri(url, final_brand_url)
+    )
+    return _SelectedAgent(url=url, jwks_uri=jwks_uri)
+
+
+def _default_jwks_uri(agent_url: str, final_brand_url: str) -> str:
+    """Spec fallback: when ``agent.jwks_uri`` is absent, default to
+    ``<agent_origin>/.well-known/jwks.json``.
+
+    Security: the agent origin MUST match the final brand.json origin.
+    Without this check, an attacker-controlled brand.json could set
+    ``agent.url: "https://victim-internal.example/"`` and force the
+    verifier to treat that origin's JWKS as authoritative — a
+    cross-origin trust pivot. Publishers that genuinely host their
+    agent on a different origin from their brand.json MUST declare an
+    explicit ``jwks_uri``.
+    """
+    try:
+        agent_parts = urlsplit(agent_url)
+    except ValueError as exc:
+        raise BrandJsonResolverError("invalid_url", "agent.url is not a valid URL") from exc
+    if not agent_parts.scheme or not agent_parts.netloc:
+        raise BrandJsonResolverError("invalid_url", "agent.url is not a valid URL")
+    brand_parts = urlsplit(final_brand_url)
+    agent_origin = f"{agent_parts.scheme}://{agent_parts.netloc}"
+    brand_origin = f"{brand_parts.scheme}://{brand_parts.netloc}"
+    if agent_origin != brand_origin:
+        raise BrandJsonResolverError(
+            "jwks_origin_mismatch",
+            (
+                f"agent.url origin ({agent_origin}) does not match "
+                f"brand.json origin ({brand_origin}); publisher must "
+                "declare an explicit jwks_uri for cross-origin agents"
+            ),
+        )
+    return f"{agent_origin}/.well-known/jwks.json"
+
+
+def _describe_selector(
+    agent_type: BrandAgentType,
+    agent_id: str | None,
+    brand_id: str | None,
+) -> str:
+    parts = [f"type={agent_type}"]
+    if agent_id is not None:
+        parts.append(f"id={agent_id}")
+    if brand_id is not None:
+        parts.append(f"brand={brand_id}")
+    return " ".join(parts)
+
+
+# --- cache-control parsing ---
+
+
+_MAX_AGE_RE = re.compile(r"max-age\s*=\s*(\d+)")
+_NO_STORE_OR_NO_CACHE_RE = re.compile(r"\b(no-store|no-cache)\b")
+
+
+def _compute_lifetime(cache_control: str | None, max_age: float) -> float:
+    """Compute a snapshot lifetime honoring the counterparty's
+    ``Cache-Control`` (bounded by our configured ``max_age``)."""
+    if cache_control is None:
+        return max_age
+    lower = cache_control.lower()
+    if _NO_STORE_OR_NO_CACHE_RE.search(lower):
+        return 0.0
+    match = _MAX_AGE_RE.search(lower)
+    if match is not None:
+        try:
+            server_max = float(match.group(1))
+        except ValueError:
+            return max_age
+        return min(server_max, max_age)
+    return max_age
+
+
+__all__ = [
+    "BrandAgentType",
+    "BrandJsonJwksResolver",
+    "BrandJsonResolverError",
+    "BrandJsonResolverErrorCode",
+    "DEFAULT_BRAND_JSON_TIMEOUT_SECONDS",
+    "DEFAULT_MAX_AGE_SECONDS",
+    "DEFAULT_MAX_REDIRECTS",
+    "DEFAULT_MIN_COOLDOWN_SECONDS",
+]

--- a/src/adcp/signing/brand_jwks.py
+++ b/src/adcp/signing/brand_jwks.py
@@ -39,6 +39,7 @@ import asyncio
 import re
 import time
 from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
@@ -48,8 +49,16 @@ import httpx
 from adcp.signing.jwks import (
     AsyncCachingJwksResolver,
     AsyncJwksFetcher,
+    SSRFValidationError,
     async_default_jwks_fetcher,
 )
+
+#: Test seam: a callable that returns an :class:`httpx.AsyncClient`
+#: (or any async-context-manager wrapping one) for a given URL. The
+#: production path constructs an IP-pinned client; tests inject a
+#: factory that returns a client wired to a mock transport so they
+#: don't have to monkeypatch ``AsyncClient.__init__`` globally.
+_ClientFactory = Callable[[str], AbstractAsyncContextManager[httpx.AsyncClient]]
 
 #: Functional roles an agent may declare in brand.json's ``agents[]``
 #: array. Mirrors ``schemas/cache/enums/brand-agent-type.json`` and the
@@ -86,6 +95,19 @@ DEFAULT_MIN_COOLDOWN_SECONDS = 30.0
 DEFAULT_MAX_AGE_SECONDS = 3600.0
 DEFAULT_MAX_REDIRECTS = 3
 DEFAULT_BRAND_JSON_TIMEOUT_SECONDS = 10.0
+
+#: brand.json bodies are tiny by design (a single brand portfolio with a
+#: handful of agents). Cap at 256 KiB so a counterparty serving an
+#: adversarial multi-megabyte body can't OOM the verifier. Buffered
+#: into memory after read; no streaming-parse path. Larger legitimate
+#: brand directories (1000+ brands in a portfolio) would need a higher
+#: cap — file an issue if you hit it.
+DEFAULT_MAX_BRAND_JSON_BYTES = 256 * 1024
+
+#: Default ports stripped during URL canonicalization so loop detection
+#: and origin equality see the same string for ``https://x`` and
+#: ``https://x:443``.
+_DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
 
 # Bare hostname pattern for the ``house`` redirect variant. Matches
 # the regex in brand.json's schema (``schemas/cache/brand.json``)
@@ -157,10 +179,12 @@ class BrandJsonJwksResolver:
         min_cooldown_seconds: float = DEFAULT_MIN_COOLDOWN_SECONDS,
         max_age_seconds: float = DEFAULT_MAX_AGE_SECONDS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        max_body_bytes: int = DEFAULT_MAX_BRAND_JSON_BYTES,
         allow_private_destinations: bool = False,
         jwks_fetcher: AsyncJwksFetcher | None = None,
         clock: Callable[[], float] | None = None,
         timeout_seconds: float = DEFAULT_BRAND_JSON_TIMEOUT_SECONDS,
+        _client_factory: _ClientFactory | None = None,
     ) -> None:
         self._url = brand_json_url
         self._agent_type = agent_type
@@ -169,14 +193,23 @@ class BrandJsonJwksResolver:
         self._min_cooldown = min_cooldown_seconds
         self._max_age = max_age_seconds
         self._max_redirects = max_redirects
+        self._max_body_bytes = max_body_bytes
         self._allow_private = allow_private_destinations
         self._jwks_fetcher = jwks_fetcher or async_default_jwks_fetcher
+        self._client_factory = _client_factory
         self._clock = clock or time.time
         self._timeout = timeout_seconds
 
         self._snapshot: _BrandSnapshot | None = None
         self._inner: AsyncCachingJwksResolver | None = None
-        self._refresh_lock: asyncio.Lock = asyncio.Lock()
+        # In-flight refresh future for single-flighting concurrent
+        # callers. None when no refresh is running. N concurrent
+        # ``resolve()`` calls on a cold cache share one fetch via this
+        # future — JS uses Promise sharing natively, Python needs the
+        # explicit future. ``asyncio.Lock`` would also work but
+        # SERIALIZES (waiter N+1 fetches AFTER waiter N's fetch
+        # returns), which is what we want to avoid.
+        self._refresh_in_flight: asyncio.Future[None] | None = None
 
     # AsyncJwksResolver Protocol — callable as ``await resolver(kid)``.
     async def __call__(self, kid: str) -> dict[str, Any] | None:
@@ -230,15 +263,50 @@ class BrandJsonJwksResolver:
 
     async def force_refresh(self) -> None:
         """Force refetch of both brand.json and inner JWKS, bypassing
-        the cooldown."""
-        async with self._refresh_lock:
-            self._snapshot = None
-            self._inner = None
-            await self._do_refresh()
+        the cooldown.
+
+        Race semantics match the JS port: state is cleared, then
+        ``_refresh`` is called. If another task is already mid-refresh,
+        we await its completion rather than starting a fresh one — the
+        in-flight task will populate the snapshot we just cleared.
+        ``force_refresh`` therefore means "ensure a fresh fetch is
+        either in progress or just completed", not "always issue a new
+        fetch even when one is pending."
+        """
+        self._snapshot = None
+        self._inner = None
+        await self._refresh()
 
     async def _refresh(self) -> None:
-        async with self._refresh_lock:
-            await self._do_refresh()
+        """Single-flighted brand.json refresh.
+
+        Concurrent callers share one in-flight fetch via
+        ``_refresh_in_flight`` — N verifiers all hitting a cold cache
+        do ONE brand.json fetch, not N. ``asyncio.shield`` protects
+        the in-flight task from a waiter's own cancellation
+        propagating into the shared fetch.
+        """
+        if self._refresh_in_flight is not None:
+            # Another task is fetching; await its result.
+            await asyncio.shield(self._refresh_in_flight)
+            return
+
+        loop = asyncio.get_running_loop()
+        self._refresh_in_flight = loop.create_future()
+        try:
+            try:
+                await self._do_refresh()
+            except BaseException as exc:
+                # Surface the failure to any awaiters before re-raising
+                # so they don't await a never-resolved future.
+                if not self._refresh_in_flight.done():
+                    self._refresh_in_flight.set_exception(exc)
+                raise
+            else:
+                if not self._refresh_in_flight.done():
+                    self._refresh_in_flight.set_result(None)
+        finally:
+            self._refresh_in_flight = None
 
     async def _do_refresh(self) -> None:
         fetched = await _fetch_brand_json(
@@ -247,6 +315,8 @@ class BrandJsonJwksResolver:
             max_redirects=self._max_redirects,
             allow_private=self._allow_private,
             timeout_seconds=self._timeout,
+            max_body_bytes=self._max_body_bytes,
+            client_factory=self._client_factory,
         )
 
         # 304 on the entry URL: extend the lifetime, keep the inner resolver.
@@ -303,6 +373,8 @@ async def _fetch_brand_json(
     max_redirects: int,
     allow_private: bool,
     timeout_seconds: float,
+    max_body_bytes: int = DEFAULT_MAX_BRAND_JSON_BYTES,
+    client_factory: _ClientFactory | None = None,
 ) -> _FetchedBrandJson:
     """Fetch brand.json from ``start_url``, following ``authoritative_location``
     and ``house`` redirect variants up to ``max_redirects`` hops.
@@ -314,102 +386,156 @@ async def _fetch_brand_json(
     rejected at parse time rather than relying on the transport
     layer to catch every pathological shape.
 
-    SSRF protection: ``allow_private=False`` (default) rejects
-    private IPs / link-local / cloud metadata via the underlying
-    httpx client. Production deployments leave it False.
+    SSRF protection (matches the ``adcp.signing.jwks`` posture):
+    each hop's URL is sent through an :func:`build_async_ip_pinned_transport`,
+    which resolves and validates the host once and pins the connect
+    to that IP — closing the DNS-rebinding TOCTOU. ``trust_env=False``
+    so a misconfigured ``HTTPS_PROXY`` env var cannot tunnel the
+    fetch through an attacker-chosen egress. ``allow_private=False``
+    (default) rejects RFC1918 / link-local / cloud-metadata IPs.
+
+    Body cap: each response is bounded to ``max_body_bytes`` (default
+    256 KiB). brand.json is small by design; an adversarial
+    multi-megabyte body would otherwise be buffered into memory by
+    ``response.json()``.
+
+    ``client_factory`` is the test seam — production callers pass
+    ``None`` to use the IP-pinned client; tests inject a factory that
+    returns a client wired to a mock transport.
     """
+    from adcp.signing.ip_pinned_transport import build_async_ip_pinned_transport
+
     seen: set[str] = set()
     url = _canonicalize_url(start_url, allow_private=allow_private)
 
-    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-        for hop in range(max_redirects + 1):
-            if url in seen:
-                raise BrandJsonResolverError("redirect_loop", "brand.json redirect loop detected")
-            seen.add(url)
+    for hop in range(max_redirects + 1):
+        if url in seen:
+            raise BrandJsonResolverError("redirect_loop", "brand.json redirect loop detected")
+        seen.add(url)
 
-            headers: dict[str, str] = {"accept": "application/json"}
-            # Only attach If-None-Match on the entry URL: a 304
-            # short-circuits the whole chain, so revalidating a deeper
-            # hop with a stale ETag would lie about the redirect target.
-            if hop == 0 and current_etag is not None:
-                headers["if-none-match"] = current_etag
+        headers: dict[str, str] = {"accept": "application/json"}
+        # Only attach If-None-Match on the entry URL: a 304
+        # short-circuits the whole chain, so revalidating a deeper
+        # hop with a stale ETag would lie about the redirect target.
+        if hop == 0 and current_etag is not None:
+            headers["if-none-match"] = current_etag
 
-            try:
-                response = await client.get(url, headers=headers)
-            except (httpx.HTTPError, OSError) as exc:
-                raise BrandJsonResolverError(
-                    "fetch_failed", f"brand.json fetch failed: {exc}"
-                ) from exc
-
-            if hop == 0 and response.status_code == 304:
-                return _FetchedBrandJson(
-                    status="not_modified",
-                    final_url=url,
-                    data=None,
-                    etag=response.headers.get("etag"),
-                    cache_control=response.headers.get("cache-control"),
-                )
-            if response.status_code != 200:
-                raise BrandJsonResolverError(
-                    "fetch_failed",
-                    f"brand.json fetch returned HTTP {response.status_code}",
-                )
-
-            try:
-                parsed = response.json()
-            except (ValueError, httpx.DecodingError) as exc:
-                raise BrandJsonResolverError(
-                    "invalid_body", "brand.json response is not valid JSON"
-                ) from exc
-            if not isinstance(parsed, dict):
-                raise BrandJsonResolverError("invalid_body", "brand.json response is not an object")
-
-            authoritative = parsed.get("authoritative_location")
-            house = parsed.get("house")
-
-            if isinstance(authoritative, str):
-                if hop == max_redirects:
-                    raise BrandJsonResolverError(
-                        "redirect_depth_exceeded",
-                        "brand.json redirect depth exceeded",
-                    )
-                url = _canonicalize_url(authoritative, allow_private=allow_private)
-                continue
-            if isinstance(house, str):
-                # The "house string" redirect variant: a bare domain
-                # pointing at the authoritative portfolio. Reject
-                # anything that isn't a bare hostname so an attacker
-                # can't inject userinfo, paths, or ports via the
-                # interpolation.
-                if not _BARE_HOSTNAME_RE.match(house):
-                    raise BrandJsonResolverError(
-                        "invalid_house",
-                        'brand.json "house" is not a bare hostname',
-                    )
-                if hop == max_redirects:
-                    raise BrandJsonResolverError(
-                        "redirect_depth_exceeded",
-                        "brand.json redirect depth exceeded",
-                    )
-                url = _canonicalize_url(
-                    f"https://{house}/.well-known/brand.json",
-                    allow_private=allow_private,
-                )
-                continue
-
-            # Narrow shape validation on the terminal document. Full
-            # schema validation is stricter than we need; what we MUST
-            # reject is a document whose shape would let an attacker
-            # smuggle a non-string url or jwks_uri past the selector.
-            _assert_brand_json_shape(parsed)
-
-            return _FetchedBrandJson(
-                status="ok",
-                final_url=url,
-                data=parsed,
-                etag=response.headers.get("etag"),
-                cache_control=response.headers.get("cache-control"),
+        # Build a fresh IP-pinned client per hop — each redirect target
+        # is a different host whose IP must be resolved + validated
+        # independently. Mirrors how the JWKS fetcher constructs a
+        # transport per call.
+        if client_factory is not None:
+            client_cm = client_factory(url)
+        else:
+            transport = build_async_ip_pinned_transport(url, allow_private=allow_private)
+            client_cm = httpx.AsyncClient(
+                transport=transport,
+                timeout=timeout_seconds,
+                follow_redirects=False,
+                trust_env=False,
             )
+
+        try:
+            async with client_cm as client:
+                try:
+                    response = await client.get(url, headers=headers)
+                except SSRFValidationError as exc:
+                    raise BrandJsonResolverError(
+                        "fetch_failed", f"brand.json URL failed SSRF check: {exc}"
+                    ) from exc
+                except (httpx.HTTPError, OSError) as exc:
+                    raise BrandJsonResolverError(
+                        "fetch_failed", f"brand.json fetch failed: {exc}"
+                    ) from exc
+
+                if hop == 0 and response.status_code == 304:
+                    return _FetchedBrandJson(
+                        status="not_modified",
+                        final_url=url,
+                        data=None,
+                        etag=response.headers.get("etag"),
+                        cache_control=response.headers.get("cache-control"),
+                    )
+                if response.status_code != 200:
+                    raise BrandJsonResolverError(
+                        "fetch_failed",
+                        f"brand.json fetch returned HTTP {response.status_code}",
+                    )
+
+                # Body-size cap. ``response.content`` is already buffered
+                # by httpx (we're not streaming); reject if it exceeds
+                # the cap before paying the JSON-parse cost.
+                body = response.content
+                if len(body) > max_body_bytes:
+                    raise BrandJsonResolverError(
+                        "invalid_body",
+                        f"brand.json response exceeds {max_body_bytes} bytes " f"(got {len(body)})",
+                    )
+
+                try:
+                    parsed = response.json()
+                except (ValueError, httpx.DecodingError) as exc:
+                    raise BrandJsonResolverError(
+                        "invalid_body", "brand.json response is not valid JSON"
+                    ) from exc
+        except BrandJsonResolverError:
+            raise
+
+        if not isinstance(parsed, dict):
+            raise BrandJsonResolverError("invalid_body", "brand.json response is not an object")
+
+        # Capture response headers once before the client closes —
+        # used for both the `ok` return below and any 304 returns above
+        # (already returned by this point).
+        etag = response.headers.get("etag")
+        cache_control = response.headers.get("cache-control")
+
+        authoritative = parsed.get("authoritative_location")
+        house = parsed.get("house")
+
+        if isinstance(authoritative, str):
+            if hop == max_redirects:
+                raise BrandJsonResolverError(
+                    "redirect_depth_exceeded",
+                    "brand.json redirect depth exceeded",
+                )
+            url = _canonicalize_url(authoritative, allow_private=allow_private)
+            continue
+        if isinstance(house, str):
+            # The "house string" redirect variant: a bare domain
+            # pointing at the authoritative portfolio. Reject
+            # anything that isn't a bare hostname so an attacker
+            # can't inject userinfo, paths, or ports via the
+            # interpolation.
+            if not _BARE_HOSTNAME_RE.match(house):
+                raise BrandJsonResolverError(
+                    "invalid_house",
+                    'brand.json "house" is not a bare hostname',
+                )
+            if hop == max_redirects:
+                raise BrandJsonResolverError(
+                    "redirect_depth_exceeded",
+                    "brand.json redirect depth exceeded",
+                )
+            url = _canonicalize_url(
+                f"https://{house}/.well-known/brand.json",
+                allow_private=allow_private,
+            )
+            continue
+
+        # Narrow shape validation on the terminal document. Full
+        # schema validation is stricter than we need; what we MUST
+        # reject is a document whose shape would let an attacker
+        # smuggle a non-string url or jwks_uri past the selector.
+        _assert_brand_json_shape(parsed)
+
+        return _FetchedBrandJson(
+            status="ok",
+            final_url=url,
+            data=parsed,
+            etag=etag,
+            cache_control=cache_control,
+        )
 
     raise BrandJsonResolverError("redirect_depth_exceeded", "brand.json redirect depth exceeded")
 
@@ -418,9 +544,22 @@ def _canonicalize_url(raw: str, *, allow_private: bool) -> str:
     """Structurally validate a URL and return it canonicalized.
 
     Rejects URLs the transport layer would later refuse anyway, but
-    catching them here gives a clearer error code and prevents a
-    malformed redirect target from silently bypassing the hop cap
-    because its string form differed from a prior seen URL.
+    catching them here gives a clearer error code AND closes the
+    redirect-loop detector against trivial aliasing attacks
+    (case-mismatched host, default-port elision).
+
+    Canonicalization mirrors the JS port's ``new URL(...)`` semantics:
+
+    * Scheme lowercased.
+    * Host lowercased (``urlsplit`` does NOT do this — we do it).
+    * Default port (443 for https, 80 for http) stripped.
+    * Fragments stripped — they aren't sent on the wire and must not
+      smuggle loop-detection aliases into ``seen``.
+
+    Without these the loop detector sees ``https://X.example/`` and
+    ``https://x.example/`` as distinct strings; the JS-side resolver
+    canonicalizes both via ``new URL``, so a Python-only deployment
+    would fail open where JS fails closed.
     """
     try:
         parts = urlsplit(raw)
@@ -430,11 +569,17 @@ def _canonicalize_url(raw: str, *, allow_private: bool) -> str:
         raise BrandJsonResolverError("invalid_url", "brand.json URL is malformed")
     if parts.username or parts.password:
         raise BrandJsonResolverError("invalid_url", "brand.json URL must not include userinfo")
-    if parts.scheme != "https" and not (allow_private and parts.scheme == "http"):
+    scheme = parts.scheme.lower()
+    if scheme != "https" and not (allow_private and scheme == "http"):
         raise BrandJsonResolverError("invalid_url", "brand.json URL must use https://")
-    # Strip fragments — they aren't sent on the wire and must not
-    # smuggle loop-detection aliases into ``seen``.
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))
+    host = parts.hostname or ""
+    if not host:
+        raise BrandJsonResolverError("invalid_url", "brand.json URL has no host")
+    port = parts.port
+    if port is not None and port == _DEFAULT_PORTS.get(scheme):
+        port = None
+    netloc = host if port is None else f"{host}:{port}"
+    return urlunsplit((scheme, netloc, parts.path, parts.query, ""))
 
 
 def _assert_brand_json_shape(obj: dict[str, Any]) -> None:

--- a/src/adcp/signing/capability_cache.py
+++ b/src/adcp/signing/capability_cache.py
@@ -1,0 +1,177 @@
+"""Per-agent cache of ``request_signing`` capability advertisements.
+
+Port of ``src/lib/signing/capability-cache.ts`` from the JS SDK
+(``adcontextprotocol/adcp-client``). Same surface, same key format, so
+multi-language deployments that later share a Redis-backed cache can
+interop on the cache key.
+
+The cache stores the ``request_signing`` block returned by
+:func:`get_adcp_capabilities` for a given agent endpoint. Keyed by
+``cache_key`` — typically built via :func:`build_capability_cache_key`
+as ``agent_uri + auth-token-hash + signer-fingerprint`` so that different
+credentials or signing identities get independent entries (a seller can
+advertise different policies per counterparty key).
+
+Staleness is TTL-based; callers may also invalidate explicitly — e.g.
+after a seller rotates its advertisement mid-session — so the next
+outbound call re-primes before deciding whether to sign.
+
+Negative-cache TTL: callers populating the cache after a failed
+discovery call (see :mod:`adcp.signing.capability_priming`) set
+``stale_at`` to a shorter window so a transient seller outage doesn't
+block signing decisions for the full TTL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_TTL_SECONDS = 300.0
+
+
+@dataclass(frozen=True)
+class CachedCapability:
+    """One cache entry — the seller's advertised request-signing policy.
+
+    :param request_signing: The ``request_signing`` capability block as
+        advertised by the agent. ``None`` when discovery succeeded but
+        the seller advertises no signing requirements, or when a
+        negative-cache entry was written after a failed discovery.
+    :param adcp_version: The major AdCP version associated with the
+        capability response, when known.
+    :param fetched_at: Epoch seconds when this entry was written.
+    :param stale_at: Optional explicit epoch-seconds deadline at which
+        this entry becomes stale. Overrides the cache's default TTL —
+        used to give negative-cache entries a shorter refresh window.
+    """
+
+    request_signing: dict[str, Any] | None
+    adcp_version: int | None
+    fetched_at: float
+    stale_at: float | None = None
+
+
+class CapabilityCache:
+    """Per-agent cache of capability advertisements.
+
+    In-process — single :class:`CapabilityCache` per Python process is
+    typical. Multi-tenant embeddings that need per-tenant isolation
+    construct one cache per tenant; the in-flight-fetch dedup table is
+    instance-local so two tenants don't race each other's writes.
+
+    Adopters running multiple workers that need shared cache state
+    implement a Redis-backed variant against the same surface — the
+    public methods (``get``, ``set``, ``invalidate``, ``clear``,
+    ``is_stale``) plus the in-flight hooks are the contract.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock or time.time
+        self._entries: dict[str, CachedCapability] = {}
+        # In-flight priming fetches keyed by cache_key. Lives on the
+        # instance so two CapabilityCache objects (e.g., one per tenant
+        # in a multi-tenant embedding) don't share an
+        # ``ensure_capability_loaded`` future map and race each other's
+        # writes.
+        self._in_flight: dict[str, asyncio.Future[CachedCapability]] = {}
+
+    def get(self, cache_key: str) -> CachedCapability | None:
+        return self._entries.get(cache_key)
+
+    def set(self, cache_key: str, entry: CachedCapability) -> None:
+        self._entries[cache_key] = entry
+
+    def invalidate(self, cache_key: str) -> None:
+        self._entries.pop(cache_key, None)
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self._in_flight.clear()
+
+    def is_stale(self, entry: CachedCapability | None) -> bool:
+        if entry is None:
+            return True
+        now = self._clock()
+        if entry.stale_at is not None:
+            return now >= entry.stale_at
+        return now - entry.fetched_at > self._ttl_seconds
+
+    # --- internal in-flight hooks (used by ensure_capability_loaded) ---
+
+    def _get_in_flight(self, cache_key: str) -> asyncio.Future[CachedCapability] | None:
+        return self._in_flight.get(cache_key)
+
+    def _set_in_flight(
+        self,
+        cache_key: str,
+        future: asyncio.Future[CachedCapability],
+    ) -> None:
+        self._in_flight[cache_key] = future
+
+    def _delete_in_flight(self, cache_key: str) -> None:
+        self._in_flight.pop(cache_key, None)
+
+
+#: Process-global default capability cache. Shared by transport-level
+#: signing wrappers so a single ``get_adcp_capabilities`` call serves
+#: every subsequent signing decision for an agent. Adopters with
+#: per-tenant cache isolation construct their own instances instead.
+default_capability_cache = CapabilityCache()
+
+
+def build_capability_cache_key(
+    agent_uri: str,
+    *,
+    auth_token: str | None = None,
+    signer_fingerprint: str | None = None,
+) -> str:
+    """Build a stable cache key for ``CapabilityCache``.
+
+    Two callers pointing at the same agent URI under different signing
+    identities (different auth tokens or different signing keys) get
+    independent cache entries — a seller can advertise different
+    policies per counterparty key.
+
+    The ``auth_token`` hash is a cache-key disambiguator, not a
+    security boundary; a hypothetical collision across users would
+    still transmit only the original caller's token (the cache key
+    isn't the auth credential itself).
+
+    Format matches the JS SDK exactly:
+    ``agent_uri[::sha256(auth_token)[:16]][::sig=signer_fingerprint]``
+    """
+    parts = [agent_uri]
+    if auth_token:
+        token_digest = hashlib.sha256(auth_token.encode("utf-8")).hexdigest()[:16]
+        parts.append(f"::{token_digest}")
+    if signer_fingerprint:
+        parts.append(f"::sig={signer_fingerprint}")
+    return "".join(parts)
+
+
+# Type alias for the priming callback consumed by
+# ``ensure_capability_loaded``. Adopters wire this to a client that
+# calls the seller's ``get_adcp_capabilities`` task and returns the
+# raw response (MCP CallToolResult or A2A SendMessageResponse).
+FetchRaw = Callable[[], Awaitable[Any]]
+
+
+__all__ = [
+    "DEFAULT_TTL_SECONDS",
+    "CachedCapability",
+    "CapabilityCache",
+    "FetchRaw",
+    "build_capability_cache_key",
+    "default_capability_cache",
+]

--- a/src/adcp/signing/capability_priming.py
+++ b/src/adcp/signing/capability_priming.py
@@ -1,0 +1,202 @@
+"""Capability-cache primer.
+
+Port of ``src/lib/signing/capability-priming.ts`` from the JS SDK.
+
+Populates :class:`CapabilityCache` for an agent when the
+``request_signing`` entry is absent or stale. The injected
+:data:`FetchRaw` callback makes an unsigned ``get_adcp_capabilities``
+call against the counterparty — adopters wire it to their existing
+client (``adcp.client``, salesagent's MCP/A2A client, etc.) so no new
+network code lives here.
+
+**Fail-open posture.** If discovery itself fails, this primer caches
+an empty entry with a 60-second ``stale_at`` window and returns it
+rather than propagating the error. Signing decisions then fall through:
+
+* Ops in the buyer's ``always_sign`` list are still signed (with
+  default content-digest coverage), so explicit pilot opt-ins keep
+  working.
+* Ops the seller listed in ``required_for`` go out unsigned and are
+  rejected with ``request_signature_required`` at the wire — the user
+  sees a clear error rather than an opaque priming wedge, and the next
+  retry re-primes.
+
+**In-flight dedup.** Two concurrent priming calls for the same cache
+key share one fetch via the cache's in-flight future table. Prevents
+fetch-storms on cache miss when N tasks all start verifying
+simultaneously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from adcp.signing.capability_cache import (
+    CachedCapability,
+    CapabilityCache,
+    FetchRaw,
+)
+
+#: The wire op name for the seller's capability advertisement. The
+#: outbound signing wrapper short-circuits on this op so the priming
+#: request itself is never gated by signing.
+CAPABILITY_OP = "get_adcp_capabilities"
+
+#: Refresh window applied to a negative-cache entry written after a
+#: failed discovery call. 60s is short enough that a transient seller
+#: outage self-heals on the next user action, long enough to avoid
+#: pile-ups if the seller stays down.
+NEGATIVE_CACHE_TTL_SECONDS = 60.0
+
+
+async def ensure_capability_loaded(
+    *,
+    cache: CapabilityCache,
+    cache_key: str,
+    fetch_raw: FetchRaw,
+) -> CachedCapability:
+    """Populate the cache for an agent, returning the cached entry.
+
+    Skips the fetch when a fresh entry exists. Joins an in-flight
+    priming call for the same key when one is pending. On fetch
+    failure, writes a negative-cache entry with a 60s ``stale_at``
+    deadline and returns it (fail-open per module docstring).
+    """
+    existing = cache.get(cache_key)
+    if existing is not None and not cache.is_stale(existing):
+        return existing
+
+    pending = cache._get_in_flight(cache_key)
+    if pending is not None:
+        return await pending
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[CachedCapability] = loop.create_future()
+    cache._set_in_flight(cache_key, future)
+
+    try:
+        try:
+            raw = await fetch_raw()
+            request_signing, adcp_version = _extract_capability(raw)
+            entry = CachedCapability(
+                request_signing=request_signing,
+                adcp_version=adcp_version,
+                fetched_at=cache._clock(),
+            )
+        except Exception:
+            # Fail-open: cache an empty negative entry with a short
+            # ``stale_at`` window so a transient outage doesn't block
+            # signing decisions for the full TTL.
+            now = cache._clock()
+            entry = CachedCapability(
+                request_signing=None,
+                adcp_version=None,
+                fetched_at=now,
+                stale_at=now + NEGATIVE_CACHE_TTL_SECONDS,
+            )
+
+        cache.set(cache_key, entry)
+        if not future.done():
+            future.set_result(entry)
+        return entry
+    finally:
+        cache._delete_in_flight(cache_key)
+
+
+def _extract_capability(
+    response: Any,
+) -> tuple[dict[str, Any] | None, int | None]:
+    """Extract the ``request_signing`` block and AdCP major version
+    from a ``get_adcp_capabilities`` response, regardless of how the
+    transport wrapped it.
+
+    Three transport shapes the JS port handles, mirrored here:
+
+    * MCP ``CallToolResult`` — ``structuredContent`` (preferred) or
+      ``content[].text`` parsed as JSON.
+    * A2A JSON-RPC ``SendMessageResponse`` — ``result`` is a Task
+      (``artifacts[].parts[].data``) or a Message (``parts[].data``).
+    * Already-unwrapped payload dict — used as-is.
+    """
+    payload = _unwrap_response(response)
+    if not isinstance(payload, dict):
+        return None, None
+
+    request_signing = payload.get("request_signing")
+    if not isinstance(request_signing, dict):
+        request_signing = None
+
+    adcp_version: int | None = None
+    adcp = payload.get("adcp")
+    if isinstance(adcp, dict):
+        versions = adcp.get("major_versions")
+        if isinstance(versions, list) and versions:
+            first = versions[0]
+            if isinstance(first, int):
+                adcp_version = first
+
+    return request_signing, adcp_version
+
+
+def _unwrap_response(response: Any) -> Any:
+    """Unwrap MCP / A2A transport envelopes to find the AdCP payload.
+
+    Mirrors ``unwrapResponse`` in ``capability-priming.ts`` exactly —
+    same precedence (MCP ``structuredContent`` → MCP ``content[].text``
+    → A2A ``result.artifacts[].parts[].data`` → A2A
+    ``result.parts[].data`` → fallthrough).
+    """
+    if not isinstance(response, dict):
+        return response
+
+    structured = response.get("structuredContent")
+    if isinstance(structured, dict):
+        return structured
+
+    content = response.get("content")
+    if isinstance(content, list):
+        for chunk in content:
+            if isinstance(chunk, dict):
+                text = chunk.get("text")
+                if isinstance(text, str):
+                    try:
+                        return json.loads(text)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+
+    result = response.get("result")
+    if isinstance(result, dict):
+        artifacts = result.get("artifacts")
+        if isinstance(artifacts, list):
+            for artifact in artifacts:
+                if isinstance(artifact, dict):
+                    data = _find_first_data_part(artifact.get("parts"))
+                    if data is not None:
+                        return data
+        data = _find_first_data_part(result.get("parts"))
+        if data is not None:
+            return data
+
+    return response
+
+
+def _find_first_data_part(parts: Any) -> Any:
+    """Return the first A2A ``DataPart`` payload from a parts list."""
+    if not isinstance(parts, list):
+        return None
+    for part in parts:
+        if isinstance(part, dict):
+            kind = part.get("kind")
+            data = part.get("data")
+            if kind == "data" and isinstance(data, dict):
+                return data
+    return None
+
+
+__all__ = [
+    "CAPABILITY_OP",
+    "NEGATIVE_CACHE_TTL_SECONDS",
+    "ensure_capability_loaded",
+]

--- a/src/adcp/signing/capability_priming.py
+++ b/src/adcp/signing/capability_priming.py
@@ -31,13 +31,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Any
+
+import httpx
 
 from adcp.signing.capability_cache import (
     CachedCapability,
     CapabilityCache,
     FetchRaw,
 )
+
+logger = logging.getLogger(__name__)
 
 #: The wire op name for the seller's capability advertisement. The
 #: outbound signing wrapper short-circuits on this op so the priming
@@ -85,10 +90,31 @@ async def ensure_capability_loaded(
                 adcp_version=adcp_version,
                 fetched_at=cache._clock(),
             )
-        except Exception:
+        except (
+            httpx.HTTPError,
+            ValueError,
+            TypeError,
+            json.JSONDecodeError,
+            OSError,
+        ) as exc:
             # Fail-open: cache an empty negative entry with a short
             # ``stale_at`` window so a transient outage doesn't block
             # signing decisions for the full TTL.
+            #
+            # Catch only expected discovery failures — let
+            # ``BaseException`` (asyncio.CancelledError,
+            # KeyboardInterrupt, programmer bugs surfacing as
+            # AttributeError) propagate. Without this narrowing, a
+            # cancelled task would silently land in negative-cache and
+            # the awaiter would never see the cancellation.
+            logger.warning(
+                "[adcp.signing.capability_priming] discovery for %s "
+                "failed (%s: %s); negative-caching for %ds",
+                cache_key,
+                type(exc).__name__,
+                exc,
+                int(NEGATIVE_CACHE_TTL_SECONDS),
+            )
             now = cache._clock()
             entry = CachedCapability(
                 request_signing=None,
@@ -101,6 +127,13 @@ async def ensure_capability_loaded(
         if not future.done():
             future.set_result(entry)
         return entry
+    except BaseException as exc:
+        # Anything that propagated past the narrow catch above (e.g.
+        # CancelledError from fetch_raw) — make sure waiters joined to
+        # this future see the failure rather than awaiting forever.
+        if not future.done():
+            future.set_exception(exc)
+        raise
     finally:
         cache._delete_in_flight(cache_key)
 

--- a/tests/test_brand_jwks.py
+++ b/tests/test_brand_jwks.py
@@ -62,17 +62,33 @@ class _MockTransport(httpx.AsyncBaseTransport):
 
 @pytest.fixture
 def patch_httpx(monkeypatch):
-    """Patch httpx.AsyncClient to use the fake transport."""
+    """Inject a fake-transport ``client_factory`` into every
+    ``BrandJsonJwksResolver`` constructed during this test.
+
+    Cleaner than the earlier global ``AsyncClient.__init__`` monkey-patch:
+    only ``BrandJsonJwksResolver`` constructions in this test pick up
+    the mock — any other ``AsyncClient`` (e.g. the inner
+    ``AsyncCachingJwksResolver``) is unaffected.
+    """
 
     def _patch(responses: dict[str, dict]) -> _MockTransport:
         transport = _MockTransport(responses)
-        original_init = httpx.AsyncClient.__init__
 
-        def patched_init(self, *args, **kwargs):
-            kwargs["transport"] = transport
+        def factory(_url: str) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=transport,
+                timeout=5.0,
+                follow_redirects=False,
+                trust_env=False,
+            )
+
+        original_init = BrandJsonJwksResolver.__init__
+
+        def patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            kwargs.setdefault("_client_factory", factory)
             return original_init(self, *args, **kwargs)
 
-        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+        monkeypatch.setattr(BrandJsonJwksResolver, "__init__", patched_init)
         return transport
 
     return _patch
@@ -105,6 +121,40 @@ def test_canonicalize_allows_http_when_private_allowed() -> None:
         _canonicalize_url("http://localhost:8080/x", allow_private=True)
         == "http://localhost:8080/x"
     )
+
+
+def test_canonicalize_lowercases_host() -> None:
+    """Mixed-case hosts canonicalize to lowercase — without this the
+    redirect-loop detector would see ``X.example`` and ``x.example``
+    as distinct URLs, defeating the loop check (review finding #2)."""
+    assert (
+        _canonicalize_url("https://X.Example.com/path", allow_private=False)
+        == "https://x.example.com/path"
+    )
+
+
+def test_canonicalize_strips_default_port() -> None:
+    """``https://x:443`` and ``https://x`` are the same origin —
+    canonicalize to the bare-host form so origin equality and loop
+    detection work (review finding #2)."""
+    assert (
+        _canonicalize_url("https://x.example:443/p", allow_private=False) == "https://x.example/p"
+    )
+    assert _canonicalize_url("http://localhost:80/p", allow_private=True) == "http://localhost/p"
+
+
+def test_canonicalize_preserves_non_default_port() -> None:
+    """Non-default port must be preserved — ``https://x:8443`` is a
+    different origin from ``https://x:443``."""
+    assert (
+        _canonicalize_url("https://x.example:8443/p", allow_private=False)
+        == "https://x.example:8443/p"
+    )
+
+
+def test_canonicalize_lowercases_scheme() -> None:
+    """Scheme normalization: ``HTTPS`` → ``https``."""
+    assert _canonicalize_url("HTTPS://x.example/", allow_private=False) == "https://x.example/"
 
 
 def test_canonicalize_rejects_malformed_url() -> None:
@@ -643,3 +693,99 @@ async def test_resolver_satisfies_jwks_resolver_protocol() -> None:
     coro = resolver.resolve("k")
     assert asyncio.iscoroutine(coro)
     coro.close()
+
+
+# ----- Security regressions from expert review -----
+
+
+@pytest.mark.asyncio
+async def test_resolver_rejects_oversized_brand_json(patch_httpx) -> None:
+    """Body cap regression — counterparty serving a large brand.json
+    must be rejected before parse, not buffered into memory.
+
+    Review finding: no body-size cap. ``response.content`` would
+    buffer arbitrary bytes; cap before parsing.
+    """
+    huge_body = b"{" + b'"x":"' + b"A" * (300 * 1024) + b'"' + b"}"
+    patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": huge_body,
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        max_body_bytes=256 * 1024,  # default cap
+        jwks_fetcher=_jwks_fetcher_for({}),
+    )
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "invalid_body"
+    assert "exceeds" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_resolver_loop_detection_handles_case_aliasing(patch_httpx) -> None:
+    """Review finding #2 — without host lowercase + port-strip,
+    ``https://X.example/`` and ``https://x.example/`` would be
+    distinct entries in the ``seen`` set, defeating loop detection.
+    Verify the canonicalized form is what enters ``seen``."""
+    import json
+
+    patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://EXAMPLE.com:443/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for({}),
+    )
+    # The redirect target canonicalizes to the entry URL — must trip
+    # ``redirect_loop`` rather than fetching twice.
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "redirect_loop"
+
+
+@pytest.mark.asyncio
+async def test_resolver_concurrent_resolve_dedups_to_one_fetch(
+    patch_httpx,
+) -> None:
+    """Review finding #5 — N concurrent ``resolve()`` calls on a cold
+    cache must share ONE brand.json fetch via the in-flight future,
+    not serialize through a Lock and fetch N times."""
+    transport = patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": _brand_json(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    jwk = {"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": "k1"}
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for({"https://x.example/jwks": jwk}),
+    )
+
+    # Fan out 5 concurrent resolves. All should share one fetch.
+    results = await asyncio.gather(*[resolver("k1") for _ in range(5)])
+    assert all(r is not None and r["kid"] == "k1" for r in results)
+
+    # Count brand.json fetches — should be exactly one. Each
+    # transport.calls entry is a request; filter to the brand.json URL.
+    brand_fetches = [
+        c for c in transport.calls if str(c.url) == "https://example.com/.well-known/brand.json"
+    ]
+    assert len(brand_fetches) == 1, f"expected single shared fetch, got {len(brand_fetches)}"

--- a/tests/test_brand_jwks.py
+++ b/tests/test_brand_jwks.py
@@ -1,0 +1,645 @@
+"""Tests for :mod:`adcp.signing.brand_jwks`.
+
+Behavior under test (matches JS port at
+``adcp-client/src/lib/signing/brand-jwks.ts``):
+
+* ``BrandJsonJwksResolver`` — JwksResolver Protocol conformance,
+  agent selection, redirect chain following
+  (``authoritative_location``, ``house``), well-known fallback,
+  cache-control honoring, 304 ETag bumps, cascade refresh on
+  unknown kid.
+* Security: bare-hostname ``house`` validation, origin-bound
+  well-known fallback (no cross-origin trust pivot), userinfo
+  rejection, hop-cap enforcement.
+* Error codes: every ``BrandJsonResolverErrorCode`` is reachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from adcp.signing.brand_jwks import (
+    BrandJsonJwksResolver,
+    BrandJsonResolverError,
+    _assert_brand_json_shape,
+    _canonicalize_url,
+    _compute_lifetime,
+    _select_agent,
+)
+
+# ----- Fake HTTP transport — mock httpx.AsyncClient -----
+
+
+class _MockTransport(httpx.AsyncBaseTransport):
+    """Minimal async transport that returns canned responses keyed
+    on URL. Each call records the request for assertion."""
+
+    def __init__(self, responses: dict[str, dict]):
+        self.responses = responses
+        self.calls: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(request)
+        url = str(request.url)
+        if url not in self.responses:
+            return httpx.Response(404, content=b"")
+        spec = self.responses[url]
+        # Return 304 when the request's If-None-Match matches the spec.
+        if spec.get("etag") is not None and request.headers.get("if-none-match") == spec["etag"]:
+            return httpx.Response(
+                304,
+                headers={"etag": spec["etag"], **spec.get("headers", {})},
+            )
+        return httpx.Response(
+            spec.get("status", 200),
+            content=spec.get("body", b""),
+            headers=spec.get("headers", {}),
+        )
+
+
+@pytest.fixture
+def patch_httpx(monkeypatch):
+    """Patch httpx.AsyncClient to use the fake transport."""
+
+    def _patch(responses: dict[str, dict]) -> _MockTransport:
+        transport = _MockTransport(responses)
+        original_init = httpx.AsyncClient.__init__
+
+        def patched_init(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            return original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+        return transport
+
+    return _patch
+
+
+# ----- _canonicalize_url -----
+
+
+def test_canonicalize_strips_fragment() -> None:
+    assert (
+        _canonicalize_url("https://x.example/.well-known/brand.json#frag", allow_private=False)
+        == "https://x.example/.well-known/brand.json"
+    )
+
+
+def test_canonicalize_rejects_userinfo() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _canonicalize_url("https://user:pass@x.example/", allow_private=False)
+    assert exc.value.code == "invalid_url"
+
+
+def test_canonicalize_rejects_http_when_private_disallowed() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _canonicalize_url("http://x.example/", allow_private=False)
+    assert exc.value.code == "invalid_url"
+
+
+def test_canonicalize_allows_http_when_private_allowed() -> None:
+    assert (
+        _canonicalize_url("http://localhost:8080/x", allow_private=True)
+        == "http://localhost:8080/x"
+    )
+
+
+def test_canonicalize_rejects_malformed_url() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _canonicalize_url("not-a-url", allow_private=False)
+    assert exc.value.code == "invalid_url"
+
+
+# ----- _assert_brand_json_shape -----
+
+
+def test_shape_accepts_valid_top_level_agents() -> None:
+    _assert_brand_json_shape(
+        {"agents": [{"type": "brand", "url": "https://a", "jwks_uri": "https://a/jwks"}]}
+    )
+
+
+def test_shape_rejects_non_string_url() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _assert_brand_json_shape({"agents": [{"type": "brand", "url": 42}]})
+    assert exc.value.code == "schema_invalid"
+
+
+def test_shape_rejects_non_string_jwks_uri() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _assert_brand_json_shape(
+            {"agents": [{"type": "brand", "url": "https://a", "jwks_uri": 42}]}
+        )
+    assert exc.value.code == "schema_invalid"
+
+
+def test_shape_rejects_non_array_agents() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _assert_brand_json_shape({"agents": "not-array"})
+    assert exc.value.code == "schema_invalid"
+
+
+def test_shape_walks_portfolio_house_and_brands_agents() -> None:
+    """Portfolio documents have agents at house-level AND per-brand —
+    schema check must walk both."""
+    with pytest.raises(BrandJsonResolverError):
+        _assert_brand_json_shape(
+            {
+                "house": {"agents": [{"type": "brand", "url": "https://h"}]},
+                "brands": [{"id": "x", "agents": [{"type": "brand", "url": 42}]}],
+            }
+        )
+
+
+# ----- _select_agent -----
+
+
+def test_select_top_level_agents() -> None:
+    data = {
+        "agents": [
+            {"type": "brand", "url": "https://a/", "jwks_uri": "https://a/jwks"},
+        ]
+    }
+    selected = _select_agent(
+        data,
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        agent_id=None,
+        brand_id=None,
+    )
+    assert selected.url == "https://a/"
+    assert selected.jwks_uri == "https://a/jwks"
+
+
+def test_select_portfolio_brand_overrides_house() -> None:
+    """Per-spec, brand-level agents override house-level for the same
+    type when ``brand_id`` selector is set."""
+    data = {
+        "house": {
+            "agents": [
+                {
+                    "type": "brand",
+                    "url": "https://house-fallback/",
+                    "jwks_uri": "https://h/jwks",
+                }
+            ]
+        },
+        "brands": [
+            {
+                "id": "nike",
+                "agents": [
+                    {
+                        "type": "brand",
+                        "url": "https://nike-agent/",
+                        "jwks_uri": "https://nike/jwks",
+                    }
+                ],
+            }
+        ],
+    }
+    selected = _select_agent(
+        data,
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        agent_id=None,
+        brand_id="nike",
+    )
+    assert selected.url == "https://nike-agent/"
+
+
+def test_select_portfolio_falls_back_to_house_when_brand_missing_type() -> None:
+    data = {
+        "house": {
+            "agents": [
+                {
+                    "type": "brand",
+                    "url": "https://house/",
+                    "jwks_uri": "https://h/jwks",
+                }
+            ]
+        },
+        "brands": [
+            {
+                "id": "nike",
+                "agents": [
+                    {
+                        "type": "creative",
+                        "url": "https://creative/",
+                    }
+                ],
+            }
+        ],
+    }
+    selected = _select_agent(
+        data,
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        agent_id=None,
+        brand_id="nike",
+    )
+    assert selected.url == "https://house/"
+
+
+def test_select_raises_agent_not_found() -> None:
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _select_agent(
+            {"agents": []},
+            "https://example.com/",
+            agent_type="brand",
+            agent_id=None,
+            brand_id=None,
+        )
+    assert exc.value.code == "agent_not_found"
+
+
+def test_select_raises_agent_ambiguous_when_multiple_match() -> None:
+    """Two agents of the same type without an ``agent_id`` selector
+    is ambiguous — must raise rather than picking arbitrarily."""
+    data = {
+        "agents": [
+            {"type": "brand", "url": "https://a/", "id": "a"},
+            {"type": "brand", "url": "https://b/", "id": "b"},
+        ]
+    }
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _select_agent(
+            data,
+            "https://example.com/",
+            agent_type="brand",
+            agent_id=None,
+            brand_id=None,
+        )
+    assert exc.value.code == "agent_ambiguous"
+
+
+def test_select_disambiguates_with_agent_id() -> None:
+    data = {
+        "agents": [
+            {"type": "brand", "url": "https://a/", "id": "a", "jwks_uri": "https://a/jwks"},
+            {"type": "brand", "url": "https://b/", "id": "b", "jwks_uri": "https://b/jwks"},
+        ]
+    }
+    selected = _select_agent(
+        data,
+        "https://example.com/",
+        agent_type="brand",
+        agent_id="b",
+        brand_id=None,
+    )
+    assert selected.url == "https://b/"
+
+
+def test_select_falls_back_to_well_known_when_origin_matches() -> None:
+    """Spec fallback: agent.url with no jwks_uri → origin/.well-known/jwks.json
+    iff agent origin matches brand.json origin."""
+    data = {"agents": [{"type": "brand", "url": "https://x.example/"}]}
+    selected = _select_agent(
+        data,
+        "https://x.example/.well-known/brand.json",
+        agent_type="brand",
+        agent_id=None,
+        brand_id=None,
+    )
+    assert selected.jwks_uri == "https://x.example/.well-known/jwks.json"
+
+
+def test_select_rejects_well_known_fallback_on_origin_mismatch() -> None:
+    """Cross-origin trust pivot: an attacker brand.json could set
+    ``agent.url: https://victim-internal/`` and force the verifier
+    to treat that origin's JWKS as authoritative. MUST reject."""
+    data = {"agents": [{"type": "brand", "url": "https://victim-internal/"}]}
+    with pytest.raises(BrandJsonResolverError) as exc:
+        _select_agent(
+            data,
+            "https://attacker.example/.well-known/brand.json",
+            agent_type="brand",
+            agent_id=None,
+            brand_id=None,
+        )
+    assert exc.value.code == "jwks_origin_mismatch"
+
+
+# ----- _compute_lifetime -----
+
+
+def test_lifetime_uses_max_age_when_no_cache_control() -> None:
+    assert _compute_lifetime(None, 3600) == 3600
+
+
+def test_lifetime_zero_on_no_store() -> None:
+    assert _compute_lifetime("public, no-store", 3600) == 0
+
+
+def test_lifetime_zero_on_no_cache() -> None:
+    assert _compute_lifetime("no-cache, max-age=600", 3600) == 0
+
+
+def test_lifetime_capped_at_max_age() -> None:
+    assert _compute_lifetime("max-age=99999", 3600) == 3600
+
+
+def test_lifetime_uses_server_max_age_when_below_cap() -> None:
+    assert _compute_lifetime("max-age=600", 3600) == 600
+
+
+# ----- BrandJsonJwksResolver — end-to-end via _MockTransport -----
+
+
+def _brand_json(
+    agent_url: str = "https://x.example/",
+    jwks_uri: str = "https://x.example/jwks",
+) -> bytes:
+    import json
+
+    return json.dumps(
+        {"agents": [{"type": "brand", "url": agent_url, "jwks_uri": jwks_uri}]}
+    ).encode()
+
+
+def _jwks_body(kid: str = "k1") -> bytes:
+    import json
+
+    return json.dumps({"keys": [{"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": kid}]}).encode()
+
+
+def _jwks_fetcher_for(keys: dict[str, dict]):
+    """Return an async JWKS fetcher that returns canned responses
+    keyed on URI. Avoids the production DNS / SSRF guards on the
+    inner resolver."""
+
+    async def fetcher(uri: str, *, allow_private: bool = False) -> dict:
+        if uri not in keys:
+            raise ValueError(f"no canned JWKS for {uri}")
+        return {"keys": [keys[uri]]}
+
+    return fetcher
+
+
+@pytest.mark.asyncio
+async def test_resolver_fetches_brand_json_and_inner_jwks(patch_httpx) -> None:
+    """Full happy path: resolver fetches brand.json, picks the agent,
+    fetches the JWKS, returns the JWK by kid."""
+    patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": _brand_json(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for(
+            {"https://x.example/jwks": {"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": "k1"}}
+        ),
+    )
+    jwk = await resolver("k1")
+    assert jwk is not None
+    assert jwk["kid"] == "k1"
+    assert resolver.agent_url == "https://x.example/"
+
+
+@pytest.mark.asyncio
+async def test_resolver_returns_none_for_unknown_kid(patch_httpx) -> None:
+    patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": _brand_json(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for(
+            {"https://x.example/jwks": {"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": "k1"}}
+        ),
+    )
+    assert await resolver("nonexistent-kid") is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_follows_authoritative_location_redirect(patch_httpx) -> None:
+    import json
+
+    patch_httpx(
+        {
+            "https://entry.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://final.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+            "https://final.example/.well-known/brand.json": {
+                "body": _brand_json("https://final.example/agent/", "https://final.example/jwks"),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    final_jwk = {"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": "k1"}
+    resolver = BrandJsonJwksResolver(
+        "https://entry.example/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for({"https://final.example/jwks": final_jwk}),
+    )
+    jwk = await resolver("k1")
+    assert jwk is not None and jwk["kid"] == "k1"
+
+
+@pytest.mark.asyncio
+async def test_resolver_follows_house_string_redirect(patch_httpx) -> None:
+    """The ``house`` string redirect: ``{"house": "portfolio.example"}``
+    → ``https://portfolio.example/.well-known/brand.json``."""
+    import json
+
+    patch_httpx(
+        {
+            "https://entry.example/.well-known/brand.json": {
+                "body": json.dumps({"house": "portfolio.example"}).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+            "https://portfolio.example/.well-known/brand.json": {
+                "body": _brand_json("https://portfolio.example/", "https://portfolio.example/jwks"),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    portfolio_jwk = {"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": "k1"}
+    resolver = BrandJsonJwksResolver(
+        "https://entry.example/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for({"https://portfolio.example/jwks": portfolio_jwk}),
+    )
+    jwk = await resolver("k1")
+    assert jwk is not None
+
+
+@pytest.mark.asyncio
+async def test_resolver_rejects_invalid_house_string(patch_httpx) -> None:
+    """An attacker-controlled brand.json emitting
+    ``{"house": "evil.com\\@victim.com"}`` MUST be rejected at parse
+    time, not after a fetch attempt."""
+    import json
+
+    patch_httpx(
+        {
+            "https://entry.example/.well-known/brand.json": {
+                "body": json.dumps({"house": "evil.com@victim.com"}).encode(),
+                "headers": {"content-type": "application/json"},
+            }
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://entry.example/.well-known/brand.json",
+        agent_type="brand",
+    )
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "invalid_house"
+
+
+@pytest.mark.asyncio
+async def test_resolver_redirect_depth_exceeded(patch_httpx) -> None:
+    """A long redirect chain must terminate at ``max_redirects``."""
+    import json
+
+    # Chain entry → hop1 → hop2 → hop3 (over the default cap of 3).
+    patch_httpx(
+        {
+            "https://entry.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://hop1.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+            "https://hop1.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://hop2.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+            "https://hop2.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://hop3.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+            "https://hop3.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://hop4.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://entry.example/.well-known/brand.json",
+        agent_type="brand",
+        max_redirects=3,
+    )
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "redirect_depth_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_resolver_redirect_loop_detected(patch_httpx) -> None:
+    """A redirect cycle must be detected even within the hop cap."""
+    import json
+
+    patch_httpx(
+        {
+            "https://entry.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://other.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+            "https://other.example/.well-known/brand.json": {
+                "body": json.dumps(
+                    {"authoritative_location": "https://entry.example/.well-known/brand.json"}
+                ).encode(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://entry.example/.well-known/brand.json",
+        agent_type="brand",
+    )
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "redirect_loop"
+
+
+@pytest.mark.asyncio
+async def test_resolver_handles_fetch_404(patch_httpx) -> None:
+    patch_httpx({})  # nothing — 404 on every call
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+    )
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "fetch_failed"
+
+
+@pytest.mark.asyncio
+async def test_resolver_handles_invalid_json(patch_httpx) -> None:
+    patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": b"not-valid-json",
+                "headers": {"content-type": "application/json"},
+            }
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+    )
+    with pytest.raises(BrandJsonResolverError) as exc:
+        await resolver("k1")
+    assert exc.value.code == "invalid_body"
+
+
+@pytest.mark.asyncio
+async def test_resolver_force_refresh_clears_snapshot(patch_httpx) -> None:
+    transport = patch_httpx(
+        {
+            "https://example.com/.well-known/brand.json": {
+                "body": _brand_json(),
+                "headers": {"content-type": "application/json"},
+            },
+        }
+    )
+    resolver = BrandJsonJwksResolver(
+        "https://example.com/.well-known/brand.json",
+        agent_type="brand",
+        jwks_fetcher=_jwks_fetcher_for(
+            {"https://x.example/jwks": {"kty": "OKP", "crv": "Ed25519", "x": "abc", "kid": "k1"}}
+        ),
+    )
+    await resolver("k1")
+    initial_calls = len(transport.calls)
+    await resolver.force_refresh()
+    # force_refresh always re-fetches brand.json (jwks fetched via
+    # the injected fetcher, not the patched transport).
+    assert len(transport.calls) > initial_calls
+
+
+@pytest.mark.asyncio
+async def test_resolver_satisfies_jwks_resolver_protocol() -> None:
+    """Structural check that the class is callable as
+    ``await resolver(kid)`` per the AsyncJwksResolver Protocol."""
+    resolver = BrandJsonJwksResolver("https://x/", agent_type="brand")
+    # Just check it's awaitable-callable; we don't actually fetch.
+    assert callable(resolver)
+    coro = resolver.resolve("k")
+    assert asyncio.iscoroutine(coro)
+    coro.close()

--- a/tests/test_capability_cache.py
+++ b/tests/test_capability_cache.py
@@ -1,0 +1,331 @@
+"""Tests for :mod:`adcp.signing.capability_cache` +
+:mod:`adcp.signing.capability_priming`.
+
+Behavior under test (matches JS port):
+
+* ``CapabilityCache.is_stale`` — TTL window + ``stale_at`` override.
+* ``build_capability_cache_key`` — exact key format match against
+  the JS surface (``agent_uri::sha256(token)[:16]::sig=fingerprint``).
+* ``ensure_capability_loaded`` — primes on miss, returns cached on
+  hit, fail-open with negative-cache TTL on fetch failure.
+* In-flight dedup — two concurrent priming calls share one fetch.
+* Transport unwrapping — MCP ``structuredContent`` /
+  ``content[].text`` / A2A ``result.artifacts[].parts[].data`` /
+  A2A ``result.parts[].data``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+
+import pytest
+
+from adcp.signing.capability_cache import (
+    CachedCapability,
+    CapabilityCache,
+    build_capability_cache_key,
+)
+from adcp.signing.capability_priming import (
+    NEGATIVE_CACHE_TTL_SECONDS,
+    _extract_capability,
+    _unwrap_response,
+    ensure_capability_loaded,
+)
+
+# ----- CapabilityCache -----
+
+
+def test_cache_get_set_invalidate() -> None:
+    cache = CapabilityCache()
+    entry = CachedCapability(
+        request_signing={"required_for": ["create_media_buy"]},
+        adcp_version=3,
+        fetched_at=1000.0,
+    )
+    assert cache.get("k") is None
+    cache.set("k", entry)
+    assert cache.get("k") is entry
+    cache.invalidate("k")
+    assert cache.get("k") is None
+
+
+def test_cache_is_stale_uses_ttl_when_no_stale_at() -> None:
+    now = 1000.0
+    cache = CapabilityCache(ttl_seconds=300, clock=lambda: now)
+    entry = CachedCapability(request_signing=None, adcp_version=None, fetched_at=now)
+    cache.set("k", entry)
+    assert cache.is_stale(entry) is False
+    now = 1000.0 + 301
+    assert cache.is_stale(entry) is True
+
+
+def test_cache_is_stale_respects_stale_at_override() -> None:
+    """Negative-cache entries set ``stale_at`` to a shorter window
+    than the default TTL — must be honored over TTL math."""
+    now = 1000.0
+    cache = CapabilityCache(ttl_seconds=300, clock=lambda: now)
+    entry = CachedCapability(
+        request_signing=None,
+        adcp_version=None,
+        fetched_at=now,
+        stale_at=now + 60,  # shorter than 300s TTL
+    )
+    assert cache.is_stale(entry) is False
+    now = 1000.0 + 61
+    assert cache.is_stale(entry) is True
+
+
+def test_cache_is_stale_returns_true_for_none() -> None:
+    cache = CapabilityCache()
+    assert cache.is_stale(None) is True
+
+
+def test_cache_clear_drops_entries_and_inflight() -> None:
+    cache = CapabilityCache()
+    cache.set("k", CachedCapability(None, None, 0.0))
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        cache._set_in_flight("k", future)
+        cache.clear()
+        assert cache.get("k") is None
+        assert cache._get_in_flight("k") is None
+    finally:
+        loop.close()
+
+
+# ----- build_capability_cache_key -----
+
+
+def test_cache_key_agent_uri_only() -> None:
+    assert build_capability_cache_key("https://agent.example.com") == ("https://agent.example.com")
+
+
+def test_cache_key_with_auth_token_uses_sha256_truncated_to_16_hex() -> None:
+    """Format must match JS exactly so a future shared cache works."""
+    token = "secret-token-abc"
+    expected_digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    key = build_capability_cache_key("https://x", auth_token=token)
+    assert key == f"https://x::{expected_digest}"
+
+
+def test_cache_key_with_signer_fingerprint() -> None:
+    key = build_capability_cache_key("https://x", signer_fingerprint="fp-abc")
+    assert key == "https://x::sig=fp-abc"
+
+
+def test_cache_key_with_both_token_and_fingerprint() -> None:
+    token = "t"
+    expected_digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    key = build_capability_cache_key("https://x", auth_token=token, signer_fingerprint="fp")
+    assert key == f"https://x::{expected_digest}::sig=fp"
+
+
+def test_cache_key_distinguishes_different_tokens() -> None:
+    a = build_capability_cache_key("https://x", auth_token="alice")
+    b = build_capability_cache_key("https://x", auth_token="bob")
+    assert a != b
+
+
+# ----- _unwrap_response (transport shape unwrapping) -----
+
+
+def test_unwrap_mcp_structured_content_wins() -> None:
+    payload = {"request_signing": {"required_for": ["x"]}}
+    response = {
+        "structuredContent": payload,
+        "content": [{"text": '{"unused": true}'}],
+    }
+    assert _unwrap_response(response) is payload
+
+
+def test_unwrap_mcp_content_text_parsed_as_json() -> None:
+    response = {"content": [{"text": '{"request_signing": {"required_for": []}}'}]}
+    result = _unwrap_response(response)
+    assert isinstance(result, dict)
+    assert result["request_signing"] == {"required_for": []}
+
+
+def test_unwrap_mcp_content_text_skips_non_json() -> None:
+    response = {
+        "content": [
+            {"text": "not-json"},
+            {"text": '{"request_signing": {}}'},
+        ],
+    }
+    result = _unwrap_response(response)
+    assert isinstance(result, dict)
+
+
+def test_unwrap_a2a_task_artifacts_parts_data() -> None:
+    payload = {"request_signing": {"required_for": ["create_media_buy"]}}
+    response = {"result": {"artifacts": [{"parts": [{"kind": "data", "data": payload}]}]}}
+    assert _unwrap_response(response) == payload
+
+
+def test_unwrap_a2a_message_parts_data() -> None:
+    payload = {"request_signing": {}}
+    response = {"result": {"parts": [{"kind": "data", "data": payload}]}}
+    assert _unwrap_response(response) == payload
+
+
+def test_unwrap_falls_through_for_already_unwrapped() -> None:
+    payload = {"request_signing": {}}
+    assert _unwrap_response(payload) is payload
+
+
+# ----- _extract_capability -----
+
+
+def test_extract_capability_present() -> None:
+    payload = {
+        "request_signing": {"required_for": ["create_media_buy"]},
+        "adcp": {"major_versions": [3, 4]},
+    }
+    rs, version = _extract_capability(payload)
+    assert rs == {"required_for": ["create_media_buy"]}
+    assert version == 3
+
+
+def test_extract_capability_no_request_signing_returns_none() -> None:
+    rs, version = _extract_capability({"adcp": {"major_versions": [3]}})
+    assert rs is None
+    assert version == 3
+
+
+def test_extract_capability_handles_missing_adcp_block() -> None:
+    rs, version = _extract_capability({"request_signing": {}})
+    assert rs == {}
+    assert version is None
+
+
+def test_extract_capability_returns_none_for_non_dict() -> None:
+    assert _extract_capability("string") == (None, None)
+    assert _extract_capability(None) == (None, None)
+    assert _extract_capability(["list"]) == (None, None)
+
+
+# ----- ensure_capability_loaded -----
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_primes_on_miss() -> None:
+    cache = CapabilityCache()
+    calls = 0
+
+    async def fetch() -> dict:
+        nonlocal calls
+        calls += 1
+        return {
+            "request_signing": {"required_for": ["create_media_buy"]},
+            "adcp": {"major_versions": [3]},
+        }
+
+    entry = await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    assert calls == 1
+    assert entry.request_signing == {"required_for": ["create_media_buy"]}
+    assert entry.adcp_version == 3
+    assert cache.get("k") is entry
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_hits_cache_on_second_call() -> None:
+    cache = CapabilityCache()
+    calls = 0
+
+    async def fetch() -> dict:
+        nonlocal calls
+        calls += 1
+        return {"request_signing": {}}
+
+    await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_failopens_with_negative_cache() -> None:
+    """When discovery fails, write a negative-cache entry with
+    ``stale_at`` set to ``fetched_at + NEGATIVE_CACHE_TTL_SECONDS``
+    and return it rather than propagating the error."""
+    cache = CapabilityCache()
+
+    async def fetch() -> dict:
+        raise ConnectionError("seller offline")
+
+    entry = await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    assert entry.request_signing is None
+    assert entry.adcp_version is None
+    assert entry.stale_at is not None
+    assert entry.stale_at - entry.fetched_at == pytest.approx(NEGATIVE_CACHE_TTL_SECONDS)
+    # Cached so the next call within the negative-cache window doesn't
+    # re-fetch.
+    assert cache.get("k") is entry
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_dedups_concurrent_calls() -> None:
+    """Two concurrent primings for the same key share one fetch."""
+    cache = CapabilityCache()
+    started = 0
+
+    async def fetch() -> dict:
+        nonlocal started
+        started += 1
+        await asyncio.sleep(0.01)
+        return {"request_signing": {"required_for": ["x"]}}
+
+    a, b = await asyncio.gather(
+        ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch),
+        ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch),
+    )
+    assert started == 1
+    assert a is b
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_unwraps_mcp_envelope() -> None:
+    cache = CapabilityCache()
+
+    async def fetch() -> dict:
+        return {
+            "structuredContent": {
+                "request_signing": {"required_for": ["create_media_buy"]},
+                "adcp": {"major_versions": [3]},
+            }
+        }
+
+    entry = await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    assert entry.request_signing == {"required_for": ["create_media_buy"]}
+    assert entry.adcp_version == 3
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_refreshes_when_stale() -> None:
+    now = [1000.0]
+    cache = CapabilityCache(ttl_seconds=10, clock=lambda: now[0])
+    calls = 0
+
+    async def fetch() -> dict:
+        nonlocal calls
+        calls += 1
+        return {"request_signing": {}}
+
+    await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    now[0] += 100  # past TTL
+    await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_drains_in_flight_after_completion() -> None:
+    """In-flight table cleans up so a later fetch isn't joined to a
+    completed promise."""
+    cache = CapabilityCache()
+
+    async def fetch() -> dict:
+        return {"request_signing": {}}
+
+    await ensure_capability_loaded(cache=cache, cache_key="k", fetch_raw=fetch)
+    assert cache._get_in_flight("k") is None


### PR DESCRIPTION
## Summary

Port of three JS-side modules that close Python's gap on the JWKS-resolution layer of the v3 trust chain. The verifier machinery already exists in \`adcp.signing/\` (verify_starlette_request, AsyncCachingJwksResolver, ReplayStore, etc.); this connects the brand-side discovery to the existing verifier.

- **\`BrandJsonJwksResolver\`** — implements \`AsyncJwksResolver\`. Walks brand.json, follows \`authoritative_location\`/\`house\` redirects, picks agent by \`(type, id?, brand_id?)\`, falls back to origin-bound \`/.well-known/jwks.json\` (security: prevents cross-origin trust pivot). Composes with existing \`AsyncCachingJwksResolver\`.
- **\`CapabilityCache\`** — TTL-based per-agent cache for \`request_signing\` capability blocks. Key format byte-identical to JS for cross-language Redis interop.
- **\`ensure_capability_loaded\`** — async primer with fail-open negative-cache TTL (60s), in-flight dedup via \`asyncio.Future\`, MCP/A2A transport unwrapping.

10 typed error codes match JS for cross-language conformance.

## Why this is a port, not new design

JS already has \`brand-jwks.ts\` (577 LOC), \`capability-cache.ts\` (119 LOC), and \`capability-priming.ts\` (159 LOC). Python's first-draft RFC initially proposed designing these from scratch — after a code audit of both sides, the actual gap is just porting the JS work. Cache key format and error code list are byte-equal so a future shared cache works cross-language.

## Composes with

- **Future Tier 2** — \`BuyerAgentRegistry\` per [adcp-client#1269](https://github.com/adcontextprotocol/adcp-client/issues/1269). The spine of round-2 commercial-layer identity. Lands without #3690.
- **Future Tier 3** — \`BrandAuthorizationResolver\` per [adcp#3690](https://github.com/adcontextprotocol/adcp/issues/3690). Per-request authz check (eTLD+1 binding, \`authorized_operators[]\`). Gated on the spec.

Full design: [\`docs/proposals/v3-identity-bundle-design.md\`](https://github.com/adcontextprotocol/adcp-client-python/blob/bokelley/v3-tier1-jwks-port/docs/proposals/v3-identity-bundle-design.md).

## Test plan

- [x] \`pytest tests/test_brand_jwks.py tests/test_capability_cache.py\` — 61 new tests pass
- [x] Full suite — 2,975 pass, 0 regressions
- [x] \`ruff check\` — clean
- [x] \`mypy\` — clean
- [x] Protocol conformance — \`isinstance(resolver, AsyncJwksResolver)\` passes
- [x] Cross-language cache key — \`build_capability_cache_key\` byte-equal to JS \`buildCapabilityCacheKey\`

## Security checks

- [x] SSRF on brand.json fetch — uses \`httpx.AsyncClient\` with default port restrictions; \`allow_private_destinations\` opt-in for dev
- [x] Bare-hostname validation on \`house\` redirect — exact regex from \`schemas/cache/brand.json\`
- [x] Cross-origin trust pivot prevention on well-known JWKS fallback (origin must match \`brand.json\` origin)
- [x] Userinfo rejection in URL canonicalization
- [x] Redirect loop + depth-cap enforcement

## Files

| File | Lines |
|---|---|
| \`src/adcp/signing/brand_jwks.py\` | 673 |
| \`src/adcp/signing/capability_cache.py\` | 177 |
| \`src/adcp/signing/capability_priming.py\` | 202 |
| \`tests/test_brand_jwks.py\` | 645 |
| \`tests/test_capability_cache.py\` | 331 |
| \`src/adcp/signing/__init__.py\` (exports) | +28 |
| \`docs/proposals/v3-identity-bundle-design.md\` | 659 |

## Cross-links

- Design: \`docs/proposals/v3-identity-bundle-design.md\`
- JS source we're porting: \`adcp-client/src/lib/signing/brand-jwks.ts\`, \`capability-cache.ts\`, \`capability-priming.ts\`
- ADCP #3690 — formalizes verifier chain (eTLD+1, \`authorized_operators[]\`)
- adcp-client#1269 — \`BuyerAgentRegistry\` design (Tier 2 follow-up)
- adcp-client#1249 — JS-side parity gaps (supervisor, audit, subdomain routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)