### PR TITLE
feat(v3-ref-seller): enable server validation + declare account.supported_billing

### DIFF
--- a/examples/v3_reference_seller/src/app.py
+++ b/examples/v3_reference_seller/src/app.py
@@ -43,6 +43,7 @@ from adcp.server import (
     ToolContext,
     current_tenant,
 )
+from adcp.validation import ValidationHookConfig
 
 from .audit import make_sink as make_audit_sink
 from .buyer_registry import make_registry as make_buyer_registry
@@ -132,6 +133,17 @@ def main() -> None:
         asgi_middleware=[
             (SubdomainTenantMiddleware, {"router": router}),
         ],
+        # Schema-driven validation in strict mode on both sides:
+        # the dispatcher validates every request against the bundled
+        # AdCP JSON schemas before the platform method runs, and
+        # validates every response after it returns. Bugs like the
+        # ``pricing_options`` shape regression that shipped in the
+        # initial v3 ref seller are caught at boot / first call
+        # rather than during a buyer's storyboard run. Adopters
+        # forking this entrypoint inherit the strict default — drop
+        # to ``responses="warn"`` only when you have a deliberate
+        # reason to ship spec-divergent responses.
+        validation=ValidationHookConfig(requests="strict", responses="strict"),
     )
 
 

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -145,6 +145,16 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         specialisms=("sales-non-guaranteed",),
         channels=("display", "video"),
         pricing_models=("cpm",),
+        # Required by the spec whenever ``media_buy`` is in
+        # ``supported_protocols`` (per
+        # ``protocol/get-adcp-capabilities-response.json``,
+        # ``account.supported_billing`` ``minItems: 1``). The
+        # framework projects this into ``account.supported_billing``
+        # on the auto-generated ``get_adcp_capabilities`` response.
+        # This reference seller invoices the operator (agency / brand
+        # buying direct) and supports agent-consolidated billing for
+        # platforms acting on behalf of multiple advertisers.
+        supported_billing=("operator", "agent"),
     )
 
     def __init__(self, *, sessionmaker: async_sessionmaker) -> None:

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -311,6 +311,54 @@ SPECIALISM_TO_ADVERTISED_TOOLS: dict[str, frozenset[str]] = {
 }
 
 
+#: Map each spec specialism slug to the wire-protocol values it
+#: contributes to ``supported_protocols`` on the
+#: ``get_adcp_capabilities`` response. Source of truth is the
+#: ``supported_protocols`` enum in
+#: ``schemas/cache/protocol/get-adcp-capabilities-response.json``
+#: (``media_buy | signals | governance | sponsored_intelligence |
+#: creative | brand``). Composes with
+#: :data:`SPECIALISM_TO_ADVERTISED_TOOLS` — a specialism whose tools
+#: cross protocol boundaries (e.g. ``audience-sync`` exposes
+#: ``sync_audiences``, a media_buy tool) declares the relevant set
+#: explicitly here.
+#:
+#: Specialisms that are pure meta-claims (``governance-aware-seller``,
+#: ``signed-requests``) contribute no protocol — they compose with a
+#: non-meta specialism that does.
+SPECIALISM_TO_PROTOCOLS: dict[str, frozenset[str]] = {
+    # Sales-* archetypes — all live under the media_buy protocol.
+    "sales-non-guaranteed": frozenset({"media_buy"}),
+    "sales-guaranteed": frozenset({"media_buy"}),
+    "sales-broadcast-tv": frozenset({"media_buy"}),
+    "sales-social": frozenset({"media_buy"}),
+    "sales-catalog-driven": frozenset({"media_buy"}),
+    "sales-proposal-mode": frozenset({"media_buy"}),
+    # Creative — generative / template / ad-server all expose creative
+    # tools; the ad-server variant additionally exposes
+    # ``get_creative_delivery`` which is a media_buy companion read,
+    # but the wire protocol is still ``creative``.
+    "creative-generative": frozenset({"creative"}),
+    "creative-template": frozenset({"creative"}),
+    "creative-ad-server": frozenset({"creative"}),
+    # Signals.
+    "signal-marketplace": frozenset({"signals"}),
+    "signal-owned": frozenset({"signals"}),
+    # Audience-sync's ``sync_audiences`` is a media_buy tool.
+    "audience-sync": frozenset({"media_buy"}),
+    # Governance.
+    "governance-spend-authority": frozenset({"governance"}),
+    "governance-delivery-monitor": frozenset({"governance"}),
+    # Brand-rights → brand protocol.
+    "brand-rights": frozenset({"brand"}),
+    # Content-standards / lists are governance-protocol tools per
+    # ``HANDLER_TO_DOMAIN`` in ``adcp.server.builder``.
+    "content-standards": frozenset({"governance"}),
+    "property-lists": frozenset({"governance"}),
+    "collection-lists": frozenset({"governance"}),
+}
+
+
 async def _resolve_buyer_agent(
     registry: BuyerAgentRegistry,
     auth_info: AuthInfo | None,
@@ -751,6 +799,94 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             resource_resolver=self._resource_resolver,
             buyer_agent=buyer_agent,
         )
