### PR TITLE
fix(decisioning): Tier 2 expert-review fix-pack

### DIFF
--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -129,16 +129,21 @@ from adcp.decisioning.types import (
     WorkflowHandoff,
 )
 
-# Conditional import: PostgresTaskRegistry needs the [pg] extra. Always expose
+# Conditional import: PgTaskRegistry needs the [pg] extra. Always expose
 # the name — when psycopg isn't installed we fall through to a stub class whose
 # constructor raises ImportError with the install hint. Matches the pattern
 # used by adcp.signing for PgReplayStore.
+#
+# ``PostgresTaskRegistry`` is the pre-4.4 name and remains as a deprecated
+# alias through the 4.4.x line; renamed to ``PgTaskRegistry`` to match the
+# ``Pg*`` convention shared with PgReplayStore / PgBuyerAgentRegistry /
+# PgWebhookDeliverySupervisor.
 try:
-    from adcp.decisioning.pg import PostgresTaskRegistry  # noqa: F401
+    from adcp.decisioning.pg import PgTaskRegistry, PostgresTaskRegistry  # noqa: F401
 except ImportError:  # pragma: no cover — exercised by the [pg] extra tests
     from typing import ClassVar as _ClassVar
 
-    class PostgresTaskRegistry:  # type: ignore[no-redef]
+    class PgTaskRegistry:  # type: ignore[no-redef]
         """Stub raised when ``adcp[pg]`` isn't installed.
 
         Attempting to instantiate raises :class:`ImportError` with the
@@ -149,10 +154,13 @@ except ImportError:  # pragma: no cover — exercised by the [pg] extra tests
 
         def __init__(self, *args: object, **kwargs: object) -> None:
             raise ImportError(
-                "PostgresTaskRegistry requires psycopg3 and psycopg-pool. "
+                "PgTaskRegistry requires psycopg3 and psycopg-pool. "
                 "Install the 'pg' extra: `pip install 'adcp[pg]'` "
                 "(Poetry: `poetry add 'adcp[pg]'`)."
             )
+
+    # Deprecated alias preserved through 4.4.x.
+    PostgresTaskRegistry: type[PgTaskRegistry] = PgTaskRegistry  # type: ignore[no-redef]
 
 
 __all__ = [
@@ -187,6 +195,7 @@ __all__ = [
     "InMemoryTaskRegistry",
     "MaybeAsync",
     "OAuthCredential",
+    "PgTaskRegistry",
     "PostgresTaskRegistry",
     "Proposal",
     "PropertyList",

--- a/src/adcp/decisioning/context.py
+++ b/src/adcp/decisioning/context.py
@@ -15,10 +15,10 @@ the platform's ``AccountStore.resolve(...)`` result.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any, ClassVar, Generic
 
 from typing_extensions import TypeVar
 
@@ -28,8 +28,6 @@ from adcp.decisioning.types import Account, TaskHandoff, WorkflowHandoff
 from adcp.server.base import ToolContext
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from adcp.decisioning.registry import (
         BuyerAgent,
         Credential,
@@ -101,9 +99,12 @@ class AuthInfo:
         credential themselves and leave the legacy fields empty.
     :param agent_url: Verified buyer-agent URL — populated from
         ``credential.agent_url`` when ``credential`` is an
-        :class:`adcp.decisioning.HttpSigCredential`, OR from
-        ``principal`` when ``kind in {'signed_request', 'http_sig'}``.
-        ``None`` for bearer / OAuth / unauthenticated traffic.
+        :class:`adcp.decisioning.HttpSigCredential`. ``None`` for
+        bearer / OAuth / unauthenticated traffic and for
+        ``kind="signed_request"`` constructions that don't pass a
+        typed credential (the SDK deliberately refuses to derive
+        ``agent_url`` from the unverified ``principal`` string —
+        see ``__post_init__`` for the rationale).
     :param operator: Operator / transport-tenant label — the AdCP v3
         operator binding (separate from the buyer agent). Distinct
         from ``ToolContext.tenant_id`` only for adopters running the
@@ -113,13 +114,24 @@ class AuthInfo:
         doesn't model (custom claims, MFA flags, internal session ids).
     """
 
