### PR TITLE
feat(examples): v3 reference seller — runnable Tier 2 + v3 wiring (#357)

### DIFF
--- a/examples/v3_reference_seller/README.md
+++ b/examples/v3_reference_seller/README.md
@@ -10,13 +10,14 @@ ships into one runnable binary:
 | Component | Module | Source |
 |---|---|---|
 | Tier 2 commercial-identity gate | `src/buyer_registry.py` | `adcp.decisioning.BuyerAgentRegistry` |
-| HTTP-Sig verifier → AuthInfo | (use `AuthInfo.from_verified_signer`) | `adcp.decisioning.AuthInfo` |
-| Subdomain tenant routing | `src/tenant_router.py` | `adcp.server.SubdomainTenantMiddleware` |
-| Account v3 projection (bank guard) | inline in platform | `adcp.types.project_account_for_response` |
+| Subdomain tenant routing | `src/tenant_router.py` + `src/app.py` | `adcp.server.SubdomainTenantMiddleware` |
+| Account v3 storage (bank-details column) | `src/models.py` | `Account.billing_entity` JSON column |
 | Audit trail | `src/audit.py` | `adcp.audit_sink.AuditSink` |
+| MCP + A2A on one binary | `src/app.py` | `serve(transport="both", asgi_middleware=...)` |
 | Durable HITL tasks (optional) | swap to `PgTaskRegistry` | `adcp.decisioning.pg.PgTaskRegistry` |
 | Durable webhook delivery (optional) | swap to `PgWebhookDeliverySupervisor` | `adcp.webhook_supervisor_pg` |
-| MCP + A2A on one binary | `src/app.py` | `serve(transport="both")` |
+| HTTP-Sig verifier → AuthInfo (TODO) | adopter middleware | `adcp.decisioning.AuthInfo.from_verified_signer` |
+| Account v3 projection on read (TODO) | adopter wires in `sync_accounts` | `adcp.types.project_account_for_response` |
 
 ## Run it
 
@@ -36,6 +37,15 @@ DATABASE_URL=postgresql+asyncpg://postgres@localhost/adcp \
 
 The server binds `0.0.0.0:3001` and serves both transports.
 
+> ⚠️ **Local-dev only.** `docker-compose.yml` uses
+> `POSTGRES_HOST_AUTH_METHOD=trust` and exposes 5432 on
+> `0.0.0.0`. Do not run this compose file on a host reachable from
+> an untrusted network. `seed.py` plants a literal dev bearer
+> token (`dev-bearer-token-acme-1`) — do not run `seed.py` against
+> a production `DATABASE_URL`. Production deployments point
+> `DATABASE_URL` at managed Postgres with scram-sha-256 + a real
+> password, and seed via the admin API (not this script).
+
 ## What's wired
 
 ### Schema (`src/models.py`)
@@ -50,9 +60,13 @@ Four tables — the spine of a multi-tenant v3 seller:
   rejects suspended (transient) and blocked (terminal) agents with
   structured errors.
 - `accounts` — buyer-side accounts under recognized agents. Carries
-  the spec 3.1-ready `billing_entity` (write-only bank details
-  guarded via `project_account_for_response`) and `reporting_bucket`
-  (offline reporting target).
+  the spec 3.1-ready `billing_entity` (write-only bank details on
+  responses) and `reporting_bucket` (offline reporting target). The
+  reference seller does not implement `sync_accounts`, so the
+  bank-details projection is a column-level architectural seam, not
+  an enforced runtime guard — adopters who add `sync_accounts`
+  MUST project through `adcp.types.project_account_for_response`
+  before returning the row.
 - `media_buys` — terminal artifact of `create_media_buy`,
   idempotency-keyed for replay safety.
 
@@ -83,10 +97,11 @@ alerting compose with `adcp.audit_sink.SlackAlertSink` via
 ### Platform (`src/platform.py`)
 
 `V3ReferenceSeller` implements `sales-non-guaranteed` — the five
-required Sales methods. Every method body reads
-`ctx.buyer_agent` (the resolved Tier 2 record) and `ctx.account`
-(the resolved account); both are populated by the framework's
-dispatch gate before the method runs.
+required Sales methods (`get_products`, `create_media_buy`,
+`update_media_buy`, `sync_creatives`, `get_media_buy_delivery`).
+Every method body reads `ctx.buyer_agent` (the resolved Tier 2
+record) and `ctx.account` (the resolved account); both are
+populated by the framework's dispatch gate before the method runs.
 
 This file is the bulk of what an adopter customizes. Everything
 else is boilerplate the seller wires once.

--- a/examples/v3_reference_seller/README.md
+++ b/examples/v3_reference_seller/README.md
@@ -1,0 +1,167 @@
+# v3 reference seller
+
+Canonical multi-tenant AdCP seller. **Spec 3.0-compliant on the wire,
+3.1-ready in architecture and storage.** Adopters fork this directory
+and replace the platform impl with their own business logic.
+
+This directory wires every Tier 2 / v3-supporting component the SDK
+ships into one runnable binary:
+
+| Component | Module | Source |
+|---|---|---|
+| Tier 2 commercial-identity gate | `src/buyer_registry.py` | `adcp.decisioning.BuyerAgentRegistry` |
+| HTTP-Sig verifier → AuthInfo | (use `AuthInfo.from_verified_signer`) | `adcp.decisioning.AuthInfo` |
+| Subdomain tenant routing | `src/tenant_router.py` | `adcp.server.SubdomainTenantMiddleware` |
+| Account v3 projection (bank guard) | inline in platform | `adcp.types.project_account_for_response` |
+| Audit trail | `src/audit.py` | `adcp.audit_sink.AuditSink` |
+| Durable HITL tasks (optional) | swap to `PgTaskRegistry` | `adcp.decisioning.pg.PgTaskRegistry` |
+| Durable webhook delivery (optional) | swap to `PgWebhookDeliverySupervisor` | `adcp.webhook_supervisor_pg` |
+| MCP + A2A on one binary | `src/app.py` | `serve(transport="both")` |
+
+## Run it
+
+```bash
+# 1. Start Postgres
+cd examples/v3_reference_seller
+docker compose up -d postgres
+
+# 2. Seed dev fixtures
+DATABASE_URL=postgresql+asyncpg://postgres@localhost/adcp \
+  python -m seed
+
+# 3. Boot the seller
+DATABASE_URL=postgresql+asyncpg://postgres@localhost/adcp \
+  python -m src.app
+```
+
+The server binds `0.0.0.0:3001` and serves both transports.
+
+## What's wired
+
+### Schema (`src/models.py`)
+
+Four tables — the spine of a multi-tenant v3 seller:
+
+- `tenants` — one row per `<subdomain>.example.com`.
+  `SubdomainTenantMiddleware` reads the request `Host` header and
+  finds the matching row.
+- `buyer_agents` — Tier 2 commercial-identity rows. The framework's
+  dispatch gate reads this BEFORE the platform method runs and
+  rejects suspended (transient) and blocked (terminal) agents with
+  structured errors.
+- `accounts` — buyer-side accounts under recognized agents. Carries
+  the spec 3.1-ready `billing_entity` (write-only bank details
+  guarded via `project_account_for_response`) and `reporting_bucket`
+  (offline reporting target).
+- `media_buys` — terminal artifact of `create_media_buy`,
+  idempotency-keyed for replay safety.
+
+### Tenant routing (`src/tenant_router.py`)
+
+`SqlSubdomainTenantRouter` implements the framework's
+`SubdomainTenantRouter` Protocol. The middleware sets the
+`current_tenant()` contextvar; downstream stores
+(`buyer_registry.py`, `platform.py`) read it without explicit
+plumbing.
+
+### Commercial-identity gate (`src/buyer_registry.py`)
+
+`TenantScopedBuyerAgentRegistry` extends the framework's
+`PgBuyerAgentRegistry` pattern with tenant scoping — the same
+`agent_url` can have different commercial postures across tenants.
+Implements both `resolve_by_agent_url` (signed traffic) and
+`resolve_by_credential` (bearer / OAuth).
+
+### Audit trail (`src/audit.py`)
+
+`DbAuditSink` writes one `audit_events` row per skill dispatch.
+Failures are swallowed by the framework's audit middleware (the
+sink is fire-and-forget by Protocol contract). Adopters with Slack
+alerting compose with `adcp.audit_sink.SlackAlertSink` via
+`CompositeAuditSink`.
+
+### Platform (`src/platform.py`)
+
+`V3ReferenceSeller` implements `sales-non-guaranteed` — the five
+required Sales methods. Every method body reads
+`ctx.buyer_agent` (the resolved Tier 2 record) and `ctx.account`
+(the resolved account); both are populated by the framework's
+dispatch gate before the method runs.
+
+This file is the bulk of what an adopter customizes. Everything
+else is boilerplate the seller wires once.
+
+## Auth modes
+
+The seller supports both v3 signed-request and pre-trust beta
+bearer auth simultaneously — the `BuyerAgentRegistry` dispatches
+on credential kind. Adopter middleware constructs `AuthInfo` two
+ways:
+
+```python
+# Signed (v3) — produces typed HttpSigCredential
+auth = AuthInfo.from_verified_signer(
+    signer,                       # from adcp.signing.verify_request_signature
+    max_verified_age_s=300.0,     # reject stale signers
+)
+
+# Bearer (pre-trust beta) — typed ApiKeyCredential
+auth = AuthInfo(
+    kind="bearer",
+    credential=ApiKeyCredential(kind="api_key", key_id=token_id),
+)
+```
+
+Both put the typed credential into `ctx.metadata['adcp.auth_info']`
+where the framework picks it up.
+
+## What's NOT wired (yet)
+
+These ship as separable follow-ups — the framework's components
+exist; the reference seller wires the simpler defaults:
+
+- **HTTP-Sig verifier middleware** — adopters add
+  `verify_request_signature` in their `context_factory` once
+  AAO publishes the brand.json registry. The Tier 1 SDK primitives
+  ship in `adcp.signing`; this seller uses bearer auth in the seed.
+- **Brand authorization (Tier 3)** — gated on ADCP spec issue
+  #3690.
+- **Postgres `TaskRegistry` / `WebhookDeliverySupervisor`** —
+  swap `InMemoryTaskRegistry` → `PgTaskRegistry` and
+  `InMemoryWebhookDeliverySupervisor` → `PgWebhookDeliverySupervisor`
+  in `src/app.py` for production durability. Both classes ship in
+  the SDK; this seller's `app.py` uses the in-memory variants for
+  fast iteration.
+- **Alembic migrations** — `Base.metadata.create_all` runs at boot
+  (idempotent). Production sellers wire Alembic + version their
+  schema changes; the in-tree DDL is the starting point.
+- **Admin CRUD API** — separate Starlette app for tenant / agent
+  CRUD. Patterns to come; for now use `seed.py` and direct SQL.
+
+## Customization
+
+Adopters typically change:
+
+1. **`src/platform.py`** — the platform method bodies. Replace the
+   stub product catalog, add your CMS query for `get_products`,
+   route `create_media_buy` into your real DSP / ad-server, etc.
+2. **`src/audit.py`** — extend `details` with adopter-specific
+   fields (decision flags, fraud scores, A/B variant ids).
+3. **Auth wiring in `src/app.py`** — wire your verifier middleware
+   that constructs `AuthInfo`.
+
+Adopters typically *don't* change:
+
+- Models — the v3 schema is the contract.
+- Tenant router logic — the Protocol shape is fixed.
+- Audit middleware composition — the framework wires it.
+- The unified MCP+A2A binary — `transport="both"` is one knob.
+
+## Spec versioning
+
+This seller is **3.0-compliant on the wire** — every field it sends
+matches the AdCP 3.0 schemas. The schema and architecture is
+**3.1-ready** (`billing_entity` + `reporting_bucket` columns,
+typed `BillingMode`, write-only bank-details projection). Sellers
+running this code today serve 3.0 buyers; the same code serves
+3.1 buyers when the spec lands.