+
+    # ----- Protocol discovery -----
+
+    async def get_adcp_capabilities(
+        self,
+        params: Any = None,
+        context: ToolContext | None = None,
+    ) -> dict[str, Any]:
+        """Project the platform's :class:`DecisioningCapabilities` into a
+        spec-conformant ``get_adcp_capabilities`` response.
+
+        Auto-derives:
+
+        * ``supported_protocols`` from the union of
+          :data:`SPECIALISM_TO_PROTOCOLS` over the platform's claimed
+          specialisms.
+        * ``account.supported_billing`` from
+          :attr:`DecisioningCapabilities.supported_billing`. Required by
+          spec (``protocol/get-adcp-capabilities-response.json`` lines
+          129-131) whenever ``media_buy`` is in ``supported_protocols``;
+          missing here surfaces as a wire-validation failure when the
+          server is wired with ``ValidationHookConfig(responses="strict")``.
+        * ``media_buy.supported_pricing_models`` from
+          :attr:`DecisioningCapabilities.pricing_models`.
+        * ``media_buy.portfolio.primary_channels`` from
+          :attr:`DecisioningCapabilities.channels`.
+
+        Adopters who need to override this projection (custom
+        capability blocks, vendor-specific feature flags) override
+        ``get_adcp_capabilities`` on a :class:`PlatformHandler`
+        subclass — the base shim is intentionally minimal so the
+        projection is auditable.
+        """
+        del params, context  # Discovery; no auth or input required.
+        caps = self._platform.capabilities
+
+        protocols: set[str] = set()
+        for slug in caps.specialisms:
+            protocols.update(SPECIALISM_TO_PROTOCOLS.get(slug, frozenset()))
+        # ``supported_protocols`` is required + minItems: 1. When a
+        # platform declares only meta specialisms (governance-aware-seller
+        # alone, signed-requests alone), we have no protocol to claim
+        # — fall through to ``media_buy`` as the most common default
+        # so the capabilities response stays spec-valid. Adopters who
+        # disagree subclass and override.
+        supported_protocols = sorted(protocols) if protocols else ["media_buy"]
+
+        from adcp.server.responses import capabilities_response
+
+        # Default to ``idempotency: {supported: false}`` when the
+        # platform doesn't declare one. The spec requires
+        # ``adcp.idempotency`` (``required: ["major_versions",
+        # "idempotency"]`` on the ``adcp`` block); a base shim that
+        # claims media_buy without it ships an invalid response.
+        # Adopters who wire :class:`adcp.server.idempotency.IdempotencyStore`
+        # override this shim and pass ``store.capability()``.
+        response = capabilities_response(
+            supported_protocols,
+            idempotency={"supported": False},
+        )
+
+        # account.supported_billing is REQUIRED on the wire whenever
+        # media_buy is claimed (spec invariant). We always emit the
+        # account block when supported_billing is declared so adopters
+        # claiming non-media-buy protocols still get a valid response.
+        if caps.supported_billing:
+            response["account"] = {
+                "supported_billing": list(caps.supported_billing),
+            }
+
+        # media_buy block: ``supported_pricing_models`` is the single
+        # field the framework can project from ``DecisioningCapabilities``
+        # without crossing a spec required-property gate. ``portfolio``
+        # would be the natural home for ``channels``, but the spec
+        # requires ``portfolio.publisher_domains`` when ``portfolio`` is
+        # present and ``DecisioningCapabilities`` doesn't carry that
+        # data — emitting ``portfolio`` from channels alone would ship
+        # an invalid response. Adopters who want ``portfolio`` override
+        # ``get_adcp_capabilities`` on a :class:`PlatformHandler`
+        # subclass and supply ``publisher_domains`` themselves.
+        if "media_buy" in supported_protocols and caps.pricing_models:
+            # Spec requires uniqueItems on supported_pricing_models;
+            # dedupe via dict.fromkeys to preserve declaration order.
+            response["media_buy"] = {
+                "supported_pricing_models": list(dict.fromkeys(caps.pricing_models)),
+            }
+
+        return response
 
     # ----- Sales tools -----
 