+    # Sentinel used as the default value of ``credential`` so
+    # ``__post_init__`` can distinguish "adopter didn't pass credential
+    # at all" (default → synthesize from flat fields) from "adopter
+    # explicitly passed credential=None" (default → leave None,
+    # don't re-synthesize). Without this sentinel,
+    # ``dataclasses.replace(auth, credential=None)`` — the natural
+    # idiom for clearing a credential — would re-trigger synthesis
+    # from the still-present flat fields, contradicting the adopter's
+    # intent.
+    _UNSET_CREDENTIAL: ClassVar[Any] = object()
+
     kind: str
     key_id: str | None = None
     principal: str | None = None
     scopes: list[str] = field(default_factory=list)
 
     # ----- Tier 2 v3-identity fields -----
-    credential: Credential | None = None
+    credential: Credential | None = _UNSET_CREDENTIAL
     agent_url: str | None = None
     operator: str | None = None
     extra: Mapping[str, Any] = field(default_factory=dict)
@@ -171,6 +183,8 @@ class AuthInfo:
         scopes: list[str] | None = None,
         operator: str | None = None,
         extra: Mapping[str, Any] | None = None,
+        max_verified_age_s: float | None = None,
+        now: float | None = None,
     ) -> AuthInfo:
         """Build :class:`AuthInfo` from a :class:`adcp.signing.VerifiedSigner`.
 
@@ -196,7 +210,9 @@ class AuthInfo:
                 body=request.get_data(),
                 options=VerifyOptions(...),
             )
-            ctx.metadata["adcp.auth_info"] = AuthInfo.from_verified_signer(signer)
+            ctx.metadata["adcp.auth_info"] = AuthInfo.from_verified_signer(
+                signer, max_verified_age_s=300.0,
+            )
 
         The verifier MUST surface ``signer.agent_url`` for the
         commercial-identity registry to dispatch — without it, the
@@ -217,10 +233,25 @@ class AuthInfo:
             deployments (AAO community proxy). Most adopters leave
             ``None``.
         :param extra: Adopter passthrough.
-        :raises ValueError: when ``signer.agent_url`` is ``None`` —
-            the verifier wasn't configured to extract the agent_url
-            claim from the signed request.
+        :param max_verified_age_s: Maximum age (seconds) of
+            ``signer.verified_at`` permitted at construction time.
+            When set and ``now() - signer.verified_at >
+            max_verified_age_s``, raises :class:`ValueError` —
+            adopter caching a stale ``VerifiedSigner`` and replaying
+            it later fails fast rather than passing a stale-but-
+            cryptographically-valid credential into the registry
+            dispatch. Default ``None`` keeps the v6.0-alpha
+            behavior; production sellers SHOULD set a short window
+            (e.g. 300s) matching the RFC 9421 nonce TTL.
+        :param now: Override ``time.time()`` for ``max_verified_age_s``
+            comparisons — only useful in tests. Default ``None``
+            uses wall-clock.
+        :raises ValueError: when ``signer.agent_url`` is ``None``,
+            or when ``max_verified_age_s`` is set and
+            ``signer.verified_at`` is older than the window.
         """
+        import time
+
         from adcp.decisioning.registry import HttpSigCredential
 
         if signer.agent_url is None:
@@ -231,6 +262,19 @@ class AuthInfo:
                 "verifier surfaces it on success. Without an agent_url, the "
                 "BuyerAgentRegistry has no key to dispatch on."
             )
