### PR TITLE
feat(buyer-agent-registry): caching + rate-limit + audit emission (#380)

### DIFF
--- a/examples/v3_reference_seller/src/app.py
+++ b/examples/v3_reference_seller/src/app.py
@@ -106,8 +106,13 @@ def main() -> None:
     asyncio.run(_bootstrap_schema(engine))
 
     router = SqlSubdomainTenantRouter(sessionmaker=sessionmaker)
-    buyer_registry = make_buyer_registry(sessionmaker)
     audit_sink = make_audit_sink(sessionmaker)
+    # The buyer registry composes cache + rate-limit + audit around
+    # the SQL-backed lookup. Wiring the same audit_sink at every
+    # layer means cached_hit / cached_miss / rate_limited / resolved
+    # / miss outcomes ALL land in the audit trail; SecOps can
+    # reconstruct every resolve attempt.
+    buyer_registry = make_buyer_registry(sessionmaker, audit_sink=audit_sink)
     # Anti-façade traffic recorder. The reference seller is a dev /
     # storyboard target, so we wire the in-memory recorder and flip
     # ``enable_debug_endpoints=True`` below to expose

--- a/examples/v3_reference_seller/src/buyer_registry.py
+++ b/examples/v3_reference_seller/src/buyer_registry.py
@@ -23,15 +23,20 @@ from sqlalchemy import select
 
 from adcp.decisioning import (
     ApiKeyCredential,
+    AuditingBuyerAgentRegistry,
     BuyerAgent,
     BuyerAgentDefaultTerms,
     BuyerAgentRegistry,
+    CachingBuyerAgentRegistry,
     OAuthCredential,
+    RateLimitedBuyerAgentRegistry,
 )
 from adcp.server import current_tenant
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from adcp.audit_sink import AuditSink
 
 from .models import BuyerAgent as BuyerAgentRow
 
@@ -130,11 +135,52 @@ def _row_to_agent(row: BuyerAgentRow) -> BuyerAgent:
     )
 
 