--- a/src/adcp/decisioning/platform.py
+++ b/src/adcp/decisioning/platform.py
@@ -59,6 +59,17 @@ class DecisioningCapabilities:
         ship. The flag itself is the contract that lands now; the
         enforcement lands in Stage 3. See
         ``docs/proposals/decisioning-platform-dispatch-design.md#d15``.
+    :param supported_billing: Billing parties this seller invoices —
+        any subset of ``{"operator", "agent", "advertiser"}``. Required
+        on the wire whenever the seller claims ``media_buy`` (per
+        ``protocol/get-adcp-capabilities-response.json`` —
+        ``account.supported_billing`` ``minItems: 1``). Surfaced on
+        the auto-projected ``get_adcp_capabilities`` response under
+        ``account.supported_billing``. ``operator`` = seller invoices
+        the operator (agency / brand buying direct); ``agent`` = agent
+        consolidates billing across brands; ``advertiser`` = seller
+        invoices the advertiser directly. Buyers MUST pass one of
+        these in ``sync_accounts``.
     """
 
     specialisms: list[str] = field(default_factory=list)
@@ -67,6 +78,7 @@ class DecisioningCapabilities:
     creative_agents: list[Any] = field(default_factory=list)
     config: dict[str, Any] = field(default_factory=dict)
     governance_aware: bool = False
+    supported_billing: list[str] = field(default_factory=list)
 
 
 #: Specialisms that depend on framework-supplied

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from a2a.server.tasks.task_store import TaskStore
 
     from adcp.server.serve import ContextFactory, SkillMiddleware
+    from adcp.validation.client_hooks import ValidationHookConfig
 
 from collections.abc import Callable  # noqa: E402
 
@@ -124,6 +125,7 @@ class ADCPAgentExecutor(AgentExecutor):
         middleware: Sequence[SkillMiddleware] | None = None,
         message_parser: MessageParser | None = None,
         advertise_all: bool = False,
+        validation: ValidationHookConfig | None = None,
     ) -> None:
         self._handler = handler
         self._context_factory = context_factory
@@ -148,7 +150,7 @@ class ADCPAgentExecutor(AgentExecutor):
             name = tool_def["name"]
             if name == "comply_test_controller" and test_controller is None:
                 continue
-            self._tool_callers[name] = create_tool_caller(handler, name)
+            self._tool_callers[name] = create_tool_caller(handler, name, validation=validation)
 
         if test_controller is not None:
             self._register_test_controller(test_controller)
@@ -598,6 +600,7 @@ def create_a2a_server(
     middleware: Sequence[SkillMiddleware] | None = None,
     message_parser: MessageParser | None = None,
     advertise_all: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> Any:
     """Create an A2A Starlette application from an ADCP handler.
 
