### PR TITLE
test(error-narrowing): rescope e2e CreativeManifest test

### DIFF
--- a/tests/test_error_narrowing.py
+++ b/tests/test_error_narrowing.py
@@ -162,12 +162,27 @@ def test_narrow_falls_back_when_variants_tie() -> None:
 # ---- End-to-end: CreativeManifest with missing field ----
 
 
-def test_e2e_creative_manifest_missing_width_height_narrows_to_image_asset() -> None:
-    """End-to-end regression for the exact Stability AI report case.
+def test_e2e_creative_manifest_missing_width_height_surfaces_actionable_errors() -> None:
+    """End-to-end regression for the Stability AI Emma report case.
 
-    Before the narrowing: 26 ValidationErrors covering every variant
-    of the asset content union. After: just the 2 ImageAsset.width /
-    ImageAsset.height errors the adopter cares about."""
+    Original symptom: constructing a CreativeManifest with an asset
+    missing required fields produced ~26 ValidationErrors covering every
+    variant of the asset-content union. The actionable mistake (one
+    missing field) was buried.
+
+    After the AdCP 3.0.2 asset-union refactor (canonical
+    ``core/assets/asset-union.json``), pydantic narrows the
+    discriminated-union ValidationError natively at the schema layer —
+    constructing the same bad manifest now yields only the 2 missing-field
+    errors directly. ``narrow_union_errors`` becomes a pass-through on
+    this input.
+
+    This test pins the integration shape: the actionable errors reach
+    the adopter without amplification, and ``narrow_union_errors``
+    doesn't over-narrow or corrupt already-narrow output. Algorithm-level
+    coverage of the narrowing logic itself lives in the synthetic
+    ``test_narrow_picks_*`` tests above.
+    """
     from pydantic import ValidationError
 
     from adcp.types import CreativeManifest, FormatReferenceStructuredObject
@@ -185,16 +200,14 @@ def test_e2e_creative_manifest_missing_width_height_narrows_to_image_asset() -> 
             },
         )
     except ValidationError as exc:
-        narrowed = narrow_union_errors(
-            exc.errors(include_input=False, include_context=False, include_url=False)
-        )
-        # Should be ~2 errors (ImageAsset's width + height), not ~26.
+        raw = exc.errors(include_input=False, include_context=False, include_url=False)
+        narrowed = narrow_union_errors(raw)
         assert (
             len(narrowed) <= 4
-        ), f"narrow_union_errors didn't narrow: {len(narrowed)} errors remain"
+        ), f"too many errors reach adopter: {len(narrowed)} (raw={len(raw)})"
         assert all("image" in err["loc"] for err in narrowed), (
-            "narrowed result should be image-asset-only; got: "
-            f"{[err['loc'] for err in narrowed]}"
+            "errors should localize to the matched 'image' asset variant; "
+            f"got: {[err['loc'] for err in narrowed]}"
         )
         missing_fields = {err["loc"][-1] for err in narrowed if err["type"] == "missing"}
         assert "width" in missing_fields and "height" in missing_fields


### PR DESCRIPTION
Follow-up to #367 / #306, flagged by code-reviewer in pre-PR review.

## Why

Pydantic narrows the discriminated asset-union ValidationError natively since the AdCP 3.0.2 asset-union refactor (synced in #367). The e2e test's original premise (26 errors → 2 via \`narrow_union_errors\`) no longer reproduces — the function becomes a pass-through on this input, and the assertion was no longer exercising what the test name promised.

## What

- Renamed \`test_e2e_creative_manifest_missing_width_height_narrows_to_image_asset\` → \`...surfaces_actionable_errors\`.
- Updated the docstring to honestly describe what the test pins now: actionable errors reach the adopter without amplification, and \`narrow_union_errors\` doesn't corrupt already-narrow output.
- Pointed readers at the synthetic \`test_narrow_picks_*\` tests above (which feed 26-style fixtures directly into the function) for the algorithm-level coverage.

No production code changes. \`narrow_union_errors\`'s heavy-lifting coverage lives in the algorithm-level tests already in this file (\`test_narrow_picks_discriminator_matched_variant\`, \`test_narrow_picks_fewest_errors_when_no_discriminator_winner\`, \`test_narrow_handles_union_tag_invalid_as_discriminator_mismatch\`, \`test_narrow_uses_innermost_variant_for_nested_unions\`).

## Test plan

- [x] \`uv run pytest tests/test_error_narrowing.py\` — 10 passed
- [x] \`uv run ruff check tests/\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)