+        if max_verified_age_s is not None:
+            current = now if now is not None else time.time()
+            age = current - signer.verified_at
+            if age > max_verified_age_s:
+                raise ValueError(
+                    f"VerifiedSigner.verified_at is {age:.1f}s old, exceeds "
+                    f"max_verified_age_s={max_verified_age_s:.1f}s. The "
+                    "verifier's signature was valid at the time of verification "
+                    "but has aged out of the freshness window — typically "
+                    "indicates a cached signer being replayed. Re-verify the "
+                    "request signature instead of constructing AuthInfo from "
+                    "a stale signer."
+                )
         credential = HttpSigCredential(
             kind="http_sig",
             keyid=signer.key_id,
@@ -266,12 +310,56 @@ class AuthInfo:
         :meth:`__post_init__` and *does* see the warning, pointing
         at the adopter callsite — which is the actionable signal
         this deprecation is meant to deliver.
+
+        Validates the dict shape — adopters porting JS-side middleware
+        sometimes write ``scopes`` as a string instead of a list, or
+        pass a raw dict where a typed :class:`Credential` is expected.
+        Silently coercing those would mask middleware bugs that only
+        surface when the registry dispatch later tries to use the
+        malformed credential. Raise :class:`TypeError` with the
+        offending field name so adopter logs surface the issue
+        immediately at server boot / first request.
         """
+        from adcp.decisioning.registry import (
+            ApiKeyCredential,
+            HttpSigCredential,
+            OAuthCredential,
+        )
+
+        # Type guards. Empty dict is fine — we project to a
+        # ``kind="derived"`` AuthInfo with no credential.
+        scopes_raw = raw.get("scopes", [])
+        if not isinstance(scopes_raw, (list, tuple)):
+            raise TypeError(
+                "adcp.auth_info dict has scopes={scopes_raw!r} of type "
+                f"{type(scopes_raw).__name__}; expected list / tuple of "
+                "strings. Adopter middleware writing a string here (e.g. "
+                "comma-separated scopes) needs to split before passing "
+                "to AuthInfo.".format(scopes_raw=scopes_raw)
+            )
+        credential = raw.get("credential")
+        if credential is not None and not isinstance(
+            credential, (ApiKeyCredential, OAuthCredential, HttpSigCredential)
+        ):
+            raise TypeError(
+                "adcp.auth_info dict has credential of type "
+                f"{type(credential).__name__}; expected an instance of "
+                "ApiKeyCredential / OAuthCredential / HttpSigCredential. "
+                "Construct the typed credential explicitly in your auth "
+                "middleware — the framework can't safely build it from a "
+                "raw dict because it can't distinguish kinds."
+            )
+        extra = raw.get("extra", {})
+        if not isinstance(extra, Mapping):
+            raise TypeError(
+                f"adcp.auth_info dict has extra={extra!r} of type "
+                f"{type(extra).__name__}; expected a Mapping."
+            )
+
         kind = raw.get("kind", "derived")
         key_id = raw.get("key_id")
         principal = raw.get("principal")
-        scopes = list(raw.get("scopes", []))
-        credential = raw.get("credential")
+        scopes = list(scopes_raw)
         if credential is None:
             credential = cls._synthesize_bearer_credential(kind, key_id, principal, scopes)
         return cls(
@@ -282,7 +370,7 @@ class AuthInfo:
             credential=credential,
             agent_url=raw.get("agent_url"),
             operator=raw.get("operator"),
-            extra=raw.get("extra", {}),
+            extra=extra,
         )
 
     def __post_init__(self) -> None:
@@ -304,7 +392,10 @@ class AuthInfo:
         """
         from adcp.decisioning.registry import HttpSigCredential
 
-        if self.credential is None:
+        if self.credential is AuthInfo._UNSET_CREDENTIAL:
+            # Default — adopter didn't pass ``credential=`` at all.
+            # Synthesize from flat fields if they describe a bearer
+            # credential; warn so the adopter migrates.
             synthesized = self._synthesize_bearer_credential(
                 self.kind, self.key_id, self.principal, self.scopes
             )
@@ -325,6 +416,13 @@ class AuthInfo:
                     DeprecationWarning,
                     stacklevel=2,
                 )