@@ -688,6 +691,7 @@ def create_a2a_server(
         middleware=middleware,
         message_parser=message_parser,
         advertise_all=advertise_all,
+        validation=validation,
     )
 
     agent_card = _build_agent_card(

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
     from adcp.server.a2a_server import MessageParser
     from adcp.server.test_controller import TestControllerStore
+    from adcp.validation.client_hooks import ValidationHookConfig
 
 
 @dataclass(frozen=True)
@@ -412,6 +413,7 @@ def serve(
     advertise_all: bool = False,
     max_request_size: int | None = None,
     streaming_responses: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> None:
     """Start an MCP or A2A server from an ADCP handler or server builder.
 
@@ -509,6 +511,16 @@ def serve(
             (MCP transports only). Note: the legacy ``transport="sse"``
             is a separate (deprecated) MCP transport, unrelated to this
             flag.
+        validation: Optional :class:`ValidationHookConfig` enabling
+            schema validation of every request and response against the
+            bundled AdCP JSON schemas. ``requests="strict"`` raises
+            ``VALIDATION_ERROR`` before the handler runs on a malformed
+            payload; ``responses="strict"`` raises after the handler
+            returns when the response shape drifts from spec. Sellers
+            who want their server to enforce wire conformance pass
+            ``ValidationHookConfig(requests="strict", responses="strict")``;
+            the default ``None`` keeps validation off (zero overhead).
+            Applies to both MCP and A2A transports.
 
     Security:
         This function does NOT configure authentication. In production,
@@ -561,6 +573,7 @@ def serve(
             message_parser=message_parser,
             advertise_all=advertise_all,
             max_request_size=max_request_size,
+            validation=validation,
         )
     elif transport in ("streamable-http", "sse", "stdio"):
         _serve_mcp(
@@ -577,6 +590,7 @@ def serve(
             advertise_all=advertise_all,
             max_request_size=max_request_size,
             streaming_responses=streaming_responses,
+            validation=validation,
         )
     elif transport == "both":
         _serve_mcp_and_a2a(
@@ -595,6 +609,7 @@ def serve(
             advertise_all=advertise_all,
             max_request_size=max_request_size,
             streaming_responses=streaming_responses,
+            validation=validation,
         )
     else:
         valid = ", ".join(sorted(("a2a", "both", "streamable-http", "sse", "stdio")))
@@ -782,6 +797,7 @@ def _serve_mcp(
     advertise_all: bool = False,
     max_request_size: int | None = None,
     streaming_responses: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> None:
     """Start an MCP server."""
     mcp = create_mcp_server(
@@ -795,6 +811,7 @@ def _serve_mcp(
         middleware=middleware,
         advertise_all=advertise_all,
         streaming_responses=streaming_responses,
+        validation=validation,
     )
 
     if test_controller is not None:
@@ -885,6 +902,7 @@ def _serve_a2a(
     message_parser: MessageParser | None = None,
     advertise_all: bool = False,
     max_request_size: int | None = None,
+    validation: ValidationHookConfig | None = None,
 ) -> None:
     """Start an A2A server using uvicorn."""
     import uvicorn
@@ -904,6 +922,7 @@ def _serve_a2a(
         middleware=middleware,
         message_parser=message_parser,
         advertise_all=advertise_all,
+        validation=validation,
     )
     app = _wrap_with_size_limit(app, max_request_size)
     app = _apply_asgi_middleware(app, asgi_middleware)
@@ -941,6 +960,7 @@ def _build_mcp_and_a2a_app(
     advertise_all: bool = False,
     max_request_size: int | None = None,
     streaming_responses: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> Any:
     """Build the unified MCP+A2A ASGI app without starting a server.
 
@@ -974,6 +994,7 @@ def _build_mcp_and_a2a_app(
         middleware=middleware,
         advertise_all=advertise_all,
         streaming_responses=streaming_responses,
+        validation=validation,
     )
     if test_controller is not None:
         from adcp.server.test_controller import register_test_controller
@@ -1000,6 +1021,7 @@ def _build_mcp_and_a2a_app(
         middleware=middleware,
         message_parser=message_parser,
         advertise_all=advertise_all,
+        validation=validation,
     )
 
     # Lifespan composition: FastMCP's session manager initializes a
@@ -1061,6 +1083,7 @@ def _serve_mcp_and_a2a(
     advertise_all: bool = False,
     max_request_size: int | None = None,
     streaming_responses: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> None:
     """Serve MCP and A2A on a single port via path dispatch.
 
@@ -1098,6 +1121,7 @@ def _serve_mcp_and_a2a(
         advertise_all=advertise_all,
         max_request_size=max_request_size,
         streaming_responses=streaming_responses,
+        validation=validation,
     )
     app = _apply_asgi_middleware(app, asgi_middleware)
 
@@ -1131,6 +1155,7 @@ def create_mcp_server(
     middleware: Sequence[SkillMiddleware] | None = None,
     advertise_all: bool = False,
     streaming_responses: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> Any:
     """Create a FastMCP server from an ADCP handler without starting it.
 
@@ -1253,6 +1278,7 @@ def create_mcp_server(
         context_factory=context_factory,
         middleware=middleware,
         advertise_all=advertise_all,
+        validation=validation,
     )
     return mcp
 
@@ -1265,6 +1291,7 @@ def _register_handler_tools(
     context_factory: ContextFactory | None = None,
     middleware: Sequence[SkillMiddleware] | None = None,
     advertise_all: bool = False,
+    validation: ValidationHookConfig | None = None,
 ) -> None:
     """Register all ADCP tools from a handler onto a FastMCP server."""
     # Freeze middleware ordering at registration time. Tuple both guards
@@ -1283,7 +1310,7 @@ def _register_handler_tools(
             continue
         description = tool_def.get("description", "")
         input_schema = tool_def.get("inputSchema", {"type": "object", "properties": {}})
-        caller = create_tool_caller(handler, tool_name)
+        caller = create_tool_caller(handler, tool_name, validation=validation)
         _register_tool(
             mcp,
             tool_name,

--- a/src/adcp/validation/schema_loader.py
+++ b/src/adcp/validation/schema_loader.py
@@ -156,13 +156,21 @@ def _load_core_registry(state: _LoaderState) -> None:
     state._core_loaded = True
 
 
-def _make_ref_resolver(state: _LoaderState, base_file: Path) -> Any:
+def _make_ref_resolver(state: _LoaderState, base_file: Path, schema: dict[str, Any]) -> Any:
     """Build a jsonschema ``RefResolver`` rooted at the file's directory.
 
     Async variant schemas use relative refs like ``../core/context.json``;
     giving the resolver a ``file://`` base URI lets those resolve against
     disk. Also seeds the core ``$id``-keyed registry so bundled schemas
     that reference a core type by canonical id still resolve.
+
+    Sets ``referrer=schema`` (not ``{}``) so fragment-only refs like
+    ``#/$defs/MediaChannel`` inside the bundled per-tool schema resolve
+    against the schema being validated. Without this, the resolver
+    walks the empty-dict referrer and raises
+    ``Unresolvable JSON pointer: '$defs/MediaChannel'`` on any
+    bundled schema that uses internal ``$defs`` (every bundled
+    capabilities-style schema does).
 
     ``RefResolver`` is deprecated in jsonschema 4.18+ (to be replaced by
     the ``referencing`` library). Suppress the warning locally so
@@ -181,7 +189,7 @@ def _make_ref_resolver(state: _LoaderState, base_file: Path) -> Any:
 
         _load_core_registry(state)
         base_uri = base_file.resolve().parent.as_uri() + "/"
-        return RefResolver(base_uri=base_uri, referrer={}, store=dict(state.registry))
+        return RefResolver(base_uri=base_uri, referrer=schema, store=dict(state.registry))
 
 
 def get_validator(tool_name: str, direction: Direction) -> Any | None:
@@ -223,7 +231,7 @@ def get_validator(tool_name: str, direction: Direction) -> Any | None:
         if cached is not None:
             return cached
         try:
-            resolver = _make_ref_resolver(state, file)
+            resolver = _make_ref_resolver(state, file, schema)
             validator = Draft7Validator(schema, resolver=resolver)
         except SchemaError as exc:
             logger.warning("Invalid schema %s for %s: %s", file, key, exc)

--- a/tests/test_decisioning_capabilities_projection.py
+++ b/tests/test_decisioning_capabilities_projection.py
@@ -1,0 +1,156 @@
+"""Capabilities projection — :meth:`PlatformHandler.get_adcp_capabilities`.
+
+Validates that the framework auto-projects
+:class:`DecisioningCapabilities` into a spec-conformant
+``get_adcp_capabilities`` response. Pre-fix the v3 reference seller
+inherited the base ADCPHandler's ``not_supported`` stub on this
+discovery tool — buyers got ``NOT_SUPPORTED`` from the most-fundamental
+handshake call, and ``account.supported_billing`` (required by spec
+when ``media_buy`` is in ``supported_protocols``) wasn't surfaced at
+all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    InMemoryTaskRegistry,
+    SingletonAccounts,
+)
+from adcp.decisioning.handler import SPECIALISM_TO_PROTOCOLS, PlatformHandler
+from adcp.validation.schema_validator import validate_response
+
+
+@pytest.fixture
+def executor():
+    pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-caps-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+def _build_handler(platform: DecisioningPlatform, executor: ThreadPoolExecutor) -> PlatformHandler:
+    return PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+
+
+class _SalesPlatform(DecisioningPlatform):
+    """Minimal sales-non-guaranteed platform for projection tests."""
+
+    capabilities = DecisioningCapabilities(
+        specialisms=["sales-non-guaranteed"],
+        channels=["display", "ctv"],
+        pricing_models=["cpm"],
+        supported_billing=["operator", "agent"],
+    )
+    accounts = SingletonAccounts(account_id="test")
+
+
+class _SignalsPlatform(DecisioningPlatform):
+    """Minimal signal-marketplace platform — no media_buy claim."""
+
+    capabilities = DecisioningCapabilities(
+        specialisms=["signal-marketplace"],
+        supported_billing=["agent"],
+    )
+    accounts = SingletonAccounts(account_id="test")
+
+
+class _BarePlatform(DecisioningPlatform):
+    """Platform with no specialisms claimed at all (pure meta)."""
+
+    capabilities = DecisioningCapabilities()
+    accounts = SingletonAccounts(account_id="test")
+
+
+def test_specialism_to_protocols_covers_every_non_meta_slug() -> None:
+    """Every non-meta specialism in
+    :data:`SPECIALISM_TO_PROTOCOLS` resolves to a wire-protocol value
+    inside the spec's ``supported_protocols`` enum.
+    """
+    spec_protocols = {
+        "media_buy",
+        "signals",
+        "governance",
+        "sponsored_intelligence",
+        "creative",
+        "brand",
+    }
+    for slug, protocols in SPECIALISM_TO_PROTOCOLS.items():
+        assert protocols, f"{slug} mapped to empty protocol set"
+        for p in protocols:
+            assert p in spec_protocols, f"{slug} → {p!r} not in spec supported_protocols enum"
+
+
+def test_sales_platform_projects_account_supported_billing(executor: ThreadPoolExecutor) -> None:
+    """Spec invariant: ``account.supported_billing`` is required when
+    ``media_buy`` is in ``supported_protocols`` (per
+    ``protocol/get-adcp-capabilities-response.json``, lines 129-131).
+    """
+    handler = _build_handler(_SalesPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["supported_protocols"] == ["media_buy"]
+    assert response["account"]["supported_billing"] == ["operator", "agent"]
+
+
+def test_sales_platform_projects_pricing_models(executor: ThreadPoolExecutor) -> None:
+    handler = _build_handler(_SalesPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["media_buy"]["supported_pricing_models"] == ["cpm"]
+
+
+def test_sales_platform_response_is_spec_conformant(executor: ThreadPoolExecutor) -> None:
+    """End-to-end: the projected response validates against the
+    bundled ``get_adcp_capabilities`` JSON schema. Catches the original
+    bug — ``account.supported_billing`` missing — at the wire level.
+    """
+    handler = _build_handler(_SalesPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    outcome = validate_response("get_adcp_capabilities", response)
+    assert outcome.valid, f"validation failed: {outcome.issues}"
+
+
+def test_signals_only_platform_emits_signals_protocol(executor: ThreadPoolExecutor) -> None:
+    """A platform claiming only ``signal-marketplace`` projects to
+    ``supported_protocols=['signals']`` — no ``media_buy`` block."""
+    handler = _build_handler(_SignalsPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["supported_protocols"] == ["signals"]
+    assert "media_buy" not in response
+    # account block still present — supported_billing was declared.
+    assert response["account"]["supported_billing"] == ["agent"]
+
+
+def test_bare_platform_falls_through_to_media_buy(executor: ThreadPoolExecutor) -> None:
+    """A platform with no specialisms still produces a spec-valid
+    response — fall through to ``media_buy`` so the response stays
+    minItems-1 valid on ``supported_protocols``."""
+    handler = _build_handler(_BarePlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["supported_protocols"] == ["media_buy"]
+    # No supported_billing declared → no account block.
+    assert "account" not in response
+
+
+def test_idempotency_defaults_to_unsupported(executor: ThreadPoolExecutor) -> None:
+    """Spec requires ``adcp.idempotency``. The base shim defaults to
+    ``{supported: false}`` so adopters who haven't wired an
+    IdempotencyStore still ship a valid capabilities response.
+    """
+    handler = _build_handler(_SalesPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["adcp"]["idempotency"] == {"supported": False}

--- a/tests/test_serve_validation_passthrough.py
+++ b/tests/test_serve_validation_passthrough.py
@@ -1,0 +1,103 @@
+"""``serve(validation=...)`` plumbing — request/response schema enforcement
+should reach the tool caller no matter which transport an adopter
+selected.
+
+Pre-fix the v3 reference seller called ``serve(...)`` without a
+``validation=`` kwarg; the underlying tool-caller factory defaulted to
+no enforcement, so spec-divergent responses (the original
+``pricing_options`` regression) flowed through silently. This test
+pins the wiring: passing ``validation=ValidationHookConfig(...)`` on
+``serve()`` reaches every tool caller the framework constructs.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from adcp.exceptions import ADCPTaskError
+from adcp.server.base import ADCPHandler, ToolContext
+from adcp.server.serve import create_mcp_server
+from adcp.validation import ValidationHookConfig
+
+# The package re-exports ``adcp.server.serve`` as the function symbol,
+# so the module itself is not reachable as ``adcp.server.serve``.
+# Resolve the underlying module via importlib for monkey-patching.
+_serve_mod = importlib.import_module("adcp.server.serve")
+
+
+class _StubHandler(ADCPHandler[Any]):
+    """Always-succeeds handler returning a fixed payload."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+
+    async def get_products(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
+        return dict(self._response)
+
+
+def test_create_mcp_server_threads_validation_to_tool_caller() -> None:
+    """``create_mcp_server(validation=...)`` must reach
+    :func:`create_tool_caller`. Without this, ``serve(validation=...)``
+    is silently a no-op on the MCP transport.
+    """
+    handler = _StubHandler({"products": []})
+    captured: list[ValidationHookConfig | None] = []
+    real_factory = _serve_mod.create_tool_caller
+    config = ValidationHookConfig(requests="strict", responses="strict")
+
+    def _spy(handler_arg: Any, method: str, **kwargs: Any) -> Any:
+        captured.append(kwargs.get("validation"))
+        return real_factory(handler_arg, method, **kwargs)
+
+    with patch.object(_serve_mod, "create_tool_caller", side_effect=_spy):
+        create_mcp_server(handler, validation=config)
+
+    assert captured, "create_tool_caller was never called"
+    assert all(
+        c is config for c in captured
+    ), f"validation kwarg dropped on the way to create_tool_caller: {captured!r}"
+
+
+def test_serve_validation_default_is_none() -> None:
+    """When ``serve(validation=)`` is omitted, tool callers see
+    ``validation=None`` — i.e., off (zero overhead). Confirms the
+    plumbing doesn't silently force a default mode.
+    """
+    handler = _StubHandler({"products": []})
+    captured: list[ValidationHookConfig | None] = []
+    real_factory = _serve_mod.create_tool_caller
+
+    def _spy(handler_arg: Any, method: str, **kwargs: Any) -> Any:
+        captured.append(kwargs.get("validation"))
+        return real_factory(handler_arg, method, **kwargs)
+
+    with patch.object(_serve_mod, "create_tool_caller", side_effect=_spy):
+        create_mcp_server(handler)
+
+    assert captured, "create_tool_caller was never called"
+    assert all(
+        c is None for c in captured
+    ), f"validation default leaked a non-None config: {captured!r}"
+
+
+@pytest.mark.asyncio
+async def test_create_tool_caller_strict_blocks_bad_request() -> None:
+    """Smoke: a tool caller built with ``validation=strict`` rejects a
+    malformed request before dispatch — the contract every transport
+    leans on.
+    """
+    from adcp.server.mcp_tools import create_tool_caller
+
+    handler = _StubHandler({"products": []})
+    caller = create_tool_caller(
+        handler,
+        "get_products",
+        validation=ValidationHookConfig(requests="strict"),
+    )
+    with pytest.raises(ADCPTaskError) as info:
+        await caller({})  # missing required ``promoted_offering``
+    assert info.value.errors[0].code == "VALIDATION_ERROR"


### PR DESCRIPTION
## Summary

Two related fixes for the v3 reference seller and the framework's capabilities projection:

- **Server-side schema validation now actually runs.** Plumbed `ValidationHookConfig` through `serve()` / `create_mcp_server()` / `create_a2a_server()` / `_register_handler_tools()` / `ADCPAgentExecutor.__init__()` so the validator that already ships in the SDK reaches the tool callers. The v3 reference seller boots with `validation=ValidationHookConfig(requests="strict", responses="strict")` — bugs like the recent `pricing_options` shape regression now surface as `VALIDATION_ERROR` at the wire instead of slipping through silently.

- **`get_adcp_capabilities` is no longer a `not_supported` stub.** Added `DecisioningCapabilities.supported_billing` and a `PlatformHandler.get_adcp_capabilities` shim that auto-projects from the platform's capability declaration. Pre-fix, every decisioning-platform adopter inherited the base handler's `not_supported` baseline on the most-fundamental discovery tool, and `account.supported_billing` (required by spec whenever `media_buy` is in `supported_protocols`) was unreachable. The shim derives `supported_protocols` via a new `SPECIALISM_TO_PROTOCOLS` map and emits a default `adcp.idempotency` so the response is spec-conformant out of the box.

- **Schema loader `$defs` fix.** The bundled per-tool schemas use internal `#/$defs/MediaChannel`-style refs, but `RefResolver` was constructed with `referrer={}` — every channel-bearing capabilities response failed with `Unresolvable JSON pointer: '$defs/MediaChannel'`. Pass the schema as the referrer so fragment-only refs resolve against the schema being validated.

## Test plan

- [x] New: `tests/test_decisioning_capabilities_projection.py` (7 tests) — pin the projection shape, the spec-conformance contract, and the `SPECIALISM_TO_PROTOCOLS` ↔ enum invariant
- [x] New: `tests/test_serve_validation_passthrough.py` (3 tests) — pin that `validation=` reaches `create_tool_caller` from `create_mcp_server`/`serve`
- [x] Full `pytest tests/` — 3163 passed, 21 skipped, 1 xfailed, 0 failures
- [x] `ruff check` clean
- [x] `mypy src/` clean
- [x] v3 reference seller smoke tests pass with the new `supported_billing` declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)