### PR TITLE
feat(types): Account v3 projection helpers — bank-details write-only guard (#356)

### DIFF
--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -605,6 +605,11 @@ from adcp.types.guards import (  # noqa: F401
     is_update_media_buy_success,
     is_validate_content_delivery_success,
 )
+from adcp.types.projections import (
+    AccountResponse,
+    BusinessEntityResponse,
+    to_account_response,
+)
 from adcp.types.registry import BrandSource
 
 # Semantic aliases for auto-generated field enum names
@@ -686,6 +691,7 @@ __all__ = [
     "AccountReference",
     "AccountReferenceById",
     "AccountReferenceByNaturalKey",
+    "AccountResponse",
     "AccountScope",
     "GetAccountFinancialsRequest",
     "GetAccountFinancialsResponse",
@@ -885,6 +891,7 @@ __all__ = [
     "BrandReference",
     "BrandSource",
     "BusinessEntity",
+    "BusinessEntityResponse",
     "BuyingMode",
     "ContextObject",
     "DateRange",
@@ -1238,6 +1245,8 @@ __all__ = [
     "Performance",
     "ProductCatalog",
     "TextSubAsset",
+    # Response-shape projection helpers
+    "to_account_response",
     # Submodules for advanced use:
     "generated",
     "aliases",

--- a/src/adcp/types/projections.py
+++ b/src/adcp/types/projections.py
@@ -1,0 +1,99 @@
+"""Response-shape projections that strip write-only fields.
+
+The AdCP spec marks certain fields as ``writeOnly: true`` — present in
+requests so adopters can populate them, but MUST NOT be echoed in
+responses. The clearest case is ``BusinessEntity.bank``: IBANs, BICs,
+routing numbers, and account numbers flow into the seller during account
+setup and stay there. Pydantic's default serialization round-trips
+everything, so an adopter who reuses an internal ``Account`` model on
+the response path can leak bank details without realizing it.
+
+The projections here type-narrow the write-only fields to ``None``:
+construction with a non-None value raises ``ValidationError``, and the
+serialization path excludes the fields regardless. Adopters opt in by
+constructing the ``*Response`` variant on the response edge, or by
+piping through ``to_account_response()``.
+
+Out of scope:
+
+* ``GovernanceAgent.authentication`` (also write-only): generated nested
+  type, separate adopter contract; track separately.
+* ``reporting_bucket``: NOT write-only — seller-provisioned, buyer-readable
+  for offline delivery coordinates. Preserved as-is by the projection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field, field_validator
+
+from adcp.types import Account, BusinessEntity
+
+
+class BusinessEntityResponse(BusinessEntity):
+    """Response projection of :class:`BusinessEntity` with bank details stripped.
+
+    Per AdCP 3.0.x ``core/business-entity.json``: ``bank.*`` fields carry
+    ``writeOnly: true`` and MUST NOT appear in responses. Sellers store
+    bank coordinates and confirm receipt without echoing them.
+
+    This subclass enforces the contract two ways:
+
+    * Construction: passing ``bank=...`` raises ``ValidationError``.
+    * Serialization: the field is excluded from ``model_dump()`` output
+      even if some path mutated it post-construction (defense in depth
+      against ``model_copy()``, idempotency replay caches, etc.).
+    """
+
+    bank: Any = Field(default=None, exclude=True)
+
+    @field_validator("bank", mode="before")
+    @classmethod
+    def _reject_bank(cls, v: Any) -> None:
+        if v is not None:
+            raise ValueError(
+                "BusinessEntityResponse must not carry bank details — bank is "
+                "write-only per AdCP spec. Drop the field before constructing "
+                "a response, or use to_account_response() to strip it."
+            )
+        return None
+
+
+class AccountResponse(Account):
+    """Response projection of :class:`Account` — billing_entity is the
+    bank-stripped variant.
+
+    Use this on the response edge of any handler that returns account
+    state (``list_accounts``, ``get_account_financials``, etc.) when
+    your internal ``Account`` records carry bank details. For convenience,
+    :func:`to_account_response` projects an existing ``Account`` instance
+    to an ``AccountResponse`` and drops bank along the way.
+    """
+
+    billing_entity: BusinessEntityResponse | None = None
+
+
+def to_account_response(account: Account) -> AccountResponse:
+    """Project an internal ``Account`` to its response shape.
+
+    Strips ``billing_entity.bank`` and returns an :class:`AccountResponse`.
+    The remaining fields (legal_name, tax_id, address, contacts, vat_id,
+    registration_number, ext) round-trip unchanged. ``reporting_bucket``,
+    ``governance_agents``, and other non-write-only fields are preserved.
+
+    Raises:
+        ValidationError: if the source ``Account`` fails revalidation
+            against the response shape (other than the bank strip).
+    """
+    payload = account.model_dump(mode="python")
+    if isinstance(payload.get("billing_entity"), dict):
+        payload["billing_entity"].pop("bank", None)
+    return AccountResponse.model_validate(payload)
+
+
+__all__ = [
+    "AccountResponse",
+    "BusinessEntityResponse",
+    "to_account_response",
+]

--- a/tests/fixtures/public_api_snapshot.json
+++ b/tests/fixtures/public_api_snapshot.json
@@ -382,6 +382,7 @@
     "AccountReference",
     "AccountReferenceById",
     "AccountReferenceByNaturalKey",
+    "AccountResponse",
     "AccountScope",
     "AcquireRightsAcquiredResponse",
     "AcquireRightsErrorResponse",
@@ -432,6 +433,7 @@
     "BuildCreativeResponse",
     "BuildCreativeSuccessResponse",
     "BusinessEntity",
+    "BusinessEntityResponse",
     "BuyingMode",
     "ByCatalogItemItem",
     "ByPackageItem",
@@ -897,6 +899,7 @@
     "WebhookMetadata",
     "WebhookResponseType",
     "aliases",
-    "generated"
+    "generated",
+    "to_account_response"
   ]
 }

--- a/tests/test_account_projections.py
+++ b/tests/test_account_projections.py
@@ -1,0 +1,170 @@
+"""Account-response projection helpers — write-only bank-details guard.
+
+Per AdCP 3.0.x spec, ``BusinessEntity.bank`` is marked ``writeOnly: true``:
+buyers send bank coordinates as part of account setup, sellers store them,
+but sellers MUST NOT echo them back in responses. Pydantic's default
+serialization round-trips everything, so an adopter who reuses an internal
+``Account`` model on the response path can leak IBAN/routing numbers
+without realizing it.
+
+The projection types in ``adcp.types.projections`` make the guard explicit:
+type-narrow ``bank`` to ``None`` so the field is unconstructable on the
+response variant, and serialize without it regardless.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from adcp.types import Account, BusinessEntity
+from adcp.types.generated_poc.core.business_entity import Address, Bank
+from adcp.types.projections import (
+    AccountResponse,
+    BusinessEntityResponse,
+    to_account_response,
+)
+
+# ---- BusinessEntityResponse — write-only bank guard ----
+
+
+def test_business_entity_response_rejects_bank_at_construction() -> None:
+    """Passing ``bank=...`` to ``BusinessEntityResponse`` raises
+    ValidationError. The whole point: an adopter cannot assemble a
+    response-shape that would echo bank details, full stop.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        BusinessEntityResponse(
+            legal_name="Acme Corp",
+            bank=Bank(account_holder="Acme Corp", iban="DE89370400440532013000"),
+        )
+    # Error must localize to the bank field.
+    assert any("bank" in str(loc) for err in excinfo.value.errors() for loc in err["loc"])
+
+
+def test_business_entity_response_accepts_other_fields_unchanged() -> None:
+    """Non-write-only fields (legal_name, vat_id, address, contacts) flow
+    through unchanged — only ``bank`` is restricted."""
+    e = BusinessEntityResponse(
+        legal_name="Pinnacle Media GmbH",
+        vat_id="DE123456789",
+        address=Address(
+            street="Friedrichstrasse 100",
+            city="Berlin",
+            postal_code="10117",
+            country="DE",
+        ),
+    )
+    assert e.legal_name == "Pinnacle Media GmbH"
+    assert e.vat_id == "DE123456789"
+    assert e.address is not None and e.address.country == "DE"
+    assert e.bank is None
+
+
+def test_business_entity_response_serializes_without_bank() -> None:
+    """``model_dump()`` MUST NOT include ``bank`` on the wire shape — even
+    if some upstream path (model_copy, in-place mutation, idempotency replay)
+    managed to set it. Defense in depth on top of the construction guard."""
+    e = BusinessEntityResponse(legal_name="Acme Corp")
+    # Smuggle bank past the type system to exercise the serialization guard
+    # specifically (mirrors what a model_copy() round-trip could do).
+    object.__setattr__(e, "bank", Bank(account_holder="Acme Corp", iban="DE89370400440532013000"))
+    dumped = e.model_dump()
+    assert "bank" not in dumped or dumped["bank"] is None
+
+
+# ---- AccountResponse — uses BusinessEntityResponse for billing_entity ----
+
+
+def test_account_response_billing_entity_is_response_projection() -> None:
+    """``AccountResponse.billing_entity`` MUST be a ``BusinessEntityResponse``
+    (not the unguarded ``BusinessEntity``). Validates the type binding —
+    the whole projection collapses if billing_entity reverts to the parent
+    type, which would silently re-admit bank.
+    """
+    fields = AccountResponse.model_fields
+    annotation = fields["billing_entity"].annotation
+    # annotation is `BusinessEntityResponse | None` — drill in.
+    args = getattr(annotation, "__args__", ())
+    assert BusinessEntityResponse in args, (
+        f"AccountResponse.billing_entity should reference BusinessEntityResponse; "
+        f"got annotation={annotation}, args={args}"
+    )
+
+
+def test_account_response_rejects_billing_entity_with_bank() -> None:
+    """Constructing ``AccountResponse`` with a billing_entity that carries
+    bank details raises at validation time — same guard one level up.
+    """
+    with pytest.raises(ValidationError):
+        AccountResponse.model_validate(
+            {
+                "account_id": "acct-1",
+                "name": "Acme",
+                "status": "active",
+                "billing_entity": {
+                    "legal_name": "Acme Corp",
+                    "bank": {
+                        "account_holder": "Acme Corp",
+                        "routing_number": "021000021",
+                        "account_number": "123456789",
+                    },
+                },
+            }
+        )
+
+
+# ---- to_account_response — adopter-facing strip helper ----
+
+
+def test_to_account_response_strips_bank_from_internal_account() -> None:
+    """Adopters with internal ``Account`` records that carry bank details
+    use ``to_account_response()`` to project to a safe response shape.
+    The bank field is dropped; everything else round-trips.
+    """
+    internal = Account(
+        account_id="acct-1",
+        name="Acme",
+        status="active",
+        billing_entity=BusinessEntity(
+            legal_name="Acme Corp",
+            tax_id="12-3456789",
+            bank=Bank(
+                account_holder="Acme Corp",
+                routing_number="021000021",
+                account_number="123456789",
+            ),
+        ),
+    )
+    response = to_account_response(internal)
+    assert isinstance(response, AccountResponse)
+    assert response.billing_entity is not None
+    assert response.billing_entity.legal_name == "Acme Corp"
+    assert response.billing_entity.tax_id == "12-3456789"
+    assert response.billing_entity.bank is None
+    # Wire form has no bank key at all.
+    assert "bank" not in (response.model_dump().get("billing_entity") or {}) or (
+        response.model_dump()["billing_entity"]["bank"] is None
+    )
+
+
+def test_to_account_response_preserves_reporting_bucket() -> None:
+    """``reporting_bucket`` is seller-provisioned and buyers actively read it
+    for offline-delivery coordinates — it is NOT write-only and MUST NOT be
+    stripped by the projection. Pinning this so the guard doesn't grow to
+    eat fields it shouldn't.
+    """
+    internal = Account(
+        account_id="acct-1",
+        name="Acme",
+        status="active",
+        reporting_bucket={
+            "protocol": "s3",
+            "bucket": "reports-acme-prod",
+            "file_retention_days": 30,
+        },
+    )
+    response = to_account_response(internal)
+    assert response.reporting_bucket is not None
+    assert response.reporting_bucket.bucket == "reports-acme-prod"
+    assert response.reporting_bucket.file_retention_days == 30


### PR DESCRIPTION
Closes #356.

## Summary

New module \`adcp.types.projections\` with response-shape projection types that close the bank-details-on-read leak path on \`Account\` responses.

Per AdCP 3.0.x \`core/business-entity.json\`, \`BusinessEntity.bank\` carries \`writeOnly: true\` — IBAN, BIC, routing/account numbers flow into the seller during account setup but MUST NOT be echoed in responses. Pydantic round-trips everything by default, so an adopter who reuses an internal \`Account\` model on the response path leaks bank details unknowingly.

## Design choice — Option 2 (projection types)

Per security-reviewer on the issue, **Option 1 (model_validator strip)** has multiple silent bypass paths: \`model_copy()\`, direct \`BusinessEntity\` serialization, idempotency cache replay. **Option 2 (projection types)** is structurally correct — the field is type-narrowed to \`None\`, so an adopter holding the projection type literally cannot construct one with bank set.

## Public surface

\`\`\`python
from adcp.types import (
    AccountResponse,
    BusinessEntityResponse,
    to_account_response,
)

# Convert an internal Account (with bank populated) to a safe response:
response = to_account_response(internal_account)
# response.billing_entity.bank is None; serialization omits the field.

# Or construct directly:
resp = AccountResponse(
    account_id="acct-1", name="Acme", status="active",
    billing_entity={"legal_name": "Acme Corp"},  # bank=... raises ValidationError
)
\`\`\`

## Behavior pinned by tests

- \`BusinessEntityResponse(bank=...)\` → \`ValidationError\`
- Other fields (\`legal_name\`, \`vat_id\`, \`address\`, \`contacts\`) round-trip unchanged
- \`model_dump()\` excludes \`bank\` even if smuggled past the type system (defense in depth)
- \`AccountResponse.billing_entity\` annotation references \`BusinessEntityResponse\` (the whole guard collapses if this binding regresses)
- \`AccountResponse.model_validate({...with nested bank...})\` raises
- \`to_account_response(internal_account)\` strips bank, preserves everything else
- \`reporting_bucket\` is NOT write-only (per ad-tech-protocol-expert clarification — seller-provisioned, buyer-readable for offline-delivery coordinates) and MUST NOT be stripped — pinned by a regression test.

## Out of scope (track separately)

- \`GovernanceAgent.authentication\` is also \`writeOnly\` but lives in a generated nested type with a different adopter contract.
- \`sync_accounts_response.Account\` is built via the \`SyncAccountsResponse1\`/\`SyncAccountsResponse2\` discriminator branches and doesn't share the \`billing_entity\` wire shape with \`core.Account\`. Different leak surface, different fix.
- The triage flagged a docstring example \`request_snapshot = req.model_dump()\` that prescribes writing IBAN into adopter stores; orthogonal to projections, deferred.

## Local gates

- \`uv run ruff check src/\` — clean
- \`uv run mypy src/adcp/\` — Success: no issues found in 744 source files
- \`uv run pytest tests/\` — all green; \`test_public_api_surface_matches_snapshot\` updated for the 3 new exports.

## Test plan

- [x] \`uv run pytest tests/test_account_projections.py -v\` — 7 passed
- [x] \`uv run pytest tests/test_public_api.py -q\` — snapshot regenerated and matches
- [x] Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)