--- a/examples/v3_reference_seller/README.md
+++ b/examples/v3_reference_seller/README.md
@@ -148,8 +148,11 @@ exist; the reference seller wires the simpler defaults:
   the SDK; this seller's `app.py` uses the in-memory variants for
   fast iteration.
 - **Alembic migrations** — `Base.metadata.create_all` runs at boot
-  (idempotent). Production sellers wire Alembic + version their
-  schema changes; the in-tree DDL is the starting point.
+  (idempotent on table existence — it does NOT detect column
+  renames or type changes on existing tables). Adopters who
+  prototyped against earlier branches and pulled new column
+  changes should drop and recreate the dev database; production
+  sellers wire Alembic and version their schema changes.
 - **Admin CRUD API** — separate Starlette app for tenant / agent
   CRUD. Patterns to come; for now use `seed.py` and direct SQL.
 

--- a/examples/v3_reference_seller/docker-compose.yml
+++ b/examples/v3_reference_seller/docker-compose.yml
@@ -1,0 +1,28 @@
+# Dev-only Postgres for the v3 reference seller. Production sellers
+# point ``DATABASE_URL`` at their managed Postgres (RDS, Cloud SQL,
+# Neon, Supabase) and skip this file entirely.
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: adcp
+      # ``trust`` is fine for the loopback dev compose; production
+      # deployments use scram-sha-256 + a real password sourced from
+      # a secrets backend (Vault, AWS Secrets Manager, sealed-secrets).
+      # No POSTGRES_PASSWORD here on purpose — the ``trust`` auth
+      # method makes it unused, and shipping a literal in version
+      # control flags secret-scanners.
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d adcp"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+volumes:
+  pg_data:

--- a/examples/v3_reference_seller/seed.py
+++ b/examples/v3_reference_seller/seed.py
@@ -1,0 +1,110 @@
+"""Dev fixtures — seed two tenants + buyer agents for local
+end-to-end testing.
+
+::
+
+    docker compose up -d postgres
+    DATABASE_URL=postgresql+asyncpg://postgres@localhost/adcp \\
+      python -m examples.v3_reference_seller.seed
+
+After seeding, hit:
+
+* ``http://acme.localhost:3001/.well-known/agent.json``  (A2A)
+* ``http://acme.localhost:3001/mcp``                     (MCP)
+
+with a buyer agent's signed-request or bearer credential matching
+the seeded ``api_key_id``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from src.models import Account, Base, BuyerAgent, Tenant
+
+
+async def main() -> None:
+    db_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres@localhost/adcp",
+    )
+    engine = create_async_engine(db_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+
+    # Insert in FK-dependency order with explicit flushes so the
+    # accounts → buyer_agents → tenants chain commits correctly.
+    async with sm() as session:
+        async with session.begin():
+            session.add_all(
+                [
+                    Tenant(id="t_acme", host="acme.localhost", display_name="Acme Publishing"),
+                    Tenant(id="t_beta", host="beta.localhost", display_name="Beta Network"),
+                ]
+            )
+            await session.flush()
+            session.add_all(
+                [
+                    BuyerAgent(
+                        id="ba_acme_signed",
+                        tenant_id="t_acme",
+                        agent_url="https://signed-buyer.example/",
+                        display_name="Signed Buyer",
+                        status="active",
+                        billing_capabilities=json.dumps(["operator", "agent"]),
+                        api_key_id=None,
+                    ),
+                    BuyerAgent(
+                        id="ba_acme_bearer",
+                        tenant_id="t_acme",
+                        agent_url="https://bearer-buyer.example/",
+                        display_name="Bearer Buyer",
+                        status="active",
+                        billing_capabilities=json.dumps(["operator"]),
+                        api_key_id="dev-bearer-token-acme-1",
+                    ),
+                    BuyerAgent(
+                        id="ba_beta_suspended",
+                        tenant_id="t_beta",
+                        agent_url="https://suspended.example/",
+                        display_name="Suspended Buyer",
+                        status="suspended",
+                        billing_capabilities=json.dumps(["operator"]),
+                    ),
+                ]
+            )
+            await session.flush()
+            session.add_all(
+                [
+                    Account(
+                        id="a_acme_1",
+                        tenant_id="t_acme",
+                        buyer_agent_id="ba_acme_signed",
+                        account_id="signed-buyer-main",
+                        name="Signed Buyer — Main",
+                        status="active",
+                        billing="operator",
+                    ),
+                    Account(
+                        id="a_acme_2",
+                        tenant_id="t_acme",
+                        buyer_agent_id="ba_acme_bearer",
+                        account_id="bearer-buyer-main",
+                        name="Bearer Buyer — Main",
+                        status="active",
+                        billing="operator",
+                    ),
+                ]
+            )
+
+    print("Seeded: 2 tenants, 3 buyer agents, 2 accounts.")
+    print("Hit: http://acme.localhost:3001/.well-known/agent.json")
+    print("Hit: http://acme.localhost:3001/mcp")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/v3_reference_seller/seed.py
+++ b/examples/v3_reference_seller/seed.py
@@ -19,7 +19,6 @@ the seeded ``api_key_id``.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -55,7 +54,7 @@ async def main() -> None:
                         agent_url="https://signed-buyer.example/",
                         display_name="Signed Buyer",
                         status="active",
-                        billing_capabilities=json.dumps(["operator", "agent"]),
+                        billing_capabilities=["operator", "agent"],
                         api_key_id=None,
                     ),
                     BuyerAgent(
@@ -64,7 +63,7 @@ async def main() -> None:
                         agent_url="https://bearer-buyer.example/",
                         display_name="Bearer Buyer",
                         status="active",
-                        billing_capabilities=json.dumps(["operator"]),
+                        billing_capabilities=["operator"],
                         api_key_id="dev-bearer-token-acme-1",
                     ),
                     BuyerAgent(
@@ -73,7 +72,7 @@ async def main() -> None:
                         agent_url="https://suspended.example/",
                         display_name="Suspended Buyer",
                         status="suspended",
-                        billing_capabilities=json.dumps(["operator"]),
+                        billing_capabilities=["operator"],
                     ),
                 ]
             )

--- a/examples/v3_reference_seller/src/__init__.py
+++ b/examples/v3_reference_seller/src/__init__.py
@@ -1,0 +1,1 @@
+"""v3 reference seller — Spec 3.0-compliant on the wire, 3.1-ready in arch."""

--- a/examples/v3_reference_seller/src/app.py
+++ b/examples/v3_reference_seller/src/app.py
@@ -1,0 +1,197 @@
+"""Main entrypoint — wires every Tier 2 / v3-supporting component
+into one runnable adopter.
+
+Boot sequence:
+
+1. Connect SQLAlchemy async engine + sessionmaker.
+2. Create schema (idempotent ``Base.metadata.create_all``).
+3. Build the framework wiring:
+
+   * :class:`SqlSubdomainTenantRouter` for ``Host`` → tenant
+   * :class:`TenantScopedBuyerAgentRegistry` for the Tier 2 gate
+   * :class:`DbAuditSink` for compliance trail
+   * :class:`V3ReferenceSeller` (the platform impl)
+
+4. ``adcp.decisioning.serve(transport="both", ...)`` — single
+   binary serving MCP at ``/mcp`` and A2A at ``/``.
+
+Adopters fork this file and replace the platform impl, the seller-
+specific column populators, and the seed fixtures. Everything else
+stays.
+
+::
+
+    cd examples/v3_reference_seller
+    docker compose up -d postgres
+    DATABASE_URL=postgresql+asyncpg://postgres@localhost/adcp \\
+      python -m src.app
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from adcp.decisioning import serve
+from adcp.server import (
+    ToolContext,
+    current_tenant,
+)
+
+from .audit import make_sink as make_audit_sink
+from .buyer_registry import make_registry as make_buyer_registry
+from .models import Base
+from .platform import V3ReferenceSeller
+from .tenant_router import SqlSubdomainTenantRouter
+
+if TYPE_CHECKING:
+    from adcp.server import RequestMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def _build_context_factory(router: SqlSubdomainTenantRouter):
+    """``context_factory`` that pins :attr:`ToolContext.tenant_id`
+    from the resolved tenant.
+
+    The middleware sets ``current_tenant()`` on the contextvar before
+    dispatch; this factory reads it and writes ``tenant_id`` so the
+    framework's idempotency middleware scopes correctly.
+    """
+    del router  # router is consumed via current_tenant(); kept for symmetry
+
+    def build(meta: RequestMetadata) -> ToolContext:
+        tenant = current_tenant()
+        return ToolContext(
+            request_id=meta.request_id,
+            tenant_id=tenant.id if tenant else None,
+        )
+
+    return build
+
+
+async def _bootstrap_schema(engine) -> None:
+    """Create all tables. Idempotent (CREATE TABLE IF NOT EXISTS).
+
+    Production adopters use Alembic — this entrypoint sticks with
+    ``create_all`` for fast iteration. The schema migration story
+    is in the README.
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def main() -> None:
+    """Entrypoint — boot the seller."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres@localhost/adcp",
+    )
+    port = int(os.environ.get("PORT", "3001"))
+
+    engine = create_async_engine(db_url, pool_size=10, max_overflow=20)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    asyncio.run(_bootstrap_schema(engine))
+
+    router = SqlSubdomainTenantRouter(sessionmaker=sessionmaker)
+    buyer_registry = make_buyer_registry(sessionmaker)
+    audit_sink = make_audit_sink(sessionmaker)
+    platform = V3ReferenceSeller(sessionmaker=sessionmaker)
+
+    logger.info(
+        "v3 reference seller booting on port=%d (transport=both, MCP at /mcp, A2A at /)",
+        port,
+    )
+    logger.info("Audit sink wired: %s. Tenant router cache: 256 hosts.", type(audit_sink).__name__)
+
+    # The framework's serve() drives uvicorn. We layer the tenant
+    # middleware on the parent Starlette app via a build hook —
+    # for the MVP we wire it inline by passing a custom ``app``
+    # builder. For the Tier-2 wiring we use the ``buyer_agent_registry``
+    # and ``context_factory`` kwargs the framework already supports.
+    serve(
+        platform=platform,
+        name="v3-reference-seller",
+        port=port,
+        transport="both",
+        buyer_agent_registry=buyer_registry,
+        context_factory=_build_context_factory(router),
+        # NOTE: SubdomainTenantMiddleware is added to the unified
+        # Starlette app via ``add_middleware``. The current public
+        # surface of ``serve()`` doesn't expose a hook for adopter
+        # ASGI middleware on the parent — adopters who want it today
+        # call ``_build_mcp_and_a2a_app`` directly and run uvicorn
+        # themselves. Filed as a follow-up DX issue: the helper
+        # below shows the pattern.
+        host="0.0.0.0",
+    )
+
+
+# Adopter-side helper for wiring SubdomainTenantMiddleware directly.
+# Until ``serve()`` accepts an ``asgi_middleware=`` kwarg, callers who
+# need tenant routing build the unified app themselves and run
+# uvicorn outside the framework's ``serve()`` wrapper.
+def build_app(
+    platform: V3ReferenceSeller,
+    *,
+    router: SqlSubdomainTenantRouter,
+    buyer_registry,  # type: ignore[no-untyped-def]
+    audit_sink,  # type: ignore[no-untyped-def]
+):
+    """Construct the unified MCP+A2A app with the tenant middleware.
+
+    Returns an ASGI app callable; the caller runs uvicorn against it.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from adcp.decisioning.handler import PlatformHandler
+    from adcp.decisioning.serve import _build_mcp_and_a2a_app
+    from adcp.decisioning.task_registry import InMemoryTaskRegistry
+
+    executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="v3-ref-")
+    handler = PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=buyer_registry,
+    )
+    app = _build_mcp_and_a2a_app(
+        handler,
+        name="v3-reference-seller",
+        port=3001,
+        host="0.0.0.0",
+        instructions=None,
+        test_controller=None,
+        context_factory=_build_context_factory(router),
+    )
+    # Wrap with the tenant middleware. ASGI middleware composes
+    # outermost-first: requests pass through the tenant resolver
+    # before reaching the dispatcher.
+    from adcp.server.tenant_router import SubdomainTenantMiddleware as _SubdomainTenantMiddleware
+
+    class _Wrapped:
+        def __init__(self, app):
+            self._app = app
+            self._mw = _SubdomainTenantMiddleware(app, router=router)
+
+        async def __call__(self, scope, receive, send):
+            await self._mw(scope, receive, send)
+
+    return _Wrapped(app)
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["build_app", "main"]

--- a/examples/v3_reference_seller/src/app.py
+++ b/examples/v3_reference_seller/src/app.py
@@ -12,8 +12,9 @@ Boot sequence:
    * :class:`DbAuditSink` for compliance trail
    * :class:`V3ReferenceSeller` (the platform impl)
 
-4. ``adcp.decisioning.serve(transport="both", ...)`` — single
-   binary serving MCP at ``/mcp`` and A2A at ``/``.
+4. ``adcp.decisioning.serve(transport="both", asgi_middleware=[...])``
+   — single binary serving MCP at ``/mcp`` and A2A at ``/`` with
+   :class:`SubdomainTenantMiddleware` layered on the outer HTTP app.
 
 Adopters fork this file and replace the platform impl, the seller-
 specific column populators, and the seed fixtures. Everything else
@@ -38,6 +39,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from adcp.decisioning import serve
 from adcp.server import (
+    SubdomainTenantMiddleware,
     ToolContext,
     current_tenant,
 )
@@ -54,7 +56,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _build_context_factory(router: SqlSubdomainTenantRouter):
+def _build_context_factory():
     """``context_factory`` that pins :attr:`ToolContext.tenant_id`
     from the resolved tenant.
 