-def make_registry(sessionmaker: async_sessionmaker) -> BuyerAgentRegistry:
+def make_registry(
+    sessionmaker: async_sessionmaker,
+    *,
+    audit_sink: AuditSink | None = None,
+    ttl_seconds: float = 60.0,
+    rps_per_tenant: float = 100.0,
+    max_entries: int = 4096,
+) -> BuyerAgentRegistry:
     """Factory for the tenant-scoped registry. Returns a
     Protocol-typed handle — adopters wire it into
-    :func:`adcp.decisioning.serve` via ``buyer_agent_registry=``."""
-    return TenantScopedBuyerAgentRegistry(sessionmaker=sessionmaker)
+    :func:`adcp.decisioning.serve` via ``buyer_agent_registry=``.
+
+    Composes three wrappers around the SQL-backed registry so the
+    Tier 2 commercial-identity gate has production-grade properties:
+
+    * **Cache** (outermost) — TTL + LRU. Both positive and negative
+      resolutions cached so an enumeration probe at the lookup
+      endpoint hits the DB at most once per ``(tenant, key)`` per
+      ``ttl_seconds`` window.
+    * **Rate limit** (middle) — token bucket per
+      ``(tenant, lookup_key)``. On exhaustion raises
+      ``PERMISSION_DENIED`` with no ``details`` so the wire shape
+      matches the registry-miss path (no enumeration oracle).
+    * **Audit** (innermost) — emits one
+      :class:`~adcp.audit_sink.AuditEvent` per DB outcome
+      (``resolved`` / ``miss``); the cache and rate-limit layers
+      add ``cached_hit`` / ``cached_miss`` / ``rate_limited``
+      events to the same sink so compliance teams reconstruct
+      every resolve attempt.
+
+    Adopters needing different defaults pass ``ttl_seconds`` /
+    ``rps_per_tenant`` / ``max_entries`` overrides.
+    """
+    sql_backed = TenantScopedBuyerAgentRegistry(sessionmaker=sessionmaker)
+    audited = AuditingBuyerAgentRegistry(sql_backed, audit_sink=audit_sink)
+    rate_limited = RateLimitedBuyerAgentRegistry(
+        audited,
+        rps_per_tenant=rps_per_tenant,
+        audit_sink=audit_sink,
+    )
+    return CachingBuyerAgentRegistry(
+        rate_limited,
+        ttl_seconds=ttl_seconds,
+        max_entries=max_entries,
+        audit_sink=audit_sink,
+    )
 
 
 __all__ = ["TenantScopedBuyerAgentRegistry", "make_registry"]

--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -87,6 +87,11 @@ from adcp.decisioning.registry import (
     signing_only_registry,
     validate_billing_for_agent,
 )
+from adcp.decisioning.registry_cache import (
+    AuditingBuyerAgentRegistry,
+    CachingBuyerAgentRegistry,
+    RateLimitedBuyerAgentRegistry,
+)
 from adcp.decisioning.resolve import (
     CollectionList,
     Format,
@@ -173,6 +178,7 @@ __all__ = [
     "AdcpError",
     "ApiKeyCredential",
     "AudiencePlatform",
+    "AuditingBuyerAgentRegistry",
     "AuthInfo",
     "BillingMode",
     "BrandRightsPlatform",
@@ -180,6 +186,7 @@ __all__ = [
     "BuyerAgentDefaultTerms",
     "BuyerAgentRegistry",
     "BuyerAgentStatus",
+    "CachingBuyerAgentRegistry",
     "CampaignGovernancePlatform",
     "CollectionList",
     "CollectionListsPlatform",
@@ -207,6 +214,7 @@ __all__ = [
     "PropertyList",
     "PropertyListReference",
     "PropertyListsPlatform",
+    "RateLimitedBuyerAgentRegistry",
     "RequestContext",
     "ResourceResolver",
     "SalesPlatform",

--- a/src/adcp/decisioning/registry_cache.py
+++ b/src/adcp/decisioning/registry_cache.py
@@ -1,0 +1,626 @@
+"""In-process wrappers around :class:`~adcp.decisioning.BuyerAgentRegistry`.
+
+The Tier 2 commercial-identity gate fires on every dispatched skill.
+A bare :class:`PgBuyerAgentRegistry` (or the v3 reference seller's
+:class:`TenantScopedBuyerAgentRegistry`) hits the database on each
+call — including the negative paths an enumeration probe will spam.
+This module supplies three composable wrappers that implement the
+:class:`BuyerAgentRegistry` Protocol and stack arbitrarily:
+
+* :class:`CachingBuyerAgentRegistry` — TTL + LRU cache for positive
+  AND negative resolutions. Negative caching is the load-shaping move:
+  an enumeration probe walking a million ``agent_url`` strings would
+  otherwise hit the DB once per probe; with negative caching it hits
+  the DB once per ``(tenant, agent_url)`` pair within the TTL window.
+* :class:`RateLimitedBuyerAgentRegistry` — per-(tenant, lookup-key)
+  token bucket. On exhaustion, raises ``PERMISSION_DENIED`` with no
+  ``details`` so the wire shape matches every other denied path
+  (registry miss, suspended, blocked) — preserves the spec's
+  omit-on-unestablished-identity rule from PR #393. A distinct
+  ``RATE_LIMITED`` code would itself be an enumeration oracle.
+* :class:`AuditingBuyerAgentRegistry` — terminal wrapper that fires
+  one :class:`~adcp.audit_sink.AuditEvent` per ``resolved`` / ``miss``
+  outcome from the inner store. Combine with the per-layer
+  ``audit_sink`` kwarg on the cache / rate-limit wrappers to capture
+  ``cached_hit`` / ``cached_miss`` / ``rate_limited`` events too.
+
+Every wrapper accepts an optional ``audit_sink``. When provided, the
+wrapper emits one :class:`AuditEvent` for any outcome it terminates
+the call on (cache hit, rate-limit reject, DB resolve). Outcomes that
+fall through to the inner wrapper are NOT re-emitted by the outer —
+ordering avoids double-counting. If no sink is wired the outcome
+logs at DEBUG.
+
+Composition
+-----------
+
+The wrappers stack outside-in. Adopters typically build::
+
+    inner = AuditingBuyerAgentRegistry(
+        sql_backed_registry,  # actual DB lookup
+        audit_sink=sink,
+    )
+    rate_limited = RateLimitedBuyerAgentRegistry(
+        inner,
+        rps_per_tenant=100,
+        audit_sink=sink,  # capture rate_limited events
+    )
+    registry = CachingBuyerAgentRegistry(
+        rate_limited,
+        ttl_seconds=60,
+        audit_sink=sink,  # capture cached_hit/cached_miss events
+    )
+
+Order matters:
+
+* Cache is OUTERMOST so cached hits skip rate-limit accounting and
+  the DB. Negative cache prevents the credential-stuffing oracle on
+  the lookup endpoint.
+* Rate limit sits BETWEEN cache and inner so the limiter only fires
+  on calls that actually need DB work. Cached hits don't burn tokens.
+* The terminal :class:`AuditingBuyerAgentRegistry` records the actual
+  DB outcome.
+
+Tenant scoping
+--------------
+
+The cache and rate limiter both key on ``(tenant_id, lookup_key)``.
+The tenant id comes from :func:`adcp.server.current_tenant` — set
+by the adopter's tenant middleware before the framework dispatches.
+Adopters running single-tenant skip this contextvar; ``tenant_id``
+falls through as ``None`` and the wrappers behave as a flat keyspace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from adcp.decisioning.registry import (
+    ApiKeyCredential,
+    BuyerAgent,
+    BuyerAgentRegistry,
+    OAuthCredential,
+)
+from adcp.decisioning.types import AdcpError
+
+if TYPE_CHECKING:
+    from adcp.audit_sink import AuditSink
+
+logger = logging.getLogger(__name__)
+
+
+# ----- Shared types --------------------------------------------------
+
+
+#: Outcome label emitted to audit + metrics. Distinct labels per code
+#: path so compliance / SecOps can filter:
+#:
+#: * ``"resolved"`` — DB hit, agent returned.
+#: * ``"miss"`` — DB hit, no row (the enumeration probe path).
+#: * ``"cached_hit"`` — served from cache (positive).
+#: * ``"cached_miss"`` — served from cache (negative).
+#: * ``"rate_limited"`` — token bucket exhausted before reaching DB.
+ResolveOutcome = str
+
+
+_DENIED_MESSAGE = (
+    "Buyer agent is not authorized for this seller. The seller's "
+    "commercial allowlist did not authorize this credential. "
+    "Resolve out-of-band via the seller's onboarding contact; this "
+    "is not a request-side error the buyer can correct."
+)
+
+
+def _denied_error() -> AdcpError:
+    """Build the wire-uniform PERMISSION_DENIED rate-limit raises.
+
+    Same shape as the registry-miss path in
+    :func:`adcp.decisioning.handler._resolve_buyer_agent` — no
+    ``details``, ``recovery="correctable"``. Preserves the spec's
+    omit-on-unestablished-identity rule: rate-limited and
+    not-recognized are wire-indistinguishable.
+    """
+    return AdcpError(
+        "PERMISSION_DENIED",
+        message=_DENIED_MESSAGE,
+        recovery="correctable",
+    )
+
+
+def _current_tenant_id() -> str | None:
+    """Read the current-tenant contextvar, falling back to ``None``.
+
+    Imported lazily to avoid a hard dependency on ``adcp.server`` at
+    module import time — the registry surface lives below the server
+    layer in the dependency graph.
+    """
+    try:
+        from adcp.server import current_tenant
+    except ImportError:  # pragma: no cover — server module always present in this SDK
+        return None
+    tenant = current_tenant()
+    return tenant.id if tenant is not None else None
+
+
+def _credential_key(credential: ApiKeyCredential | OAuthCredential) -> str:
+    """Project a credential to a stable cache / rate-limit key.
+
+    The key is namespaced (``"api_key:..."`` / ``"oauth:..."``) so
+    a colliding ``key_id`` and ``client_id`` don't share a bucket.
+    """
+    if isinstance(credential, ApiKeyCredential):
+        return f"api_key:{credential.key_id}"
+    if isinstance(credential, OAuthCredential):
+        return f"oauth:{credential.client_id}"
+    # Defensive: future Credential variants the wrapper can't dispatch.
+    return f"unknown:{type(credential).__name__}"
+
+
+async def _emit_audit(
+    sink: AuditSink | None,
+    *,
+    operation: str,
+    outcome: ResolveOutcome,
+    lookup_key: str,
+    tenant_id: str | None,
+    agent: BuyerAgent | None = None,
+    sink_timeout_seconds: float = 5.0,
+) -> None:
+    """Emit a single registry-outcome audit event.
+
+    The wrapper layers all funnel through here so the event shape is
+    uniform across cache / rate-limit / terminal outcomes.
+
+    Sink failures are bounded + swallowed — a sink stall (DB outage,
+    Slack 429) NEVER blocks the registry resolution.
+    """
+    from adcp.audit_sink import AuditEvent
+
+    details: dict[str, object] = {"outcome": outcome, "lookup_key": lookup_key}
+    if agent is not None:
+        details["agent_url"] = agent.agent_url
+        details["agent_status"] = agent.status
+
+    event = AuditEvent(
+        operation=operation,
+        success=outcome in ("resolved", "cached_hit"),
+        occurred_at=datetime.now(timezone.utc),
+        tenant_id=tenant_id,
+        details=details,
+    )
+
+    if sink is None:
+        logger.debug(
+            "[adcp.registry_cache] %s outcome=%s tenant=%s lookup=%s",
+            operation,
+            outcome,
+            tenant_id,
+            lookup_key,
+        )
+        return
+    try:
+        await asyncio.wait_for(sink.record(event), timeout=sink_timeout_seconds)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[adcp.registry_cache] audit sink %s timed out after %ss for %s",
+            type(sink).__name__,
+            sink_timeout_seconds,
+            operation,
+        )
+    except Exception:  # noqa: BLE001 — sink failures must not propagate
+        logger.warning(
+            "[adcp.registry_cache] audit sink %s raised for %s",
+            type(sink).__name__,
+            operation,
+            exc_info=True,
+        )
+
+
+# ----- TTL + LRU cache ----------------------------------------------
+
+
+@dataclass
+class _CacheEntry:
+    """One cached resolution (positive or negative)."""
+
+    value: BuyerAgent | None
+    expires_at: float
+
+
+#: Type alias for the metric callback. Counters are incremented by 1
+#: each call. Adopters wire this to Prometheus, OpenTelemetry,
+#: StatsD, etc.
+MetricCallback = Callable[[str], None]
+
+
+class CachingBuyerAgentRegistry:
+    """In-process TTL + LRU cache wrapping any
+    :class:`BuyerAgentRegistry`.
+
+    Caches BOTH positive and negative resolutions. Negative caching
+    is the load-shaping move — an enumeration probe walking arbitrary
+    ``agent_url`` strings would otherwise hit the DB once per probe;
+    with negative caching it hits the DB at most once per
+    ``(tenant, agent_url)`` pair within the TTL window.
+
+    :param inner: The wrapped :class:`BuyerAgentRegistry` — typically
+        a :class:`RateLimitedBuyerAgentRegistry` or a SQL-backed impl.
+    :param ttl_seconds: How long a resolution stays cached. Default
+        60s — long enough to absorb burst traffic during a media-buy
+        flight, short enough that a status flip (active → suspended)
+        propagates within a minute.
+    :param max_entries: LRU cap. Default 4096 — bounded so an
+        enumeration probe can't blow up memory, large enough that
+        steady-state hot agents stay resident.
+    :param hit_callback: Optional counter-style metric hook fired
+        on every cache event. Receives ``"hit"`` / ``"miss"`` /
+        ``"negative_hit"`` / ``"expired"``.
+    :param audit_sink: Optional audit sink — emits ``cached_hit`` /
+        ``cached_miss`` events for served-from-cache outcomes.
+        Misses fall through to the inner wrapper which emits its
+        own event for the actual resolution.
+    :param time_source: Override for tests — defaults to
+        :func:`time.monotonic`. Use a fake clock to drive TTL expiry.
+
+    Concurrency
+    -----------
+
+    The cache uses an ``asyncio.Lock`` to serialize entry insertion
+    and LRU promotion. The lock is held only across the dict update —
+    the inner ``resolve_*`` call happens OUTSIDE the lock, so
+    concurrent misses against different keys race the inner backend
+    in parallel. A burst of concurrent misses against the SAME key
+    will all hit the backend (no thundering-herd dedup) — adopters
+    needing single-flight wrap with their own dedup. The simpler
+    "all races to the backend" shape avoids the complexity of an
+    in-flight registry while accepting bounded duplicate work.
+    """
+
+    def __init__(
+        self,
+        inner: BuyerAgentRegistry,
+        *,
+        ttl_seconds: float = 60.0,
+        max_entries: int = 4096,
+        hit_callback: MetricCallback | None = None,
+        audit_sink: AuditSink | None = None,
+        sink_timeout_seconds: float = 5.0,
+        time_source: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be > 0, got {ttl_seconds!r}")
+        if max_entries <= 0:
+            raise ValueError(f"max_entries must be > 0, got {max_entries!r}")
+        self._inner = inner
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._hit_cb = hit_callback
+        self._sink = audit_sink
+        self._sink_timeout = sink_timeout_seconds
+        self._now = time_source
+        # OrderedDict gives us O(1) move-to-end for LRU semantics on
+        # every hit, plus O(1) popitem(last=False) for eviction.
+        self._cache: OrderedDict[tuple[str | None, str], _CacheEntry] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def resolve_by_agent_url(self, agent_url: str) -> BuyerAgent | None:
+        """Resolve via cache, falling through to ``inner`` on miss."""
+        tenant_id = _current_tenant_id()
+        lookup_key = f"agent_url:{agent_url}"
+        key = (tenant_id, lookup_key)
+        cached = await self._lookup(key)
+        if cached is not None:
+            await _emit_audit(
+                self._sink,
+                operation="buyer_agent_registry.resolve_by_agent_url",
+                outcome="cached_hit" if cached.value is not None else "cached_miss",
+                lookup_key=lookup_key,
+                tenant_id=tenant_id,
+                agent=cached.value,
+                sink_timeout_seconds=self._sink_timeout,
+            )
+            return cached.value
+        result = await self._inner.resolve_by_agent_url(agent_url)
+        await self._store(key, result)
+        return result
+
+    async def resolve_by_credential(
+        self, credential: ApiKeyCredential | OAuthCredential
+    ) -> BuyerAgent | None:
+        """Resolve via cache, falling through to ``inner`` on miss."""
+        tenant_id = _current_tenant_id()
+        lookup_key = _credential_key(credential)
+        key = (tenant_id, lookup_key)
+        cached = await self._lookup(key)
+        if cached is not None:
+            await _emit_audit(
+                self._sink,
+                operation="buyer_agent_registry.resolve_by_credential",
+                outcome="cached_hit" if cached.value is not None else "cached_miss",
+                lookup_key=lookup_key,
+                tenant_id=tenant_id,
+                agent=cached.value,
+                sink_timeout_seconds=self._sink_timeout,
+            )
+            return cached.value
+        result = await self._inner.resolve_by_credential(credential)
+        await self._store(key, result)
+        return result
+
+    async def _lookup(self, key: tuple[str | None, str]) -> _CacheEntry | None:
+        """Return a non-expired cache entry for ``key`` or ``None``.
+
+        Lock held only for the dict mutation; the entry itself is
+        immutable so dropping the lock before returning is safe.
+        """
+        async with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                self._fire("miss")
+                return None
+            if entry.expires_at <= self._now():
+                # Expired — evict and treat as miss so the caller
+                # re-fetches from the inner backend.
+                del self._cache[key]
+                self._fire("expired")
+                return None
+            # Promote to most-recently-used.
+            self._cache.move_to_end(key)
+            self._fire("hit" if entry.value is not None else "negative_hit")
+            return entry
+
+    async def _store(self, key: tuple[str | None, str], value: BuyerAgent | None) -> None:
+        async with self._lock:
+            self._cache[key] = _CacheEntry(
+                value=value,
+                expires_at=self._now() + self._ttl,
+            )
+            self._cache.move_to_end(key)
+            while len(self._cache) > self._max:
+                self._cache.popitem(last=False)
+
+    def _fire(self, label: str) -> None:
+        if self._hit_cb is not None:
+            try:
+                self._hit_cb(label)
+            except Exception:  # noqa: BLE001 — metric callback must not break dispatch
+                logger.warning(
+                    "[adcp.registry_cache] hit_callback raised for label=%s",
+                    label,
+                    exc_info=True,
+                )
+
+    def invalidate(self, *, tenant_id: str | None, lookup_key: str) -> None:
+        """Drop a single ``(tenant_id, lookup_key)`` entry.
+
+        Called by admin / management code on a status flip — e.g.,
+        when an operator suspends an agent the management API calls
+        ``invalidate`` so the next dispatch sees the new status
+        immediately rather than waiting for TTL expiry.
+        """
+        self._cache.pop((tenant_id, lookup_key), None)
+
+    def clear(self) -> None:
+        """Drop every cached entry. For tests + post-config-reload."""
+        self._cache.clear()
+
+
+# ----- Token-bucket rate limiter ------------------------------------
+
+
+@dataclass
+class _Bucket:
+    """Token-bucket state for one ``(tenant, lookup_key)`` pair."""
+
+    tokens: float
+    last_refill: float
+
+
+class RateLimitedBuyerAgentRegistry:
+    """Per-tenant token-bucket rate limiter wrapping a
+    :class:`BuyerAgentRegistry`.
+
+    Sized for the credential-stuffing oracle: the registry's
+    :meth:`resolve_by_credential` is queryable with arbitrary
+    ``key_id`` strings; without a rate limit, an attacker can
+    enumerate the keyspace at line rate. The bucket sits between
+    the request and the DB so probe traffic gets rejected before
+    the SQL query runs.
+
+    :param inner: The wrapped :class:`BuyerAgentRegistry`.
+    :param rps_per_tenant: Steady-state requests per second per
+        ``(tenant_id, lookup_key)`` bucket. Default 100 — high
+        enough to absorb a real buyer's storyboard burst, low
+        enough that an enumeration probe at line rate gets cut off.
+    :param burst: Maximum bucket capacity (tokens). Default
+        ``rps_per_tenant`` so a steady state can sustain
+        ``rps_per_tenant`` calls/sec but bursts are capped at the
+        same number. Adopters with bursty real traffic raise this.
+    :param audit_sink: Optional audit sink — emits ``rate_limited``
+        events when the bucket is exhausted. The most interesting
+        event for security review (repeated rate-limit exhaustion
+        is the credential-stuffing signal an attacker is actively
+        probing).
+    :param time_source: Override for tests — defaults to
+        :func:`time.monotonic`.
+
+    Failure mode
+    ------------
+
+    On bucket exhaustion, raises :class:`AdcpError`
+    ``PERMISSION_DENIED`` with NO ``details`` and a generic message
+    matching the registry-miss path. This is deliberate — a distinct
+    ``RATE_LIMITED`` code or any populated ``details`` field would
+    itself be an enumeration oracle (the attacker learns "this
+    ``agent_url`` is interesting enough to be rate-limited"). The
+    spec's omit-on-unestablished-identity rule from PR #393 applies.
+    """
+
+    def __init__(
+        self,
+        inner: BuyerAgentRegistry,
+        *,
+        rps_per_tenant: float = 100.0,
+        burst: float | None = None,
+        audit_sink: AuditSink | None = None,
+        sink_timeout_seconds: float = 5.0,
+        time_source: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if rps_per_tenant <= 0:
+            raise ValueError(f"rps_per_tenant must be > 0, got {rps_per_tenant!r}")
+        if burst is not None and burst <= 0:
+            raise ValueError(f"burst must be > 0, got {burst!r}")
+        self._inner = inner
+        self._rate = rps_per_tenant
+        self._burst = burst if burst is not None else rps_per_tenant
+        self._sink = audit_sink
+        self._sink_timeout = sink_timeout_seconds
+        self._now = time_source
+        self._buckets: dict[tuple[str | None, str], _Bucket] = {}
+        self._lock = asyncio.Lock()
+
+    async def resolve_by_agent_url(self, agent_url: str) -> BuyerAgent | None:
+        tenant_id = _current_tenant_id()
+        lookup_key = f"agent_url:{agent_url}"
+        await self._charge(
+            (tenant_id, lookup_key),
+            operation="buyer_agent_registry.resolve_by_agent_url",
+            tenant_id=tenant_id,
+        )
+        return await self._inner.resolve_by_agent_url(agent_url)
+
+    async def resolve_by_credential(
+        self, credential: ApiKeyCredential | OAuthCredential
+    ) -> BuyerAgent | None:
+        tenant_id = _current_tenant_id()
+        lookup_key = _credential_key(credential)
+        await self._charge(
+            (tenant_id, lookup_key),
+            operation="buyer_agent_registry.resolve_by_credential",
+            tenant_id=tenant_id,
+        )
+        return await self._inner.resolve_by_credential(credential)
+
+    async def _charge(
+        self,
+        key: tuple[str | None, str],
+        *,
+        operation: str,
+        tenant_id: str | None,
+    ) -> None:
+        """Spend one token from ``key``'s bucket; raise + audit on
+        exhaustion."""
+        now = self._now()
+        async with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                # New bucket — start full so a fresh tenant gets the
+                # burst allowance immediately.
+                bucket = _Bucket(tokens=self._burst, last_refill=now)
+                self._buckets[key] = bucket
+            else:
+                # Refill at ``rate`` tokens/sec, capped at ``burst``.
+                elapsed = now - bucket.last_refill
+                bucket.tokens = min(self._burst, bucket.tokens + elapsed * self._rate)
+                bucket.last_refill = now
+            if bucket.tokens < 1.0:
+                exhausted = True
+            else:
+                bucket.tokens -= 1.0
+                exhausted = False
+        if exhausted:
+            # Audit emission OUTSIDE the lock — the sink may be slow.
+            await _emit_audit(
+                self._sink,
+                operation=operation,
+                outcome="rate_limited",
+                lookup_key=key[1],
+                tenant_id=tenant_id,
+                sink_timeout_seconds=self._sink_timeout,
+            )
+            raise _denied_error()
+
+
+# ----- Audit-emitting terminal wrapper -----------------------------
+
+
+class AuditingBuyerAgentRegistry:
+    """Terminal wrapper that emits one :class:`AuditEvent` per
+    resolution outcome from the inner store.
+
+    Wrap the SQL-backed registry with this so every DB lookup
+    (``resolved`` / ``miss``) lands in the audit trail. Compliance
+    teams reconstruct who tried what when from these records;
+    SecOps correlates spikes in ``miss`` events with
+    credential-stuffing activity.
+
+    The event ``operation`` is namespaced
+    (``"buyer_agent_registry.resolve_by_agent_url"`` /
+    ``"...resolve_by_credential"``) so audit queries can filter
+    registry traffic from the higher-level skill dispatches.
+
+    :param inner: Wrapped :class:`BuyerAgentRegistry` — typically
+        the actual SQL-backed impl.
+    :param audit_sink: :class:`AuditSink` to write events to. If
+        ``None``, outcomes log at ``DEBUG`` instead.
+    :param sink_timeout_seconds: Per-sink timeout. Default 5s
+        matching :func:`adcp.audit_sink.make_audit_middleware`. A
+        sink that wedges (DB stall, S3 outage) NEVER blocks dispatch.
+    """
+
+    def __init__(
+        self,
+        inner: BuyerAgentRegistry,
+        *,
+        audit_sink: AuditSink | None = None,
+        sink_timeout_seconds: float = 5.0,
+    ) -> None:
+        self._inner = inner
+        self._sink = audit_sink
+        self._sink_timeout = sink_timeout_seconds
+
+    async def resolve_by_agent_url(self, agent_url: str) -> BuyerAgent | None:
+        tenant_id = _current_tenant_id()
+        result = await self._inner.resolve_by_agent_url(agent_url)
+        await _emit_audit(
+            self._sink,
+            operation="buyer_agent_registry.resolve_by_agent_url",
+            outcome="resolved" if result is not None else "miss",
+            lookup_key=f"agent_url:{agent_url}",
+            tenant_id=tenant_id,
+            agent=result,
+            sink_timeout_seconds=self._sink_timeout,
+        )
+        return result
+
+    async def resolve_by_credential(
+        self, credential: ApiKeyCredential | OAuthCredential
+    ) -> BuyerAgent | None:
+        tenant_id = _current_tenant_id()
+        result = await self._inner.resolve_by_credential(credential)
+        await _emit_audit(
+            self._sink,
+            operation="buyer_agent_registry.resolve_by_credential",
+            outcome="resolved" if result is not None else "miss",
+            lookup_key=_credential_key(credential),
+            tenant_id=tenant_id,
+            agent=result,
+            sink_timeout_seconds=self._sink_timeout,
+        )
+        return result
+
+
+__all__ = [
+    "AuditingBuyerAgentRegistry",
+    "CachingBuyerAgentRegistry",
+    "MetricCallback",
+    "RateLimitedBuyerAgentRegistry",
+    "ResolveOutcome",
+]

--- a/src/adcp/decisioning/registry_cache.py
+++ b/src/adcp/decisioning/registry_cache.py
@@ -397,19 +397,30 @@ class CachingBuyerAgentRegistry:
                     exc_info=True,
                 )
 
-    def invalidate(self, *, tenant_id: str | None, lookup_key: str) -> None:
+    async def invalidate(self, *, tenant_id: str | None, lookup_key: str) -> None:
         """Drop a single ``(tenant_id, lookup_key)`` entry.
 
         Called by admin / management code on a status flip — e.g.,
         when an operator suspends an agent the management API calls
         ``invalidate`` so the next dispatch sees the new status
         immediately rather than waiting for TTL expiry.
-        """
-        self._cache.pop((tenant_id, lookup_key), None)
 
-    def clear(self) -> None:
-        """Drop every cached entry. For tests + post-config-reload."""
-        self._cache.clear()
+        Async + lock-held because admin paths run concurrently with
+        dispatch traffic; mutating the underlying ``OrderedDict``
+        while ``_store`` is reordering or evicting can corrupt the
+        LRU order or raise ``RuntimeError: OrderedDict mutated
+        during iteration``.
+        """
+        async with self._lock:
+            self._cache.pop((tenant_id, lookup_key), None)
+
+    async def clear(self) -> None:
+        """Drop every cached entry. For tests + post-config-reload.
+
+        Async + lock-held for the same reason as :meth:`invalidate`.
+        """
+        async with self._lock:
+            self._cache.clear()
 
 
 # ----- Token-bucket rate limiter ------------------------------------

--- a/tests/test_buyer_agent_registry_cache.py
+++ b/tests/test_buyer_agent_registry_cache.py
@@ -225,7 +225,7 @@ async def test_cache_invalidate_drops_single_entry() -> None:
     await cache.resolve_by_agent_url("https://agent.example/")
     assert inner.agent_url_calls == 1
 
-    cache.invalidate(tenant_id=None, lookup_key="agent_url:https://agent.example/")
+    await cache.invalidate(tenant_id=None, lookup_key="agent_url:https://agent.example/")
 
     await cache.resolve_by_agent_url("https://agent.example/")
     assert inner.agent_url_calls == 2

--- a/tests/test_buyer_agent_registry_cache.py
+++ b/tests/test_buyer_agent_registry_cache.py
@@ -1,0 +1,619 @@
+"""Tests for :mod:`adcp.decisioning.registry_cache` — caching,
+rate-limiting, and audit-emission wrappers around
+:class:`~adcp.decisioning.BuyerAgentRegistry`.
+
+Behavior under test:
+
+* Cache returns the same object on hit as on miss.
+* Negative resolutions (``None``) are also cached so an enumeration
+  probe doesn't repeatedly hit the DB.
+* TTL expiry forces a re-fetch from the inner store.
+* Rate limit raises spec-conformant ``PERMISSION_DENIED`` (no
+  ``details``) when the bucket is exhausted — wire-uniform with
+  the registry-miss path.
+* Audit emission fires for every outcome label
+  (``resolved`` / ``miss`` / ``cached_hit`` / ``cached_miss`` /
+  ``rate_limited``).
+* Wrappers compose end-to-end through chained construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from adcp.audit_sink import AuditEvent
+from adcp.decisioning.registry import (
+    ApiKeyCredential,
+    BuyerAgent,
+    OAuthCredential,
+)
+from adcp.decisioning.registry_cache import (
+    AuditingBuyerAgentRegistry,
+    CachingBuyerAgentRegistry,
+    RateLimitedBuyerAgentRegistry,
+)
+from adcp.decisioning.types import AdcpError
+
+# ----- Test doubles --------------------------------------------------
+
+
+class FakeRegistry:
+    """In-memory :class:`BuyerAgentRegistry` for the wrapper tests.
+
+    Tracks call counts so tests can assert cache-hit / miss behavior
+    without faking an entire DB. Returns ``None`` by default unless
+    the caller seeded the lookup map.
+    """
+
+    def __init__(
+        self,
+        *,
+        agents: dict[str, BuyerAgent] | None = None,
+        credentials: dict[str, BuyerAgent] | None = None,
+    ) -> None:
+        self._agents = agents or {}
+        self._credentials = credentials or {}
+        self.agent_url_calls = 0
+        self.credential_calls = 0
+
+    async def resolve_by_agent_url(self, agent_url: str) -> BuyerAgent | None:
+        self.agent_url_calls += 1
+        return self._agents.get(agent_url)
+
+    async def resolve_by_credential(
+        self, credential: ApiKeyCredential | OAuthCredential
+    ) -> BuyerAgent | None:
+        self.credential_calls += 1
+        if isinstance(credential, ApiKeyCredential):
+            return self._credentials.get(credential.key_id)
+        return self._credentials.get(credential.client_id)
+
+
+class CapturingAuditSink:
+    """In-memory :class:`AuditSink` for tests."""
+
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+class FakeClock:
+    """Manually-advanced clock for TTL / rate-limit refill tests."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+# ----- Cache: hit returns same object -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_returns_same_object_as_miss() -> None:
+    """On cache hit the wrapper returns the SAME BuyerAgent instance
+    the inner store returned on the original miss — the cache is a
+    pass-through, not a value-copy."""
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=60.0)
+
+    first = await cache.resolve_by_agent_url("https://agent.example/")
+    second = await cache.resolve_by_agent_url("https://agent.example/")
+
+    assert first is expected
+    assert second is expected
+    # Inner only hit once — second call served from cache.
+    assert inner.agent_url_calls == 1
+
+
+# ----- Cache: negative caching prevents repeat DB hits -------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_negatively_caches_unknown_agents() -> None:
+    """An enumeration probe walking unknown ``agent_url`` strings
+    must not be able to spam the DB. Negative results are cached
+    just like positive ones."""
+    inner = FakeRegistry(agents={})  # everything misses
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=60.0)
+
+    for _ in range(5):
+        result = await cache.resolve_by_agent_url("https://unknown.example/")
+        assert result is None
+
+    # Inner was only hit ONCE despite 5 calls. Without negative
+    # caching this would be 5 — the DB protection that closes the
+    # credential-stuffing oracle.
+    assert inner.agent_url_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_negative_credential_lookup_only_hits_inner_once() -> None:
+    inner = FakeRegistry(credentials={})
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=60.0)
+    cred = ApiKeyCredential(kind="api_key", key_id="probe-key")
+
+    for _ in range(10):
+        assert await cache.resolve_by_credential(cred) is None
+
+    assert inner.credential_calls == 1
+
+
+# ----- Cache: TTL expiry forces re-fetch --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_expiry_causes_refetch() -> None:
+    """After ``ttl_seconds`` elapses the cached entry expires and
+    the next call re-fetches from the inner store."""
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    clock = FakeClock(start=0.0)
+    cache = CachingBuyerAgentRegistry(
+        inner,
+        ttl_seconds=10.0,
+        time_source=clock,
+    )
+
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert inner.agent_url_calls == 1
+
+    # Within the TTL window — cached.
+    clock.advance(5.0)
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert inner.agent_url_calls == 1
+
+    # Past the TTL — refetch.
+    clock.advance(6.0)  # total 11 > 10
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert inner.agent_url_calls == 2
+
+
+# ----- Cache: LRU eviction enforces max_entries --------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_evicts_least_recently_used_when_capacity_full() -> None:
+    inner = FakeRegistry(agents={})
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=600.0, max_entries=3)
+
+    # Populate 4 distinct keys — the first should evict.
+    for i in range(4):
+        await cache.resolve_by_agent_url(f"https://agent-{i}/")
+    assert inner.agent_url_calls == 4
+
+    # The first key was evicted — re-fetching it hits inner again.
+    await cache.resolve_by_agent_url("https://agent-0/")
+    assert inner.agent_url_calls == 5
+
+    # The most-recent ones are still cached.
+    await cache.resolve_by_agent_url("https://agent-3/")
+    assert inner.agent_url_calls == 5
+
+
+# ----- Cache: invalidate / clear -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidate_drops_single_entry() -> None:
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=600.0)
+
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert inner.agent_url_calls == 1
+
+    cache.invalidate(tenant_id=None, lookup_key="agent_url:https://agent.example/")
+
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert inner.agent_url_calls == 2
+
+
+# ----- Cache: hit_callback fires correct labels -------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_callback_fires_per_outcome() -> None:
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    labels: list[str] = []
+    cache = CachingBuyerAgentRegistry(
+        inner,
+        ttl_seconds=60.0,
+        hit_callback=labels.append,
+    )
+
+    await cache.resolve_by_agent_url("https://agent.example/")  # miss
+    await cache.resolve_by_agent_url("https://agent.example/")  # hit
+    await cache.resolve_by_agent_url("https://unknown/")  # miss
+    await cache.resolve_by_agent_url("https://unknown/")  # negative_hit
+
+    assert labels == ["miss", "hit", "miss", "negative_hit"]
+
+
+# ----- Rate limit: raises PERMISSION_DENIED at threshold ----------------
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_raises_permission_denied_at_threshold() -> None:
+    """The token bucket starts full at ``burst``. After ``burst``
+    successive calls within one tick the next call exhausts the
+    bucket and raises :class:`AdcpError` with code
+    ``PERMISSION_DENIED`` and NO ``details`` — wire-uniform with the
+    registry-miss path so the rejection isn't an enumeration oracle."""
+    inner = FakeRegistry()
+    clock = FakeClock(start=0.0)
+    limiter = RateLimitedBuyerAgentRegistry(
+        inner,
+        rps_per_tenant=2.0,  # 2 tokens per second; burst=2
+        time_source=clock,
+    )
+
+    # First 2 calls succeed (initial burst capacity).
+    await limiter.resolve_by_agent_url("https://agent/")
+    await limiter.resolve_by_agent_url("https://agent/")
+
+    # Third call within the same tick — exhausted.
+    with pytest.raises(AdcpError) as exc_info:
+        await limiter.resolve_by_agent_url("https://agent/")
+
+    err = exc_info.value
+    assert err.code == "PERMISSION_DENIED"
+    assert err.recovery == "correctable"
+    # CRITICAL: details must be EMPTY — wire-uniform with registry
+    # miss. A populated details (or distinct code) would itself be
+    # an enumeration oracle.
+    assert err.details == {}
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_refills_over_time() -> None:
+    inner = FakeRegistry()
+    clock = FakeClock(start=0.0)
+    limiter = RateLimitedBuyerAgentRegistry(
+        inner,
+        rps_per_tenant=10.0,
+        time_source=clock,
+    )
+
+    # Drain the bucket.
+    for _ in range(10):
+        await limiter.resolve_by_agent_url("https://agent/")
+    with pytest.raises(AdcpError):
+        await limiter.resolve_by_agent_url("https://agent/")
+
+    # Advance time so the bucket refills.
+    clock.advance(1.0)  # 10 tokens regenerated
+    await limiter.resolve_by_agent_url("https://agent/")  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_isolates_distinct_lookup_keys() -> None:
+    """Each ``(tenant, lookup_key)`` gets its own bucket — exhausting
+    one does not affect another."""
+    inner = FakeRegistry()
+    clock = FakeClock(start=0.0)
+    limiter = RateLimitedBuyerAgentRegistry(
+        inner,
+        rps_per_tenant=1.0,
+        time_source=clock,
+    )
+
+    await limiter.resolve_by_agent_url("https://agent-A/")
+    with pytest.raises(AdcpError):
+        await limiter.resolve_by_agent_url("https://agent-A/")
+
+    # Different key — fresh bucket.
+    await limiter.resolve_by_agent_url("https://agent-B/")
+
+
+# ----- Audit emission: every outcome fires an event --------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_emits_resolved_outcome() -> None:
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    sink = CapturingAuditSink()
+    audited = AuditingBuyerAgentRegistry(inner, audit_sink=sink)
+
+    result = await audited.resolve_by_agent_url("https://agent.example/")
+
+    assert result is expected
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.operation == "buyer_agent_registry.resolve_by_agent_url"
+    assert event.success is True
+    assert event.details["outcome"] == "resolved"
+    assert event.details["agent_url"] == "https://agent.example/"
+    assert event.details["agent_status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_audit_emits_miss_outcome() -> None:
+    inner = FakeRegistry(agents={})
+    sink = CapturingAuditSink()
+    audited = AuditingBuyerAgentRegistry(inner, audit_sink=sink)
+
+    result = await audited.resolve_by_agent_url("https://unknown/")
+
+    assert result is None
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.success is False
+    assert event.details["outcome"] == "miss"
+    # Misses do NOT include agent_url in details — only the lookup_key.
+    assert "agent_url" not in event.details
+    assert event.details["lookup_key"] == "agent_url:https://unknown/"
+
+
+@pytest.mark.asyncio
+async def test_audit_emits_credential_resolution() -> None:
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(credentials={"key-1": expected})
+    sink = CapturingAuditSink()
+    audited = AuditingBuyerAgentRegistry(inner, audit_sink=sink)
+
+    await audited.resolve_by_credential(ApiKeyCredential(kind="api_key", key_id="key-1"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].operation == "buyer_agent_registry.resolve_by_credential"
+    assert sink.events[0].details["lookup_key"] == "api_key:key-1"
+
+
+@pytest.mark.asyncio
+async def test_audit_sink_failure_does_not_break_resolve() -> None:
+    """A misbehaving sink (DB stall, S3 outage) must NEVER block the
+    registry resolution — failures are bounded + swallowed."""
+
+    class BrokenSink:
+        async def record(self, event: AuditEvent) -> None:
+            raise RuntimeError("sink down")
+
+    inner = FakeRegistry(
+        agents={
+            "https://agent.example/": BuyerAgent(
+                agent_url="https://agent.example/",
+                display_name="Acme",
+                status="active",
+            )
+        }
+    )
+    audited = AuditingBuyerAgentRegistry(inner, audit_sink=BrokenSink())  # type: ignore[arg-type]
+
+    result = await audited.resolve_by_agent_url("https://agent.example/")
+    assert result is not None  # resolution still succeeded
+
+
+@pytest.mark.asyncio
+async def test_audit_sink_timeout_does_not_break_resolve() -> None:
+    class StallingSink:
+        async def record(self, event: AuditEvent) -> None:
+            await asyncio.sleep(60.0)  # would hang indefinitely
+
+    inner = FakeRegistry(
+        agents={
+            "https://agent.example/": BuyerAgent(
+                agent_url="https://agent.example/",
+                display_name="Acme",
+                status="active",
+            )
+        }
+    )
+    audited = AuditingBuyerAgentRegistry(
+        inner,
+        audit_sink=StallingSink(),  # type: ignore[arg-type]
+        sink_timeout_seconds=0.05,
+    )
+
+    # The sink would hang for 60s — but the wrapper bounds at 0.05s.
+    result = await asyncio.wait_for(
+        audited.resolve_by_agent_url("https://agent.example/"),
+        timeout=2.0,
+    )
+    assert result is not None
+
+
+# ----- Cache emits cached_hit / cached_miss to the same sink -------------
+
+
+@pytest.mark.asyncio
+async def test_cache_emits_cached_hit_event() -> None:
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    sink = CapturingAuditSink()
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=60.0, audit_sink=sink)
+
+    # First call: miss — falls through to inner. Cache layer does
+    # NOT emit on miss (would double-count if inner has its own
+    # audit wrapper).
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert sink.events == []
+
+    # Second call: hit — the cache emits cached_hit.
+    await cache.resolve_by_agent_url("https://agent.example/")
+    assert len(sink.events) == 1
+    assert sink.events[0].details["outcome"] == "cached_hit"
+
+
+@pytest.mark.asyncio
+async def test_cache_emits_cached_miss_event_for_negative_hit() -> None:
+    """Negative cache hit (cached ``None``) emits ``cached_miss`` so
+    enumeration-probe traffic is still visible in the audit trail."""
+    inner = FakeRegistry(agents={})
+    sink = CapturingAuditSink()
+    cache = CachingBuyerAgentRegistry(inner, ttl_seconds=60.0, audit_sink=sink)
+
+    await cache.resolve_by_agent_url("https://unknown/")  # initial miss, no event
+    await cache.resolve_by_agent_url("https://unknown/")  # cached negative — emits
+
+    assert len(sink.events) == 1
+    assert sink.events[0].details["outcome"] == "cached_miss"
+    assert sink.events[0].success is False
+
+
+# ----- Rate limit emits rate_limited audit event ---------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_emits_audit_event_on_exhaustion() -> None:
+    inner = FakeRegistry()
+    clock = FakeClock(start=0.0)
+    sink = CapturingAuditSink()
+    limiter = RateLimitedBuyerAgentRegistry(
+        inner,
+        rps_per_tenant=1.0,
+        time_source=clock,
+        audit_sink=sink,
+    )
+
+    await limiter.resolve_by_agent_url("https://agent/")  # bucket starts full
+    with pytest.raises(AdcpError):
+        await limiter.resolve_by_agent_url("https://agent/")
+
+    # Exactly one rate-limited event was emitted.
+    rate_limited_events = [e for e in sink.events if e.details.get("outcome") == "rate_limited"]
+    assert len(rate_limited_events) == 1
+    assert rate_limited_events[0].success is False
+    assert rate_limited_events[0].operation == "buyer_agent_registry.resolve_by_agent_url"
+
+
+# ----- Composability: chained wrappers work end-to-end ------------------
+
+
+@pytest.mark.asyncio
+async def test_composed_stack_chains_cache_rate_limit_audit() -> None:
+    """Build the production stack and verify each layer participates:
+
+    * Cache shortcuts repeat lookups (single inner call across N
+      cache hits).
+    * Rate limit fires on exhaustion (and emits rate_limited).
+    * Audit sink sees ``resolved`` (from inner audit layer) AND
+      ``cached_hit`` (from cache layer).
+    """
+    expected = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="Acme",
+        status="active",
+    )
+    inner = FakeRegistry(agents={"https://agent.example/": expected})
+    sink = CapturingAuditSink()
+
+    # Production stack — same shape as the v3 reference seller.
+    audited = AuditingBuyerAgentRegistry(inner, audit_sink=sink)
+    rate_limited = RateLimitedBuyerAgentRegistry(
+        audited,
+        rps_per_tenant=1000.0,
+        audit_sink=sink,
+    )
+    stack = CachingBuyerAgentRegistry(
+        rate_limited,
+        ttl_seconds=60.0,
+        audit_sink=sink,
+    )
+
+    # 3 calls — first miss, two cached hits.
+    for _ in range(3):
+        result = await stack.resolve_by_agent_url("https://agent.example/")
+        assert result is expected
+
+    # Inner DB only hit once.
+    assert inner.agent_url_calls == 1
+
+    # Audit events: 1 ``resolved`` (from terminal layer) + 2
+    # ``cached_hit`` (from cache layer). Rate limit didn't fire.
+    outcomes = [e.details["outcome"] for e in sink.events]
+    assert outcomes.count("resolved") == 1
+    assert outcomes.count("cached_hit") == 2
+
+
+@pytest.mark.asyncio
+async def test_composed_stack_caches_negative_resolutions_and_audits_them() -> None:
+    """End-to-end: a probe walking unknown agents hits the DB once,
+    then is served from the negative cache. Audit sink sees one
+    ``miss`` and N-1 ``cached_miss`` events."""
+    inner = FakeRegistry(agents={})
+    sink = CapturingAuditSink()
+
+    audited = AuditingBuyerAgentRegistry(inner, audit_sink=sink)
+    rate_limited = RateLimitedBuyerAgentRegistry(
+        audited,
+        rps_per_tenant=1000.0,
+        audit_sink=sink,
+    )
+    stack = CachingBuyerAgentRegistry(
+        rate_limited,
+        ttl_seconds=60.0,
+        audit_sink=sink,
+    )
+
+    for _ in range(5):
+        assert await stack.resolve_by_agent_url("https://probe/") is None
+
+    assert inner.agent_url_calls == 1
+    outcomes = [e.details["outcome"] for e in sink.events]
+    assert outcomes.count("miss") == 1
+    assert outcomes.count("cached_miss") == 4
+
+
+# ----- Validation of constructor args ---------------------------------
+
+
+def test_cache_rejects_zero_ttl() -> None:
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        CachingBuyerAgentRegistry(FakeRegistry(), ttl_seconds=0.0)
+
+
+def test_cache_rejects_zero_max_entries() -> None:
+    with pytest.raises(ValueError, match="max_entries"):
+        CachingBuyerAgentRegistry(FakeRegistry(), max_entries=0)
+
+
+def test_rate_limit_rejects_zero_rps() -> None:
+    with pytest.raises(ValueError, match="rps_per_tenant"):
+        RateLimitedBuyerAgentRegistry(FakeRegistry(), rps_per_tenant=0.0)
+
+
+# ----- Suppress unused import warning for clarity in ide -----------
+
+
+def _imports_intact() -> Any:
+    return OAuthCredential


### PR DESCRIPTION
## Summary

The v3 seller's Tier 2 commercial-identity gate (`BuyerAgentRegistry`) hits the DB on every dispatch with no cache, no rate limit, and no audit emission. Production sellers eat unnecessary load and the lookup endpoint is a credential-stuffing oracle. This PR adds three composable wrappers and wires them into the v3 reference seller.

- `CachingBuyerAgentRegistry` — TTL + LRU (default 60s / 4096 entries). Caches positive AND negative resolutions; negative caching closes the enumeration probe path so a probe walking arbitrary `agent_url` strings hits the DB at most once per `(tenant, key)` per TTL window. Hit-callback hook for Prometheus / OTel counters.
- `RateLimitedBuyerAgentRegistry` — per-`(tenant, lookup_key)` token bucket (default 100 RPS). On exhaustion raises `PERMISSION_DENIED` with NO `details` and a generic message — wire-uniform with the registry-miss path from PR #393. A distinct `RATE_LIMITED` code would itself be an enumeration oracle.
- `AuditingBuyerAgentRegistry` — terminal wrapper emitting one `AuditEvent` per DB outcome (`resolved` / `miss`). The cache and rate-limit layers accept the same `audit_sink` kwarg so `cached_hit` / `cached_miss` / `rate_limited` outcomes land in the same trail.

## Composition

The wrappers stack outside-in. Adopters build `Caching(RateLimited(Auditing(SQL-backed)))` — cache shortcuts repeated lookups before the rate limiter or DB sees them; rate limiter stops probe traffic before the DB; audit layer captures every actual lookup. The v3 reference seller's `make_registry` factory now composes this stack with the same audit sink at every layer.

## Wire-shape contract

The rate-limit denial path matches PR #393's spec-conformant `PERMISSION_DENIED` shape: same code, same `_denied_message` text, same `recovery="correctable"`, NO `details`. Rate-limited and not-recognized are wire-indistinguishable — preserves the spec's omit-on-unestablished-identity rule.

## Test plan

- [x] `pytest tests/ -k "registry_cache or buyer_agent_registry"` — 42 passed (23 new + 19 existing)
- [x] `ruff check src/ examples/` — no new errors (6 pre-existing in unrelated example files)
- [x] `mypy src/adcp/` — Success: no issues found in 746 source files
- [x] v3 reference seller smoke tests pass
- [x] Tier 2 dispatch + spec-conformance tests pass (44 / 44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)