### PR TITLE
feat(signing): verify_from_agent_url — single-call resolver+verifier factory

### DIFF
--- a/src/adcp/signing/__init__.py
+++ b/src/adcp/signing/__init__.py
@@ -94,6 +94,7 @@ from adcp.signing.agent_resolver import (
     TraceEntry,
     async_resolve_agent,
     resolve_agent,
+    verify_from_agent_url,
 )
 from adcp.signing.autosign import (
     SigningConfig,
@@ -393,6 +394,7 @@ __all__ = [
     "validate_jwks_uri",
     "verify_detached_jws",
     "verify_flask_request",
+    "verify_from_agent_url",
     "verify_jws_document",
     "verify_request_signature",
     "verify_signature",

--- a/src/adcp/signing/agent_resolver.py
+++ b/src/adcp/signing/agent_resolver.py
@@ -509,6 +509,115 @@ def resolve_agent(
     )
 
 
+# ---- verify factory ----
+
+
+async def verify_from_agent_url(
+    request: Any,
+    agent_url: str,
+    *,
+    agent_type: BrandAgentType,
+    operation: str,
+    agent_id: str | None = None,
+    brand_id: str | None = None,
+    capability: Any = None,
+    now: float | None = None,
+    replay_store: Any = None,
+    revocation_checker: Any = None,
+    revocation_list: Any = None,
+    allow_private_destinations: bool = False,
+) -> Any:
+    """Single-call factory: resolve ``agent_url`` and verify the
+    request signature against the resolved JWKS.
+
+    Composes :func:`async_resolve_agent` (3-hop walk to the JWK set)
+    with the existing :func:`verify_starlette_request` verifier. Use
+    this when the verifier is handed an agent URL and needs to
+    bootstrap to that agent's signing keys without out-of-band
+    knowledge of the operator domain — the common path for buyer-side
+    request verification on AdCP 3.x sellers.
+
+    ``request`` is a Starlette / FastAPI ``Request``-shaped object
+    (matches :func:`verify_starlette_request`'s duck type — needs
+    ``method``, ``url``, ``headers``, and ``await body()``). Body is
+    consumed once; downstream handlers calling ``await request.body()``
+    again get the same cached bytes (Starlette behavior).
+
+    Resolver-side failures (capabilities unreachable, brand.json
+    walk failed, JWKS fetch failed) are mapped to
+    :class:`SignatureVerificationError` with
+    ``REQUEST_SIGNATURE_JWKS_UNAVAILABLE`` so callers handle
+    resolution and verification failures through one ``except`` clause.
+    The exception to that rule is ``invalid_agent_url`` — that's a
+    trust-boundary rejection, so it maps to
+    ``REQUEST_SIGNATURE_JWKS_UNTRUSTED``.
+
+    Adopters needing finer-grain dispatch on the resolver-side cause
+    can read ``exc.__cause__`` and check the
+    :class:`AgentResolverError.code` directly — both exception
+    hierarchies are preserved.
+
+    Returns
+    -------
+    VerifiedSigner
+        On success — carries the verified ``key_id`` and metadata.
+
+    Raises
+    ------
+    SignatureVerificationError
+        Either from the resolver (mapped per above) or from the
+        verifier (passes through with the spec ``code`` already set).
+    """
+    import time as _time
+
+    from adcp.signing.errors import (
+        REQUEST_SIGNATURE_JWKS_UNAVAILABLE,
+        REQUEST_SIGNATURE_JWKS_UNTRUSTED,
+        SignatureVerificationError,
+    )
+    from adcp.signing.jwks import StaticJwksResolver
+    from adcp.signing.middleware import verify_starlette_request
+    from adcp.signing.verifier import VerifierCapability, VerifyOptions
+
+    try:
+        resolution = await async_resolve_agent(
+            agent_url,
+            agent_type=agent_type,
+            agent_id=agent_id,
+            brand_id=brand_id,
+            allow_private_destinations=allow_private_destinations,
+        )
+    except AgentResolverError as exc:
+        # invalid_agent_url is a trust-boundary rejection (URL wouldn't
+        # canonicalize / scheme / SSRF-banned host). Everything else
+        # (capabilities_unreachable, brand_json_resolution_failed,
+        # jwks_fetch_failed) is a discovery-time failure even when
+        # underlying cause was SSRF — verifiers map those to
+        # JWKS_UNAVAILABLE per the spec's "couldn't get keys" reading.
+        mapped = (
+            REQUEST_SIGNATURE_JWKS_UNTRUSTED
+            if exc.code == "invalid_agent_url"
+            else REQUEST_SIGNATURE_JWKS_UNAVAILABLE
+        )
+        raise SignatureVerificationError(
+            mapped,
+            step="resolve",
+            message=f"agent-url resolution failed ({exc.code}): {exc.message}",
+        ) from exc
+
+    options = VerifyOptions(
+        now=now if now is not None else _time.time(),
+        capability=capability if capability is not None else VerifierCapability(supported=True),
+        operation=operation,
+        jwks_resolver=StaticJwksResolver(resolution.jwks),
+        replay_store=replay_store,
+        revocation_checker=revocation_checker,
+        revocation_list=revocation_list,
+        agent_url=resolution.agent_entry.get("url"),
+    )
+    return await verify_starlette_request(request, options=options)
+
+
 # ---- helpers ----
 
 
@@ -539,4 +648,5 @@ __all__ = [
     "TraceEntry",
     "async_resolve_agent",
     "resolve_agent",
+    "verify_from_agent_url",
 ]

--- a/tests/test_verify_from_agent_url.py
+++ b/tests/test_verify_from_agent_url.py
@@ -1,0 +1,226 @@
+"""``verify_from_agent_url`` — single-call resolver+verifier factory.
+
+Tests the orchestration layer: resolver feeds a JWK set to a
+:class:`StaticJwksResolver`, that JWKS resolver feeds the existing
+:func:`verify_starlette_request` verifier, errors map cleanly between
+the two hierarchies. Happy-path JWKS verification is covered
+end-to-end in ``tests/conformance/signing/test_e2e_fastapi.py``; this
+file focuses on the factory's value-add (composition + error mapping).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.signing import agent_resolver
+from adcp.signing.agent_resolver import (
+    AgentResolution,
+    AgentResolverError,
+    verify_from_agent_url,
+)
+from adcp.signing.errors import (
+    REQUEST_SIGNATURE_JWKS_UNAVAILABLE,
+    REQUEST_SIGNATURE_JWKS_UNTRUSTED,
+    SignatureVerificationError,
+)
+
+# ---- Test seams ----
+
+
+class _FakeStarletteRequest:
+    """Duck-types just enough of Starlette's Request for
+    :func:`verify_starlette_request`."""
+
+    def __init__(
+        self,
+        *,
+        method: str = "POST",
+        url: str = "https://seller.example.com/mcp",
+        headers=None,
+        body: bytes = b"",
+    ) -> None:
+        self.method = method
+        self.url = url
+        self.headers = headers or {}
+        self._body = body
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+_RESOLVED_AGENT = AgentResolution(
+    agent_url="https://buyer.example.com/mcp",
+    brand_json_url="https://example.com/.well-known/brand.json",
+    agent_entry={
+        "type": "sales",
+        "url": "https://buyer.example.com/mcp",
+        "jwks_uri": "https://example.com/.well-known/jwks.json",
+    },
+    jwks_uri="https://example.com/.well-known/jwks.json",
+    jwks={"keys": []},
+    fetched_at=0.0,
+    trace=[],
+)
+
+
+# ---- Happy path: resolver feeds verifier ----
+
+
+@pytest.mark.asyncio
+async def test_factory_passes_resolved_jwks_to_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the resolver returns a JWK set, the verifier is constructed
+    with a :class:`StaticJwksResolver` over those keys, the resolved
+    agent_url is forwarded as ``options.agent_url``, and the verifier's
+    return value flows back through unchanged. Pins the wiring so a
+    refactor of the inner ``VerifyOptions`` shape can't silently drop
+    the JWKS.
+    """
+    seen: dict[str, Any] = {}
+
+    async def fake_resolve(*args, **kwargs):
+        return _RESOLVED_AGENT
+
+    async def fake_verify_starlette(request, *, options):  # type: ignore[no-untyped-def]
+        seen["options"] = options
+        seen["request"] = request
+        return "verified-signer-sentinel"
+
+    monkeypatch.setattr(agent_resolver, "async_resolve_agent", fake_resolve)
+    monkeypatch.setattr("adcp.signing.middleware.verify_starlette_request", fake_verify_starlette)
+
+    request = _FakeStarletteRequest()
+    result = await verify_from_agent_url(
+        request,
+        "https://buyer.example.com/mcp",
+        agent_type="sales",
+        operation="get_products",
+    )
+    assert result == "verified-signer-sentinel"
+    assert seen["options"].operation == "get_products"
+    assert seen["options"].agent_url == "https://buyer.example.com/mcp"
+    # JWKS resolver constructed from the resolution's jwks set.
+    assert seen["options"].jwks_resolver is not None
+
+
+# ---- Resolver failure mapping ----
+
+
+@pytest.mark.asyncio
+async def test_factory_maps_capabilities_unreachable_to_jwks_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``capabilities_unreachable`` is a discovery-time failure; verifier
+    callers should see ``REQUEST_SIGNATURE_JWKS_UNAVAILABLE`` and emit
+    a 401 with that code on the WWW-Authenticate header. The original
+    :class:`AgentResolverError` chains via ``__cause__`` so adopters
+    can drill into the resolver-side code if needed.
+    """
+
+    async def fake_resolve(*args, **kwargs):
+        raise AgentResolverError("capabilities_unreachable", "503")
+
+    monkeypatch.setattr(agent_resolver, "async_resolve_agent", fake_resolve)
+
+    with pytest.raises(SignatureVerificationError) as exc:
+        await verify_from_agent_url(
+            _FakeStarletteRequest(),
+            "https://buyer.example.com/mcp",
+            agent_type="sales",
+            operation="get_products",
+        )
+    assert exc.value.code == REQUEST_SIGNATURE_JWKS_UNAVAILABLE
+    assert exc.value.step == "resolve"
+    assert isinstance(exc.value.__cause__, AgentResolverError)
+    assert exc.value.__cause__.code == "capabilities_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_factory_maps_invalid_agent_url_to_jwks_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``invalid_agent_url`` is a trust-boundary rejection (URL didn't
+    canonicalize / scheme banned / SSRF-banned host) — the verifier-side
+    semantic is ``JWKS_UNTRUSTED``, NOT ``JWKS_UNAVAILABLE``. Pins
+    this discrimination so a refactor of the mapping table doesn't
+    silently downgrade the security signal.
+    """
+
+    async def fake_resolve(*args, **kwargs):
+        raise AgentResolverError("invalid_agent_url", "scheme: http not https")
+
+    monkeypatch.setattr(agent_resolver, "async_resolve_agent", fake_resolve)
+
+    with pytest.raises(SignatureVerificationError) as exc:
+        await verify_from_agent_url(
+            _FakeStarletteRequest(),
+            "http://buyer.example.com/mcp",
+            agent_type="sales",
+            operation="get_products",
+        )
+    assert exc.value.code == REQUEST_SIGNATURE_JWKS_UNTRUSTED
+
+
+@pytest.mark.asyncio
+async def test_factory_maps_brand_json_failure_to_jwks_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """brand.json walk failure is also a discovery-time issue —
+    verifier sees JWKS_UNAVAILABLE so the receiver can retry / fail
+    gracefully without treating the buyer as adversarial."""
+
+    async def fake_resolve(*args, **kwargs):
+        raise AgentResolverError(
+            "brand_json_resolution_failed",
+            "brand.json resolution failed: fetch_failed: HTTP 404",
+        )
+
+    monkeypatch.setattr(agent_resolver, "async_resolve_agent", fake_resolve)
+
+    with pytest.raises(SignatureVerificationError) as exc:
+        await verify_from_agent_url(
+            _FakeStarletteRequest(),
+            "https://buyer.example.com/mcp",
+            agent_type="sales",
+            operation="get_products",
+        )
+    assert exc.value.code == REQUEST_SIGNATURE_JWKS_UNAVAILABLE
+
+
+# ---- Verifier failure passes through ----
+
+
+@pytest.mark.asyncio
+async def test_factory_passes_verifier_errors_through_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the resolver succeeds but the verifier rejects (e.g.
+    missing Signature header), the original
+    :class:`SignatureVerificationError` propagates with its spec code
+    intact — the factory does NOT remap verifier-side failures."""
+
+    async def fake_resolve(*args, **kwargs):
+        return _RESOLVED_AGENT
+
+    async def fake_verify_starlette(request, *, options):  # type: ignore[no-untyped-def]
+        raise SignatureVerificationError(
+            "request_signature_required",
+            step=0,
+            message="Signature header missing",
+        )
+
+    monkeypatch.setattr(agent_resolver, "async_resolve_agent", fake_resolve)
+    monkeypatch.setattr("adcp.signing.middleware.verify_starlette_request", fake_verify_starlette)
+
+    with pytest.raises(SignatureVerificationError) as exc:
+        await verify_from_agent_url(
+            _FakeStarletteRequest(),
+            "https://buyer.example.com/mcp",
+            agent_type="sales",
+            operation="get_products",
+        )
+    assert exc.value.code == "request_signature_required"
+    assert exc.value.step == 0


### PR DESCRIPTION
Follow-up to #389 (\`async_resolve_agent\`). Closes the verifier-side half of #344.

## Summary

\`adcp.signing.verify_from_agent_url\` — single async call that composes \`async_resolve_agent\` (3-hop walk to JWKS) with the existing \`verify_starlette_request\` verifier. The common pattern for AdCP 3.x sellers handed an agent_url and asked to verify a signed request from that agent.

\`\`\`python
from adcp.signing import verify_from_agent_url

verified_signer = await verify_from_agent_url(
    request,                                    # Starlette/FastAPI Request
    \"https://buyer.example.com/mcp\",
    agent_type=\"sales\",
    operation=\"get_products\",
)
\`\`\`

## Error mapping

Resolver-side \`AgentResolverError\` is mapped to \`SignatureVerificationError\` with the closest spec error code so adopters handle both failures through one \`except\` clause:

| Resolver code | Verifier code emitted |
|---|---|
| \`invalid_agent_url\` | \`REQUEST_SIGNATURE_JWKS_UNTRUSTED\` (trust-boundary rejection) |
| \`capabilities_unreachable\` | \`REQUEST_SIGNATURE_JWKS_UNAVAILABLE\` |
| \`capabilities_invalid\` | \`REQUEST_SIGNATURE_JWKS_UNAVAILABLE\` |
| \`brand_json_url_missing\` | \`REQUEST_SIGNATURE_JWKS_UNAVAILABLE\` |
| \`brand_json_resolution_failed\` | \`REQUEST_SIGNATURE_JWKS_UNAVAILABLE\` |
| \`jwks_fetch_failed\` | \`REQUEST_SIGNATURE_JWKS_UNAVAILABLE\` |

Original \`AgentResolverError\` chains via \`__cause__\` so adopters needing finer-grain dispatch can read \`exc.__cause__.code\`. Verifier-side \`SignatureVerificationError\` passes through unchanged.

## Note on \"8 typed request_signature_* exceptions\"

The original #344 acceptance criterion called for typed exceptions per spec error code. The existing \`SignatureVerificationError(code=...)\` already provides typed-exception semantics via \`.code\`, matching the \`BrandJsonResolverError(code=...)\` pattern the design-decision triage called out (see [#344 comment](https://github.com/adcontextprotocol/adcp-client-python/issues/344#issuecomment-4365018440)). There are 18 \`REQUEST_SIGNATURE_*\` code constants exported from \`adcp.signing.errors\`; subclassing each would add 18 import lines per adopter for no semantic gain over \`if exc.code == REQUEST_SIGNATURE_X:\`. Following codebase convention rather than fighting it.

## Tests

5 unit tests in \`tests/test_verify_from_agent_url.py\`:

- happy path — resolver feeds JWKS to verifier, return value flows through, \`options.agent_url\` forwarded, \`StaticJwksResolver\` constructed
- 3 resolver-failure mappings (capabilities, invalid URL, brand_json) hit the right verifier code with \`__cause__\` preserved
- verifier-side error passes through with spec code intact

## Local gates

- \`ruff check src/\` — clean
- \`mypy src/adcp/\` — Success: no issues found in 745 source files
- \`pytest tests/\` — 3114 passed, 26 skipped, 1 xfailed
- Public-API snapshot regenerated (1 new export: \`verify_from_agent_url\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)