@@ -62,7 +64,6 @@ def _build_context_factory(router: SqlSubdomainTenantRouter):
     dispatch; this factory reads it and writes ``tenant_id`` so the
     framework's idempotency middleware scopes correctly.
     """
-    del router  # router is consumed via current_tenant(); kept for symmetry
 
     def build(meta: RequestMetadata) -> ToolContext:
         tenant = current_tenant()
@@ -114,84 +115,28 @@ def main() -> None:
     )
     logger.info("Audit sink wired: %s. Tenant router cache: 256 hosts.", type(audit_sink).__name__)
 
-    # The framework's serve() drives uvicorn. We layer the tenant
-    # middleware on the parent Starlette app via a build hook —
-    # for the MVP we wire it inline by passing a custom ``app``
-    # builder. For the Tier-2 wiring we use the ``buyer_agent_registry``
-    # and ``context_factory`` kwargs the framework already supports.
     serve(
         platform=platform,
         name="v3-reference-seller",
         port=port,
+        host="0.0.0.0",
         transport="both",
         buyer_agent_registry=buyer_registry,
-        context_factory=_build_context_factory(router),
-        # NOTE: SubdomainTenantMiddleware is added to the unified
-        # Starlette app via ``add_middleware``. The current public
-        # surface of ``serve()`` doesn't expose a hook for adopter
-        # ASGI middleware on the parent — adopters who want it today
-        # call ``_build_mcp_and_a2a_app`` directly and run uvicorn
-        # themselves. Filed as a follow-up DX issue: the helper
-        # below shows the pattern.
-        host="0.0.0.0",
+        context_factory=_build_context_factory(),
+        # SubdomainTenantMiddleware reads the request Host header,
+        # resolves it via the SQL router, and sets the
+        # ``current_tenant()`` contextvar before the handler runs.
+        # The buyer_registry, AccountStore, and audit sink all read
+        # that contextvar — this is the only multi-tenant wiring
+        # point.
+        asgi_middleware=[
+            (SubdomainTenantMiddleware, {"router": router}),
+        ],
     )
-
-
-# Adopter-side helper for wiring SubdomainTenantMiddleware directly.
-# Until ``serve()`` accepts an ``asgi_middleware=`` kwarg, callers who
-# need tenant routing build the unified app themselves and run
-# uvicorn outside the framework's ``serve()`` wrapper.
-def build_app(
-    platform: V3ReferenceSeller,
-    *,
-    router: SqlSubdomainTenantRouter,
-    buyer_registry,  # type: ignore[no-untyped-def]
-    audit_sink,  # type: ignore[no-untyped-def]
-):
-    """Construct the unified MCP+A2A app with the tenant middleware.
-
-    Returns an ASGI app callable; the caller runs uvicorn against it.
-    """
-    from concurrent.futures import ThreadPoolExecutor
-
-    from adcp.decisioning.handler import PlatformHandler
-    from adcp.decisioning.serve import _build_mcp_and_a2a_app
-    from adcp.decisioning.task_registry import InMemoryTaskRegistry
-
-    executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="v3-ref-")
-    handler = PlatformHandler(
-        platform,
-        executor=executor,
-        registry=InMemoryTaskRegistry(),
-        buyer_agent_registry=buyer_registry,
-    )
-    app = _build_mcp_and_a2a_app(
-        handler,
-        name="v3-reference-seller",
-        port=3001,
-        host="0.0.0.0",
-        instructions=None,
-        test_controller=None,
-        context_factory=_build_context_factory(router),
-    )
-    # Wrap with the tenant middleware. ASGI middleware composes
-    # outermost-first: requests pass through the tenant resolver
-    # before reaching the dispatcher.
-    from adcp.server.tenant_router import SubdomainTenantMiddleware as _SubdomainTenantMiddleware
-
-    class _Wrapped:
-        def __init__(self, app):
-            self._app = app
-            self._mw = _SubdomainTenantMiddleware(app, router=router)
-
-        async def __call__(self, scope, receive, send):
-            await self._mw(scope, receive, send)
-
-    return _Wrapped(app)
 
 
 if __name__ == "__main__":
     main()
 
 
-__all__ = ["build_app", "main"]
+__all__ = ["main"]

--- a/examples/v3_reference_seller/src/audit.py
+++ b/examples/v3_reference_seller/src/audit.py
@@ -5,14 +5,17 @@ durable trail for compliance review, anomaly detection, and ops
 queries ("who suspended buyer X yesterday?").
 
 Adopters with Slack / PagerDuty alerting compose this sink with
-:class:`adcp.audit_sink.SlackAlertSink` via a
-``CompositeAuditSink`` — both fire on every event; Slack is
-fire-and-forget, the DB sink is the durable record.
+:class:`adcp.audit_sink.SlackAlertSink` via a ``CompositeAuditSink``
+so each sink fires on every event — Slack for the alert, this DB
+sink for the durable record.
 
-The sink is **fire-and-forget** by contract: failures inside
-:meth:`record` are bounded and swallowed by the framework's audit
-middleware. Adopters needing transactional audit (refusing the
-request if audit fails) implement their own pre-dispatch middleware.
+Failure semantics: ``record()`` is **best-effort** — it ``await`` s
+the DB write inline, then swallows any exception so the audit step
+never fails the request. The audit step is therefore in the latency
+path of every skill call; adopters with high-volume audit traffic
+either decouple via an ``asyncio.Queue`` worker or batch writes.
+Adopters needing transactional audit (refusing the request if audit
+fails) implement their own pre-dispatch middleware.
 """
 
 from __future__ import annotations