+            else:
+                self.credential = None
+        # ELSE: adopter passed ``credential=...`` explicitly (real
+        # credential or ``None``). Honor their value verbatim — no
+        # synthesis, no warning. This makes
+        # ``dataclasses.replace(auth, credential=None)`` correctly
+        # clear the credential without re-running synthesis.
 
         if self.agent_url is None and isinstance(self.credential, HttpSigCredential):
             self.agent_url = self.credential.agent_url

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -340,15 +340,37 @@ async def _resolve_buyer_agent(
         — the buyer cannot retry their way out of a commercial-state
         rejection.
     """
+    from adcp.decisioning.registry import (
+        ApiKeyCredential,
+        HttpSigCredential,
+        OAuthCredential,
+    )
     from adcp.decisioning.types import AdcpError
 
     credential = auth_info.credential if auth_info is not None else None
     agent: BuyerAgent | None = None
     if credential is not None:
-        if credential.kind == "http_sig":
+        if isinstance(credential, HttpSigCredential):
             agent = await registry.resolve_by_agent_url(credential.agent_url)
-        else:
+        elif isinstance(credential, (ApiKeyCredential, OAuthCredential)):
             agent = await registry.resolve_by_credential(credential)
+        else:
+            # Defensive: a future Credential variant lands and the
+            # dispatch path doesn't know how to route it. Fail closed
+            # with INTERNAL_ERROR rather than silently passing the
+            # request through (which would skip the registry gate
+            # entirely and leak the upgrade footgun into production).
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"BuyerAgentRegistry dispatch received an unknown "
+                    f"Credential variant {type(credential).__name__!r}. "
+                    "The framework's resolver doesn't know which registry "
+                    "method to call. Update _resolve_buyer_agent in "
+                    "adcp.decisioning.handler to dispatch the new variant."
+                ),
+                recovery="terminal",
+            )
 
     if agent is None:
         raise AdcpError(
@@ -711,10 +733,15 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         Reads the resolved :class:`BuyerAgent` from
         ``tool_ctx.metadata['adcp.buyer_agent']`` (stashed by
         :meth:`_resolve_account` when a registry is wired) and passes
-        it through to the typed :class:`RequestContext`.
+        it through to the typed :class:`RequestContext`. Uses
+        ``pop`` so the value is consumed once — protects against
+        the pathological case where a misconfigured ``context_factory``
+        returns the same ``ToolContext`` across requests, which would
+        otherwise leak the prior request's resolved buyer-agent into
+        the next dispatch.
         """
         auth_info = self._extract_auth_info(tool_ctx)
-        buyer_agent = tool_ctx.metadata.get("adcp.buyer_agent") if tool_ctx.metadata else None
+        buyer_agent = tool_ctx.metadata.pop("adcp.buyer_agent", None) if tool_ctx.metadata else None
         return _build_request_context(
             tool_ctx,
             account,

--- a/src/adcp/decisioning/pg/__init__.py
+++ b/src/adcp/decisioning/pg/__init__.py
@@ -11,12 +11,13 @@ Available when ``adcp[pg]`` is installed:
   request to gate dispatch on the seller's commercial relationship
   with the buyer agent (allowlist + onboarding state + billing
   capabilities).
-* :class:`PostgresTaskRegistry` — durable
+* :class:`PgTaskRegistry` — durable
   :class:`~adcp.decisioning.TaskRegistry` for HITL task state. Survives
   process restarts and is safe for multi-worker deployments sharing a
   single Postgres database. Drop-in replacement for
   :class:`~adcp.decisioning.InMemoryTaskRegistry` that satisfies the
-  production-mode durability gate.
+  production-mode durability gate. (``PostgresTaskRegistry`` is the
+  pre-4.4 name and remains as a deprecated alias through 4.4.x.)
 
 The schema DDL ships alongside the Python code (e.g.
 ``adcp/decisioning/pg/buyer_agent_registry.sql``,
@@ -31,11 +32,12 @@ from adcp.decisioning.pg.buyer_agent_registry import (
     PG_AVAILABLE,
     PgBuyerAgentRegistry,
 )
-from adcp.decisioning.pg.task_registry import PostgresTaskRegistry
+from adcp.decisioning.pg.task_registry import PgTaskRegistry, PostgresTaskRegistry
 
 __all__ = [
     "DEFAULT_TABLE_NAME",
     "PG_AVAILABLE",
     "PgBuyerAgentRegistry",
+    "PgTaskRegistry",
     "PostgresTaskRegistry",
 ]

--- a/src/adcp/decisioning/pg/decisioning_tasks.sql
+++ b/src/adcp/decisioning/pg/decisioning_tasks.sql
@@ -1,6 +1,6 @@
 -- AdCP decisioning task registry — durable HITL task state.
 --
--- Run this once per deployment. Tracked by PostgresTaskRegistry;
+-- Run this once per deployment. Tracked by PgTaskRegistry;
 -- see src/adcp/decisioning/pg/task_registry.py for the query shapes
 -- the Python code executes.
 --
@@ -9,7 +9,7 @@
 -- which could collapse distinct task_ids or account_ids. "C" is the
 -- byte-for-byte comparison we actually want.
 --
--- Alternatively, call PostgresTaskRegistry.create_schema() from
+-- Alternatively, call PgTaskRegistry.create_schema() from
 -- application code — it runs the equivalent DDL idempotently on boot.
 
 CREATE TABLE IF NOT EXISTS decisioning_tasks (

--- a/src/adcp/decisioning/pg/task_registry.py
+++ b/src/adcp/decisioning/pg/task_registry.py
@@ -15,7 +15,7 @@ Quickstart
 
     import asyncio
     from psycopg_pool import AsyncConnectionPool
-    from adcp.decisioning import PostgresTaskRegistry, serve
+    from adcp.decisioning import PgTaskRegistry, serve
     from myapp import MyPlatform
 
     async def main():
@@ -24,7 +24,7 @@ Quickstart
             min_size=2,
             max_size=10,
         ) as pool:
-            registry = PostgresTaskRegistry(pool=pool)
+            registry = PgTaskRegistry(pool=pool)
             await registry.create_schema()  # idempotent; safe on every boot
             serve(MyPlatform(), registry=registry)
 
@@ -79,7 +79,7 @@ except ImportError:
     PG_AVAILABLE = False
 
 _INSTALL_HINT = (
-    "PostgresTaskRegistry requires psycopg3 and psycopg-pool. "
+    "PgTaskRegistry requires psycopg3 and psycopg-pool. "
     "Install the 'pg' extra: `pip install 'adcp[pg]'` "
     "(Poetry: `poetry add 'adcp[pg]'`)."
 )
@@ -92,7 +92,7 @@ _DEFAULT_TABLE = "decisioning_tasks"
 _SAFE_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
 
 
-class PostgresTaskRegistry:
+class PgTaskRegistry:
     """PostgreSQL-backed :class:`~adcp.decisioning.TaskRegistry` — v6.1.
 
     Durable counterpart to :class:`~adcp.decisioning.InMemoryTaskRegistry`.
@@ -122,9 +122,7 @@ class PostgresTaskRegistry:
         if not PG_AVAILABLE:
             raise ImportError(_INSTALL_HINT)
         if not _SAFE_IDENTIFIER_RE.fullmatch(_table):
-            raise ValueError(
-                f"_table must match [a-z_][a-z0-9_]* (ASCII only), got {_table!r}"
-            )
+            raise ValueError(f"_table must match [a-z_][a-z0-9_]* (ASCII only), got {_table!r}")
         self._pool = pool
         self._table = _table
 
@@ -153,11 +151,17 @@ class PostgresTaskRegistry:
             f" WHERE task_id = %s AND state NOT IN ('completed', 'failed')"
             f" RETURNING task_id"
         )
+        # Explicit ``::text`` cast on the optional account-filter
+        # parameter so psycopg's bind-param type inference doesn't
+        # fail with ``IndeterminateDatatype: could not determine
+        # data type of parameter $2``. Without the cast, the
+        # ``%s IS NULL`` predicate gives psycopg no type context
+        # for the parameter and the query fails at prepare time.
         self._sql_get = (  # noqa: S608
             f"SELECT task_id, account_id, state, task_type,"
             f"       progress, result, error, created_at, updated_at"
             f" FROM {self._table}"
-            f" WHERE task_id = %s AND (%s IS NULL OR account_id = %s)"
+            f" WHERE task_id = %s AND (%s::text IS NULL OR account_id = %s)"
         )
         self._sql_get_state_result = (  # noqa: S608
             f"SELECT state, result FROM {self._table} WHERE task_id = %s"
@@ -167,7 +171,7 @@ class PostgresTaskRegistry:
         )
         self._sql_discard = f"DELETE FROM {self._table} WHERE task_id = %s"  # noqa: S608
         self._sql_ddl = (  # noqa: S608
-            f'CREATE TABLE IF NOT EXISTS {self._table} ('
+            f"CREATE TABLE IF NOT EXISTS {self._table} ("
             f'    task_id     TEXT             COLLATE "C" NOT NULL PRIMARY KEY,'
             f'    account_id  TEXT             COLLATE "C" NOT NULL,'
             f"    state       TEXT             NOT NULL DEFAULT 'submitted',"
@@ -265,9 +269,7 @@ class PostgresTaskRegistry:
         race each other into double-completion without detection.
         """
         async with self._pool.connection() as conn:
-            cur = await conn.execute(
-                self._sql_complete, (json.dumps(result), time.time(), task_id)
-            )
+            cur = await conn.execute(self._sql_complete, (json.dumps(result), time.time(), task_id))
             if await cur.fetchone() is not None:
                 return  # updated successfully
 
@@ -294,9 +296,7 @@ class PostgresTaskRegistry:
         :class:`ValueError` on conflicting re-failure.
         """
         async with self._pool.connection() as conn:
-            cur = await conn.execute(
-                self._sql_fail, (json.dumps(error), time.time(), task_id)
-            )
+            cur = await conn.execute(self._sql_fail, (json.dumps(error), time.time(), task_id))
             if await cur.fetchone() is not None:
                 return  # updated successfully
 
@@ -354,4 +354,12 @@ class PostgresTaskRegistry:
             await conn.execute(self._sql_discard, (task_id,))
 
 
-__all__ = ["PG_AVAILABLE", "PostgresTaskRegistry"]
+#: Backwards-compat alias. Renamed to :class:`PgTaskRegistry` in
+#: 4.4.0 to match the framework's ``Pg*`` convention shared with
+#: :class:`adcp.signing.PgReplayStore` and
+#: :class:`adcp.decisioning.PgBuyerAgentRegistry`. The old name keeps
+#: working for one minor (4.4.x) and is removed in 4.5.0.
+PostgresTaskRegistry = PgTaskRegistry
+
+
+__all__ = ["PG_AVAILABLE", "PgTaskRegistry", "PostgresTaskRegistry"]

--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -240,7 +240,7 @@ def create_adcp_server_from_platform(
                     "— silent in-memory fallback would lose tasks across "
                     "process restarts. Either wire a durable "
                     "TaskRegistry impl (set is_durable=True on the class; "
-                    "v6.1 ships PostgresTaskRegistry) OR set "
+                    "v6.1 ships PgTaskRegistry) OR set "
                     "ADCP_DECISIONING_ALLOW_INMEMORY_TASKS=1 to "
                     "explicitly opt into in-memory tasks (e.g., for "
                     "single-process pilots)."

--- a/src/adcp/webhook_supervisor_pg.py
+++ b/src/adcp/webhook_supervisor_pg.py
@@ -252,7 +252,12 @@ class PgWebhookDeliverySupervisor:
         # {ct}.column_name in DO UPDATE SET refers to the *existing* row's value
         # (before the update), which is what Postgres requires for self-referential
         # ON CONFLICT expressions.
-        failure_t = self._circuit_policy.failure_threshold
+        # Coerce thresholds via ``int()`` before f-string interpolation —
+        # an adopter passing an ``IntEnum`` / ``bool`` / custom ``__index__``
+        # subclass for ``failure_threshold`` would format verbatim into
+        # SQL otherwise. Coercion produces a plain int whose ``str()``
+        # is byte-safe for static SQL emission.
+        failure_t = int(self._circuit_policy.failure_threshold)
         self._sql_circuit_failure = (
             f"INSERT INTO {ct} "  # noqa: S608
             f"(breaker_key, state, failure_count, success_count, updated_at) "
@@ -274,7 +279,7 @@ class PgWebhookDeliverySupervisor:
         # eliminates the half-open race: two concurrent workers see different final
         # counts and only the worker whose UPDATE produces count >= threshold
         # transitions to 'closed'.
-        success_t = self._circuit_policy.success_threshold
+        success_t = int(self._circuit_policy.success_threshold)
         self._sql_circuit_success = (
             f"INSERT INTO {ct} "  # noqa: S608
             f"(breaker_key, state, failure_count, success_count, updated_at) "
@@ -654,9 +659,7 @@ class PgWebhookDeliverySupervisor:
                     self._retry.delay_for_attempt(attempt_number + 1) if will_retry else None
                 )
                 next_retry_at = (
-                    occurred_at + timedelta(seconds=next_delay)
-                    if next_delay is not None
-                    else None
+                    occurred_at + timedelta(seconds=next_delay) if next_delay is not None else None
                 )
 
                 if will_retry:

--- a/tests/test_decisioning_buyer_agent_dispatch.py
+++ b/tests/test_decisioning_buyer_agent_dispatch.py
@@ -280,6 +280,89 @@ def test_authinfo_from_verified_signer_builds_typed_http_sig_credential() -> Non
     assert auth.extra == {"session_id": "s_42"}
 
 
+def test_authinfo_replace_credential_none_does_not_resynthesize() -> None:
+    """Adopter idiom: ``dataclasses.replace(auth, credential=None)``
+    explicitly clears the credential. Without the sentinel default,
+    ``__post_init__`` would re-synthesize from the still-present flat
+    fields — defeating the adopter's intent and re-firing the
+    deprecation warning at the framework callsite."""
+    import warnings as _w
+
+    cred = ApiKeyCredential(kind="api_key", key_id="k1")
+    auth = AuthInfo(kind="bearer", key_id="k1", credential=cred)
+    with _w.catch_warnings():
+        _w.simplefilter("error", DeprecationWarning)
+        cleared = dataclasses.replace(auth, credential=None)
+    assert cleared.credential is None
+    # Original is untouched.
+    assert auth.credential is cred
+
+
+def test_authinfo_from_legacy_dict_rejects_string_scopes() -> None:
+    """Adopter middleware writing ``scopes="read,write"`` (string
+    instead of list) — fail fast with a typed error rather than
+    silently coercing characters into per-letter scopes."""
+    with pytest.raises(TypeError, match="scopes"):
+        AuthInfo._from_legacy_dict({"kind": "bearer", "scopes": "read,write"})
+
+
+def test_authinfo_from_legacy_dict_rejects_dict_credential() -> None:
+    """The framework can't safely synthesize a typed Credential from
+    a raw dict — kinds aren't structurally distinguishable. Fail
+    fast with a typed error pointing at the adopter callsite."""
+    with pytest.raises(TypeError, match="credential"):
+        AuthInfo._from_legacy_dict(
+            {
+                "kind": "bearer",
+                "credential": {"kind": "api_key", "key_id": "k1"},
+            }
+        )
+
+
+def test_authinfo_from_legacy_dict_rejects_non_mapping_extra() -> None:
+    with pytest.raises(TypeError, match="extra"):
+        AuthInfo._from_legacy_dict({"kind": "bearer", "extra": "not-a-mapping"})
+
+
+def test_authinfo_from_verified_signer_max_verified_age_rejects_stale() -> None:
+    """A cached VerifiedSigner replayed past the freshness window
+    fails fast — adopter caught replaying a stale signer instead of
+    re-verifying gets a clear error."""
+    from adcp.signing import VerifiedSigner
+
+    signer = VerifiedSigner(
+        key_id="kid-1",
+        alg="ed25519",
+        label="sig1",
+        verified_at=1700000000.0,
+        agent_url="https://agent.example/",
+    )
+    with pytest.raises(ValueError, match="max_verified_age_s"):
+        AuthInfo.from_verified_signer(
+            signer,
+            max_verified_age_s=300.0,
+            now=1700001000.0,  # 1000s elapsed > 300s window
+        )
+
+
+def test_authinfo_from_verified_signer_max_verified_age_passes_fresh() -> None:
+    from adcp.signing import VerifiedSigner
+
+    signer = VerifiedSigner(
+        key_id="kid-1",
+        alg="ed25519",
+        label="sig1",
+        verified_at=1700000000.0,
+        agent_url="https://agent.example/",
+    )
+    auth = AuthInfo.from_verified_signer(
+        signer,
+        max_verified_age_s=300.0,
+        now=1700000100.0,  # 100s elapsed < 300s window
+    )
+    assert isinstance(auth.credential, HttpSigCredential)
+
+
 def test_authinfo_from_verified_signer_rejects_missing_agent_url() -> None:
     """Without ``agent_url`` the registry has no key to dispatch on.
     Surface the verifier-config bug with a clear server-side error


### PR DESCRIPTION
## Summary

Fix-pack from the 4-expert holistic review of the merged Tier 2 v3-identity bundle, plus the IndeterminateDatatype SQL fix that was lost during the #361 rebase.

**Eight items addressed:**

1. \`AuthInfo.replace(credential=None)\` correctly clears (sentinel default; was re-synthesizing).
2. \`AuthInfo.agent_url\` docstring matches implementation (drop "from principal" claim).
3. \`AuthInfo.from_verified_signer\` accepts \`max_verified_age_s\` for staleness rejection.
4. \`AuthInfo._from_legacy_dict\` validates dict shape (string scopes, raw-dict credential, non-Mapping extra → TypeError).
5. \`_resolve_buyer_agent\` isinstance-guards the credential variant (unknown → INTERNAL_ERROR).
6. \`PlatformHandler._build_ctx\` uses \`metadata.pop\` for buyer-agent stash (defends against ToolContext reuse).
7. \`PostgresTaskRegistry\` → \`PgTaskRegistry\` rename (matches \`Pg*\` convention; old name kept as deprecated alias through 4.4.x).
8. \`PgWebhookDeliverySupervisor\` coerces failure/success thresholds via \`int()\` before SQL interpolation.

**Plus:** \`PgTaskRegistry._sql_get\` uses \`%s::text IS NULL\` to fix IndeterminateDatatype on cross-tenant probes (was lost during the #361 rebase).

**Not in this PR (validated as non-issues):**
- \`governance_agents.auth_credentials\` projection — field isn't in the wire schema; \`extra="forbid"\` blocks adopters from adding it.
- \`AGENT_SUSPENDED\` etc. spec PR — separate scope (spec repo).
- Lifespan startup half-open in unified app — Python's nested \`async with\` correctly unwinds.

## Test plan

- [x] 6 new tests for AuthInfo replace, dict validation, freshness window
- [x] Full suite: 3132 passed (was 3126; +6)
- [x] PG conformance against postgres:16: 65 passed (15 BuyerAgent + 22 TaskRegistry + 28 WebhookSupervisor)
- [x] Public API snapshot regenerated (PgTaskRegistry alias added)
- [x] ruff/mypy/black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)