### PR TITLE
feat(server): SubdomainTenantRouter middleware for multi-tenant deployments (#355)

### DIFF
--- a/src/adcp/server/__init__.py
+++ b/src/adcp/server/__init__.py
@@ -132,6 +132,13 @@ from adcp.server.serve import (
     serve,
 )
 from adcp.server.sponsored_intelligence import SponsoredIntelligenceHandler
+from adcp.server.tenant_router import (
+    InMemorySubdomainTenantRouter,
+    SubdomainTenantMiddleware,
+    SubdomainTenantRouter,
+    Tenant,
+    current_tenant,
+)
 from adcp.server.test_controller import (
     TestControllerError,
     TestControllerStore,
@@ -188,6 +195,12 @@ __all__ = [
     # Idempotency middleware (AdCP #2315 seller side)
     "IdempotencyStore",
     "MemoryBackend",
+    # Subdomain tenant routing
+    "InMemorySubdomainTenantRouter",
+    "SubdomainTenantMiddleware",
+    "SubdomainTenantRouter",
+    "Tenant",
+    "current_tenant",
     # Test controller
     "TestControllerStore",
     "TestControllerError",

--- a/src/adcp/server/tenant_router.py
+++ b/src/adcp/server/tenant_router.py
@@ -1,0 +1,311 @@
+"""Subdomain-based tenant routing for multi-tenant deployments.
+
+Multi-tenant AdCP sellers fronted by ``*.example.com`` use the
+incoming ``Host`` header to decide which tenant the request belongs
+to. salesagent ships a hand-rolled ``domain_routing.py`` (~250 LOC);
+this module ships the same shape behind a typed Protocol so adopters
+get the routing seam without writing the parser.
+
+Surface
+-------
+
+* :class:`Tenant` — the resolved tenant. Adopters extend with
+  ``ext`` for whatever per-tenant data their downstream stores need
+  (DB shard, locale, billing entity, etc.).
+* :class:`SubdomainTenantRouter` — runtime-checkable Protocol with
+  one async ``resolve(host: str) -> Tenant | None`` method.
+* :class:`InMemorySubdomainTenantRouter` — reference impl for
+  dev/test backed by a static ``host → Tenant`` dict. Production
+  adopters back the Protocol with their tenant table.
+* :class:`SubdomainTenantMiddleware` — Starlette ASGI middleware
+  that calls the router, stashes the result in a
+  :class:`contextvars.ContextVar`, and ``404`` s on unknown hosts.
+* :func:`current_tenant` — accessor for the threaded contextvar.
+  ``context_factory`` callbacks read it to populate
+  :attr:`ToolContext.tenant_id`.
+
+Wire-up
+-------
+
+::
+
+    from starlette.applications import Starlette
+    from adcp.server import (
+        InMemorySubdomainTenantRouter,
+        SubdomainTenantMiddleware,
+        Tenant,
+        current_tenant,
+    )
+
+    router = InMemorySubdomainTenantRouter(
+        tenants={
+            "acme.example.com": Tenant(id="acme", display_name="Acme"),
+            "beta.example.com": Tenant(id="beta", display_name="Beta"),
+        }
+    )
+
+    app = Starlette()
+    app.add_middleware(SubdomainTenantMiddleware, router=router)
+
+    def build_context(meta):
+        tenant = current_tenant()
+        return ToolContext(
+            request_id=meta.request_id,
+            tenant_id=tenant.id if tenant else None,
+            ...
+        )
+
+Composition
+-----------
+
+The contextvar threads down to ``AccountStore``,
+``BuyerAgentRegistry``, ``TaskRegistry``, etc., letting all
+downstream stores filter by tenant without explicit plumbing —
+each store reads :func:`current_tenant` (or the
+:attr:`ToolContext.tenant_id` set from it) and scopes accordingly.
+
+Security
+--------
+
+* Unknown hosts return ``404 Not Found`` with no body — the
+  middleware MUST NOT 200 a request to a host the router can't
+  resolve. Buyers probing for tenant existence get the same
+  response shape regardless of whether the host is unrecognized
+  or the tenant is suspended (suspension is a per-tenant decision
+  surfaced downstream).
+* The ``Host`` header is the source of truth, not ``X-Forwarded-Host``
+  or any reverse-proxy header — adopters terminating TLS on a
+  proxy are responsible for passing the original host through
+  correctly.
+* The contextvar is request-scoped via the ASGI middleware's
+  per-call ``set()``; ASGI doesn't reuse contexts across requests.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+@dataclass(frozen=True)
+class Tenant:
+    """The resolved tenant for a request.
+
+    Frozen — the middleware caches resolved tenants in a contextvar
+    that's read by downstream stores; mutation in-place would create
+    cross-store inconsistency.
+
+    :param id: Stable tenant identifier. Used as
+        :attr:`ToolContext.tenant_id` and the scope key for
+        per-tenant DB queries / cache scoping.
+    :param display_name: Human-readable name for logging and admin
+        UIs. Not used for routing.
+    :param ext: Adopter passthrough — DB shard pointer, billing
+        entity FK, locale, sandbox flag, etc.
+    """
+
+    id: str
+    display_name: str = ""
+    ext: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class SubdomainTenantRouter(Protocol):
+    """Resolves an HTTP ``Host`` header value to a :class:`Tenant`.
+
+    Adopters back this Protocol with their tenant table — typically
+    a SQL query against the deployment's tenant registry. The
+    middleware calls :meth:`resolve` once per request; production
+    adopters cache hot lookups in the impl since the host header is
+    request-scoped.
+
+    Returning ``None`` causes the middleware to ``404`` the
+    request — unknown hosts MUST NOT pass through.
+    """
+
+    async def resolve(self, host: str) -> Tenant | None:
+        """Return the :class:`Tenant` for ``host`` or ``None`` to 404.
+
+        ``host`` is the raw ``Host`` header value (lower-cased by
+        the middleware before this call). Implementations strip any
+        ``:port`` suffix as needed; the middleware doesn't.
+        """
+        ...
+
+
+class InMemorySubdomainTenantRouter:
+    """Reference :class:`SubdomainTenantRouter` for dev / test.
+
+    Backed by a static ``host → Tenant`` dict. Lookup is exact
+    match on the lower-cased host (with the port suffix stripped).
+    Production adopters swap to a SQL-backed impl that hits their
+    tenant table.
+    """
+
+    def __init__(self, tenants: Mapping[str, Tenant]) -> None:
+        # Normalize keys to lower-cased + port-stripped at construction
+        # so resolve() can be a single dict lookup. Adopters who pass
+        # mixed case (``Acme.Example.com``) get the obvious behavior.
+        self._tenants: dict[str, Tenant] = {
+            _normalize_host(host): tenant for host, tenant in tenants.items()
+        }
+
+    async def resolve(self, host: str) -> Tenant | None:
+        return self._tenants.get(_normalize_host(host))
+
+
+# Module-level contextvar — request-scoped via the ASGI middleware's
+# per-call `set()`. ASGI guarantees per-task context isolation, so
+# concurrent requests on the same process see only their own tenant.
+_current_tenant: contextvars.ContextVar[Tenant | None] = contextvars.ContextVar(
+    "adcp_current_tenant",
+    default=None,
+)
+
+
+def current_tenant() -> Tenant | None:
+    """Return the resolved :class:`Tenant` for the current request.
+
+    Returns ``None`` outside the middleware's request scope, or
+    when the request isn't tenant-routed (e.g., health-check paths
+    excluded from the middleware).
+
+    Adopter ``context_factory`` callbacks read this and write the
+    tenant id onto :attr:`ToolContext.tenant_id` so downstream
+    framework primitives (idempotency middleware, AccountStore,
+    BuyerAgentRegistry) scope by tenant.
+    """
+    return _current_tenant.get()
+
+
+class SubdomainTenantMiddleware:
+    """Starlette ASGI middleware: ``Host`` header → :class:`Tenant`.
+
+    Wire via ``app.add_middleware(SubdomainTenantMiddleware,
+    router=...)``. The middleware:
+
+    1. Reads the ``Host`` header from the ASGI scope.
+    2. Calls the router's ``resolve()`` method.
+    3. On hit, sets the :data:`current_tenant` contextvar for the
+       remainder of the request's lifetime.
+    4. On miss, returns ``404 Not Found`` immediately — the wrapped
+       app is never called.
+
+    Non-HTTP scopes (websocket, lifespan) pass through unchanged
+    so the middleware is safe on the standard Starlette stack.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        router: SubdomainTenantRouter,
+        excluded_paths: frozenset[str] = frozenset(),
+    ) -> None:
+        """Construct the middleware.
+
+        :param app: The wrapped ASGI app (the next layer).
+        :param router: The :class:`SubdomainTenantRouter` impl.
+        :param excluded_paths: HTTP paths that bypass tenant routing
+            entirely — typically ``{"/healthz", "/readyz"}``.
+            Requests to these paths skip the router call and the
+            contextvar set; downstream code sees
+            :func:`current_tenant` returning ``None``.
+        """
+        self._app = app
+        self._router = router
+        self._excluded = excluded_paths
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path in self._excluded:
+            await self._app(scope, receive, send)
+            return
+
+        host = _extract_host_header(scope)
+        if host is None:
+            await _send_404(send, reason="missing-host-header")
+            return
+
+        tenant = await self._router.resolve(host)
+        if tenant is None:
+            await _send_404(send, reason="unknown-host")
+            return
+
+        token = _current_tenant.set(tenant)
+        try:
+            await self._app(scope, receive, send)
+        finally:
+            _current_tenant.reset(token)
+
+
+# ----- helpers -----------------------------------------------------------
+
+
+def _normalize_host(host: str) -> str:
+    """Lower-case and strip ``:port`` suffix.
+
+    The ``Host`` header is case-insensitive per RFC 7230, but a
+    case-sensitive dict lookup would miss legitimate variations.
+    Also strips the port suffix so ``acme.example.com:443`` resolves
+    the same as ``acme.example.com``.
+    """
+    normalized = host.strip().lower()
+    if ":" in normalized:
+        normalized = normalized.split(":", 1)[0]
+    return normalized
+
+
+def _extract_host_header(scope: Scope) -> str | None:
+    """Pull the ``Host`` header from an ASGI scope.
+
+    ASGI normalizes header names to lower-cased bytes and stores
+    them as a list of ``(name, value)`` tuples on ``scope["headers"]``.
+    """
+    headers = scope.get("headers") or []
+    for name, value in headers:
+        if name == b"host":
+            decoded: str = bytes(value).decode("latin-1")
+            return decoded
+    return None
+
+
+async def _send_404(send: Send, *, reason: str) -> None:
+    """Emit a minimal ``404 Not Found`` response.
+
+    No body — buyers probing for tenant existence get the same
+    response shape regardless of why the host was rejected. The
+    ``X-Adcp-Tenant-Reject-Reason`` header carries an opaque
+    diagnostic for adopter logs / observability without leaking
+    tenant-existence info to the buyer.
+    """
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 404,
+            "headers": [
+                (b"content-length", b"0"),
+                (b"x-adcp-tenant-reject-reason", reason.encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": b""})
+
+
+__all__ = [
+    "InMemorySubdomainTenantRouter",
+    "SubdomainTenantMiddleware",
+    "SubdomainTenantRouter",
+    "Tenant",
+    "current_tenant",
+]

--- a/tests/test_subdomain_tenant_router.py
+++ b/tests/test_subdomain_tenant_router.py
@@ -1,0 +1,265 @@
+"""Tests for :mod:`adcp.server.tenant_router`.
+
+Covers the ASGI middleware integration via Starlette's
+:class:`TestClient`:
+
+* Known host → 200 + tenant available via :func:`current_tenant`
+* Unknown host → 404 with reject-reason header
+* Missing Host header → 404
+* Port suffix is stripped before router lookup
+* Case-insensitive host match
+* Excluded paths bypass routing entirely
+* Non-HTTP scopes pass through (websocket / lifespan)
+* ContextVar is reset after each request (no cross-request leak)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+starlette = pytest.importorskip("starlette")
+
+from starlette.applications import Starlette  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+from starlette.responses import JSONResponse  # noqa: E402
+from starlette.routing import Route  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from adcp.server import (  # noqa: E402
+    InMemorySubdomainTenantRouter,
+    SubdomainTenantMiddleware,
+    SubdomainTenantRouter,
+    Tenant,
+    current_tenant,
+)
+
+# ----- handler that surfaces the resolved tenant ------------------------
+
+
+def _build_app(router: SubdomainTenantRouter, **mw_kwargs) -> Starlette:
+    async def whoami(request: Request) -> JSONResponse:
+        tenant = current_tenant()
+        return JSONResponse(
+            {
+                "tenant_id": tenant.id if tenant else None,
+                "display_name": tenant.display_name if tenant else None,
+            }
+        )
+
+    app = Starlette(routes=[Route("/whoami", whoami), Route("/healthz", whoami)])
+    app.add_middleware(SubdomainTenantMiddleware, router=router, **mw_kwargs)
+    return app
+
+
+# ----- Tenant dataclass ------------------------------------------------
+
+
+def test_tenant_is_frozen() -> None:
+    """Tenant is frozen — middleware caches resolved tenants in a
+    contextvar that downstream stores read; mutation in-place would
+    break per-request isolation."""
+    t = Tenant(id="acme", display_name="Acme")
+    with pytest.raises((AttributeError, Exception)):
+        t.id = "beta"  # type: ignore[misc]
+
+
+def test_tenant_carries_ext_passthrough() -> None:
+    t = Tenant(id="acme", display_name="Acme", ext={"db_shard": "us-east"})
+    assert t.ext == {"db_shard": "us-east"}
+
+
+# ----- InMemorySubdomainTenantRouter ----------------------------------
+
+
+def test_in_memory_router_resolves_known_host() -> None:
+    router = InMemorySubdomainTenantRouter(
+        tenants={"acme.example.com": Tenant(id="acme", display_name="Acme")}
+    )
+    result = asyncio.run(router.resolve("acme.example.com"))
+    assert result is not None
+    assert result.id == "acme"
+
+
+def test_in_memory_router_returns_none_for_unknown_host() -> None:
+    router = InMemorySubdomainTenantRouter(tenants={})
+    result = asyncio.run(router.resolve("unknown.example.com"))
+    assert result is None
+
+
+def test_in_memory_router_normalizes_case_insensitive() -> None:
+    """Host header is case-insensitive per RFC 7230 — adopter passing
+    mixed case at construction OR receiving mixed case at request
+    time both resolve correctly."""
+    router = InMemorySubdomainTenantRouter(
+        tenants={"Acme.Example.com": Tenant(id="acme", display_name="Acme")}
+    )
+    result = asyncio.run(router.resolve("ACME.example.COM"))
+    assert result is not None
+    assert result.id == "acme"
+
+
+def test_in_memory_router_strips_port_suffix() -> None:
+    router = InMemorySubdomainTenantRouter(
+        tenants={"acme.example.com": Tenant(id="acme", display_name="Acme")}
+    )
+    result = asyncio.run(router.resolve("acme.example.com:8080"))
+    assert result is not None
+    assert result.id == "acme"
+
+
+def test_in_memory_router_satisfies_protocol() -> None:
+    router = InMemorySubdomainTenantRouter(tenants={})
+    assert isinstance(router, SubdomainTenantRouter)
+
+
+# ----- middleware: known host happy path ------------------------------
+
+
+def test_middleware_resolves_known_host() -> None:
+    router = InMemorySubdomainTenantRouter(
+        tenants={
+            "acme.example.com": Tenant(id="acme", display_name="Acme"),
+            "beta.example.com": Tenant(id="beta", display_name="Beta"),
+        }
+    )
+    client = TestClient(_build_app(router))
+
+    resp = client.get("/whoami", headers={"Host": "acme.example.com"})
+    assert resp.status_code == 200
+    assert resp.json() == {"tenant_id": "acme", "display_name": "Acme"}
+
+
+def test_middleware_per_request_tenant_isolation() -> None:
+    """Sequential requests on different hosts each see only their
+    own tenant — the contextvar resets between requests."""
+    router = InMemorySubdomainTenantRouter(
+        tenants={
+            "acme.example.com": Tenant(id="acme", display_name="Acme"),
+            "beta.example.com": Tenant(id="beta", display_name="Beta"),
+        }
+    )
+    client = TestClient(_build_app(router))
+
+    r1 = client.get("/whoami", headers={"Host": "acme.example.com"})
+    r2 = client.get("/whoami", headers={"Host": "beta.example.com"})
+    assert r1.json()["tenant_id"] == "acme"
+    assert r2.json()["tenant_id"] == "beta"
+
+
+def test_middleware_clears_contextvar_after_request() -> None:
+    """Outside the request scope, ``current_tenant()`` returns None
+    even after the middleware resolved a tenant for a request."""
+    router = InMemorySubdomainTenantRouter(
+        tenants={"acme.example.com": Tenant(id="acme", display_name="Acme")}
+    )
+    client = TestClient(_build_app(router))
+    client.get("/whoami", headers={"Host": "acme.example.com"})
+    assert current_tenant() is None
+
+
+# ----- middleware: unknown host / missing host → 404 ------------------
+
+
+def test_middleware_404s_unknown_host() -> None:
+    router = InMemorySubdomainTenantRouter(tenants={})
+    client = TestClient(_build_app(router))
+
+    resp = client.get("/whoami", headers={"Host": "stranger.example.com"})
+    assert resp.status_code == 404
+    assert resp.headers.get("x-adcp-tenant-reject-reason") == "unknown-host"
+    assert resp.content == b""  # no body — same shape as missing-host
+
+
+def test_middleware_404s_missing_host_header() -> None:
+    """Lower-level test: an ASGI scope with no Host header returns
+    404. Buyer probing for tenant existence can't distinguish missing
+    vs unknown."""
+    router = InMemorySubdomainTenantRouter(tenants={})
+    middleware = SubdomainTenantMiddleware(_async_pass_through, router=router)
+
+    sent: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b""}
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/whoami",
+        "headers": [],  # No Host header.
+    }
+    asyncio.run(middleware(scope, receive, send))
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 404
+    headers = dict(start["headers"])
+    assert headers[b"x-adcp-tenant-reject-reason"] == b"missing-host-header"
+
+
+# ----- middleware: excluded paths -------------------------------------
+
+
+def test_middleware_bypasses_excluded_paths() -> None:
+    """Health-check endpoints typically don't carry a tenant Host —
+    the middleware skips routing for paths in ``excluded_paths``."""
+    router = InMemorySubdomainTenantRouter(tenants={})  # no tenants
+    client = TestClient(_build_app(router, excluded_paths=frozenset({"/healthz"})))
+
+    # Excluded path with unknown host still 200s — bypass.
+    resp = client.get("/healthz", headers={"Host": "stranger.example.com"})
+    assert resp.status_code == 200
+    # Tenant contextvar wasn't set for the bypass.
+    assert resp.json()["tenant_id"] is None
+
+
+def test_middleware_routes_non_excluded_paths_normally() -> None:
+    """Same router, same handler — non-excluded paths still 404
+    on unknown host."""
+    router = InMemorySubdomainTenantRouter(tenants={})
+    client = TestClient(_build_app(router, excluded_paths=frozenset({"/healthz"})))
+
+    resp = client.get("/whoami", headers={"Host": "stranger.example.com"})
+    assert resp.status_code == 404
+
+
+# ----- middleware: non-HTTP scopes pass through -----------------------
+
+
+def test_middleware_passes_websocket_scope_through() -> None:
+    """ASGI middleware must be safe on non-HTTP scopes (websocket,
+    lifespan) — the router never gets called."""
+    sentinel: list[str] = []
+
+    async def app(scope, receive, send):
+        sentinel.append(scope["type"])
+
+    class _BombRouter:
+        async def resolve(self, host: str) -> Tenant | None:
+            raise AssertionError("router must not be called on non-HTTP scope")
+
+    middleware = SubdomainTenantMiddleware(app, router=_BombRouter())
+
+    async def noop_receive():
+        return {"type": "websocket.connect"}
+
+    async def noop_send(_message):
+        pass
+
+    asyncio.run(middleware({"type": "websocket"}, noop_receive, noop_send))
+    asyncio.run(middleware({"type": "lifespan"}, noop_receive, noop_send))
+
+    assert sentinel == ["websocket", "lifespan"]
+
+
+# ----- helpers --------------------------------------------------------
+
+
+async def _async_pass_through(scope, receive, send) -> None:
+    """Inert ASGI app for tests that exercise the middleware in
+    isolation. Never reached when the middleware short-circuits."""
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b""})


### PR DESCRIPTION
## Summary

Multi-tenant AdCP sellers fronted by \`*.example.com\` use the incoming \`Host\` header to route to the right tenant. salesagent's \`domain_routing.py\` is ~250 LOC; this PR ships the same shape behind a typed Protocol so adopters get the routing seam without writing the parser.

- \`Tenant\` (frozen dataclass), \`SubdomainTenantRouter\` Protocol, \`InMemorySubdomainTenantRouter\` reference.
- \`SubdomainTenantMiddleware\` Starlette ASGI middleware: \`Host\` header → router → contextvar, 404 on unknown/missing host with reject-reason header, \`excluded_paths\` bypass for healthchecks, non-HTTP scopes pass through.
- \`current_tenant()\` contextvar accessor for downstream stores.

Closes #355.

## Test plan

- [x] 15 tests via Starlette TestClient (happy path, per-request isolation, contextvar cleanup, 404 shapes, port suffix, case-insensitive lookup, excluded paths, websocket/lifespan passthrough)
- [x] Full suite: 3074 passed
- [x] Public API snapshot regenerated
- [x] ruff/mypy/black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)