--- a/examples/v3_reference_seller/src/audit.py
+++ b/examples/v3_reference_seller/src/audit.py
@@ -1,0 +1,117 @@
+"""DB-backed :class:`adcp.audit_sink.AuditSink` for the v3 reference seller.
+
+Every dispatched skill logs one row into ``audit_events`` — a
+durable trail for compliance review, anomaly detection, and ops
+queries ("who suspended buyer X yesterday?").
+
+Adopters with Slack / PagerDuty alerting compose this sink with
+:class:`adcp.audit_sink.SlackAlertSink` via a
+``CompositeAuditSink`` — both fire on every event; Slack is
+fire-and-forget, the DB sink is the durable record.
+
+The sink is **fire-and-forget** by contract: failures inside
+:meth:`record` are bounded and swallowed by the framework's audit
+middleware. Adopters needing transactional audit (refusing the
+request if audit fails) implement their own pre-dispatch middleware.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, BigInteger, DateTime, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from adcp.audit_sink import AuditEvent, AuditSink
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from .models import Base
+
+logger = logging.getLogger(__name__)
+
+
+class AuditEventRow(Base):
+    """Audit-event row.
+
+    Wide columns for the structured fields adopters query on
+    (``tenant_id``, ``operation``, ``caller_identity``); free-form
+    JSON for the adopter-defined ``details`` blob. Adopters with
+    high audit volume partition by ``occurred_at`` (monthly).
+    """
+
+    __tablename__ = "audit_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    tenant_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    request_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    operation: Mapped[str] = mapped_column(String(64), nullable=False)
+    caller_identity: Mapped[str | None] = mapped_column(String(512), nullable=True)
+
+    success: Mapped[bool] = mapped_column(nullable=False)
+    error_type: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    #: Adopter-defined free-form payload — buyer_agent_url, account_id,
+    #: media_buy_id, decision flags, etc. Treat as potentially
+    #: sensitive.
+    details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    __table_args__ = (
+        Index("audit_events_tenant_idx", "tenant_id", "occurred_at"),
+        Index("audit_events_operation_idx", "operation", "occurred_at"),
+        Index("audit_events_caller_idx", "caller_identity", "occurred_at"),
+    )
+
+
+class DbAuditSink:
+    """Persistent :class:`AuditSink` writing one row per skill dispatch.
+
+    Implements the framework's :class:`AuditSink` Protocol.
+    Failures are swallowed by the framework's audit middleware
+    (per the Protocol's documented contract).
+    """
+
+    def __init__(self, *, sessionmaker: async_sessionmaker) -> None:
+        self._sessionmaker = sessionmaker
+
+    async def record(self, event: AuditEvent) -> None:
+        try:
+            row = AuditEventRow(
+                occurred_at=event.occurred_at,
+                tenant_id=event.tenant_id,
+                request_id=event.request_id,
+                operation=event.operation,
+                caller_identity=event.caller_identity,
+                success=event.success,
+                error_type=event.error_type,
+                error_message=event.error_message,
+                details=dict(event.details) if event.details else None,
+            )
+            async with self._sessionmaker() as session, session.begin():
+                session.add(row)
+        except Exception:  # noqa: BLE001 — sink failures must not propagate
+            logger.exception(
+                "Audit-event write failed for operation=%s tenant=%s",
+                event.operation,
+                event.tenant_id,
+            )
+
+
+def make_sink(sessionmaker: async_sessionmaker) -> AuditSink:
+    """Factory returning a Protocol-typed handle for the audit
+    middleware."""
+    return DbAuditSink(sessionmaker=sessionmaker)
+
+
+__all__ = ["AuditEventRow", "DbAuditSink", "make_sink"]

--- a/examples/v3_reference_seller/src/buyer_registry.py
+++ b/examples/v3_reference_seller/src/buyer_registry.py
@@ -16,7 +16,6 @@ async dispatch the framework calls.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -106,10 +105,10 @@ class TenantScopedBuyerAgentRegistry:
 
 def _row_to_agent(row: BuyerAgentRow) -> BuyerAgent:
     """Project ORM row → framework typed :class:`BuyerAgent`."""
-    capabilities = frozenset(json.loads(row.billing_capabilities))
+    capabilities = frozenset(row.billing_capabilities or ())
     terms: BuyerAgentDefaultTerms | None = None
-    if row.default_terms_json:
-        d = json.loads(row.default_terms_json)
+    if row.default_terms:
+        d = row.default_terms
         terms = BuyerAgentDefaultTerms(
             rate_card=d.get("rate_card"),
             payment_terms=d.get("payment_terms"),
@@ -118,7 +117,7 @@ def _row_to_agent(row: BuyerAgentRow) -> BuyerAgent:
         )
     brands: frozenset[str] | None = None
     if row.allowed_brands:
-        brands = frozenset(json.loads(row.allowed_brands))
+        brands = frozenset(row.allowed_brands)
     return BuyerAgent(
         agent_url=row.agent_url,
         display_name=row.display_name,

--- a/examples/v3_reference_seller/src/buyer_registry.py
+++ b/examples/v3_reference_seller/src/buyer_registry.py
@@ -1,0 +1,140 @@
+"""Tenant-scoped :class:`adcp.decisioning.BuyerAgentRegistry`.
+
+The framework's :class:`adcp.decisioning.PgBuyerAgentRegistry` looks
+up buyer agents by ``agent_url`` only — a single global table. For
+multi-tenant deployments where the same ``agent_url`` may have
+different commercial postures across tenants (active under one,
+suspended under another), this adopter wraps the
+``buyer_agents`` SQL table and scopes resolution by the current
+tenant from :func:`adcp.server.current_tenant`.
+
+The registry's ``resolve_*`` methods read the tenant-scoped row
+without explicit kwarg threading — the contextvar set by the
+:class:`adcp.server.SubdomainTenantMiddleware` propagates into the
+async dispatch the framework calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from adcp.decisioning import (
+    ApiKeyCredential,
+    BuyerAgent,
+    BuyerAgentDefaultTerms,
+    BuyerAgentRegistry,
+    OAuthCredential,
+)
+from adcp.server import current_tenant
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from .models import BuyerAgent as BuyerAgentRow
+
+logger = logging.getLogger(__name__)
+
+
+class TenantScopedBuyerAgentRegistry:
+    """SQLAlchemy + tenant-scoped lookups against the
+    ``buyer_agents`` table.
+
+    Resolves to ``None`` when the request has no tenant context
+    (i.e., :func:`current_tenant` returns ``None`` because the
+    middleware bypassed routing or the host wasn't registered) — the
+    framework's dispatch then rejects with
+    ``REQUEST_AUTH_UNRECOGNIZED_AGENT``.
+
+    Implements both methods of the
+    :class:`adcp.decisioning.BuyerAgentRegistry` Protocol so the
+    seller can run the full mixed (signing + bearer) posture against
+    the same backing table.
+    """
+
+    def __init__(self, *, sessionmaker: async_sessionmaker) -> None:
+        self._sessionmaker = sessionmaker
+
+    async def resolve_by_agent_url(self, agent_url: str) -> BuyerAgent | None:
+        """Verified-signed-request path.
+
+        The framework has already validated the RFC 9421 signature;
+        this method's only job is the commercial lookup.
+        """
+        tenant = current_tenant()
+        if tenant is None:
+            logger.debug(
+                "resolve_by_agent_url called without a tenant context (agent_url=%s)",
+                agent_url,
+            )
+            return None
+        async with self._sessionmaker() as session:
+            result = await session.execute(
+                select(BuyerAgentRow).where(
+                    BuyerAgentRow.tenant_id == tenant.id,
+                    BuyerAgentRow.agent_url == agent_url,
+                )
+            )
+            row = result.scalar_one_or_none()
+        return _row_to_agent(row) if row else None
+
+    async def resolve_by_credential(
+        self, credential: ApiKeyCredential | OAuthCredential
+    ) -> BuyerAgent | None:
+        """Pre-trust beta path — bearer / OAuth lookup against the
+        seller's existing key column."""
+        tenant = current_tenant()
+        if tenant is None:
+            return None
+        if isinstance(credential, ApiKeyCredential):
+            key = credential.key_id
+        else:
+            key = credential.client_id
+        async with self._sessionmaker() as session:
+            result = await session.execute(
+                select(BuyerAgentRow).where(
+                    BuyerAgentRow.tenant_id == tenant.id,
+                    BuyerAgentRow.api_key_id == key,
+                )
+            )
+            row = result.scalar_one_or_none()
+        return _row_to_agent(row) if row else None
+
+
+def _row_to_agent(row: BuyerAgentRow) -> BuyerAgent:
+    """Project ORM row → framework typed :class:`BuyerAgent`."""
+    capabilities = frozenset(json.loads(row.billing_capabilities))
+    terms: BuyerAgentDefaultTerms | None = None
+    if row.default_terms_json:
+        d = json.loads(row.default_terms_json)
+        terms = BuyerAgentDefaultTerms(
+            rate_card=d.get("rate_card"),
+            payment_terms=d.get("payment_terms"),
+            credit_limit=d.get("credit_limit"),
+            billing_entity=d.get("billing_entity"),
+        )
+    brands: frozenset[str] | None = None
+    if row.allowed_brands:
+        brands = frozenset(json.loads(row.allowed_brands))
+    return BuyerAgent(
+        agent_url=row.agent_url,
+        display_name=row.display_name,
+        status=row.status,  # type: ignore[arg-type]
+        billing_capabilities=capabilities,
+        default_account_terms=terms,
+        allowed_brands=brands,
+        ext=dict(row.ext or {}),
+    )
+
+
+def make_registry(sessionmaker: async_sessionmaker) -> BuyerAgentRegistry:
+    """Factory for the tenant-scoped registry. Returns a
+    Protocol-typed handle — adopters wire it into
+    :func:`adcp.decisioning.serve` via ``buyer_agent_registry=``."""
+    return TenantScopedBuyerAgentRegistry(sessionmaker=sessionmaker)
+
+
+__all__ = ["TenantScopedBuyerAgentRegistry", "make_registry"]

--- a/examples/v3_reference_seller/src/models.py
+++ b/examples/v3_reference_seller/src/models.py
@@ -27,7 +27,6 @@ Admin API and protocol-side audit log live in separate tables
 
 from __future__ import annotations
 
-import json
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -131,8 +130,9 @@ class BuyerAgent(Base):
     :class:`buyer_registry.TenantScopedBuyerAgentRegistry` on top.
 
     ``billing_capabilities`` is the framework-enforced
-    ``frozenset[BillingMode]`` from the spec — adopters store as a
-    JSON array and project at the seam.
+    ``frozenset[BillingMode]`` from the spec — stored as a native
+    JSON array column and projected to ``frozenset`` at the
+    registry seam.
     """
 
     __tablename__ = "buyer_agents"
@@ -156,11 +156,11 @@ class BuyerAgent(Base):
     #: (terminal) before the platform method runs.
     status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
 
-    #: JSON-encoded list of permitted ``BillingMode`` values. Default
-    #: ``["operator"]`` is the pre-trust passthrough posture — agents
-    #: under this row get operator-billed accounts only.
-    billing_capabilities: Mapped[str] = mapped_column(
-        String(255), nullable=False, default=lambda: json.dumps(["operator"])
+    #: List of permitted ``BillingMode`` values. Default ``["operator"]``
+    #: is the pre-trust passthrough posture — agents under this row
+    #: get operator-billed accounts only.
+    billing_capabilities: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=lambda: ["operator"]
     )
 
     #: Pre-trust beta API key. Adopters running signing-only auth
@@ -168,12 +168,12 @@ class BuyerAgent(Base):
     api_key_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     #: Default account terms (rate card, payment terms, credit limit,
-    #: billing entity FK). JSON for portability.
-    default_terms_json: Mapped[str | None] = mapped_column(String, nullable=True)
+    #: billing entity FK).
+    default_terms: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     #: Pre-RFC allowlist of brand domains. Layered with the (Tier 3)
     #: ``BrandAuthorizationResolver`` once spec #3690 lands.
-    allowed_brands: Mapped[str | None] = mapped_column(String, nullable=True)
+    allowed_brands: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
 
     #: Adopter passthrough — internal ids, contract refs, etc.
     ext: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)

--- a/examples/v3_reference_seller/src/models.py
+++ b/examples/v3_reference_seller/src/models.py
@@ -1,0 +1,347 @@
+"""SQLAlchemy models for the v3 reference seller.
+
+The schema is **3.0-compliant on the wire, 3.1-ready in architecture
+and storage**. Adopters fork this file and extend the columns with
+their own seller-side audit / contract / billing fields.
+
+Four tables make up the spine:
+
+* :class:`Tenant` — multi-tenant root. The
+  :class:`adcp.server.SubdomainTenantMiddleware` resolves
+  ``Host: <subdomain>.example.com`` to a row here and threads the
+  tenant id onto the request scope.
+* :class:`BuyerAgent` — Tier 2 commercial-identity record. The
+  framework's :class:`adcp.decisioning.BuyerAgentRegistry` reads
+  this row before every dispatch to gate on
+  ``status`` + ``billing_capabilities``.
+* :class:`Account` — buyer-side account under a recognized agent.
+  Carries 3.1-ready columns ``billing_entity`` (write-only bank
+  details — projection-guarded) and ``reporting_bucket`` (offline
+  delivery target).
+* :class:`MediaBuy` — terminal artifact of ``create_media_buy``.
+  Idempotency-keyed for replay safety.
+
+Admin API and protocol-side audit log live in separate tables
+(:mod:`audit` ships :class:`AuditEvent`).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Project-local declarative base.
+
+    Adopters with an existing SQLAlchemy app integrate by either
+    re-using their own ``Base`` (replace this import) or composing
+    their models alongside via metadata-merging at boot.
+    """
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Tenant — multi-tenant root
+# ---------------------------------------------------------------------------
+
+
+class Tenant(Base):
+    """Operator-owned tenant. One row per ``<subdomain>.example.com``.
+
+    The ``host`` column is the lookup key for
+    :class:`adcp.server.SubdomainTenantRouter` — the middleware reads
+    the request's ``Host`` header (lower-cased, port-stripped) and
+    finds the matching row.
+
+    All downstream tables (buyer agents, accounts, media buys, audit
+    events) FK back to :attr:`Tenant.id` so a single Postgres
+    instance hosts multiple tenants without per-tenant table sharding.
+    """
+
+    __tablename__ = "tenants"
+
+    id: Mapped[str] = mapped_column(
+        String(64), primary_key=True, default=lambda: f"t_{uuid.uuid4().hex[:12]}"
+    )
+    host: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="active",
+    )
+
+    # Operator-side branding / config the framework doesn't model.
+    ext: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        CheckConstraint("status IN ('active', 'suspended', 'archived')", name="tenants_status_ck"),
+        Index("tenants_host_idx", "host"),
+    )
+
+    buyer_agents: Mapped[list[BuyerAgent]] = relationship(
+        "BuyerAgent", back_populates="tenant", cascade="all, delete-orphan"
+    )
+    accounts: Mapped[list[Account]] = relationship(
+        "Account", back_populates="tenant", cascade="all, delete-orphan"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BuyerAgent — Tier 2 commercial identity
+# ---------------------------------------------------------------------------
+
+
+class BuyerAgent(Base):
+    """Tier 2 commercial-identity record per recognized buyer agent.
+
+    Tenant-scoped so the same ``agent_url`` can have different
+    commercial postures across tenants (e.g., active under one tenant,
+    suspended under another). The reference
+    :class:`adcp.decisioning.PgBuyerAgentRegistry` looks up rows by
+    ``agent_url`` only — for tenant-scoped enforcement, this seller
+    layers its own
+    :class:`buyer_registry.TenantScopedBuyerAgentRegistry` on top.
+
+    ``billing_capabilities`` is the framework-enforced
+    ``frozenset[BillingMode]`` from the spec — adopters store as a
+    JSON array and project at the seam.
+    """
+
+    __tablename__ = "buyer_agents"
+
+    id: Mapped[str] = mapped_column(
+        String(64), primary_key=True, default=lambda: f"ba_{uuid.uuid4().hex[:12]}"
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+
+    #: AdCP v3 canonical identifier — the buyer agent's well-known
+    #: URL. Used as the dispatch key for HTTP-Signatures-verified
+    #: traffic (the framework calls
+    #: ``BuyerAgentRegistry.resolve_by_agent_url`` with this value).
+    agent_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    #: Lifecycle: active / suspended / blocked. The framework's
+    #: dispatch layer rejects suspended (transient) and blocked
+    #: (terminal) before the platform method runs.
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+
+    #: JSON-encoded list of permitted ``BillingMode`` values. Default
+    #: ``["operator"]`` is the pre-trust passthrough posture — agents
+    #: under this row get operator-billed accounts only.
+    billing_capabilities: Mapped[str] = mapped_column(
+        String(255), nullable=False, default=lambda: json.dumps(["operator"])
+    )
+
+    #: Pre-trust beta API key. Adopters running signing-only auth
+    #: leave NULL.
+    api_key_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    #: Default account terms (rate card, payment terms, credit limit,
+    #: billing entity FK). JSON for portability.
+    default_terms_json: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    #: Pre-RFC allowlist of brand domains. Layered with the (Tier 3)
+    #: ``BrandAuthorizationResolver`` once spec #3690 lands.
+    allowed_brands: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    #: Adopter passthrough — internal ids, contract refs, etc.
+    ext: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'suspended', 'blocked')", name="buyer_agents_status_ck"
+        ),
+        UniqueConstraint("tenant_id", "agent_url", name="buyer_agents_tenant_agent_uk"),
+        Index("buyer_agents_tenant_idx", "tenant_id"),
+        Index(
+            "buyer_agents_api_key_idx",
+            "api_key_id",
+            postgresql_where=(api_key_id.is_not(None)),  # type: ignore[has-type]
+        ),
+    )
+
+    tenant: Mapped[Tenant] = relationship("Tenant", back_populates="buyer_agents")
+
+
+# ---------------------------------------------------------------------------
+# Account — 3.1-ready buyer account
+# ---------------------------------------------------------------------------
+
+
+class Account(Base):
+    """Buyer-side account under a recognized agent.
+
+    Carries the spec 3.1-ready columns:
+
+    * ``billing_entity`` — full :class:`adcp.types.BusinessEntity`
+      blob including bank details (write-only on response per spec).
+      The seller projects through
+      :func:`adcp.types.project_account_for_response` before
+      serializing on the wire.
+    * ``reporting_bucket`` — offline-reporting delivery target.
+
+    ``billing`` carries the spec ``BillingParty`` enum (operator /
+    agent / advertiser); the framework's ``sync_accounts`` dispatch
+    rejects mismatches against
+    :attr:`BuyerAgent.billing_capabilities` before the platform
+    method runs.
+    """
+
+    __tablename__ = "accounts"
+
+    id: Mapped[str] = mapped_column(
+        String(64), primary_key=True, default=lambda: f"a_{uuid.uuid4().hex[:12]}"
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    buyer_agent_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("buyer_agents.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    #: Wire ``account_id`` — what the buyer puts in
+    #: ``request.account.account_id``. Stable across renames.
+    account_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+
+    #: Billing party — operator / agent / advertiser.
+    billing: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    #: Full BusinessEntity JSON including bank details (write-only on
+    #: response). Adopters MUST project through
+    #: :func:`adcp.types.project_account_for_response` before
+    #: serializing on any response payload.
+    billing_entity: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    #: ReportingBucket JSON — offline reporting target.
+    reporting_bucket: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    rate_card: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    payment_terms: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    credit_limit: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    sandbox: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    ext: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'pending_approval', 'suspended', 'closed')",
+            name="accounts_status_ck",
+        ),
+        UniqueConstraint("tenant_id", "account_id", name="accounts_tenant_acct_uk"),
+        Index("accounts_tenant_idx", "tenant_id"),
+        Index("accounts_buyer_agent_idx", "buyer_agent_id"),
+    )
+
+    tenant: Mapped[Tenant] = relationship("Tenant", back_populates="accounts")
+
+
+# ---------------------------------------------------------------------------
+# MediaBuy — terminal artifact of create_media_buy
+# ---------------------------------------------------------------------------
+
+
+class MediaBuy(Base):
+    """Terminal artifact of ``create_media_buy``.
+
+    Idempotency-keyed for replay safety — the framework's idempotency
+    middleware caches by ``(scope_key, idempotency_key)`` and replays
+    the same response. This row is what the platform method returns
+    on the canonical insert.
+
+    Row state mirrors the spec's :class:`MediaBuyStatus` literal.
+    """
+
+    __tablename__ = "media_buys"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    account_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("accounts.id", ondelete="RESTRICT"), nullable=False
+    )
+
+    #: Wire ``media_buy_id`` returned to the buyer.
+    media_buy_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+
+    #: The buyer's idempotency key for ``create_media_buy``.
+    idempotency_key: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+
+    brand_domain: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    total_budget: Mapped[float | None] = mapped_column(Float, nullable=True)
+    currency: Mapped[str | None] = mapped_column(String(3), nullable=True)
+    start_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    end_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    request_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    response_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "idempotency_key", name="media_buys_idem_uk"),
+        Index("media_buys_tenant_idx", "tenant_id"),
+        Index("media_buys_account_idx", "account_id"),
+    )
+
+
+__all__ = ["Account", "Base", "BuyerAgent", "MediaBuy", "Tenant"]

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -24,6 +24,7 @@ boilerplate the seller wires once and forgets.
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -198,7 +199,21 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 message="Dispatch should have populated buyer_agent and account.",
                 recovery="terminal",
             )
-        media_buy_id = f"mb_{req.idempotency_key[:16]}"
+        # The (tenant_id, idempotency_key) unique constraint already
+        # enforces replay safety; the public id just needs to be
+        # globally unique. Don't derive from the idempotency key —
+        # a 16-hex prefix of a UUID v4 collides at scale, throwing
+        # IntegrityError on the unique constraint over media_buy_id.
+        media_buy_id = f"mb_{uuid.uuid4().hex}"
+        # CreateMediaBuyRequest fields:
+        #   total_budget: TotalBudget | None  (with .amount + .currency)
+        #   start_time: StartTiming           (root: 'asap' | AwareDatetime)
+        #   end_time:   AwareDatetime
+        # Project at the seam — the SQL columns are flat float / str /
+        # datetime so the platform owns the unwrapping.
+        budget_amount = req.total_budget.amount if req.total_budget else None
+        budget_currency = req.total_budget.currency if req.total_budget else None
+        start_dt = _project_start_time(req.start_time)
         row = MediaBuyRow(
             tenant_id=ctx.account.metadata["tenant_id"],
             account_id=ctx.account.id,
@@ -206,10 +221,10 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             idempotency_key=req.idempotency_key,
             status="active",
             brand_domain=getattr(req.brand, "domain", None) if req.brand else None,
-            total_budget=getattr(req, "total_budget", None),
-            currency=getattr(req, "currency", None),
-            start_time=_to_dt(req.start_time),
-            end_time=_to_dt(req.end_time),
+            total_budget=budget_amount,
+            currency=budget_currency,
+            start_time=start_dt,
+            end_time=req.end_time,
             request_snapshot=req.model_dump(mode="json"),
         )
         async with self._sessionmaker() as session, session.begin():
@@ -291,18 +306,27 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         return GetMediaBuyDeliveryResponse(media_buys=[])
 
 
-def _to_dt(value: Any) -> datetime | None:
-    """Best-effort coercion to timezone-aware UTC datetime."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
-    if isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-    return None
+def _project_start_time(value: Any) -> datetime:
+    """Project :class:`StartTiming` (root: ``'asap'`` | :class:`AwareDatetime`)
+    into a flat timezone-aware datetime for SQL storage.
+
+    The spec lets buyers send either ``'asap'`` or an ISO 8601 datetime;
+    this seller normalizes ``'asap'`` to ``now()`` so the column is
+    always populated. Adopters who need to preserve the literal flag
+    add a separate ``start_immediately`` boolean column and project
+    here.
+    """
+    root = getattr(value, "root", value)
+    if root == "asap":
+        return datetime.now(timezone.utc)
+    if isinstance(root, datetime):
+        return root if root.tzinfo else root.replace(tzinfo=timezone.utc)
+    raise AdcpError(
+        "INVALID_REQUEST",
+        message=f"Unrecognized StartTiming value {root!r}.",
+        recovery="terminal",
+        field="start_time",
+    )
 
 
 __all__ = ["V3ReferenceSeller"]

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -1,0 +1,308 @@
+"""DecisioningPlatform impl for the v3 reference seller.
+
+Sales-non-guaranteed specialism with the five required Sales methods:
+
+* :meth:`get_products` — read inventory catalog
+* :meth:`create_media_buy` — terminal artifact insert; idempotency-keyed
+* :meth:`update_media_buy` — patch (status / pause / spend cap)
+* :meth:`sync_creatives` — accept creative manifests
+* :meth:`get_media_buy_delivery` — read delivery actuals
+
+All five run against the SQLAlchemy models in :mod:`models`. The
+platform reads the resolved :class:`adcp.decisioning.BuyerAgent`
+from :attr:`RequestContext.buyer_agent` (set by the framework's
+dispatch gate) and the :class:`adcp.decisioning.Account` from
+:attr:`RequestContext.account` (set by the platform's
+``AccountStore``) — both already filtered to the active tenant via
+:func:`adcp.server.current_tenant`.
+
+This file is the bulk of what an adopter customizes. Everything
+else (auth verifier, registry, audit sink, tenant routing) is
+boilerplate the seller wires once and forgets.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from adcp.decisioning import (
+    Account,
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    ExplicitAccounts,
+)
+from adcp.decisioning.specialisms import SalesPlatform
+from adcp.types import (
+    CreateMediaBuyRequest,
+    CreateMediaBuySuccessResponse,
+    GetMediaBuyDeliveryRequest,
+    GetMediaBuyDeliveryResponse,
+    GetProductsRequest,
+    GetProductsResponse,
+    Product,
+    SyncCreativesRequest,
+    SyncCreativesSuccessResponse,
+    UpdateMediaBuyRequest,
+    UpdateMediaBuySuccessResponse,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from adcp.decisioning import RequestContext
+
+from .models import Account as AccountRow
+from .models import MediaBuy as MediaBuyRow
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# AccountStore — explicit (wire ref drives lookup)
+# ---------------------------------------------------------------------------
+
+
+def _make_account_store(sessionmaker: async_sessionmaker) -> ExplicitAccounts:
+    """Adopter ``AccountStore`` — resolves
+    ``request.account.account_id`` against the ``accounts`` table.
+
+    The framework calls this BEFORE the platform method runs.
+    Returns the typed :class:`Account` dataclass that lands on
+    :attr:`RequestContext.account`.
+
+    Tenant scoping happens implicitly: the request's tenant is
+    pinned by :class:`SubdomainTenantMiddleware`, threads onto
+    :attr:`ToolContext.tenant_id`, and we filter accounts by it
+    here.
+    """
+
+    async def loader(account_id: str) -> Account[dict[str, Any]]:
+        # Read tenant from the contextvar set by the middleware.
+        from adcp.server import current_tenant
+
+        tenant = current_tenant()
+        if tenant is None:
+            raise AdcpError(
+                "AUTH_INVALID",
+                message=(
+                    "AccountStore.resolve called without a tenant context. "
+                    "Wire the SubdomainTenantMiddleware before serve()."
+                ),
+                recovery="terminal",
+            )
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AccountRow).where(
+                    AccountRow.tenant_id == tenant.id,
+                    AccountRow.account_id == account_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+        if row is None or row.status != "active":
+            raise AdcpError(
+                "ACCOUNT_NOT_FOUND",
+                message=f"No active account {account_id!r} under tenant {tenant.id!r}.",
+                recovery="terminal",
+                field="account.account_id",
+            )
+        return Account(
+            id=row.id,
+            name=row.name,
+            status=row.status,
+            metadata={
+                "tenant_id": row.tenant_id,
+                "buyer_agent_id": row.buyer_agent_id,
+                "account_id": row.account_id,
+                "billing": row.billing,
+                "sandbox": row.sandbox,
+            },
+        )
+
+    return ExplicitAccounts(loader=loader)
+
+
+# ---------------------------------------------------------------------------
+# Platform — sales-non-guaranteed
+# ---------------------------------------------------------------------------
+
+
+class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
+    """Sales-non-guaranteed seller against the v3 reference schema.
+
+    Every method body reads :attr:`RequestContext.buyer_agent` (the
+    Tier 2 commercial-identity record) and :attr:`account` (the
+    resolved account for this request). Both are populated by the
+    framework's dispatch layer before the method runs.
+    """
+
+    capabilities = DecisioningCapabilities(
+        specialisms=("sales-non-guaranteed",),
+        channels=("display", "video"),
+        pricing_models=("cpm",),
+    )
+
+    def __init__(self, *, sessionmaker: async_sessionmaker) -> None:
+        self._sessionmaker = sessionmaker
+        self.accounts = _make_account_store(sessionmaker)
+
+    # ----- get_products ----------------------------------------------------
+
+    async def get_products(
+        self, req: GetProductsRequest, ctx: RequestContext
+    ) -> GetProductsResponse:
+        """Static product catalog for the reference seller. Real
+        adopters query a CMS / forecasting service."""
+        del req, ctx  # this reference impl ignores brief / context
+        return GetProductsResponse(
+            products=[
+                Product(
+                    product_id="display-run-of-network",
+                    name="Display run-of-network",
+                    delivery_type="non_guaranteed",
+                    creative_policy={
+                        "co_branding": "neither",
+                        "landing_page": "any",
+                    },
+                    pricing_options=[
+                        {
+                            "type": "cpm",
+                            "rate": 5.00,
+                            "currency": "USD",
+                        }
+                    ],
+                )
+            ]
+        )
+
+    # ----- create_media_buy ------------------------------------------------
+
+    async def create_media_buy(
+        self, req: CreateMediaBuyRequest, ctx: RequestContext
+    ) -> CreateMediaBuySuccessResponse:
+        """Insert the canonical media-buy row.
+
+        Idempotency-keyed: the framework's outer middleware caches by
+        ``(scope_key, idempotency_key)`` and serves the cached
+        response on retry. We additionally enforce uniqueness at the
+        DB level via ``UniqueConstraint(tenant_id, idempotency_key)``
+        so a misconfigured cache can't double-insert.
+        """
+        if ctx.buyer_agent is None or ctx.account is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated buyer_agent and account.",
+                recovery="terminal",
+            )
+        media_buy_id = f"mb_{req.idempotency_key[:16]}"
+        row = MediaBuyRow(
+            tenant_id=ctx.account.metadata["tenant_id"],
+            account_id=ctx.account.id,
+            media_buy_id=media_buy_id,
+            idempotency_key=req.idempotency_key,
+            status="active",
+            brand_domain=getattr(req.brand, "domain", None) if req.brand else None,
+            total_budget=getattr(req, "total_budget", None),
+            currency=getattr(req, "currency", None),
+            start_time=_to_dt(req.start_time),
+            end_time=_to_dt(req.end_time),
+            request_snapshot=req.model_dump(mode="json"),
+        )
+        async with self._sessionmaker() as session, session.begin():
+            session.add(row)
+        logger.info(
+            "Created media buy %s for account=%s buyer=%s",
+            media_buy_id,
+            ctx.account.id,
+            ctx.buyer_agent.agent_url,
+        )
+        return CreateMediaBuySuccessResponse(
+            media_buy_id=media_buy_id,
+            packages=[],
+            status="active",
+        )
+
+    # ----- update_media_buy ------------------------------------------------
+
+    async def update_media_buy(
+        self, media_buy_id: str, patch: UpdateMediaBuyRequest, ctx: RequestContext
+    ) -> UpdateMediaBuySuccessResponse:
+        """Patch a media buy's status / pause flag.
+
+        Tenant + account scoped — the SQL UPDATE includes both in the
+        WHERE clause so a misrouted request can't mutate rows
+        belonging to another tenant.
+        """
+        if ctx.account is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated account.",
+                recovery="terminal",
+            )
+        async with self._sessionmaker() as session, session.begin():
+            result = await session.execute(
+                select(MediaBuyRow).where(
+                    MediaBuyRow.tenant_id == ctx.account.metadata["tenant_id"],
+                    MediaBuyRow.account_id == ctx.account.id,
+                    MediaBuyRow.media_buy_id == media_buy_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                raise AdcpError(
+                    "MEDIA_BUY_NOT_FOUND",
+                    message=f"No media buy {media_buy_id!r} under this account.",
+                    recovery="terminal",
+                )
+            if patch.paused is True and row.status == "active":
+                row.status = "paused"
+            elif patch.paused is False and row.status == "paused":
+                row.status = "active"
+            row.updated_at = datetime.now(timezone.utc)
+        return UpdateMediaBuySuccessResponse(
+            media_buy_id=row.media_buy_id,
+            status=row.status,  # type: ignore[arg-type]
+            packages=[],
+        )
+
+    # ----- sync_creatives --------------------------------------------------
+
+    async def sync_creatives(
+        self, req: SyncCreativesRequest, ctx: RequestContext
+    ) -> SyncCreativesSuccessResponse:
+        """Accept creative manifests — the reference impl persists
+        nothing; production adopters route to their creative review
+        pipeline here."""
+        del req, ctx
+        return SyncCreativesSuccessResponse(creatives=[])
+
+    # ----- get_media_buy_delivery ------------------------------------------
+
+    async def get_media_buy_delivery(
+        self, req: GetMediaBuyDeliveryRequest, ctx: RequestContext
+    ) -> GetMediaBuyDeliveryResponse:
+        """Stub delivery — production adopters wire their real
+        delivery / pacing query."""
+        del req, ctx
+        return GetMediaBuyDeliveryResponse(media_buys=[])
+
+
+def _to_dt(value: Any) -> datetime | None:
+    """Best-effort coercion to timezone-aware UTC datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+__all__ = ["V3ReferenceSeller"]

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -169,11 +169,17 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                         "co_branding": "neither",
                         "landing_page": "any",
                     },
