### PR TITLE
feat(decisioning): WebhookDeliverySupervisor + SQLAlchemy A2A stores example

### DIFF
--- a/examples/a2a_sqlalchemy_tasks.py
+++ b/examples/a2a_sqlalchemy_tasks.py
@@ -1,0 +1,434 @@
+"""Example: A2A agent with SQLAlchemy-backed durable stores.
+
+Companion to :file:`examples/a2a_db_tasks.py` (raw-SQLite reference).
+Uses SQLAlchemy ORM so the same code runs against any backend SQLA
+supports — SQLite for the demo, Postgres / MySQL in production.
+
+**Why this exists.** Adopters with an existing SQLAlchemy schema
+(salesagent, custom seller agents, anything Flask-SQLAlchemy-based)
+don't need to write raw SQL — they wrap their existing models behind
+the a2a-sdk Protocols. This example is the template:
+
+* :class:`A2ATaskRow` — minimal ORM model for the task store.
+* :class:`A2APushConfigRow` — minimal ORM model for the
+  push-notif-config store.
+* :class:`SqlAlchemyTaskStore` /
+  :class:`SqlAlchemyPushNotificationConfigStore` — the Protocol
+  implementations.
+
+Adopters with richer existing schemas keep their seller-side columns
+(salesagent's ``auth_blocked_at``, ``webhook_secret``, ``is_active``,
+etc.) and the wrapper just maps those that the protocol cares about.
+
+**Security model — same as the SQLite reference.** Tenant-scoped
+lookups via ``ServerCallContext.user.user_name``; SSRF-vulnerable
+``PushNotificationConfig.url`` MUST be validated by the seller before
+persistence (this example does NOT validate — see the SQLite reference
+docstring for the egress-allowlist pattern). Webhook secrets in
+``authentication.credentials`` / ``token`` should be envelope-encrypted
+or moved to a secrets backend in production; this example persists
+them plaintext for runnability.
+
+**Production switches:**
+
+* Swap the engine URL: ``sqlite:///a2a.db`` →
+  ``postgresql+asyncpg://...`` for Postgres.
+* Use an ``AsyncSession`` + ``create_async_engine`` for end-to-end
+  async persistence (this example uses sync sessions for clarity;
+  the Protocol methods are async, sync-engine calls run in a default
+  threadpool).
+* Add row-level TTL / GC for completed tasks.
+* Add a version column for optimistic concurrency on ``save()``.
+* Replace plaintext ``credentials`` storage with an envelope-encrypted
+  column or a secrets-backend pointer.
+
+Run::
+
+    uv run python examples/a2a_sqlalchemy_tasks.py
+
+Then connect any A2A client to ``http://localhost:3001/`` —
+``message/send`` carries a ``configuration.push_notification_config``
+that lands in the ``a2a_push_configs`` SQLite table; ``tasks/get``
+reads from ``a2a_tasks``. Tear down by deleting ``a2a_sqlalchemy.db``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import warnings
+from contextvars import ContextVar
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+from pathlib import Path
+from typing import Any
+
+from a2a import types as pb
+from a2a.server.context import ServerCallContext
+from a2a.server.tasks.push_notification_config_store import (
+    PushNotificationConfigStore,
+)
+from a2a.server.tasks.task_store import TaskStore
+
+# 1.0 folded ``PushNotificationConfig`` into
+# :class:`a2a.types.TaskPushNotificationConfig`; the protocol method
+# signatures still reference the old name. Alias for clarity.
+from a2a.types import TaskPushNotificationConfig as PushNotificationConfig
+from google.protobuf.json_format import MessageToJson, Parse
+
+try:
+    from sqlalchemy import (
+        Boolean,
+        DateTime,
+        ForeignKeyConstraint,
+        Index,
+        String,
+        Text,
+        create_engine,
+        delete,
+        select,
+    )
+    from sqlalchemy.orm import (
+        DeclarativeBase,
+        Mapped,
+        Session,
+        mapped_column,
+        sessionmaker,
+    )
+except ImportError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "examples/a2a_sqlalchemy_tasks.py needs SQLAlchemy. Install with "
+        "`pip install 'sqlalchemy>=2.0'` or `uv add sqlalchemy` and re-run."
+    ) from exc
+
+from adcp.server import ADCPHandler, capabilities_response, products_response, serve
+
+# ----------------------------------------------------------------------
+# ORM models — minimal protocol-driven schema
+# ----------------------------------------------------------------------
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class A2ATaskRow(_Base):
+    """One row per A2A task. Scope-isolated by ``scope``.
+
+    Adopters with existing seller-side task tables wrap their model
+    instead — this is the *minimum* the protocol needs. The
+    ``payload`` column carries the full ``Task.model_dump_json()``
+    blob; partial-update queries (e.g., status-only) use SQLAlchemy
+    update statements over that column.
+    """
+
+    __tablename__ = "a2a_tasks"
+
+    scope: Mapped[str] = mapped_column(String(255), primary_key=True)
+    task_id: Mapped[str] = mapped_column(String(100), primary_key=True)
+    payload: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+    __table_args__ = (Index("idx_a2a_tasks_scope", "scope"),)
+
+
+class A2APushConfigRow(_Base):
+    """One row per registered push-notification config.
+
+    Mirror of salesagent's ``push_notification_configs`` minus the
+    seller-specific columns (``auth_blocked_at``, ``is_active``,
+    ``webhook_secret``). Adopters extending this row keep their
+    existing columns and the ``A2APushConfigRow`` wrapper just maps the
+    Protocol-required subset.
+    """
+
+    __tablename__ = "a2a_push_configs"
+
+    scope: Mapped[str] = mapped_column(String(255), primary_key=True)
+    task_id: Mapped[str] = mapped_column(String(100), primary_key=True)
+    config_id: Mapped[str] = mapped_column(String(100), primary_key=True)
+    payload: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["scope", "task_id"],
+            ["a2a_tasks.scope", "a2a_tasks.task_id"],
+            ondelete="CASCADE",
+        ),
+        Index("idx_a2a_push_configs_task", "scope", "task_id"),
+    )
+
+
+# ----------------------------------------------------------------------
+# Scope resolution — derives tenant key from ServerCallContext
+# ----------------------------------------------------------------------
+
+
+_NO_AUTH_SCOPE = "anonymous"
+
+
+def _scope_from_context(context: ServerCallContext | None) -> str:
+    """Pull the tenant scope key from the call context.
+
+    Adopters with richer identity (typed ``tenant_id`` columns,
+    organization IDs) override this — the protocol only requires that
+    every read/write be filtered by the same scope value.
+
+    Returns ``_NO_AUTH_SCOPE`` for unauthenticated calls so a missing
+    context never falls through to a "no filter" query that would leak
+    other tenants' tasks.
+    """
+    if context is None or context.user is None:
+        return _NO_AUTH_SCOPE
+    return context.user.user_name or _NO_AUTH_SCOPE
+
+
+# Adopter-side push-notif scope hook. The
+# ``PushNotificationConfigStore`` Protocol does NOT receive the
+# ``ServerCallContext`` (a2a-sdk caveat — see the SQLite reference's
+# docstring); adopters compose with their tenant-scoped ``TaskStore``
+# to derive scope by walking from ``task_id`` to the owning row. This
+# example uses a contextvar that the surrounding handler populates
+# from its own auth middleware.
+_push_config_scope: ContextVar[str | None] = ContextVar("_push_config_scope", default=None)
+
+
+# ----------------------------------------------------------------------
+# TaskStore — the protocol implementation
+# ----------------------------------------------------------------------
+
+
+class SqlAlchemyTaskStore(TaskStore):
+    """Tenant-scoped, SQLAlchemy-backed :class:`TaskStore`.
+
+    All four protocol methods filter by the scope derived from
+    ``ServerCallContext`` so cross-tenant id-collision (or guessing) can
+    never leak another principal's task.
+
+    ``save`` uses ORM ``merge`` (last-writer-wins). Production stores
+    that need optimistic concurrency add a ``version`` column +
+    ``WHERE version = ?`` predicate.
+    """
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    async def save(
+        self,
+        task: pb.Task,
+        context: ServerCallContext | None = None,
+    ) -> None:
+        scope = _scope_from_context(context)
+        # a2a-sdk Tasks are protobuf messages — serialize via the proto
+        # JSON form so a different reader on the same DB (gRPC bridge,
+        # future client) sees canonical bytes.
+        with self._session_factory() as session:
+            row = A2ATaskRow(
+                scope=scope,
+                task_id=task.id,
+                payload=MessageToJson(task, preserving_proto_field_name=True),
+                updated_at=datetime.now(UTC),
+            )
+            session.merge(row)
+            session.commit()
+
+    async def get(
+        self,
+        task_id: str,
+        context: ServerCallContext | None = None,
+    ) -> pb.Task | None:
+        scope = _scope_from_context(context)
+        with self._session_factory() as session:
+            row = session.execute(
+                select(A2ATaskRow).where(A2ATaskRow.scope == scope, A2ATaskRow.task_id == task_id)
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            return Parse(row.payload, pb.Task())
+
+    async def delete(
+        self,
+        task_id: str,
+        context: ServerCallContext | None = None,
+    ) -> None:
+        scope = _scope_from_context(context)
+        with self._session_factory() as session:
+            session.execute(
+                delete(A2ATaskRow).where(A2ATaskRow.scope == scope, A2ATaskRow.task_id == task_id)
+            )
+            session.commit()
+
+    async def list(
+        self,
+        params: pb.ListTasksRequest | None = None,
+        context: ServerCallContext | None = None,
+    ) -> pb.ListTasksResponse:
+        """Return all tasks owned by the current scope.
+
+        Pagination (``params.page_token`` / ``page_size``) is left as a
+        seller exercise; production deployments add keyset pagination on
+        ``(updated_at, task_id)``.
+        """
+        scope = _scope_from_context(context)
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(A2ATaskRow)
+                .where(A2ATaskRow.scope == scope)
+                .order_by(A2ATaskRow.updated_at.desc())
+            ).scalars()
+            tasks = [Parse(row.payload, pb.Task()) for row in rows]
+        return pb.ListTasksResponse(tasks=tasks)
+
+
+# ----------------------------------------------------------------------
+# PushNotificationConfigStore — the protocol implementation
+# ----------------------------------------------------------------------
+
+
+class SqlAlchemyPushNotificationConfigStore(PushNotificationConfigStore):
+    """Tenant-scoped, SQLAlchemy-backed push-notification config store.
+
+    URL validation is the seller's responsibility. This example does
+    NOT validate ``config.push_notification_config.url`` before
+    persisting — production deployments MUST reject non-https,
+    RFC-1918, link-local IPv6, and the cloud metadata service URL
+    before this method runs. See the SQLite reference's module
+    docstring for the SSRF threat model.
+    """
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @staticmethod
+    def _scope() -> str:
+        scope = _push_config_scope.get()
+        if scope is None:
+            warnings.warn(
+                "PushNotificationConfigStore scope contextvar unset — "
+                "falling back to anonymous scope. Wire the contextvar "
+                "from your auth middleware so per-tenant config is "
+                "isolated.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return _NO_AUTH_SCOPE
+        return scope
+
+    async def set_info(
+        self,
+        task_id: str,
+        notification_config: PushNotificationConfig,
+    ) -> None:
+        scope = self._scope()
+        config_id = (
+            notification_config.push_notification_config.id
+            or notification_config.push_notification_config.url
+        )
+        with self._session_factory() as session:
+            row = A2APushConfigRow(
+                scope=scope,
+                task_id=task_id,
+                config_id=config_id,
+                payload=MessageToJson(notification_config, preserving_proto_field_name=True),
+                created_at=datetime.now(UTC),
+                is_active=True,
+            )
+            session.merge(row)
+            session.commit()
+
+    async def get_info(self, task_id: str) -> list[PushNotificationConfig]:
+        scope = self._scope()
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(A2APushConfigRow).where(
+                    A2APushConfigRow.scope == scope,
+                    A2APushConfigRow.task_id == task_id,
+                    A2APushConfigRow.is_active.is_(True),
+                )
+            ).scalars()
+            return [Parse(row.payload, PushNotificationConfig()) for row in rows]
+
+    async def delete_info(self, task_id: str, config_id: str | None = None) -> None:
+        scope = self._scope()
+        with self._session_factory() as session:
+            stmt = delete(A2APushConfigRow).where(
+                A2APushConfigRow.scope == scope,
+                A2APushConfigRow.task_id == task_id,
+            )
+            if config_id is not None:
+                stmt = stmt.where(A2APushConfigRow.config_id == config_id)
+            session.execute(stmt)
+            session.commit()
+
+
+# ----------------------------------------------------------------------
+# Engine + session factory builders
+# ----------------------------------------------------------------------
+
+
+def build_engine_and_sessions(
+    *, database_url: str = "sqlite:///a2a_sqlalchemy.db"
+) -> sessionmaker[Session]:
+    """Build a :class:`sessionmaker` for a chosen backend.
+
+    SQLite for the demo. Switch to ``postgresql+psycopg://...`` or
+    ``mysql+pymysql://...`` for production — the rest of this file
+    is unchanged.
+    """
+    if database_url.startswith("sqlite:///") and database_url != "sqlite:///:memory:":
+        # Restrict file mode on first creation so a co-tenant process
+        # on the same host can't read it. Production deployments use
+        # OS-level access control on the data directory; this match
+        # the SQLite reference's posture.
+        path = Path(database_url.removeprefix("sqlite:///")).expanduser()
+        existed = path.exists()
+        engine = create_engine(database_url, future=True)
+        _Base.metadata.create_all(engine)
+        if not existed:
+            with contextlib.suppress(OSError):
+                path.chmod(0o600)
+    else:
+        engine = create_engine(database_url, future=True)
+        _Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+
+# ----------------------------------------------------------------------
+# Minimal handler so the example runs end-to-end
+# ----------------------------------------------------------------------
+
+
+class DemoAgent(ADCPHandler):
+    async def get_adcp_capabilities(self, params: Any, context: Any = None) -> dict[str, Any]:
+        return capabilities_response(["media_buy"])
+
+    async def get_products(self, params: Any, context: Any = None) -> dict[str, Any]:
+        return products_response([{"product_id": "demo_display", "name": "Demo display placement"}])
+
+
+# ----------------------------------------------------------------------
+# Wiring — pass the stores through ``serve()``.
+# ----------------------------------------------------------------------
+
+
+def main() -> None:
+    session_factory = build_engine_and_sessions()
+    task_store = SqlAlchemyTaskStore(session_factory)
+    push_store = SqlAlchemyPushNotificationConfigStore(session_factory)
+    serve(
+        DemoAgent(),
+        name="a2a-sqlalchemy-demo",
+        transport="a2a",
+        task_store=task_store,
+        push_config_store=push_store,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -148,6 +148,7 @@ if TYPE_CHECKING:
     from adcp.decisioning.task_registry import TaskRegistry
     from adcp.decisioning.types import Account
     from adcp.webhook_sender import WebhookSender
+    from adcp.webhook_supervisor import WebhookDeliverySupervisor
 
 
 # ---------------------------------------------------------------------------
@@ -465,6 +466,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         state_reader: StateReader | None = None,
         resource_resolver: ResourceResolver | None = None,
         webhook_sender: WebhookSender | None = None,
+        webhook_supervisor: WebhookDeliverySupervisor | None = None,
         auto_emit_completion_webhooks: bool = True,
     ) -> None:
         super().__init__()
@@ -474,6 +476,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         self._state_reader = state_reader
         self._resource_resolver = resource_resolver
         self._webhook_sender = webhook_sender
+        self._webhook_supervisor = webhook_supervisor
         self._auto_emit_completion_webhooks = auto_emit_completion_webhooks
 
     # ----- account resolution helper -----
@@ -569,6 +572,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             return
         maybe_emit_sync_completion(
             sender=self._webhook_sender,
+            supervisor=self._webhook_supervisor,
             enabled=self._auto_emit_completion_webhooks,
             method_name=method_name,
             params=params,

--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from adcp.decisioning.state import StateReader
     from adcp.decisioning.task_registry import TaskRegistry
     from adcp.webhook_sender import WebhookSender
+    from adcp.webhook_supervisor import WebhookDeliverySupervisor
 
 
 def _is_production_env() -> bool:
@@ -77,6 +78,7 @@ def create_adcp_server_from_platform(
     state_reader: StateReader | None = None,
     resource_resolver: ResourceResolver | None = None,
     webhook_sender: WebhookSender | None = None,
+    webhook_supervisor: WebhookDeliverySupervisor | None = None,
     auto_emit_completion_webhooks: bool = True,
 ) -> tuple[PlatformHandler, ThreadPoolExecutor, TaskRegistry]:
     """Build the :class:`PlatformHandler` + supporting wiring from a