+                    # Conformant CpmPricingOption shape: discriminator
+                    # ``pricing_model`` (not ``type``), required
+                    # ``pricing_option_id``, ``fixed_price`` (not
+                    # ``rate``). See the spec's
+                    # ``pricing_options/cpm_option.json``.
                     pricing_options=[
                         {
-                            "type": "cpm",
-                            "rate": 5.00,
+                            "pricing_option_id": "ron-cpm-5usd",
+                            "pricing_model": "cpm",
                             "currency": "USD",
+                            "fixed_price": 5.00,
                         }
                     ],
                 )

--- a/examples/v3_reference_seller/src/tenant_router.py
+++ b/examples/v3_reference_seller/src/tenant_router.py
@@ -1,0 +1,94 @@
+"""SQL-backed :class:`adcp.server.SubdomainTenantRouter`.
+
+Resolves the request ``Host`` header to a :class:`adcp.server.Tenant`
+by hitting the ``tenants`` table. The framework's ASGI middleware
+threads the result onto the ``current_tenant()`` contextvar; the
+adopter's ``context_factory`` reads it to populate
+:attr:`ToolContext.tenant_id`.
+
+Cached lookups via a small in-process LRU keep the hot path off the
+database. The cache is invalidated when an admin update changes
+``tenants.host`` (admin API publishes a tenant-changed event;
+production sellers wire a Postgres LISTEN / pub-sub for the
+invalidation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from adcp.server import Tenant
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from .models import Tenant as TenantRow
+
+
+class SqlSubdomainTenantRouter:
+    """Production-shape adopter impl.
+
+    Adopters with a separate cache layer (Redis, in-process LRU)
+    swap this out — the Protocol is one async method.
+    """
+
+    def __init__(
+        self,
+        *,
+        sessionmaker: async_sessionmaker,
+        cache_size: int = 256,
+    ) -> None:
+        self._sessionmaker = sessionmaker
+        self._cache: dict[str, Tenant | None] = {}
+        self._cache_size = cache_size
+        self._cache_lock = asyncio.Lock()
+
+    async def resolve(self, host: str) -> Tenant | None:
+        # Tiny LRU-ish cache — first-write-wins eviction. Adopters
+        # under heavy traffic swap to a real LRU (functools.lru_cache
+        # doesn't compose with async, so we hand-roll).
+        async with self._cache_lock:
+            if host in self._cache:
+                return self._cache[host]
+        async with self._sessionmaker() as session:
+            result = await session.execute(select(TenantRow).where(TenantRow.host == host))
+            row = result.scalar_one_or_none()
+        tenant: Tenant | None
+        if row is None or row.status != "active":
+            # Suspended / archived tenants resolve to None — same
+            # outer behavior as unknown hosts (404 with no body).
+            tenant = None
+        else:
+            tenant = Tenant(
+                id=row.id,
+                display_name=row.display_name,
+                ext={"db_status": row.status, **(row.ext or {})},
+            )
+        async with self._cache_lock:
+            if len(self._cache) >= self._cache_size:
+                # Simple eviction: drop one arbitrary entry. With
+                # cache_size=256 across thousands of QPS this
+                # smoothly cycles. Adopters needing strict LRU swap
+                # in ``cachetools.LRUCache``.
+                self._cache.pop(next(iter(self._cache)))
+            self._cache[host] = tenant
+        return tenant
+
+    def invalidate(self, host: str) -> None:
+        """Drop a single host from the cache.
+
+        Called by the admin API after CRUD that touches the tenants
+        table. Production sellers wire a Postgres LISTEN to broadcast
+        invalidations across worker processes.
+        """
+        self._cache.pop(host, None)
+
+    def clear_cache(self) -> None:
+        """Drop all cached entries — useful after bulk edits."""
+        self._cache.clear()
+
+
+__all__ = ["SqlSubdomainTenantRouter"]

--- a/examples/v3_reference_seller/src/tenant_router.py
+++ b/examples/v3_reference_seller/src/tenant_router.py
@@ -6,8 +6,10 @@ threads the result onto the ``current_tenant()`` contextvar; the
 adopter's ``context_factory`` reads it to populate
 :attr:`ToolContext.tenant_id`.
 
-Cached lookups via a small in-process LRU keep the hot path off the
-database. The cache is invalidated when an admin update changes
+Cached lookups via a small in-process bounded FIFO keep the hot
+path off the database. Adopters with > ``cache_size`` distinct
+hosts under load swap to ``cachetools.LRUCache`` — the Protocol is
+one method. The cache is invalidated when an admin update changes
 ``tenants.host`` (admin API publishes a tenant-changed event;
 production sellers wire a Postgres LISTEN / pub-sub for the
 invalidation).
@@ -47,9 +49,11 @@ class SqlSubdomainTenantRouter:
         self._cache_lock = asyncio.Lock()
 
     async def resolve(self, host: str) -> Tenant | None:
-        # Tiny LRU-ish cache — first-write-wins eviction. Adopters
-        # under heavy traffic swap to a real LRU (functools.lru_cache
-        # doesn't compose with async, so we hand-roll).
+        # Bounded FIFO cache — when full, the oldest insertion is
+        # evicted regardless of access frequency. Fine for stable
+        # tenant sets under ``cache_size``; adopters with churn or
+        # > 256 active hosts swap in ``cachetools.LRUCache``
+        # (functools.lru_cache doesn't compose with async).
         async with self._cache_lock:
             if host in self._cache:
                 return self._cache[host]
@@ -69,10 +73,8 @@ class SqlSubdomainTenantRouter:
             )
         async with self._cache_lock:
             if len(self._cache) >= self._cache_size:
-                # Simple eviction: drop one arbitrary entry. With
-                # cache_size=256 across thousands of QPS this
-                # smoothly cycles. Adopters needing strict LRU swap
-                # in ``cachetools.LRUCache``.
+                # Drop the oldest insertion (dict iteration order is
+                # insertion-order in CPython 3.7+).
                 self._cache.pop(next(iter(self._cache)))
             self._cache[host] = tenant
         return tenant

--- a/examples/v3_reference_seller/tests/test_smoke.py
+++ b/examples/v3_reference_seller/tests/test_smoke.py
@@ -1,0 +1,113 @@
+"""Smoke tests for the v3 reference seller.
+
+Verify the components import cleanly, the Protocol shapes match the
+framework's expectations, and the platform constructs without errors.
+End-to-end PG tests live in the README's docker-compose flow — these
+tests are the no-PG-needed safety net.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the example dir to sys.path so `src.*` imports resolve.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+
+def test_models_import_and_declare_tables() -> None:
+    from src.models import Account, Base, BuyerAgent, MediaBuy, Tenant
+
+    table_names = {t.name for t in Base.metadata.tables.values()}
+    assert {"tenants", "buyer_agents", "accounts", "media_buys"} <= table_names
+    # Sanity: every model is in the metadata.
+    for cls in (Tenant, BuyerAgent, Account, MediaBuy):
+        assert cls.__tablename__ in table_names
+
+
+def test_platform_satisfies_decisioning_protocol() -> None:
+    """The platform impl exists and can be inspected without an
+    actual session — adopter middleware would never construct without
+    a real sessionmaker, but the class shape doesn't depend on it."""
+    from src.platform import V3ReferenceSeller
+
+    from adcp.decisioning import DecisioningPlatform
+    from adcp.decisioning.specialisms import SalesPlatform
+
+    assert issubclass(V3ReferenceSeller, DecisioningPlatform)
+    assert issubclass(V3ReferenceSeller, SalesPlatform)
+    assert "sales-non-guaranteed" in V3ReferenceSeller.capabilities.specialisms
+
+
+def test_buyer_registry_satisfies_protocol() -> None:
+    from src.buyer_registry import TenantScopedBuyerAgentRegistry
+
+    from adcp.decisioning import BuyerAgentRegistry
+
+    # Construct without a sessionmaker — the registry's lookups never
+    # fire here, so a placeholder is fine for the structural check.
+    registry = TenantScopedBuyerAgentRegistry(sessionmaker=lambda: None)  # type: ignore[arg-type]
+    assert isinstance(registry, BuyerAgentRegistry)
+
+
+def test_audit_sink_implements_protocol() -> None:
+    from src.audit import DbAuditSink
+
+    from adcp.audit_sink import AuditSink
+
+    sink = DbAuditSink(sessionmaker=lambda: None)  # type: ignore[arg-type]
+    assert isinstance(sink, AuditSink)
+
+
+def test_tenant_router_satisfies_protocol() -> None:
+    from src.tenant_router import SqlSubdomainTenantRouter
+
+    from adcp.server import SubdomainTenantRouter
+
+    router = SqlSubdomainTenantRouter(sessionmaker=lambda: None)  # type: ignore[arg-type]
+    assert isinstance(router, SubdomainTenantRouter)
+
+
+@pytest.mark.asyncio
+async def test_tenant_router_returns_none_without_session_match() -> None:
+    """Resolution against a session that yields no row returns None
+    — the middleware then 404s the request."""
+    from src.tenant_router import SqlSubdomainTenantRouter
+
+    class _NullSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def execute(self, _stmt):
+            class _Result:
+                def scalar_one_or_none(self):
+                    return None
+
+            return _Result()
+
+    router = SqlSubdomainTenantRouter(sessionmaker=lambda: _NullSession())  # type: ignore[arg-type]
+    result = await router.resolve("unknown.example.com")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_buyer_registry_returns_none_without_tenant() -> None:
+    """Without a tenant context (ContextVar unset), the registry
+    returns None — the framework dispatch then rejects with
+    REQUEST_AUTH_UNRECOGNIZED_AGENT."""
+    from src.buyer_registry import TenantScopedBuyerAgentRegistry
+
+    from adcp.decisioning import ApiKeyCredential
+
+    registry = TenantScopedBuyerAgentRegistry(sessionmaker=lambda: None)  # type: ignore[arg-type]
+    # No `current_tenant()` set — the registry should short-circuit
+    # to None without touching the DB.
+    cred = ApiKeyCredential(kind="api_key", key_id="any")
+    assert await registry.resolve_by_agent_url("https://x/") is None
+    assert await registry.resolve_by_credential(cred) is None

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -407,6 +407,7 @@ def serve(
     task_store: TaskStore | None = None,
     push_config_store: PushNotificationConfigStore | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
+    asgi_middleware: Sequence[tuple[type, dict[str, Any]]] | None = None,
     message_parser: MessageParser | None = None,
     advertise_all: bool = False,
     max_request_size: int | None = None,
@@ -452,6 +453,17 @@ def serve(
             rate limiting, tracing. Composes outermost-first. See
             :data:`SkillMiddleware` for the signature and composition
             semantics.
+        asgi_middleware: Optional sequence of ``(MiddlewareClass, kwargs)``
+            tuples — Starlette-shape ASGI middleware applied to the
+            outer HTTP app before uvicorn binds. Use for cross-cutting
+            HTTP concerns the SDK does not own: tenant resolution
+            (:class:`adcp.server.SubdomainTenantMiddleware`), CORS,
+            request-id propagation, IP allowlists, custom auth.
+            Composes outermost-first — the first entry sees every
+            request before later entries. Each class is invoked as
+            ``cls(app, **kwargs)``. Applied on every HTTP transport
+            (``streamable-http``, ``a2a``, ``both``); ignored on
+            ``stdio``.
         message_parser: Optional
             :data:`~adcp.server.a2a_server.MessageParser` callable for
             alternative A2A wire shapes (A2A transport only). The
@@ -539,6 +551,7 @@ def serve(
             task_store=task_store,
             push_config_store=push_config_store,
             middleware=middleware,
+            asgi_middleware=asgi_middleware,
             message_parser=message_parser,
             advertise_all=advertise_all,
             max_request_size=max_request_size,
@@ -554,6 +567,7 @@ def serve(
             test_controller=test_controller,
             context_factory=context_factory,
             middleware=middleware,
+            asgi_middleware=asgi_middleware,
             advertise_all=advertise_all,
             max_request_size=max_request_size,
             streaming_responses=streaming_responses,
@@ -570,6 +584,7 @@ def serve(
             task_store=task_store,
             push_config_store=push_config_store,
             middleware=middleware,
+            asgi_middleware=asgi_middleware,
             message_parser=message_parser,
             advertise_all=advertise_all,
             max_request_size=max_request_size,
@@ -578,6 +593,26 @@ def serve(
     else:
         valid = ", ".join(sorted(("a2a", "both", "streamable-http", "sse", "stdio")))
         raise ValueError(f"Unknown transport {transport!r}. Valid: {valid}")
+
+
+def _apply_asgi_middleware(
+    app: Any,
+    asgi_middleware: Sequence[tuple[type, dict[str, Any]]] | None,
+) -> Any:
+    """Wrap ``app`` with operator-supplied Starlette-style ASGI middleware.
+
+    Each entry is ``(MiddlewareClass, kwargs)`` and is invoked as
+    ``cls(app, **kwargs)``. Composition is outermost-first — the first
+    entry sees every request before later entries — so we wrap in
+    reverse, matching :meth:`Starlette.add_middleware` semantics.
+
+    No-op when the sequence is empty or ``None``.
+    """
+    if not asgi_middleware:
+        return app
+    for cls, kwargs in reversed(list(asgi_middleware)):
+        app = cls(app, **kwargs)
+    return app
 
 
 def _wrap_with_path_normalize(app: Any) -> Any:
@@ -737,6 +772,7 @@ def _serve_mcp(
     test_controller: TestControllerStore | None,
     context_factory: ContextFactory | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
+    asgi_middleware: Sequence[tuple[type, dict[str, Any]]] | None = None,
     advertise_all: bool = False,
     max_request_size: int | None = None,
     streaming_responses: bool = False,
@@ -761,13 +797,24 @@ def _serve_mcp(
         register_test_controller(mcp, test_controller, context_factory=context_factory)
 
     if transport in ("streamable-http", "sse"):
-        _run_mcp_http(mcp, transport=transport, max_request_size=max_request_size)
+        _run_mcp_http(
+            mcp,
+            transport=transport,
+            max_request_size=max_request_size,
+            asgi_middleware=asgi_middleware,
+        )
     else:
         # stdio — no listening socket, nothing to configure.
         mcp.run(transport=transport)
 
 
-def _run_mcp_http(mcp: Any, *, transport: str, max_request_size: int | None = None) -> None:
+def _run_mcp_http(
+    mcp: Any,
+    *,
+    transport: str,
+    max_request_size: int | None = None,
+    asgi_middleware: Sequence[tuple[type, dict[str, Any]]] | None = None,
+) -> None:
     """Run FastMCP's HTTP transports with a pre-bound SO_REUSEADDR socket.
 
     FastMCP builds its own ``uvicorn.Server(config).serve()`` inside
@@ -790,6 +837,7 @@ def _run_mcp_http(mcp: Any, *, transport: str, max_request_size: int | None = No
 
     app = _wrap_with_path_normalize(app)
     app = _wrap_with_size_limit(app, max_request_size)
+    app = _apply_asgi_middleware(app, asgi_middleware)
 
     sock = _bind_reusable_socket(host, port)
     try:
@@ -827,6 +875,7 @@ def _serve_a2a(
     task_store: TaskStore | None = None,
     push_config_store: PushNotificationConfigStore | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
+    asgi_middleware: Sequence[tuple[type, dict[str, Any]]] | None = None,
     message_parser: MessageParser | None = None,
     advertise_all: bool = False,
     max_request_size: int | None = None,
@@ -851,6 +900,7 @@ def _serve_a2a(
         advertise_all=advertise_all,
     )
     app = _wrap_with_size_limit(app, max_request_size)
+    app = _apply_asgi_middleware(app, asgi_middleware)
     sock = _bind_reusable_socket("0.0.0.0", resolved_port)
     try:
         # Same bind-boundary INFO as the MCP path so A2A adopters
@@ -1000,6 +1050,7 @@ def _serve_mcp_and_a2a(
     task_store: TaskStore | None = None,
     push_config_store: PushNotificationConfigStore | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
+    asgi_middleware: Sequence[tuple[type, dict[str, Any]]] | None = None,
     message_parser: MessageParser | None = None,
     advertise_all: bool = False,
     max_request_size: int | None = None,
@@ -1042,6 +1093,7 @@ def _serve_mcp_and_a2a(
         max_request_size=max_request_size,
         streaming_responses=streaming_responses,
     )
+    app = _apply_asgi_middleware(app, asgi_middleware)
 
     sock = _bind_reusable_socket(resolved_host, resolved_port)
     try:

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -464,6 +464,12 @@ def serve(
             ``cls(app, **kwargs)``. Applied on every HTTP transport
             (``streamable-http``, ``a2a``, ``both``); ignored on
             ``stdio``.
+
+            Middleware sees ``lifespan`` and ``websocket`` scopes in
+            addition to ``http`` — guard non-HTTP scopes by passing
+            them through unchanged (``if scope['type'] != 'http':
+            await self.app(scope, receive, send); return``) so the
+            framework's lifespan composition still runs.
         message_parser: Optional
             :data:`~adcp.server.a2a_server.MessageParser` callable for
             alternative A2A wire shapes (A2A transport only). The

--- a/tests/test_serve_asgi_middleware.py
+++ b/tests/test_serve_asgi_middleware.py
@@ -1,0 +1,67 @@
+"""Tests for the ``serve(asgi_middleware=...)`` kwarg.
+
+Operators wiring tenant routing, CORS, request-id propagation, and
+custom auth use this kwarg to layer Starlette-style ASGI middleware
+on the outer HTTP app before uvicorn binds. The kwarg accepts a
+sequence of ``(MiddlewareClass, kwargs)`` tuples and composes
+outermost-first.
+"""
+
+from __future__ import annotations
+
+from adcp.server.serve import _apply_asgi_middleware
+
+
+class _NoOpAsgi:
+    """Bare ASGI app stub — never actually invoked in these tests."""
+
+    async def __call__(self, scope, receive, send):  # pragma: no cover
+        return None
+
+
+class _TaggingMiddleware:
+    """Records its name onto the outer app's call list when constructed."""
+
+    def __init__(self, app, *, name):
+        self.app = app
+        self.name = name
+
+
+def test_apply_asgi_middleware_no_op_for_empty_sequence():
+    app = _NoOpAsgi()
+    out = _apply_asgi_middleware(app, None)
+    assert out is app
+    out2 = _apply_asgi_middleware(app, [])
+    assert out2 is app
+
+
+def test_apply_asgi_middleware_wraps_in_outermost_first_order():
+    """First entry in the sequence is the outermost wrapper.
+
+    Adopters reading ``[(A, {}), (B, {})]`` expect A to see every
+    request before B — same semantics as Starlette's
+    ``add_middleware``. The implementation reverses the iteration
+    order so the first entry ends up wrapping the result of the
+    later entries.
+    """
+    app = _NoOpAsgi()
+    wrapped = _apply_asgi_middleware(
+        app,
+        [
+            (_TaggingMiddleware, {"name": "outer"}),
+            (_TaggingMiddleware, {"name": "inner"}),
+        ],
+    )
+    assert isinstance(wrapped, _TaggingMiddleware)
+    assert wrapped.name == "outer"
+    assert isinstance(wrapped.app, _TaggingMiddleware)
+    assert wrapped.app.name == "inner"
+    assert wrapped.app.app is app
+
+
+def test_apply_asgi_middleware_passes_kwargs_through():
+    app = _NoOpAsgi()
+    wrapped = _apply_asgi_middleware(app, [(_TaggingMiddleware, {"name": "audit"})])
+    assert isinstance(wrapped, _TaggingMiddleware)
+    assert wrapped.name == "audit"
+    assert wrapped.app is app


### PR DESCRIPTION
## Summary

Multi-file directory under \`examples/v3_reference_seller/\` that wires every Tier 2 / v3-supporting component into one runnable adopter pattern. **Spec 3.0-compliant on the wire, 3.1-ready in architecture and storage.**

The directory is the canonical fork-and-modify starting point for adopters building a v3 seller.

### What's wired

| Component | Module |
|---|---|
| Multi-tenant root | \`src/models.py\` (Tenant) + \`src/tenant_router.py\` |
| Tier 2 commercial-identity gate | \`src/models.py\` (BuyerAgent) + \`src/buyer_registry.py\` |
| 3.1-ready Account schema | \`src/models.py\` (Account with billing_entity + reporting_bucket) |
| Audit trail | \`src/audit.py\` (DbAuditSink) |
| Platform impl | \`src/platform.py\` (sales-non-guaranteed) |
| Unified MCP+A2A binary | \`src/app.py\` (\`serve(transport="both")\`) |
| Dev fixtures | \`seed.py\` |

### What's NOT wired (yet)

Separable follow-ups; framework components exist:
- HTTP-Sig verifier middleware in context_factory (gated on AAO brand.json registry)
- Brand authorization Tier 3 (gated on ADCP #3690)
- Postgres TaskRegistry / WebhookDeliverySupervisor swap (one-line change)
- Alembic migrations (currently \`create_all\` at boot)
- Admin CRUD REST API

Closes #357 (MVP).

## Test plan

- [x] 7 smoke tests in \`tests/test_smoke.py\` — imports, Protocol conformance, tenant-context fallthrough (no PG required)
- [x] End-to-end: \`docker compose up postgres\` + seed.py creates schema and persists fixtures against postgres:16
- [x] Public surface: imports use only the stable \`adcp.decisioning\` / \`adcp.server\` / \`adcp.audit_sink\` paths
- [x] ruff/black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)