@@ -122,11 +124,22 @@ def create_adcp_server_from_platform(
         v6.1).
     :param webhook_sender: Bring-your-own
         :class:`adcp.webhook_sender.WebhookSender` for sync-completion
-        and HITL-completion webhook delivery. Default ``None`` — when
-        unset, sync-completion auto-emit is a silent no-op (no URL to
-        deliver to, framework can't synthesize a sender). Adopters
-        wiring webhook delivery pass a configured sender (with their
-        signing key, IP-pinned transport, etc.).
+        and HITL-completion webhook delivery. Default ``None``. The
+        sender is the *transport* — one HTTP-Signatures POST per call,
+        no retry, no breaker. Production sellers typically wrap the
+        sender in a :class:`~adcp.webhook_supervisor.WebhookDeliverySupervisor`
+        and pass that via ``webhook_supervisor=`` instead.
+    :param webhook_supervisor: Bring-your-own
+        :class:`~adcp.webhook_supervisor.WebhookDeliverySupervisor` for
+        reliable delivery (retry, circuit breaker, attempt audit). When
+        passed, the F12 auto-emit path routes through it instead of
+        ``webhook_sender``. The reference
+        :class:`~adcp.webhook_supervisor.InMemoryWebhookDeliverySupervisor`
+        wraps a sender; adopters with infra-side retry (Celery, Kafka,
+        durable outbox) implement the Protocol against their queue.
+        Mutually optional with ``webhook_sender``; passing both is
+        valid (supervisor wins for auto-emit, sender remains available
+        for direct calls inside platform methods).
     :param auto_emit_completion_webhooks: F12 feature gate. When
         ``True`` (default), the framework auto-fires a completion
         webhook on the sync-success arm of mutating tools whenever the
@@ -235,6 +248,7 @@ def create_adcp_server_from_platform(
         state_reader=state_reader,
         resource_resolver=resource_resolver,
         webhook_sender=webhook_sender,
+        webhook_supervisor=webhook_supervisor,
         auto_emit_completion_webhooks=auto_emit_completion_webhooks,
     )
 
@@ -255,6 +269,7 @@ def create_adcp_server_from_platform(
     validate_webhook_sender_for_platform(
         advertised_tools=handler.advertised_tools_for_instance(),
         sender=webhook_sender,
+        supervisor=webhook_supervisor,
         auto_emit=auto_emit_completion_webhooks,
     )
 
@@ -271,6 +286,7 @@ def serve(
     state_reader: StateReader | None = None,
     resource_resolver: ResourceResolver | None = None,
     webhook_sender: WebhookSender | None = None,
+    webhook_supervisor: WebhookDeliverySupervisor | None = None,
     auto_emit_completion_webhooks: bool = True,
     advertise_all: bool = False,
     **serve_kwargs: Any,
@@ -294,7 +310,15 @@ def serve(
     :param resource_resolver: Custom :class:`ResourceResolver` impl (D15).
     :param webhook_sender: BYO :class:`adcp.webhook_sender.WebhookSender`
         for completion webhook delivery (sync auto-emit + HITL terminal).
-        ``None`` disables auto-emit silently.
+        Transport only — one attempt, no retry. ``None`` disables
+        auto-emit silently.
+    :param webhook_supervisor: BYO
+        :class:`~adcp.webhook_supervisor.WebhookDeliverySupervisor` for
+        reliable delivery (retry, circuit breaker, attempt audit).
+        Takes precedence over ``webhook_sender`` for F12 auto-emit
+        when both are passed. Production sellers typically pass an
+        :class:`~adcp.webhook_supervisor.InMemoryWebhookDeliverySupervisor`
+        wrapping their sender.
     :param auto_emit_completion_webhooks: F12 — auto-fire a completion
         webhook on the sync-success arm of mutating tools when the
         request supplied ``push_notification_config.url``. Default
@@ -322,6 +346,7 @@ def serve(
         state_reader=state_reader,
         resource_resolver=resource_resolver,
         webhook_sender=webhook_sender,
+        webhook_supervisor=webhook_supervisor,
         auto_emit_completion_webhooks=auto_emit_completion_webhooks,
     )
 

--- a/src/adcp/decisioning/webhook_emit.py
+++ b/src/adcp/decisioning/webhook_emit.py
@@ -47,6 +47,9 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from adcp.webhook_sender import WebhookSender
+    from adcp.webhook_supervisor import WebhookDeliverySupervisor
+
+    DeliveryTarget = WebhookSender | WebhookDeliverySupervisor
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +128,7 @@ def _extract_push_notification_url_and_token(
 
 async def _emit_sync_completion_webhook(
     *,
-    sender: WebhookSender,
+    target: DeliveryTarget,
     url: str,
     token: str | None,
     method_name: str,
@@ -139,10 +142,15 @@ async def _emit_sync_completion_webhook(
     correlate primarily via resource ids on ``result``
     (``media_buy_id``, ``creative_id``, etc.); ``task_id`` here is
     informational for the spec's required-field shape.
+
+    ``target`` is either a bare :class:`WebhookSender` (one attempt,
+    no breaker) or a :class:`WebhookDeliverySupervisor` (retry, breaker,
+    optional delivery log). Both expose ``send_mcp(...)`` with
+    compatible kwargs; the call site is polymorphic.
     """
     task_id = f"sync-{uuid.uuid4().hex[:16]}"
     try:
-        await sender.send_mcp(
+        await target.send_mcp(
             url=url,
             task_id=task_id,
             status="completed",
@@ -169,6 +177,7 @@ def maybe_emit_sync_completion(
     method_name: str,
     params: Any,
     result: Any,
+    supervisor: WebhookDeliverySupervisor | None = None,
 ) -> None:
     """Fire-and-forget auto-emit gate. Called by handler shims after
     the sync-success arm of mutating tools.
@@ -217,7 +226,8 @@ def maybe_emit_sync_completion(
         if config is None:
             return  # buyer didn't register — nothing to do
 
-        if sender is None:
+        target = supervisor or sender
+        if target is None:
             # Buyer registered a webhook config but the adopter didn't
             # wire a sender. Without this branch, the buyer's
             # notification quietly disappears — they think they
@@ -237,8 +247,8 @@ def maybe_emit_sync_completion(
             logger.warning(
                 "[adcp.decisioning] buyer registered "
                 "push_notification_config (url=%s) for %s but auto-emit "
-                "webhook_sender is None — webhook silently dropped. "
-                "Pass webhook_sender to "
+                "has neither webhook_sender nor webhook_supervisor — "
+                "webhook silently dropped. Pass one to "
                 "adcp.decisioning.serve.create_adcp_server_from_platform, "
                 "or set auto_emit_completion_webhooks=False to silence "
                 "this warning.",
@@ -279,7 +289,7 @@ def maybe_emit_sync_completion(
             return
         bg = loop.create_task(
             _emit_sync_completion_webhook(
-                sender=sender,
+                target=target,
                 url=url,
                 token=token,
                 method_name=method_name,
@@ -307,6 +317,7 @@ def validate_webhook_sender_for_platform(
     advertised_tools: frozenset[str] | set[str],
     sender: Any,
     auto_emit: bool,
+    supervisor: Any = None,
 ) -> None:
     """Server-boot fail-fast for the F12 misconfig (Emma sales-direct
     P0 root cause).
@@ -314,9 +325,9 @@ def validate_webhook_sender_for_platform(
     When an adopter claims a specialism whose tool surface includes
     any spec-eligible webhook task type (e.g., ``create_media_buy``,
     ``activate_signal``, ``acquire_rights``) AND auto-emit is on AND
-    no ``webhook_sender`` is wired, every buyer who registers
-    ``push_notification_config.url`` would have their notification
-    silently dropped. The runtime gate at
+    neither ``webhook_sender`` nor ``webhook_supervisor`` is wired,
+    every buyer who registers ``push_notification_config.url`` would
+    have their notification silently dropped. The runtime gate at
     :func:`maybe_emit_sync_completion` warns on the FIRST call, but
     by then the buyer has already burned a request and the adopter
     has shipped without webhook wiring.
@@ -335,7 +346,7 @@ def validate_webhook_sender_for_platform(
     """
     if not auto_emit:
         return
-    if sender is not None:
+    if sender is not None or supervisor is not None:
         return
     eligible = SPEC_WEBHOOK_TASK_TYPES & set(advertised_tools)
     if not eligible:
@@ -347,18 +358,19 @@ def validate_webhook_sender_for_platform(
         message=(
             "auto_emit_completion_webhooks is enabled and the platform's "
             "claimed specialisms expose webhook-eligible tools "
-            f"{sorted(eligible)!r}, but no webhook_sender was wired. "
-            "Buyers who register push_notification_config.url on these "
-            "tools would have their notifications silently dropped. "
-            "Either pass a configured WebhookSender via "
-            "adcp.decisioning.serve.create_adcp_server_from_platform("
-            "..., webhook_sender=...), or set "
-            "auto_emit_completion_webhooks=False if you handle webhooks "
-            "manually inside your platform methods."
+            f"{sorted(eligible)!r}, but neither webhook_sender nor "
+            "webhook_supervisor was wired. Buyers who register "
+            "push_notification_config.url on these tools would have their "
+            "notifications silently dropped. Pass a configured "
+            "WebhookSender (transport only) or InMemoryWebhookDeliverySupervisor "
+            "(retry + circuit breaker) to "
+            "adcp.decisioning.serve.create_adcp_server_from_platform, "
+            "or set auto_emit_completion_webhooks=False if you handle "
+            "webhooks manually inside your platform methods."
         ),
         recovery="terminal",
         details={
-            "missing": "webhook_sender",
+            "missing": "webhook_sender_or_supervisor",
             "webhook_eligible_tools": sorted(eligible),
         },
     )

--- a/src/adcp/webhook_supervisor.py
+++ b/src/adcp/webhook_supervisor.py
@@ -44,12 +44,17 @@ import asyncio
 import logging
 import random
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-
-UTC = timezone.utc
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+
+# Python 3.11 added ``datetime.UTC`` as an alias; we still target 3.10
+# so we reach for ``timezone.utc`` and re-export the short name. Defined
+# AFTER all imports so the import block stays clean for ruff's
+# isort rule.
+UTC = timezone.utc
 
 if TYPE_CHECKING:
     from adcp.types import GeneratedTaskStatus
@@ -68,12 +73,19 @@ class RetryPolicy:
     Defaults match the salesagent reference adopter (3 attempts,
     exponential backoff with jitter, 1s base, 30s cap). Adopters with
     different SLAs override per-supervisor.
+
+    ``sink_timeout_seconds`` bounds how long a slow
+    :class:`DeliveryLogSink.record` call can stall the supervisor's
+    hot path (default 5s). Sink timeouts log a warning and continue
+    delivery — a misbehaving sink must not be able to wedge the
+    delivery pipeline.
     """
 
     max_attempts: int = 3
     base_delay_seconds: float = 1.0
     max_delay_seconds: float = 30.0
     jitter: bool = True
+    sink_timeout_seconds: float = 5.0
 
     def delay_for_attempt(self, attempt_number: int) -> float:
         """Compute the sleep before ``attempt_number`` (1-indexed).
@@ -124,6 +136,20 @@ class DeliveryAttempt:
     Sellers wire a sink that maps these to their existing
     ``webhook_delivery_log`` schema. The supervisor itself doesn't
     persist anything — the sink is the BYO storage seam.
+
+    .. note::
+        ``error_message`` may contain bytes from the buyer's webhook
+        receiver (sliced via ``repr()`` to 200 chars). Adopters
+        persisting this field to wide-readable logs SHOULD redact
+        further at the sink layer; an attacker buyer could include
+        prejudicial content in their error response body.
+
+    ``notification_type`` is provided as a passthrough for delivery
+    reports (per ``schemas/cache/media-buy/get-media-buy-delivery-response.json``:
+    ``scheduled`` / ``final`` / ``adjusted`` / ``delayed`` /
+    ``window_update``). Sync-completion auto-emit (F12) is not a
+    delivery report and leaves this ``None``; adopters firing
+    delivery reports manually populate it.
     """
 
     url: str
@@ -141,6 +167,7 @@ class DeliveryAttempt:
     task_type: str | None
     task_id: str | None
     payload_size_bytes: int | None
+    notification_type: str | None = None
 
 
 @runtime_checkable
@@ -217,7 +244,12 @@ class _CircuitBreaker:
                     self._success_count = 0
                     return True
                 return False
-            return True  # HALF_OPEN allows one test attempt at a time
+            # HALF_OPEN: every caller passes through and runs an attempt.
+            # No in-flight counter — concurrent attempts are intentional
+            # so one slow response doesn't gate other readiness probes.
+            # ``success_threshold`` consecutive successes still required
+            # to transition back to CLOSED.
+            return True
 
     def record_success(self) -> None:
         with self._lock:
@@ -228,9 +260,20 @@ class _CircuitBreaker:
                     self._state = CircuitState.CLOSED
                     self._success_count = 0
             elif self._state is CircuitState.OPEN:
-                # Defensive: a success while OPEN means the breaker raced
-                # past its timeout. Reset cleanly.
-                self._state = CircuitState.CLOSED
+                # A success while OPEN should be unreachable because
+                # ``can_attempt()`` is the only path that lets a sender
+                # call through. If it does happen, treat as the start of
+                # a HALF_OPEN probe rather than a clean recovery — a
+                # single racy success isn't enough to declare the
+                # endpoint healthy. Surface a warning so the underlying
+                # state-machine bug becomes visible.
+                logger.warning(
+                    "[adcp.webhook_supervisor] CircuitBreaker.record_success "
+                    "called while state=OPEN — transitioning to HALF_OPEN. "
+                    "This indicates a state-machine race; please report."
+                )
+                self._state = CircuitState.HALF_OPEN
+                self._success_count = 1
 
     def record_failure(self) -> None:
         with self._lock:
@@ -278,32 +321,72 @@ class InMemoryWebhookDeliverySupervisor:
         circuit: CircuitBreakerPolicy | None = None,
         log_sink: DeliveryLogSink | None = None,
     ) -> None:
+        # Fail-fast: a None sender would later AttributeError on every
+        # send_mcp call. The boot-time webhook gate also passes when a
+        # supervisor is wired, so we'd defeat its fail-fast intent
+        # without this check.
+        if sender is None:
+            raise ValueError(
+                "InMemoryWebhookDeliverySupervisor requires a non-None "
+                "WebhookSender. Construct one via WebhookSender.from_jwk(...) "
+                "or WebhookSender.from_pem(...) and pass it as the first "
+                "positional argument."
+            )
         self._sender = sender
         self._retry = retry or RetryPolicy()
         self._circuit_policy = circuit or CircuitBreakerPolicy()
         self._log_sink = log_sink
+        # Breakers keyed on (breaker_key or url). When two tenants share
+        # a SaaS receiver URL (Zapier, Make, etc.), pass a tenant-scoped
+        # ``breaker_key`` to ``send_mcp`` so one tenant's failures don't
+        # quarantine another tenant's deliveries.
         self._breakers: dict[str, _CircuitBreaker] = {}
+        # Per-``sequence_key`` monotonic counter. Recommend using a
+        # per-stream key like ``f"{media_buy_id}:{url}"`` for delivery
+        # reports — multiple subscribers per media_buy each need their
+        # own sequence numbering. In-memory only; multi-instance
+        # deployments will collide on the wire and need to implement
+        # the Protocol against durable storage. This warning fires once
+        # at first allocation so operators see it on cold start.
         self._sequence_numbers: dict[str, int] = {}
+        self._sequence_warned = False
         self._state_lock = threading.Lock()
 
     def next_sequence(self, key: str) -> int:
         """Allocate the next sequence number for ``key`` (1-indexed).
 
+        Recommend a per-stream key like ``f"{media_buy_id}:{url}"`` for
+        delivery-report webhooks — multiple subscribers per media buy
+        each need their own monotonic stream. ``media_buy_id`` alone
+        would have all subscribers share a sequence, which the spec's
+        delivery-report semantics don't support (each receiver sees
+        non-contiguous numbers).
+
         Sellers who manage sequence numbers themselves (e.g., persisted
-        in a database column) ignore this and pass their own value via
-        wherever it's used downstream.
+        in a database column for cross-restart durability) ignore this
+        and pass their own value via wherever it's used downstream.
         """
         with self._state_lock:
+            if not self._sequence_warned:
+                self._sequence_warned = True
+                logger.info(
+                    "[adcp.webhook_supervisor] in-process sequence numbers "
+                    "are not durable across process restart and not shared "
+                    "across multi-worker deployments. Sellers needing "
+                    "cross-restart sequence semantics should implement "
+                    "WebhookDeliverySupervisor against their persistence "
+                    "layer."
+                )
             current = self._sequence_numbers.get(key, 0) + 1
             self._sequence_numbers[key] = current
             return current
 
-    def _breaker_for(self, url: str) -> _CircuitBreaker:
+    def _breaker_for(self, key: str) -> _CircuitBreaker:
         with self._state_lock:
-            breaker = self._breakers.get(url)
+            breaker = self._breakers.get(key)
             if breaker is None:
                 breaker = _CircuitBreaker(self._circuit_policy)
-                self._breakers[url] = breaker
+                self._breakers[key] = breaker
             return breaker
 
     async def send_mcp(
@@ -316,6 +399,8 @@ class InMemoryWebhookDeliverySupervisor:
         result: Any = None,
         token: str | None = None,
         sequence_key: str | None = None,
+        breaker_key: str | None = None,
+        notification_type: str | None = None,
     ) -> WebhookDeliveryResult | None:
         """Deliver one MCP-style webhook with retry + circuit-breaker.
 
@@ -324,18 +409,45 @@ class InMemoryWebhookDeliverySupervisor:
         breaker is OPEN and no attempt is made (the audit log records
         a ``circuit_open`` row regardless).
 
+        :param breaker_key: Override the circuit-breaker key (default:
+            ``url``). Multi-tenant sellers whose buyers register
+            shared SaaS receiver URLs (Zapier, Make, etc.) MUST pass a
+            tenant-scoped key (e.g., ``f"{tenant_id}:{url}"``) so one
+            tenant's failures don't quarantine deliveries to the same
+            URL for another tenant.
+        :param sequence_key: Allocates a per-stream sequence number
+            via :meth:`next_sequence`. Recommend
+            ``f"{media_buy_id}:{url}"`` (per-receiver stream); see
+            :meth:`next_sequence` for the rationale.
+        :param notification_type: Passthrough to ``DeliveryAttempt``
+            for delivery-report webhooks (``scheduled`` / ``final`` /
+            ``adjusted`` / ``delayed`` / ``window_update``). F12
+            sync-completion auto-emit doesn't use this.
+
+        **Idempotency-key reuse on retry** (per spec
+        ``mcp-webhook-payload.json``: "Publishers MUST … reuse the
+        same key on every retry"): attempts 2+ replay the exact bytes
+        of attempt 1 via :meth:`WebhookSender.resend`, preserving the
+        ``idempotency_key`` for receiver-side dedup. Only attempt 1
+        (or any attempt whose predecessor raised before producing a
+        result) calls ``send_mcp`` fresh.
+
+        Each attempt is logged to the :class:`DeliveryLogSink` if one
+        is configured. Sink failures are swallowed; a slow sink is
+        bounded by ``RetryPolicy.sink_timeout_seconds``.
+
         Each attempt is logged to the :class:`DeliveryLogSink` if one
         is configured. Sink failures are swallowed.
         """
-        breaker = self._breaker_for(url)
-        sequence_number = self.next_sequence(sequence_key) if sequence_key is not None else None
+        breaker = self._breaker_for(breaker_key or url)
+        sequence_number: int | None = None  # allocated AFTER breaker check
 
         if not breaker.can_attempt():
             await self._record(
                 DeliveryAttempt(
                     url=url,
                     sequence_key=sequence_key,
-                    sequence_number=sequence_number,
+                    sequence_number=None,
                     attempt_number=0,
                     max_attempts=self._retry.max_attempts,
                     outcome="circuit_open",
@@ -348,6 +460,7 @@ class InMemoryWebhookDeliverySupervisor:
                     task_type=task_type,
                     task_id=task_id,
                     payload_size_bytes=None,
+                    notification_type=notification_type,
                 )
             )
             logger.warning(
@@ -357,6 +470,13 @@ class InMemoryWebhookDeliverySupervisor:
             )
             return None
 
+        # Allocate sequence number AFTER the breaker check so we don't
+        # burn numbers on circuit-open skips. Once allocated, the same
+        # sequence number is used for every attempt of THIS delivery
+        # (per-delivery, not per-attempt).
+        if sequence_key is not None:
+            sequence_number = self.next_sequence(sequence_key)
+
         last_result: WebhookDeliveryResult | None = None
         for attempt_number in range(1, self._retry.max_attempts + 1):
             delay = self._retry.delay_for_attempt(attempt_number)
@@ -364,16 +484,25 @@ class InMemoryWebhookDeliverySupervisor:
                 await asyncio.sleep(delay)
 
             attempt_started = datetime.now(UTC)
+            attempt_started_monotonic = time.monotonic()
             try:
-                last_result = await self._sender.send_mcp(
-                    url=url,
-                    task_id=task_id,
-                    status=status,
-                    task_type=task_type,
-                    result=result,
-                    token=token,
-                )
-                response_time_ms = int((datetime.now(UTC) - attempt_started).total_seconds() * 1000)
+                # Spec-compliant retry: replay the exact bytes (same
+                # idempotency_key) on attempts 2+ via ``resend``. Only
+                # attempt 1, or attempts whose predecessor raised
+                # before producing a result with bytes, call send_mcp
+                # fresh.
+                if last_result is not None and last_result.sent_body:
+                    last_result = await self._sender.resend(last_result)
+                else:
+                    last_result = await self._sender.send_mcp(
+                        url=url,
+                        task_id=task_id,
+                        status=status,
+                        task_type=task_type,
+                        result=result,
+                        token=token,
+                    )
+                response_time_ms = int((time.monotonic() - attempt_started_monotonic) * 1000)
                 if last_result.ok:
                     breaker.record_success()
                     await self._record(
@@ -393,6 +522,7 @@ class InMemoryWebhookDeliverySupervisor:
                             task_type=task_type,
                             task_id=task_id,
                             payload_size_bytes=len(last_result.sent_body),
+                            notification_type=notification_type,
                         )
                     )
                     return last_result
@@ -427,10 +557,11 @@ class InMemoryWebhookDeliverySupervisor:
                         task_type=task_type,
                         task_id=task_id,
                         payload_size_bytes=len(last_result.sent_body),
+                        notification_type=notification_type,
                     )
                 )
             except Exception as exc:
-                response_time_ms = int((datetime.now(UTC) - attempt_started).total_seconds() * 1000)
+                response_time_ms = int((time.monotonic() - attempt_started_monotonic) * 1000)
                 will_retry = attempt_number < self._retry.max_attempts
                 next_delay = (
                     self._retry.delay_for_attempt(attempt_number + 1) if will_retry else None
@@ -458,6 +589,7 @@ class InMemoryWebhookDeliverySupervisor:
                         task_type=task_type,
                         task_id=task_id,
                         payload_size_bytes=None,
+                        notification_type=notification_type,
                     )
                 )
                 if not will_retry:
@@ -466,10 +598,29 @@ class InMemoryWebhookDeliverySupervisor:
         return last_result
 
     async def _record(self, attempt: DeliveryAttempt) -> None:
+        """Persist one attempt to the configured sink.
+
+        Bounded by ``RetryPolicy.sink_timeout_seconds`` (default 5s)
+        so a misbehaving sink (DB stall, lock contention, unbounded
+        queue) cannot freeze the supervisor's hot path. Both timeout
+        and exception are logged-and-swallowed — a broken sink must
+        not cascade into webhook delivery loss.
+        """
         if self._log_sink is None:
             return
         try:
-            await self._log_sink.record(attempt)
+            await asyncio.wait_for(
+                self._log_sink.record(attempt),
+                timeout=self._retry.sink_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[adcp.webhook_supervisor] DeliveryLogSink timed out "
+                "after %ss on attempt for %s — log dropped, delivery "
+                "unaffected",
+                self._retry.sink_timeout_seconds,
+                attempt.url,
+            )
         except Exception:
             logger.warning(
                 "[adcp.webhook_supervisor] DeliveryLogSink raised on attempt "

--- a/src/adcp/webhook_supervisor.py
+++ b/src/adcp/webhook_supervisor.py
@@ -1,0 +1,511 @@
+"""Webhook delivery supervisor — retry, circuit breaker, attempt audit.
+
+:class:`~adcp.webhook_sender.WebhookSender` is the *transport* layer:
+HTTP-Signatures-aware POST, one attempt, returns a result. It does not
+retry, does not isolate failing endpoints, and does not record attempts.
+
+Production sellers wrap that transport with reliability logic — the
+salesagent reference adopter ships ~1,000 LOC of circuit breaker,
+exponential backoff, and persisted delivery log around it. This module
+is the SDK home for that pattern so adopters don't have to write it
+from scratch.
+
+Two seams:
+
+* :class:`WebhookDeliverySupervisor` — Protocol. Adopters with their
+  own infra-side retry (Celery, Kafka, durable outbox) implement this
+  against their queue and pass it to
+  :func:`adcp.decisioning.serve.serve` instead of (or alongside) a
+  bare ``WebhookSender``.
+
+* :class:`InMemoryWebhookDeliverySupervisor` — reference impl. Wraps a
+  :class:`WebhookSender` with per-endpoint :class:`CircuitBreaker` and
+  retry-with-jitter. Single-process, in-memory state — adequate for
+  single-instance servers; multi-instance deployments that need shared
+  breaker state should implement the Protocol against Redis or
+  similar.
+
+Audit trail: every attempt produces a :class:`DeliveryAttempt` record
+that an optional :class:`DeliveryLogSink` can persist. Adopters with an
+existing ``webhook_delivery_log`` table wire a sink that maps the
+record to their schema; adopters without one can ignore the seam.
+
+Sequence numbers: the supervisor maintains a per-``sequence_key``
+monotonic counter so adopters that need it (e.g., delivery report
+webhooks where the buyer correlates by sequence #) can request one via
+:meth:`InMemoryWebhookDeliverySupervisor.next_sequence`. Sellers who
+need durable cross-restart sequence numbers implement the Protocol
+against their persistence layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from adcp.types import GeneratedTaskStatus
+    from adcp.webhook_sender import WebhookDeliveryResult, WebhookSender
+
+logger = logging.getLogger(__name__)
+
+
+# ----- Policy dataclasses -----
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Retry behavior for a single :meth:`send_mcp` call.
+
+    Defaults match the salesagent reference adopter (3 attempts,
+    exponential backoff with jitter, 1s base, 30s cap). Adopters with
+    different SLAs override per-supervisor.
+    """
+
+    max_attempts: int = 3
+    base_delay_seconds: float = 1.0
+    max_delay_seconds: float = 30.0
+    jitter: bool = True
+
+    def delay_for_attempt(self, attempt_number: int) -> float:
+        """Compute the sleep before ``attempt_number`` (1-indexed).
+
+        Attempt 1 has no preceding delay; attempts 2+ use exponential
+        backoff capped at ``max_delay_seconds`` with optional jitter.
+        """
+        if attempt_number <= 1:
+            return 0.0
+        delay: float = min(
+            self.base_delay_seconds * (2 ** (attempt_number - 2)),
+            self.max_delay_seconds,
+        )
+        if self.jitter:
+            delay = delay * (0.5 + random.random() * 0.5)
+        return delay
+
+
+@dataclass(frozen=True)
+class CircuitBreakerPolicy:
+    """Per-endpoint circuit breaker tuning.
+
+    Defaults match the salesagent reference (5 consecutive failures
+    open, 60s recovery test, 2 successes close).
+    """
+
+    failure_threshold: int = 5
+    success_threshold: int = 2
+    open_timeout_seconds: float = 60.0
+
+
+# ----- Attempt record + sink -----
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+AttemptOutcome = Literal["success", "failure", "circuit_open"]
+
+
+@dataclass(frozen=True)
+class DeliveryAttempt:
+    """One record passed to :class:`DeliveryLogSink` per delivery attempt.
+
+    Sellers wire a sink that maps these to their existing
+    ``webhook_delivery_log`` schema. The supervisor itself doesn't
+    persist anything — the sink is the BYO storage seam.
+    """
+
+    url: str
+    sequence_key: str | None
+    sequence_number: int | None
+    attempt_number: int
+    max_attempts: int
+    outcome: AttemptOutcome
+    http_status_code: int | None
+    error_message: str | None
+    response_time_ms: int
+    occurred_at: datetime
+    will_retry: bool
+    next_retry_at: datetime | None
+    task_type: str | None
+    task_id: str | None
+    payload_size_bytes: int | None
+
+
+@runtime_checkable
+class DeliveryLogSink(Protocol):
+    """Optional persistence hook for delivery attempts.
+
+    Called once per attempt. Failures inside ``record`` are
+    logged-and-swallowed by the supervisor — a broken sink must not
+    cascade into webhook delivery loss.
+
+    Adopters typically wire this to a ``webhook_delivery_log`` table in
+    their existing schema. No-op implementations are valid for adopters
+    who don't need attempt-level audit.
+    """
+
+    async def record(self, attempt: DeliveryAttempt) -> None: ...
+
+
+# ----- Supervisor Protocol -----
+
+
+@runtime_checkable
+class WebhookDeliverySupervisor(Protocol):
+    """Reliable webhook delivery surface.
+
+    Conforms to the ``send_mcp`` shape used by F12 sync-completion
+    webhooks. Adopters that route deliveries through a durable queue
+    (Celery, Kafka, outbox-pattern) implement this Protocol against
+    their queue's enqueue API; the SDK's call site is identical.
+
+    The reference :class:`InMemoryWebhookDeliverySupervisor` wraps a
+    :class:`~adcp.webhook_sender.WebhookSender` with circuit breaker +
+    retry; sellers with their own infra implement the Protocol
+    directly without using the reference.
+    """
+
+    async def send_mcp(
+        self,
+        *,
+        url: str,
+        task_id: str,
+        status: GeneratedTaskStatus | str,
+        task_type: str | None = None,
+        result: Any = None,
+        token: str | None = None,
+        sequence_key: str | None = None,
+    ) -> WebhookDeliveryResult | None: ...
+
+
+# ----- Reference implementation -----
+
+
+class _CircuitBreaker:
+    """Per-endpoint breaker. Internal — sellers tune via :class:`CircuitBreakerPolicy`."""
+
+    def __init__(self, policy: CircuitBreakerPolicy) -> None:
+        self._policy = policy
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._success_count = 0
+        self._opened_at: datetime | None = None
+        self._lock = threading.Lock()
+
+    def can_attempt(self) -> bool:
+        with self._lock:
+            if self._state is CircuitState.CLOSED:
+                return True
+            if self._state is CircuitState.OPEN:
+                if self._opened_at is None:
+                    return True
+                elapsed = (datetime.now(UTC) - self._opened_at).total_seconds()
+                if elapsed >= self._policy.open_timeout_seconds:
+                    self._state = CircuitState.HALF_OPEN
+                    self._success_count = 0
+                    return True
+                return False
+            return True  # HALF_OPEN allows one test attempt at a time
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failure_count = 0
+            if self._state is CircuitState.HALF_OPEN:
+                self._success_count += 1
+                if self._success_count >= self._policy.success_threshold:
+                    self._state = CircuitState.CLOSED
+                    self._success_count = 0
+            elif self._state is CircuitState.OPEN:
+                # Defensive: a success while OPEN means the breaker raced
+                # past its timeout. Reset cleanly.
+                self._state = CircuitState.CLOSED
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._failure_count += 1
+            if self._state is CircuitState.HALF_OPEN:
+                self._state = CircuitState.OPEN
+                self._opened_at = datetime.now(UTC)
+                self._success_count = 0
+            elif (
+                self._state is CircuitState.CLOSED
+                and self._failure_count >= self._policy.failure_threshold
+            ):
+                self._state = CircuitState.OPEN
+                self._opened_at = datetime.now(UTC)
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+
+class InMemoryWebhookDeliverySupervisor:
+    """Reference :class:`WebhookDeliverySupervisor` with in-process state.
+
+    Single-instance — circuit breaker counters live in the running
+    process. Multi-instance deployments that need shared breaker state
+    implement the Protocol against a distributed cache (Redis,
+    Memcached) instead of using this class.
+
+    Wraps an underlying :class:`~adcp.webhook_sender.WebhookSender` for
+    actual HTTP-Signatures send. Per-endpoint state isolation: each
+    URL gets its own breaker so one buyer's outage doesn't quarantine
+    another.
+
+    Sequence numbers: per-``sequence_key`` monotonic counters live in
+    memory. Sellers that need cross-restart sequence numbers (e.g., to
+    persist delivery report sequence # in their database) implement the
+    Protocol directly against their persistence layer instead.
+    """
+
+    def __init__(
+        self,
+        sender: WebhookSender,
+        *,
+        retry: RetryPolicy | None = None,
+        circuit: CircuitBreakerPolicy | None = None,
+        log_sink: DeliveryLogSink | None = None,
+    ) -> None:
+        self._sender = sender
+        self._retry = retry or RetryPolicy()
+        self._circuit_policy = circuit or CircuitBreakerPolicy()
+        self._log_sink = log_sink
+        self._breakers: dict[str, _CircuitBreaker] = {}
+        self._sequence_numbers: dict[str, int] = {}
+        self._state_lock = threading.Lock()
+
+    def next_sequence(self, key: str) -> int:
+        """Allocate the next sequence number for ``key`` (1-indexed).
+
+        Sellers who manage sequence numbers themselves (e.g., persisted
+        in a database column) ignore this and pass their own value via
+        wherever it's used downstream.
+        """
+        with self._state_lock:
+            current = self._sequence_numbers.get(key, 0) + 1
+            self._sequence_numbers[key] = current
+            return current
+
+    def _breaker_for(self, url: str) -> _CircuitBreaker:
+        with self._state_lock:
+            breaker = self._breakers.get(url)
+            if breaker is None:
+                breaker = _CircuitBreaker(self._circuit_policy)
+                self._breakers[url] = breaker
+            return breaker
+
+    async def send_mcp(
+        self,
+        *,
+        url: str,
+        task_id: str,
+        status: GeneratedTaskStatus | str,
+        task_type: str | None = None,
+        result: Any = None,
+        token: str | None = None,
+        sequence_key: str | None = None,
+    ) -> WebhookDeliveryResult | None:
+        """Deliver one MCP-style webhook with retry + circuit-breaker.
+
+        Returns the final attempt's :class:`WebhookDeliveryResult` on
+        success or the last failed attempt; returns ``None`` when the
+        breaker is OPEN and no attempt is made (the audit log records
+        a ``circuit_open`` row regardless).
+
+        Each attempt is logged to the :class:`DeliveryLogSink` if one
+        is configured. Sink failures are swallowed.
+        """
+        breaker = self._breaker_for(url)
+        sequence_number = self.next_sequence(sequence_key) if sequence_key is not None else None
+
+        if not breaker.can_attempt():
+            await self._record(
+                DeliveryAttempt(
+                    url=url,
+                    sequence_key=sequence_key,
+                    sequence_number=sequence_number,
+                    attempt_number=0,
+                    max_attempts=self._retry.max_attempts,
+                    outcome="circuit_open",
+                    http_status_code=None,
+                    error_message=(f"circuit breaker OPEN for {url} — skipped delivery"),
+                    response_time_ms=0,
+                    occurred_at=datetime.now(UTC),
+                    will_retry=False,
+                    next_retry_at=None,
+                    task_type=task_type,
+                    task_id=task_id,
+                    payload_size_bytes=None,
+                )
+            )
+            logger.warning(
+                "[adcp.webhook_supervisor] circuit OPEN for %s — skipped %s",
+                url,
+                task_type or "webhook",
+            )
+            return None
+
+        last_result: WebhookDeliveryResult | None = None
+        for attempt_number in range(1, self._retry.max_attempts + 1):
+            delay = self._retry.delay_for_attempt(attempt_number)
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+            attempt_started = datetime.now(UTC)
+            try:
+                last_result = await self._sender.send_mcp(
+                    url=url,
+                    task_id=task_id,
+                    status=status,
+                    task_type=task_type,
+                    result=result,
+                    token=token,
+                )
+                response_time_ms = int((datetime.now(UTC) - attempt_started).total_seconds() * 1000)
+                if last_result.ok:
+                    breaker.record_success()
+                    await self._record(
+                        DeliveryAttempt(
+                            url=url,
+                            sequence_key=sequence_key,
+                            sequence_number=sequence_number,
+                            attempt_number=attempt_number,
+                            max_attempts=self._retry.max_attempts,
+                            outcome="success",
+                            http_status_code=last_result.status_code,
+                            error_message=None,
+                            response_time_ms=response_time_ms,
+                            occurred_at=attempt_started,
+                            will_retry=False,
+                            next_retry_at=None,
+                            task_type=task_type,
+                            task_id=task_id,
+                            payload_size_bytes=len(last_result.sent_body),
+                        )
+                    )
+                    return last_result
+                # Non-2xx — count as failure for breaker, retry
+                will_retry = attempt_number < self._retry.max_attempts
+                next_delay = (
+                    self._retry.delay_for_attempt(attempt_number + 1) if will_retry else None
+                )
+                next_retry_at = (
+                    attempt_started + timedelta(seconds=next_delay)
+                    if next_delay is not None
+                    else None
+                )
+                breaker.record_failure()
+                await self._record(
+                    DeliveryAttempt(
+                        url=url,
+                        sequence_key=sequence_key,
+                        sequence_number=sequence_number,
+                        attempt_number=attempt_number,
+                        max_attempts=self._retry.max_attempts,
+                        outcome="failure",
+                        http_status_code=last_result.status_code,
+                        error_message=(
+                            f"HTTP {last_result.status_code}: "
+                            f"{last_result.response_body[:200]!r}"
+                        ),
+                        response_time_ms=response_time_ms,
+                        occurred_at=attempt_started,
+                        will_retry=will_retry,
+                        next_retry_at=next_retry_at,
+                        task_type=task_type,
+                        task_id=task_id,
+                        payload_size_bytes=len(last_result.sent_body),
+                    )
+                )
+            except Exception as exc:
+                response_time_ms = int((datetime.now(UTC) - attempt_started).total_seconds() * 1000)
+                will_retry = attempt_number < self._retry.max_attempts
+                next_delay = (
+                    self._retry.delay_for_attempt(attempt_number + 1) if will_retry else None
+                )
+                next_retry_at = (
+                    attempt_started + timedelta(seconds=next_delay)
+                    if next_delay is not None
+                    else None
+                )
+                breaker.record_failure()
+                await self._record(
+                    DeliveryAttempt(
+                        url=url,
+                        sequence_key=sequence_key,
+                        sequence_number=sequence_number,
+                        attempt_number=attempt_number,
+                        max_attempts=self._retry.max_attempts,
+                        outcome="failure",
+                        http_status_code=None,
+                        error_message=f"{type(exc).__name__}: {exc}",
+                        response_time_ms=response_time_ms,
+                        occurred_at=attempt_started,
+                        will_retry=will_retry,
+                        next_retry_at=next_retry_at,
+                        task_type=task_type,
+                        task_id=task_id,
+                        payload_size_bytes=None,
+                    )
+                )
+                if not will_retry:
+                    raise
+
+        return last_result
+
+    async def _record(self, attempt: DeliveryAttempt) -> None:
+        if self._log_sink is None:
+            return
+        try:
+            await self._log_sink.record(attempt)
+        except Exception:
+            logger.warning(
+                "[adcp.webhook_supervisor] DeliveryLogSink raised on attempt "
+                "for %s — log dropped, delivery unaffected",
+                attempt.url,
+                exc_info=True,
+            )
+
+
+# ----- Helpers -----
+
+
+def supervisor_or_sender(
+    *,
+    sender: WebhookSender | None,
+    supervisor: WebhookDeliverySupervisor | None,
+) -> WebhookDeliverySupervisor | WebhookSender | None:
+    """Resolve the F12-callsite delivery target.
+
+    Supervisor takes precedence when both are passed. Either alone is
+    valid; both ``None`` opts out of auto-emit. Used by
+    :mod:`adcp.decisioning.webhook_emit` to keep the call site
+    polymorphic over the two surfaces (both expose ``send_mcp`` with
+    compatible signatures).
+    """
+    return supervisor or sender
+
+
+__all__ = [
+    "AttemptOutcome",
+    "CircuitBreakerPolicy",
+    "CircuitState",
+    "DeliveryAttempt",
+    "DeliveryLogSink",
+    "InMemoryWebhookDeliverySupervisor",
+    "RetryPolicy",
+    "WebhookDeliverySupervisor",
+    "supervisor_or_sender",
+]

--- a/tests/test_decisioning_serve.py
+++ b/tests/test_decisioning_serve.py
@@ -448,7 +448,7 @@ def test_serve_fails_fast_when_sales_platform_missing_webhook_sender() -> None:
     assert "create_media_buy" in msg
     # Structured details so adopter harnesses can programmatically
     # surface the exact missing piece + eligible tool list.
-    assert exc_info.value.details["missing"] == "webhook_sender"
+    assert exc_info.value.details["missing"] == "webhook_sender_or_supervisor"
     assert "create_media_buy" in exc_info.value.details["webhook_eligible_tools"]
 
 

--- a/tests/test_decisioning_webhook_emit.py
+++ b/tests/test_decisioning_webhook_emit.py
@@ -176,8 +176,9 @@ async def test_maybe_emit_warns_when_sender_none_but_buyer_registered_url(
         )
     messages = [r.message for r in caplog.records]
     assert any(
-        "webhook_sender is None" in m and "buyer.example.com/wh" in m for m in messages
-    ), f"expected sender-None warning citing the buyer URL; got {messages}"
+        "neither webhook_sender nor webhook_supervisor" in m and "buyer.example.com/wh" in m
+        for m in messages
+    ), f"expected sender/supervisor-None warning citing the buyer URL; got {messages}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webhook_supervisor.py
+++ b/tests/test_webhook_supervisor.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-
-UTC = timezone.utc
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -35,6 +33,10 @@ from adcp.decisioning.webhook_emit import (
     validate_webhook_sender_for_platform,
 )
 from adcp.webhook_sender import WebhookDeliveryResult
+
+# 3.10 doesn't have ``datetime.UTC`` (added in 3.11); alias to ``timezone.utc``.
+UTC = timezone.utc
+
 from adcp.webhook_supervisor import (
     CircuitBreakerPolicy,
     CircuitState,
@@ -101,6 +103,25 @@ def _supervisor(
         circuit=circuit,
         log_sink=sink,
     )
+
+
+def _make_sender(send_mcp_returns=None, resend_returns=None) -> MagicMock:
+    """Build a sender mock with both ``send_mcp`` and ``resend`` async-mocked.
+
+    ``resend`` is invoked by the supervisor on attempts 2+ to replay
+    the same idempotency_key per spec. Tests that exercise the retry
+    path must configure both.
+    """
+    sender = MagicMock()
+    if send_mcp_returns is not None:
+        sender.send_mcp = AsyncMock(**send_mcp_returns)
+    else:
+        sender.send_mcp = AsyncMock(return_value=_ok())
+    if resend_returns is not None:
+        sender.resend = AsyncMock(**resend_returns)
+    else:
+        sender.resend = AsyncMock(return_value=_ok())
+    return sender
 
 
 # ----- RetryPolicy.delay_for_attempt -----
@@ -217,8 +238,12 @@ async def test_supervisor_success_first_attempt_records_one_log() -> None:
 
 @pytest.mark.asyncio
 async def test_supervisor_retries_on_5xx_then_succeeds() -> None:
+    """Spec-compliant retry: attempt 1 calls ``send_mcp`` (fresh
+    idempotency_key), attempts 2+ call ``resend(last_result)``
+    (replays bytes including idempotency_key for receiver dedup)."""
     sender = MagicMock()
-    sender.send_mcp = AsyncMock(side_effect=[_fail(503), _fail(502), _ok()])
+    sender.send_mcp = AsyncMock(return_value=_fail(503))
+    sender.resend = AsyncMock(side_effect=[_fail(502), _ok()])
     sink = _RecordingSink()
     sup = _supervisor(sender, sink=sink)
 
@@ -228,7 +253,14 @@ async def test_supervisor_retries_on_5xx_then_succeeds() -> None:
         status="completed",
     )
     assert result is not None and result.ok
-    assert sender.send_mcp.await_count == 3
+    # Spec: only the first attempt calls ``send_mcp`` fresh; retries
+    # call ``resend`` to preserve the idempotency_key.
+    assert sender.send_mcp.await_count == 1
+    assert sender.resend.await_count == 2
+    # The same WebhookDeliveryResult instance is passed to each
+    # resend (replays the same idempotency_key bytes).
+    first_call = sender.resend.await_args_list[0][0][0]
+    assert first_call.idempotency_key == "k1"
     assert [c.outcome for c in sink.calls] == ["failure", "failure", "success"]
     assert [c.attempt_number for c in sink.calls] == [1, 2, 3]
     assert sink.calls[0].will_retry is True
@@ -239,7 +271,8 @@ async def test_supervisor_retries_on_5xx_then_succeeds() -> None:
 @pytest.mark.asyncio
 async def test_supervisor_returns_last_failure_after_max_attempts() -> None:
     sender = MagicMock()
-    sender.send_mcp = AsyncMock(side_effect=[_fail(), _fail(), _fail()])
+    sender.send_mcp = AsyncMock(return_value=_fail())
+    sender.resend = AsyncMock(return_value=_fail())
     sink = _RecordingSink()
     sup = _supervisor(sender, sink=sink)
 
@@ -250,14 +283,19 @@ async def test_supervisor_returns_last_failure_after_max_attempts() -> None:
     )
     assert result is not None
     assert not result.ok
-    assert sender.send_mcp.await_count == 3
+    assert sender.send_mcp.await_count == 1
+    assert sender.resend.await_count == 2
     assert [c.outcome for c in sink.calls] == ["failure", "failure", "failure"]
 
 
 @pytest.mark.asyncio
 async def test_supervisor_records_exception_and_reraises_on_final_attempt() -> None:
+    """When ``send_mcp`` raises mid-flight, no result-with-bytes is
+    produced — the next attempt MUST call ``send_mcp`` fresh again
+    (a new idempotency_key) since there's nothing to ``resend``."""
     sender = MagicMock()
     sender.send_mcp = AsyncMock(side_effect=ConnectionError("dns"))
+    sender.resend = AsyncMock(side_effect=AssertionError("should not be called"))
     sink = _RecordingSink()
     sup = _supervisor(sender, sink=sink)
 
@@ -267,7 +305,9 @@ async def test_supervisor_records_exception_and_reraises_on_final_attempt() -> N
             task_id="t1",
             status="completed",
         )
-    assert len(sink.calls) == 3  # all 3 attempts recorded
+    assert sender.send_mcp.await_count == 3
+    assert sender.resend.await_count == 0
+    assert len(sink.calls) == 3
     for attempt in sink.calls:
         assert attempt.outcome == "failure"
         assert attempt.http_status_code is None
@@ -281,6 +321,7 @@ async def test_supervisor_records_exception_and_reraises_on_final_attempt() -> N
 async def test_supervisor_skips_delivery_when_circuit_open() -> None:
     sender = MagicMock()
     sender.send_mcp = AsyncMock(return_value=_fail())
+    sender.resend = AsyncMock(return_value=_fail())
     sink = _RecordingSink()
     sup = _supervisor(
         sender,
@@ -307,7 +348,11 @@ async def test_supervisor_skips_delivery_when_circuit_open() -> None:
     assert len(sink.calls) == 1
     assert sink.calls[0].outcome == "circuit_open"
     assert sink.calls[0].attempt_number == 0
-    assert sender.send_mcp.await_count == 3  # only the first delivery's attempts
+    # First delivery's attempts: 1 send_mcp + 2 resend (per spec
+    # idempotency-key reuse). Second delivery is circuit_open and
+    # makes no calls at all.
+    assert sender.send_mcp.await_count == 1
+    assert sender.resend.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -321,6 +366,8 @@ async def test_supervisor_isolates_breakers_per_endpoint() -> None:
 
     sender = MagicMock()
     sender.send_mcp = AsyncMock(side_effect=_routed)
+    # Resend always returns _fail() — the retry path on endpoint A.
+    sender.resend = AsyncMock(return_value=_fail())
     sup = _supervisor(
         sender,
         circuit=CircuitBreakerPolicy(failure_threshold=2),
@@ -487,3 +534,217 @@ def test_validate_webhook_sender_raises_when_neither_wired() -> None:
         )
     assert exc_info.value.code == "INVALID_REQUEST"
     assert exc_info.value.details["missing"] == "webhook_sender_or_supervisor"
+
+
+def test_validate_webhook_sender_passes_when_only_sender_wired() -> None:
+    """Backward-compat: legacy adopters wire just a sender — gate
+    accepts. Symmetric to the supervisor-only case above."""
+    validate_webhook_sender_for_platform(
+        advertised_tools=frozenset({"create_media_buy"}),
+        sender=MagicMock(),
+        supervisor=None,
+        auto_emit=True,
+    )  # must not raise
+
+
+# ----- Constructor validation -----
+
+
+def test_supervisor_init_rejects_none_sender() -> None:
+    """Review #6: ``InMemoryWebhookDeliverySupervisor(None)`` would
+    later AttributeError on every send. Must fail fast at __init__,
+    matching the boot-time gate's fail-fast intent."""
+    with pytest.raises(ValueError, match="non-None WebhookSender"):
+        InMemoryWebhookDeliverySupervisor(None)  # type: ignore[arg-type]
+
+
+# ----- breaker_key for cross-tenant isolation -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_breaker_key_isolates_tenants_on_shared_url() -> None:
+    """Two tenants registering the same SaaS receiver URL must NOT
+    share a circuit breaker. Tenant A's failures opening the breaker
+    must not quarantine tenant B's deliveries to the same URL.
+
+    Review finding M2: bare-URL keying is single-tenant only;
+    multi-tenant adopters pass a ``breaker_key=f"{tenant}:{url}"``.
+    """
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_fail())
+    sender.resend = AsyncMock(return_value=_fail())
+    sup = _supervisor(
+        sender,
+        circuit=CircuitBreakerPolicy(failure_threshold=2, open_timeout_seconds=60),
+    )
+
+    # Tenant A trips the breaker for "tenant_a:https://shared/wh".
+    await sup.send_mcp(
+        url="https://shared/wh",
+        task_id="t1",
+        status="completed",
+        breaker_key="tenant_a:https://shared/wh",
+    )
+    # Tenant B uses the same URL but a different breaker_key —
+    # should NOT be circuit-open (return None); should attempt and
+    # fail like tenant A's first delivery.
+    sender.send_mcp.reset_mock()
+    sender.resend.reset_mock()
+    result = await sup.send_mcp(
+        url="https://shared/wh",
+        task_id="t2",
+        status="completed",
+        breaker_key="tenant_b:https://shared/wh",
+    )
+    # Tenant B made it through to attempt delivery (not circuit_open).
+    assert result is not None
+    assert sender.send_mcp.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_supervisor_breaker_key_defaults_to_url() -> None:
+    """When no breaker_key is provided, falls back to URL — preserves
+    the v1 default and the JS-parity contract."""
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_fail())
+    sender.resend = AsyncMock(return_value=_fail())
+    sup = _supervisor(
+        sender,
+        circuit=CircuitBreakerPolicy(failure_threshold=2, open_timeout_seconds=60),
+    )
+
+    await sup.send_mcp(url="https://shared/wh", task_id="t1", status="completed")
+    # Same URL → same breaker → second delivery is circuit_open.
+    result = await sup.send_mcp(url="https://shared/wh", task_id="t2", status="completed")
+    assert result is None
+
+
+# ----- Sequence number after breaker check -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_does_not_burn_sequence_on_circuit_open() -> None:
+    """Review #5: sequence number must NOT be allocated when the
+    breaker is OPEN. Burning numbers on circuit-open creates gaps in
+    the buyer-facing sequence stream."""
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_fail())
+    sender.resend = AsyncMock(return_value=_fail())
+    sup = _supervisor(
+        sender,
+        circuit=CircuitBreakerPolicy(failure_threshold=2, open_timeout_seconds=60),
+    )
+
+    # First delivery: opens breaker; allocates sequence_number=1
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+        sequence_key="media_buy:abc:https://buyer.example.com/wh",
+    )
+    # Second delivery: circuit_open, MUST NOT allocate a sequence.
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t2",
+        status="completed",
+        sequence_key="media_buy:abc:https://buyer.example.com/wh",
+    )
+    # Third delivery: still circuit_open if breaker hasn't recovered.
+    # When breaker recovers and a delivery succeeds, the next
+    # sequence number should be 2 (not 3 — circuit-open didn't burn).
+    assert (
+        sup.next_sequence("media_buy:abc:https://buyer.example.com/wh") == 2
+    ), "sequence skipped circuit-open burns"
+
+
+# ----- Sink timeout -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_bounds_slow_sink_with_timeout() -> None:
+    """Review M1: a slow sink must NOT freeze the supervisor. The
+    sink timeout (default 5s, configurable via
+    ``RetryPolicy.sink_timeout_seconds``) bounds wait time."""
+    import time as _time
+
+    @dataclass
+    class _SlowSink:
+        async def record(self, attempt: DeliveryAttempt) -> None:
+            await asyncio.sleep(10.0)  # would freeze without timeout
+
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+    sender.resend = AsyncMock(return_value=_ok())
+    sup = InMemoryWebhookDeliverySupervisor(
+        sender,
+        retry=RetryPolicy(
+            max_attempts=1,
+            base_delay_seconds=0.0,
+            jitter=False,
+            sink_timeout_seconds=0.05,  # 50ms — well under the sink's 10s
+        ),
+        log_sink=_SlowSink(),
+    )
+
+    started = _time.monotonic()
+    result = await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+    )
+    elapsed = _time.monotonic() - started
+    # Delivery succeeded despite sink timeout.
+    assert result is not None and result.ok
+    # Sink shouldn't have blocked the supervisor for the full 10s.
+    assert elapsed < 1.0, f"sink timeout didn't bound wait; elapsed={elapsed}"
+
+
+# ----- Notification-type passthrough -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_records_notification_type_passthrough() -> None:
+    """Review #9: ``notification_type`` (delivery-report concept —
+    'scheduled' / 'final' / 'adjusted' / 'delayed' / 'window_update')
+    flows through to ``DeliveryAttempt`` for adopter persistence."""
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+    sender.resend = AsyncMock(return_value=_ok())
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+        notification_type="scheduled",
+    )
+    assert sink.calls[0].notification_type == "scheduled"
+
+
+# ----- Monotonic clock for response_time_ms -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_response_time_uses_monotonic_clock() -> None:
+    """Review #7: ``response_time_ms`` must use ``time.monotonic()``
+    to be NTP-step-resilient. Sanity-check by asserting it's a
+    non-negative integer (deeper testing would mock time.monotonic)."""
+    sender = MagicMock()
+
+    async def _slow_send(**_: Any) -> WebhookDeliveryResult:
+        await asyncio.sleep(0.02)
+        return _ok()
+
+    sender.send_mcp = AsyncMock(side_effect=_slow_send)
+    sender.resend = AsyncMock(side_effect=_slow_send)
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+    )
+    assert sink.calls[0].response_time_ms >= 10  # at least 10ms (we slept 20)
+    assert sink.calls[0].response_time_ms < 1000  # not absurd

--- a/tests/test_webhook_supervisor.py
+++ b/tests/test_webhook_supervisor.py
@@ -1,0 +1,489 @@
+"""Tests for :mod:`adcp.webhook_supervisor` — retry, circuit breaker,
+attempt audit log, F12 wire-through.
+
+Behavior under test (per the Protocol contract):
+
+* :class:`InMemoryWebhookDeliverySupervisor` retries failed deliveries
+  per :class:`RetryPolicy` and records each attempt to a configured
+  :class:`DeliveryLogSink`.
+* :class:`_CircuitBreaker` opens after ``failure_threshold`` consecutive
+  failures, tests recovery in HALF_OPEN, and skips delivery when OPEN.
+* The F12 auto-emit gate routes through ``webhook_supervisor`` when
+  configured, falling back to ``webhook_sender`` otherwise.
+* Boot validation accepts either a sender or a supervisor.
+
+Tests use a fake :class:`WebhookSender` (just records calls) — exercising
+the supervisor's orchestration without real HTTP. Real-HTTP coverage
+lives in :mod:`tests.test_webhook_handling` and is out of scope here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adcp.decisioning.types import AdcpError
+from adcp.decisioning.webhook_emit import (
+    maybe_emit_sync_completion,
+    validate_webhook_sender_for_platform,
+)
+from adcp.webhook_sender import WebhookDeliveryResult
+from adcp.webhook_supervisor import (
+    CircuitBreakerPolicy,
+    CircuitState,
+    DeliveryAttempt,
+    InMemoryWebhookDeliverySupervisor,
+    RetryPolicy,
+    WebhookDeliverySupervisor,
+    _CircuitBreaker,
+)
+
+# ----- helpers -----
+
+
+def _ok(idempotency_key: str = "k1", status_code: int = 200) -> WebhookDeliveryResult:
+    return WebhookDeliveryResult(
+        status_code=status_code,
+        idempotency_key=idempotency_key,
+        url="https://buyer.example.com/wh",
+        response_headers={},
+        response_body=b"{}",
+        sent_body=b'{"x":1}',
+    )
+
+
+def _fail(status_code: int = 503) -> WebhookDeliveryResult:
+    return WebhookDeliveryResult(
+        status_code=status_code,
+        idempotency_key="k1",
+        url="https://buyer.example.com/wh",
+        response_headers={},
+        response_body=b"upstream",
+        sent_body=b'{"x":1}',
+    )
+
+
+@dataclass
+class _RecordingSink:
+    """In-memory :class:`DeliveryLogSink` for assertions."""
+
+    calls: list[DeliveryAttempt] = field(default_factory=list)
+
+    async def record(self, attempt: DeliveryAttempt) -> None:
+        self.calls.append(attempt)
+
+
+@dataclass
+class _BrokenSink:
+    """Sink that raises — supervisor must swallow and continue."""
+
+    async def record(self, attempt: DeliveryAttempt) -> None:
+        raise RuntimeError("sink down")
+
+
+def _supervisor(
+    sender: Any,
+    *,
+    retry: RetryPolicy | None = None,
+    circuit: CircuitBreakerPolicy | None = None,
+    sink: Any = None,
+) -> InMemoryWebhookDeliverySupervisor:
+    return InMemoryWebhookDeliverySupervisor(
+        sender,
+        retry=retry or RetryPolicy(max_attempts=3, base_delay_seconds=0.0, jitter=False),
+        circuit=circuit,
+        log_sink=sink,
+    )
+
+
+# ----- RetryPolicy.delay_for_attempt -----
+
+
+def test_retry_policy_no_delay_on_first_attempt() -> None:
+    policy = RetryPolicy(base_delay_seconds=2.0, jitter=False)
+    assert policy.delay_for_attempt(1) == 0.0
+
+
+def test_retry_policy_exponential_backoff_without_jitter() -> None:
+    policy = RetryPolicy(base_delay_seconds=2.0, max_delay_seconds=60.0, jitter=False)
+    # attempt 2 → 2s, attempt 3 → 4s, attempt 4 → 8s, capped at max
+    assert policy.delay_for_attempt(2) == 2.0
+    assert policy.delay_for_attempt(3) == 4.0
+    assert policy.delay_for_attempt(4) == 8.0
+
+
+def test_retry_policy_caps_at_max_delay() -> None:
+    policy = RetryPolicy(base_delay_seconds=10.0, max_delay_seconds=15.0, jitter=False)
+    # attempt 3 would be 20s but capped
+    assert policy.delay_for_attempt(3) == 15.0
+    assert policy.delay_for_attempt(10) == 15.0
+
+
+def test_retry_policy_jitter_within_half_to_full() -> None:
+    policy = RetryPolicy(base_delay_seconds=4.0, jitter=True)
+    # Jitter scales delay to [0.5x, 1.0x] — bounded check
+    for _ in range(20):
+        d = policy.delay_for_attempt(2)
+        assert 2.0 <= d <= 4.0
+
+
+# ----- _CircuitBreaker -----
+
+
+def test_circuit_breaker_opens_after_failure_threshold() -> None:
+    breaker = _CircuitBreaker(CircuitBreakerPolicy(failure_threshold=3, open_timeout_seconds=60))
+    assert breaker.state is CircuitState.CLOSED
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.state is CircuitState.CLOSED
+    assert breaker.can_attempt()
+    breaker.record_failure()
+    assert breaker.state is CircuitState.OPEN
+    assert not breaker.can_attempt()
+
+
+def test_circuit_breaker_half_open_after_timeout() -> None:
+    breaker = _CircuitBreaker(CircuitBreakerPolicy(failure_threshold=2, open_timeout_seconds=0.001))
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.state is CircuitState.OPEN
+    # Force the opened_at to be in the past so timeout has elapsed.
+    breaker._opened_at = datetime.fromtimestamp(0, tz=UTC)
+    assert breaker.can_attempt()
+    assert breaker.state is CircuitState.HALF_OPEN
+
+
+def test_circuit_breaker_closes_after_success_threshold_in_half_open() -> None:
+    breaker = _CircuitBreaker(
+        CircuitBreakerPolicy(failure_threshold=2, success_threshold=2, open_timeout_seconds=0.001)
+    )
+    breaker.record_failure()
+    breaker.record_failure()
+    breaker._opened_at = datetime.fromtimestamp(0, tz=UTC)
+    breaker.can_attempt()  # transition to HALF_OPEN
+    breaker.record_success()
+    assert breaker.state is CircuitState.HALF_OPEN
+    breaker.record_success()
+    assert breaker.state is CircuitState.CLOSED
+
+
+def test_circuit_breaker_failure_in_half_open_reopens() -> None:
+    breaker = _CircuitBreaker(
+        CircuitBreakerPolicy(failure_threshold=2, success_threshold=2, open_timeout_seconds=0.001)
+    )
+    breaker.record_failure()
+    breaker.record_failure()
+    breaker._opened_at = datetime.fromtimestamp(0, tz=UTC)
+    breaker.can_attempt()
+    breaker.record_failure()
+    assert breaker.state is CircuitState.OPEN
+
+
+# ----- Supervisor: success path -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_success_first_attempt_records_one_log() -> None:
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    result = await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+        task_type="create_media_buy",
+        result={"media_buy_id": "mb_1"},
+    )
+    assert result is not None and result.ok
+    assert sender.send_mcp.await_count == 1
+    assert len(sink.calls) == 1
+    assert sink.calls[0].outcome == "success"
+    assert sink.calls[0].attempt_number == 1
+    assert sink.calls[0].http_status_code == 200
+    assert sink.calls[0].will_retry is False
+
+
+# ----- Supervisor: retry path -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_retries_on_5xx_then_succeeds() -> None:
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(side_effect=[_fail(503), _fail(502), _ok()])
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    result = await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+    )
+    assert result is not None and result.ok
+    assert sender.send_mcp.await_count == 3
+    assert [c.outcome for c in sink.calls] == ["failure", "failure", "success"]
+    assert [c.attempt_number for c in sink.calls] == [1, 2, 3]
+    assert sink.calls[0].will_retry is True
+    assert sink.calls[1].will_retry is True
+    assert sink.calls[2].will_retry is False
+
+
+@pytest.mark.asyncio
+async def test_supervisor_returns_last_failure_after_max_attempts() -> None:
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(side_effect=[_fail(), _fail(), _fail()])
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    result = await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+    )
+    assert result is not None
+    assert not result.ok
+    assert sender.send_mcp.await_count == 3
+    assert [c.outcome for c in sink.calls] == ["failure", "failure", "failure"]
+
+
+@pytest.mark.asyncio
+async def test_supervisor_records_exception_and_reraises_on_final_attempt() -> None:
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(side_effect=ConnectionError("dns"))
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    with pytest.raises(ConnectionError):
+        await sup.send_mcp(
+            url="https://buyer.example.com/wh",
+            task_id="t1",
+            status="completed",
+        )
+    assert len(sink.calls) == 3  # all 3 attempts recorded
+    for attempt in sink.calls:
+        assert attempt.outcome == "failure"
+        assert attempt.http_status_code is None
+        assert "ConnectionError" in (attempt.error_message or "")
+
+
+# ----- Supervisor: circuit breaker -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_skips_delivery_when_circuit_open() -> None:
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_fail())
+    sink = _RecordingSink()
+    sup = _supervisor(
+        sender,
+        circuit=CircuitBreakerPolicy(failure_threshold=2, open_timeout_seconds=60),
+        sink=sink,
+    )
+
+    # First delivery records 3 failures (max_attempts=3) — that's
+    # 3 ≥ failure_threshold=2 so the breaker opens. The 2nd delivery
+    # finds the circuit OPEN and skips entirely.
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+    )
+    sink.calls.clear()
+
+    result = await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t2",
+        status="completed",
+    )
+    assert result is None
+    assert len(sink.calls) == 1
+    assert sink.calls[0].outcome == "circuit_open"
+    assert sink.calls[0].attempt_number == 0
+    assert sender.send_mcp.await_count == 3  # only the first delivery's attempts
+
+
+@pytest.mark.asyncio
+async def test_supervisor_isolates_breakers_per_endpoint() -> None:
+    """Endpoint A's breaker opens (failures); endpoint B unaffected."""
+
+    async def _routed(*, url: str, **_: Any) -> WebhookDeliveryResult:
+        if url == "https://A/wh":
+            return _fail()
+        return _ok()
+
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(side_effect=_routed)
+    sup = _supervisor(
+        sender,
+        circuit=CircuitBreakerPolicy(failure_threshold=2),
+    )
+
+    # Endpoint A fails enough to open its breaker (3 attempts ≥ 2).
+    await sup.send_mcp(url="https://A/wh", task_id="t1", status="completed")
+    # Endpoint B should be unaffected — succeeds on first attempt.
+    result = await sup.send_mcp(url="https://B/wh", task_id="t2", status="completed")
+    assert result is not None and result.ok
+
+
+# ----- Supervisor: sequence numbers -----
+
+
+def test_supervisor_next_sequence_is_per_key_and_monotonic() -> None:
+    sup = _supervisor(MagicMock())
+    assert sup.next_sequence("media_buy:1") == 1
+    assert sup.next_sequence("media_buy:1") == 2
+    assert sup.next_sequence("media_buy:2") == 1
+    assert sup.next_sequence("media_buy:1") == 3
+
+
+@pytest.mark.asyncio
+async def test_supervisor_records_sequence_number_when_key_supplied() -> None:
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+    sink = _RecordingSink()
+    sup = _supervisor(sender, sink=sink)
+
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+        sequence_key="media_buy:abc",
+    )
+    await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t2",
+        status="completed",
+        sequence_key="media_buy:abc",
+    )
+    assert [c.sequence_number for c in sink.calls] == [1, 2]
+    assert all(c.sequence_key == "media_buy:abc" for c in sink.calls)
+
+
+# ----- Supervisor: sink failure isolation -----
+
+
+@pytest.mark.asyncio
+async def test_supervisor_swallows_sink_exceptions(caplog: pytest.LogCaptureFixture) -> None:
+    """A broken sink must not break delivery."""
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+    sup = _supervisor(sender, sink=_BrokenSink())
+
+    result = await sup.send_mcp(
+        url="https://buyer.example.com/wh",
+        task_id="t1",
+        status="completed",
+    )
+    assert result is not None and result.ok
+
+
+# ----- Protocol conformance -----
+
+
+def test_in_memory_supervisor_satisfies_protocol() -> None:
+    """Runtime structural check — the reference impl conforms to
+    :class:`WebhookDeliverySupervisor`."""
+    sup = _supervisor(MagicMock())
+    assert isinstance(sup, WebhookDeliverySupervisor)
+
+
+# ----- F12 wire-through: maybe_emit_sync_completion routes via supervisor -----
+
+
+@pytest.mark.asyncio
+async def test_maybe_emit_routes_through_supervisor_when_configured() -> None:
+    """When both sender and supervisor are passed, supervisor wins."""
+
+    class _Cfg:
+        url = "https://buyer.example.com/wh"
+        token = None
+
+    class _Params:
+        push_notification_config = _Cfg()
+
+    # Only the supervisor's send_mcp should be awaited.
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+    supervisor = MagicMock()
+    supervisor.send_mcp = AsyncMock(return_value=_ok())
+
+    maybe_emit_sync_completion(
+        sender=sender,
+        supervisor=supervisor,
+        enabled=True,
+        method_name="create_media_buy",
+        params=_Params(),
+        result={"media_buy_id": "mb_1"},
+    )
+    # Drain background tasks
+    await asyncio.sleep(0)
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    assert supervisor.send_mcp.await_count == 1
+    assert sender.send_mcp.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_maybe_emit_uses_sender_when_supervisor_none() -> None:
+    """Backward compat — bare sender path still works."""
+
+    class _Cfg:
+        url = "https://buyer.example.com/wh"
+        token = None
+
+    class _Params:
+        push_notification_config = _Cfg()
+
+    sender = MagicMock()
+    sender.send_mcp = AsyncMock(return_value=_ok())
+
+    maybe_emit_sync_completion(
+        sender=sender,
+        supervisor=None,
+        enabled=True,
+        method_name="create_media_buy",
+        params=_Params(),
+        result={"media_buy_id": "mb_1"},
+    )
+    await asyncio.sleep(0)
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    assert sender.send_mcp.await_count == 1
+
+
+# ----- Boot validation: supervisor satisfies the gate -----
+
+
+def test_validate_webhook_sender_passes_when_only_supervisor_wired() -> None:
+    """Adopters can wire ONLY a supervisor (with the sender embedded inside)
+    and the F12 boot gate must accept that."""
+    validate_webhook_sender_for_platform(
+        advertised_tools=frozenset({"create_media_buy"}),
+        sender=None,
+        supervisor=MagicMock(),  # any non-None
+        auto_emit=True,
+    )  # must not raise
+
+
+def test_validate_webhook_sender_raises_when_neither_wired() -> None:
+    with pytest.raises(AdcpError) as exc_info:
+        validate_webhook_sender_for_platform(
+            advertised_tools=frozenset({"create_media_buy"}),
+            sender=None,
+            supervisor=None,
+            auto_emit=True,
+        )
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.details["missing"] == "webhook_sender_or_supervisor"


### PR DESCRIPTION
## Summary

Round-2 P1: Protocol seam for webhook delivery reliability. The existing \`WebhookSender\` is the transport (HTTP-Signatures POST, one attempt, no retry); production sellers wrap it with retry / circuit breaker / per-attempt audit. This adds the SDK-side seam so adopters compose existing primitives instead of writing ~1,000 LOC of reliability themselves.

Plus a SQLAlchemy A2A stores example (companion to the existing SQLite reference) so adopters with existing SQLAlchemy schemas wrap their models behind \`TaskStore\` + \`PushNotificationConfigStore\`.

## What's new

\`src/adcp/webhook_supervisor.py\` (522 LOC):

- **\`WebhookDeliverySupervisor\` Protocol** — async \`send_mcp\` surface. Adopters with infra-side retry (Celery, Kafka, durable outbox) implement against their queue.
- **\`InMemoryWebhookDeliverySupervisor\`** — reference impl. Wraps a \`WebhookSender\` with:
  - Per-endpoint \`CircuitBreaker\` (CLOSED / OPEN / HALF_OPEN state machine, 5-failure threshold, 60s recovery, 2-success close)
  - \`RetryPolicy\` (exponential backoff with jitter, max 3 attempts, 30s cap)
  - Per-\`sequence_key\` monotonic counter for delivery-report sequence numbers
  - Optional \`DeliveryLogSink\` Protocol for BYO persistence
- **\`DeliveryAttempt\`** frozen dataclass — one record per attempt (success / failure / circuit_open) for audit-log persistence
- **\`DeliveryLogSink\` Protocol** — adopters wire to their existing \`webhook_delivery_log\` tables; sink failures swallowed (broken sink must not cascade into delivery loss)

## Wire-through

- \`PlatformHandler\` accepts \`webhook_supervisor=\`; F12 auto-emit routes through supervisor when configured, falls back to bare sender otherwise. **Backward-compat: existing \`webhook_sender=\` path unchanged.**
- \`serve()\` + \`create_adcp_server_from_platform()\` forward the new param.
- Boot-time \`validate_webhook_sender_for_platform\` now accepts either a sender or a supervisor (missing-sender error code: \`webhook_sender_or_supervisor\`).

## SQLAlchemy A2A stores example

\`examples/a2a_sqlalchemy_tasks.py\` (450 LOC) — companion to \`examples/a2a_db_tasks.py\` (raw-SQLite reference). Same Protocol surface backed by SQLAlchemy ORM so the same code runs against any backend SQLA supports — SQLite for the demo, Postgres / MySQL in production. Salesagent and other SQLAlchemy-based sellers wrap their existing models behind the Protocols.

## Salesagent impact

- \`webhook_delivery_service.py\` (567 LOC) → wraps existing HMAC sender with \`InMemoryWebhookDeliverySupervisor\`, plug \`WebhookDeliveryLog\` table into \`DeliveryLogSink\`. Net delete: ~500 LOC.
- \`protocol_webhook_service.py\` (474 LOC) → similarly composes against the Protocol.
- A2A stores: their \`Task\` + \`PushNotificationConfig\` models wrap behind the SQLAlchemy reference's pattern (~50 LOC adopter code, replacing 200+ LOC of bespoke A2A-store wiring).

## Test plan

- [x] \`pytest tests/test_webhook_supervisor.py\` — 22 new tests pass
- [x] \`pytest tests/test_decisioning_serve.py tests/test_decisioning_webhook_emit.py\` — 57 affected tests pass (existing tests updated for supervisor parameter)
- [x] Full suite passes
- [x] \`ruff check\` clean
- [x] \`mypy\` clean

## Cross-links

- Round-2 RFC: \`docs/proposals/v3-identity-bundle-design.md\` (merged with #345)
- JS parity: [adcp-client#1249](https://github.com/adcontextprotocol/adcp-client/issues/1249) — supervisor still flagged as a JS-side gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)