### PR TITLE
feat(v3-ref-seller): broaden sales surface + sync_accounts + invoice_recipient

### DIFF
--- a/examples/v3_reference_seller/seed.py
+++ b/examples/v3_reference_seller/seed.py
@@ -22,7 +22,7 @@ import asyncio
 import os
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from src.models import Account, Base, BuyerAgent, Tenant
+from src.models import Account, Base, BuyerAgent, Creative, Tenant
 
 
 async def main() -> None:
@@ -99,8 +99,49 @@ async def main() -> None:
                     ),
                 ]
             )
+            await session.flush()
+            session.add_all(
+                [
+                    Creative(
+                        id="cr_demo_1",
+                        tenant_id="t_acme",
+                        account_id="a_acme_1",
+                        creative_id="signed-300x250-spring",
+                        name="Spring 300x250 Display",
+                        format_id={
+                            "agent_url": "https://reference.adcp.org",
+                            "id": "display_300x250",
+                        },
+                        status="approved",
+                        manifest_json={
+                            "creative_id": "signed-300x250-spring",
+                            "name": "Spring 300x250 Display",
+                            "format_id": {
+                                "agent_url": "https://reference.adcp.org",
+                                "id": "display_300x250",
+                            },
+                        },
+                    ),
+                    Creative(
+                        id="cr_demo_2",
+                        tenant_id="t_acme",
+                        account_id="a_acme_2",
+                        creative_id="bearer-video-30s",
+                        name="Bearer Buyer Video 30s",
+                        format_id={
+                            "agent_url": "https://reference.adcp.org",
+                            "id": "video_16x9_30s",
+                        },
+                        status="approved",
+                        manifest_json={
+                            "creative_id": "bearer-video-30s",
+                            "name": "Bearer Buyer Video 30s",
+                        },
+                    ),
+                ]
+            )
 
-    print("Seeded: 2 tenants, 3 buyer agents, 2 accounts.")
+    print("Seeded: 2 tenants, 3 buyer agents, 2 accounts, 2 creatives.")
     print("Hit: http://acme.localhost:3001/.well-known/agent.json")
     print("Hit: http://acme.localhost:3001/mcp")
 

--- a/examples/v3_reference_seller/src/models.py
+++ b/examples/v3_reference_seller/src/models.py
@@ -330,6 +330,16 @@ class MediaBuy(Base):
     request_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     response_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
+    #: Per-buy invoice override. When the buyer supplies
+    #: ``CreateMediaBuyRequest.invoice_recipient`` (a
+    #: :class:`adcp.types.BusinessEntity`), the seller persists the
+    #: full payload here — bank details included — so invoicing can
+    #: route to a recipient different from the account default. The
+    #: column is response-projected through
+    #: :func:`adcp.decisioning.project_business_entity_for_response`
+    #: before serialization (write-only ``bank``).
+    invoice_recipient: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utcnow
     )
@@ -344,4 +354,117 @@ class MediaBuy(Base):
     )
 
 
-__all__ = ["Account", "Base", "BuyerAgent", "MediaBuy", "Tenant"]
+# ---------------------------------------------------------------------------
+# Creative — seller-side view of buyer-uploaded creatives
+# ---------------------------------------------------------------------------
+
+
+class Creative(Base):
+    """Seller-side projection of a buyer-uploaded creative.
+
+    Populated by ``sync_creatives``; surfaced by ``list_creatives``.
+    Idempotency is keyed on ``(tenant_id, creative_id)`` so a buyer
+    re-syncing the same creative under the same wire id updates the
+    existing row in place.
+
+    The full creative manifest (assets, format parameters, tags) is
+    persisted in ``manifest_json`` — production adopters split the hot
+    fields (format_id, status) into typed columns and route the rest
+    to a creative-management service.
+    """
+
+    __tablename__ = "creatives"
+
+    id: Mapped[str] = mapped_column(
+        String(64), primary_key=True, default=lambda: f"cr_{uuid.uuid4().hex[:12]}"
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    account_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False
+    )
+
+    #: Wire ``creative_id`` provided by the buyer.
+    creative_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    #: Format reference — stored as the structured object
+    #: ``{agent_url, id}`` from the spec. We persist the JSON shape so
+    #: adopters can layer on parameterized template formats without a
+    #: column migration.
+    format_id: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+
+    #: Spec ``CreativeStatus`` — pending_review / approved / rejected /
+    #: archived / processing.
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="approved")
+
+    #: Full creative manifest (assets, tags, ext) — projection-time
+    #: shape kept opaque so spec evolution doesn't force migrations.
+    manifest_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "creative_id", name="creatives_tenant_creative_uk"),
+        Index("creatives_tenant_idx", "tenant_id"),
+        Index("creatives_account_idx", "account_id"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PerformanceFeedback — buyer-supplied performance signal
+# ---------------------------------------------------------------------------
+
+
+class PerformanceFeedback(Base):
+    """Persisted record of a ``provide_performance_feedback`` call.
+
+    Buyer-supplied attribution / measurement signals route into this
+    table for downstream optimization. ``value`` carries the full
+    request payload (performance_index, metric_type, package_id,
+    creative_id, measurement_period) so adopters can backfill new
+    dimensions without column migrations.
+    """
+
+    __tablename__ = "performance_feedback"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    media_buy_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("media_buys.id", ondelete="CASCADE"), nullable=False
+    )
+
+    #: Spec ``MetricType`` — overall_performance / conversion_rate /
+    #: ctr / brand_safety / etc.
+    feedback_type: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    #: Full request payload (performance_index, period bounds, source).
+    value: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("performance_feedback_tenant_idx", "tenant_id"),
+        Index("performance_feedback_media_buy_idx", "media_buy_id"),
+    )
+
+
+__all__ = [
+    "Account",
+    "Base",
+    "BuyerAgent",
+    "Creative",
+    "MediaBuy",
+    "PerformanceFeedback",
+    "Tenant",
+]

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -1,24 +1,39 @@
 """DecisioningPlatform impl for the v3 reference seller.
 
-Sales-non-guaranteed specialism with the five required Sales methods:
+Sales-non-guaranteed specialism with the full Sales surface:
+
+Required (every sales-* specialism):
 
 * :meth:`get_products` — read inventory catalog
 * :meth:`create_media_buy` — terminal artifact insert; idempotency-keyed
-* :meth:`update_media_buy` — patch (status / pause / spend cap)
-* :meth:`sync_creatives` — accept creative manifests
+* :meth:`update_media_buy` — patch (status / pause / spend cap /
+  invoice recipient)
+* :meth:`sync_creatives` — accept creative manifests, persist to
+  ``creatives`` table
 * :meth:`get_media_buy_delivery` — read delivery actuals
 
-All five run against the SQLAlchemy models in :mod:`models`. The
-platform reads the resolved :class:`adcp.decisioning.BuyerAgent`
-from :attr:`RequestContext.buyer_agent` (set by the framework's
-dispatch gate) and the :class:`adcp.decisioning.Account` from
-:attr:`RequestContext.account` (set by the platform's
-``AccountStore``) — both already filtered to the active tenant via
-:func:`adcp.server.current_tenant`.
+Optional (v6.0 rc.1+ — present for sales-non-guaranteed):
 
-This file is the bulk of what an adopter customizes. Everything
-else (auth verifier, registry, audit sink, tenant routing) is
-boilerplate the seller wires once and forgets.
+* :meth:`get_media_buys` — list buys for the resolved account with
+  cursor-friendly limit/offset paging
+* :meth:`provide_performance_feedback` — persist buyer-supplied
+  performance signals
+* :meth:`list_creative_formats` — static catalog of accepted formats
+* :meth:`list_creatives` — seller-side view of buyer-uploaded
+  creatives
+
+Account ops (3.1-readiness anchor):
+
+* :meth:`sync_accounts` — upsert with full :class:`BusinessEntity`
+  payload (bank details persisted; never echoed)
+* :meth:`list_accounts` — projected through
+  :func:`adcp.decisioning.project_account_for_response` so bank
+  details never leak on response
+
+All methods run against the SQLAlchemy models in :mod:`models`. The
+platform reads :attr:`RequestContext.buyer_agent` and
+:attr:`account` from the typed request context, both populated by
+the framework's dispatch layer before the method runs.
 """
 
 from __future__ import annotations
@@ -26,9 +41,9 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from adcp.decisioning import (
     Account,
@@ -37,21 +52,43 @@ from adcp.decisioning import (
     DecisioningPlatform,
     ExplicitAccounts,
     MockAdServer,
+    project_account_for_response,
+    project_business_entity_for_response,
 )
 from adcp.decisioning.specialisms import SalesPlatform
 from adcp.types import (
+    Account as AccountWire,
+)
+from adcp.types import (
+    BusinessEntity,
     CreateMediaBuyRequest,
     CreateMediaBuySuccessResponse,
+    Format,
     GetMediaBuyDeliveryRequest,
     GetMediaBuyDeliveryResponse,
+    GetMediaBuysRequest,
+    GetMediaBuysResponse,
     GetProductsRequest,
     GetProductsResponse,
+    ListAccountsRequest,
+    ListAccountsResponse,
+    ListCreativeFormatsRequest,
+    ListCreativeFormatsResponse,
+    ListCreativesRequest,
+    ListCreativesResponse,
+    MediaBuy as MediaBuyWire,
     Product,
+    ProvidePerformanceFeedbackRequest,
+    ProvidePerformanceFeedbackSuccessResponse,
+    SyncAccountsRequest,
+    SyncAccountsSuccessResponse,
+    SyncCreativeResult,
     SyncCreativesRequest,
     SyncCreativesSuccessResponse,
     UpdateMediaBuyRequest,
     UpdateMediaBuySuccessResponse,
 )
+from adcp.server import current_tenant
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -59,7 +96,10 @@ if TYPE_CHECKING:
     from adcp.decisioning import RequestContext
 
 from .models import Account as AccountRow
+from .models import BuyerAgent as BuyerAgentRow
+from .models import Creative as CreativeRow
 from .models import MediaBuy as MediaBuyRow
+from .models import PerformanceFeedback as PerformanceFeedbackRow
 
 logger = logging.getLogger(__name__)
 
@@ -85,8 +125,6 @@ def _make_account_store(sessionmaker: async_sessionmaker) -> ExplicitAccounts:
 
     async def loader(account_id: str) -> Account[dict[str, Any]]:
         # Read tenant from the contextvar set by the middleware.
-        from adcp.server import current_tenant
-
         tenant = current_tenant()
         if tenant is None:
             raise AdcpError(
@@ -228,6 +266,14 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         response on retry. We additionally enforce uniqueness at the
         DB level via ``UniqueConstraint(tenant_id, idempotency_key)``
         so a misconfigured cache can't double-insert.
+
+        :attr:`CreateMediaBuyRequest.invoice_recipient` is persisted
+        as a flat JSON column on the row (full
+        :class:`BusinessEntity` payload, bank details included). The
+        seller projects through
+        :func:`project_business_entity_for_response` only when
+        echoing on a response — the SQL column is the durable
+        invoicing record.
         """
         if ctx.buyer_agent is None or ctx.account is None:
             raise AdcpError(
@@ -250,6 +296,13 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         budget_amount = req.total_budget.amount if req.total_budget else None
         budget_currency = req.total_budget.currency if req.total_budget else None
         start_dt = _project_start_time(req.start_time)
+        invoice_recipient_payload: dict[str, Any] | None = None
+        if req.invoice_recipient is not None:
+            # Persist full payload (bank included) — write-only on
+            # response, not on storage.
+            invoice_recipient_payload = req.invoice_recipient.model_dump(
+                mode="json", exclude_none=True
+            )
         row = MediaBuyRow(
             tenant_id=ctx.account.metadata["tenant_id"],
             account_id=ctx.account.id,
@@ -261,6 +314,7 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             currency=budget_currency,
             start_time=start_dt,
             end_time=req.end_time,
+            invoice_recipient=invoice_recipient_payload,
             request_snapshot=req.model_dump(mode="json"),
         )
         async with self._sessionmaker() as session, session.begin():
@@ -286,11 +340,14 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
     async def update_media_buy(
         self, media_buy_id: str, patch: UpdateMediaBuyRequest, ctx: RequestContext
     ) -> UpdateMediaBuySuccessResponse:
-        """Patch a media buy's status / pause flag.
+        """Patch a media buy's status / pause flag / invoice recipient.
 
         Tenant + account scoped — the SQL UPDATE includes both in the
         WHERE clause so a misrouted request can't mutate rows
-        belonging to another tenant.
+        belonging to another tenant. ``invoice_recipient`` overrides
+        replace the full :class:`BusinessEntity` payload (bank
+        included) when present on the patch — 3.1-ready for per-buy
+        invoice override semantics.
         """
         if ctx.account is None:
             raise AdcpError(
@@ -317,6 +374,9 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 row.status = "paused"
             elif patch.paused is False and row.status == "paused":
                 row.status = "active"
+            patch_invoice = getattr(patch, "invoice_recipient", None)
+            if patch_invoice is not None:
+                row.invoice_recipient = patch_invoice.model_dump(mode="json", exclude_none=True)
             row.updated_at = datetime.now(timezone.utc)
         self._record(
             "media_buy.update",
@@ -333,13 +393,70 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
     async def sync_creatives(
         self, req: SyncCreativesRequest, ctx: RequestContext
     ) -> SyncCreativesSuccessResponse:
-        """Accept creative manifests — the reference impl persists
-        nothing; production adopters route to their creative review
-        pipeline here."""
-        del ctx
-        creative_count = len(req.creatives) if req.creatives else 0
-        self._record("creative.upload", {"count": creative_count})
-        return SyncCreativesSuccessResponse(creatives=[])
+        """Accept creative manifests and persist to the ``creatives``
+        table.
+
+        Idempotency-keyed on ``(tenant_id, creative_id)`` — re-syncing
+        the same wire id under the same tenant updates the existing
+        row in place (UPSERT). Auto-approves on ingest; production
+        adopters route to a creative-review pipeline that flips
+        ``status`` to ``pending_review`` and signs back via
+        :meth:`adcp.decisioning.RequestContext.publish_status_change`.
+        """
+        if ctx.account is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated account.",
+                recovery="terminal",
+            )
+        tenant_id = ctx.account.metadata["tenant_id"]
+        results: list[SyncCreativeResult] = []
+        async with self._sessionmaker() as session, session.begin():
+            for creative in req.creatives:
+                manifest_json = creative.model_dump(mode="json", exclude_none=True)
+                format_id_payload = manifest_json.get("format_id") or {}
+                # Look up by natural key first so we know whether
+                # this is a create or update for the response action
+                # field — UPSERT alone collapses both to one path.
+                existing_q = await session.execute(
+                    select(CreativeRow).where(
+                        CreativeRow.tenant_id == tenant_id,
+                        CreativeRow.creative_id == creative.creative_id,
+                    )
+                )
+                existing = existing_q.scalar_one_or_none()
+                if existing is None:
+                    session.add(
+                        CreativeRow(
+                            tenant_id=tenant_id,
+                            account_id=ctx.account.id,
+                            creative_id=creative.creative_id,
+                            name=creative.name,
+                            format_id=format_id_payload,
+                            status=(creative.status or "approved"),
+                            manifest_json=manifest_json,
+                        )
+                    )
+                    action: Literal["created", "updated"] = "created"
+                else:
+                    existing.name = creative.name
+                    existing.format_id = format_id_payload
+                    existing.manifest_json = manifest_json
+                    if creative.status is not None:
+                        existing.status = creative.status
+                    existing.updated_at = datetime.now(timezone.utc)
+                    action = "updated"
+                results.append(
+                    SyncCreativeResult.model_validate(
+                        {
+                            "creative_id": creative.creative_id,
+                            "action": action,
+                            "status": creative.status or "approved",
+                        }
+                    )
+                )
+        self._record("creative.upload", {"count": len(req.creatives) if req.creatives else 0})
+        return SyncCreativesSuccessResponse(creatives=results)
 
     # ----- get_media_buy_delivery ------------------------------------------
 
@@ -351,6 +468,438 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         del req, ctx
         self._record("delivery.read", {})
         return GetMediaBuyDeliveryResponse(media_buys=[])
+
+    # ----- get_media_buys --------------------------------------------------
+
+    async def get_media_buys(
+        self, req: GetMediaBuysRequest, ctx: RequestContext
+    ) -> GetMediaBuysResponse:
+        """List media buys for the resolved account.
+
+        Filters by ``(tenant_id, account_id)`` from the resolved
+        :class:`Account`. Pagination is offset/limit on the request's
+        :class:`PaginationRequest` — adopters with billions of buys
+        upgrade to seek-pagination on ``(created_at, id)``.
+        """
+        if ctx.account is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated account.",
+                recovery="terminal",
+            )
+        limit = 50
+        offset = 0
+        if req.pagination is not None:
+            limit = getattr(req.pagination, "limit", None) or 50
+            offset = getattr(req.pagination, "offset", None) or 0
+        async with self._sessionmaker() as session:
+            result = await session.execute(
+                select(MediaBuyRow)
+                .where(
+                    MediaBuyRow.tenant_id == ctx.account.metadata["tenant_id"],
+                    MediaBuyRow.account_id == ctx.account.id,
+                )
+                .order_by(MediaBuyRow.created_at.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+            rows = list(result.scalars())
+        media_buys: list[MediaBuyWire] = []
+        for row in rows:
+            invoice_recipient: BusinessEntity | None = None
+            if row.invoice_recipient is not None:
+                # Project bank details out before echoing on response.
+                entity = BusinessEntity.model_validate(row.invoice_recipient)
+                invoice_recipient = project_business_entity_for_response(entity)
+            media_buys.append(
+                MediaBuyWire.model_validate(
+                    {
+                        "media_buy_id": row.media_buy_id,
+                        "status": row.status,
+                        "currency": row.currency or "USD",
+                        "total_budget": row.total_budget or 0.0,
+                        "start_time": row.start_time,
+                        "end_time": row.end_time,
+                        "created_at": row.created_at,
+                        "updated_at": row.updated_at,
+                        "packages": [],
+                        "invoice_recipient": invoice_recipient,
+                    }
+                )
+            )
+        self._record(
+            "media_buys.list",
+            {"account_id": ctx.account.id, "limit": limit, "offset": offset},
+        )
+        return GetMediaBuysResponse(media_buys=media_buys)
+
+    # ----- provide_performance_feedback ------------------------------------
+
+    async def provide_performance_feedback(
+        self, req: ProvidePerformanceFeedbackRequest, ctx: RequestContext
+    ) -> ProvidePerformanceFeedbackSuccessResponse:
+        """Persist buyer-supplied performance signal.
+
+        Looks up the media buy by ``(tenant_id, media_buy_id)`` —
+        rejects with ``MEDIA_BUY_NOT_FOUND`` if the buyer's id doesn't
+        resolve under this tenant. Production adopters route the
+        feedback into their optimization / pacing service from here.
+        """
+        if ctx.account is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated account.",
+                recovery="terminal",
+            )
+        tenant_id = ctx.account.metadata["tenant_id"]
+        async with self._sessionmaker() as session, session.begin():
+            result = await session.execute(
+                select(MediaBuyRow).where(
+                    MediaBuyRow.tenant_id == tenant_id,
+                    MediaBuyRow.media_buy_id == req.media_buy_id,
+                )
+            )
+            mb = result.scalar_one_or_none()
+            if mb is None:
+                raise AdcpError(
+                    "MEDIA_BUY_NOT_FOUND",
+                    message=f"No media buy {req.media_buy_id!r} under this tenant.",
+                    recovery="terminal",
+                    field="media_buy_id",
+                )
+            metric_type = (
+                (
+                    req.metric_type.value
+                    if hasattr(req.metric_type, "value")
+                    else str(req.metric_type)
+                )
+                if req.metric_type is not None
+                else "overall_performance"
+            )
+            session.add(
+                PerformanceFeedbackRow(
+                    tenant_id=tenant_id,
+                    media_buy_id=mb.id,
+                    feedback_type=metric_type,
+                    value=req.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        self._record(
+            "performance.feedback",
+            {"media_buy_id": req.media_buy_id, "feedback_type": metric_type},
+        )
+        return ProvidePerformanceFeedbackSuccessResponse.model_validate({"success": True})
+
+    # ----- list_creative_formats -------------------------------------------
+
+    async def list_creative_formats(
+        self, req: ListCreativeFormatsRequest, ctx: RequestContext
+    ) -> ListCreativeFormatsResponse:
+        """Static catalog of accepted formats.
+
+        Real adopters drive this from a creative-format registry
+        keyed on the seller's actual placement / template inventory.
+        """
+        del req, ctx
+        agent_url = "https://reference.adcp.org"
+        formats = [
+            Format.model_validate(
+                {
+                    "format_id": {"agent_url": agent_url, "id": "display_300x250"},
+                    "name": "Display 300x250 (medium rectangle)",
+                    "description": "IAB standard 300x250 display banner.",
+                }
+            ),
+            Format.model_validate(
+                {
+                    "format_id": {"agent_url": agent_url, "id": "display_728x90"},
+                    "name": "Display 728x90 (leaderboard)",
+                    "description": "IAB standard 728x90 display banner.",
+                }
+            ),
+            Format.model_validate(
+                {
+                    "format_id": {"agent_url": agent_url, "id": "video_16x9_30s"},
+                    "name": "Video 16:9 30s",
+                    "description": "Standard 30-second 16:9 video creative.",
+                }
+            ),
+        ]
+        self._record("creatives.formats", {})
+        return ListCreativeFormatsResponse(formats=formats)
+
+    # ----- list_creatives --------------------------------------------------
+
+    async def list_creatives(
+        self, req: ListCreativesRequest, ctx: RequestContext
+    ) -> ListCreativesResponse:
+        """List the seller's view of buyer-uploaded creatives for the
+        resolved account.
+
+        Sourced from the ``creatives`` table populated by
+        :meth:`sync_creatives`. Pagination is offset/limit; adopters
+        with millions of creatives per buyer upgrade to seek-pagination.
+        """
+        if ctx.account is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated account.",
+                recovery="terminal",
+            )
+        limit = 50
+        offset = 0
+        if req.pagination is not None:
+            limit = getattr(req.pagination, "limit", None) or 50
+            offset = getattr(req.pagination, "offset", None) or 0
+        async with self._sessionmaker() as session:
+            count_q = await session.execute(
+                select(func.count())
+                .select_from(CreativeRow)
+                .where(
+                    CreativeRow.tenant_id == ctx.account.metadata["tenant_id"],
+                    CreativeRow.account_id == ctx.account.id,
+                )
+            )
+            total = int(count_q.scalar() or 0)
+            page_q = await session.execute(
+                select(CreativeRow)
+                .where(
+                    CreativeRow.tenant_id == ctx.account.metadata["tenant_id"],
+                    CreativeRow.account_id == ctx.account.id,
+                )
+                .order_by(CreativeRow.created_at.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+            rows = list(page_q.scalars())
+        creatives = [
+            {
+                "creative_id": row.creative_id,
+                "name": row.name,
+                "format_id": row.format_id,
+                "status": row.status,
+                "created_date": row.created_at,
+                "updated_date": row.updated_at,
+            }
+            for row in rows
+        ]
+        has_more = offset + len(creatives) < total
+        self._record(
+            "creatives.list",
+            {"account_id": ctx.account.id, "limit": limit, "offset": offset},
+        )
+        return ListCreativesResponse.model_validate(
+            {
+                "query_summary": {"total_matching": total, "returned": len(creatives)},
+                "pagination": {"has_more": has_more, "total_count": total},
+                "creatives": creatives,
+            }
+        )
+
+    # ----- sync_accounts ---------------------------------------------------
+
+    async def sync_accounts(
+        self, req: SyncAccountsRequest, ctx: RequestContext
+    ) -> SyncAccountsSuccessResponse:
+        """Upsert incoming accounts under the authenticated buyer agent.
+
+        Persists the full :class:`BusinessEntity` payload (bank
+        details included) on ``billing_entity`` — the column is the
+        durable invoicing record. The response goes through
+        :func:`project_business_entity_for_response` so bank details
+        never echo on the wire.
+
+        Natural key: ``(tenant_id, brand.domain + operator)``. The
+        wire ``account_id`` is seller-assigned on first sight and
+        stable thereafter.
+        """
+        if ctx.buyer_agent is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated buyer_agent.",
+                recovery="terminal",
+            )
+        tenant = current_tenant()
+        if tenant is None:
+            raise AdcpError(
+                "AUTH_INVALID",
+                message="sync_accounts requires a tenant context.",
+                recovery="terminal",
+            )
+        results: list[dict[str, Any]] = []
+        async with self._sessionmaker() as session, session.begin():
+            # Look up the buyer-agent SQL row id by agent_url.
+            ba_q = await session.execute(
+                select(BuyerAgentRow).where(
+                    BuyerAgentRow.tenant_id == tenant.id,
+                    BuyerAgentRow.agent_url == ctx.buyer_agent.agent_url,
+                )
+            )
+            buyer_agent_row = ba_q.scalar_one_or_none()
+            if buyer_agent_row is None:
+                raise AdcpError(
+                    "INTERNAL_ERROR",
+                    message=(
+                        "Authenticated buyer_agent has no matching row — " "registry / table drift."
+                    ),
+                    recovery="terminal",
+                )
+            for incoming in req.accounts:
+                # Natural key per the spec — brand.domain + operator
+                # under the buyer's agent. Both fields are required by
+                # the schema (BrandReference.domain, Account.brand) so
+                # no None guard is needed.
+                brand_domain = incoming.brand.domain
+                natural_account_id = f"{brand_domain}::{incoming.operator}"
+                billing_entity_payload: dict[str, Any] | None = None
+                if incoming.billing_entity is not None:
+                    billing_entity_payload = incoming.billing_entity.model_dump(
+                        mode="json", exclude_none=True
+                    )
+                existing_q = await session.execute(
+                    select(AccountRow).where(
+                        AccountRow.tenant_id == tenant.id,
+                        AccountRow.account_id == natural_account_id,
+                    )
+                )
+                existing = existing_q.scalar_one_or_none()
+                billing_value = (
+                    incoming.billing.value
+                    if hasattr(incoming.billing, "value")
+                    else str(incoming.billing)
+                )
+                if existing is None:
+                    new_row = AccountRow(
+                        tenant_id=tenant.id,
+                        buyer_agent_id=buyer_agent_row.id,
+                        account_id=natural_account_id,
+                        name=f"{brand_domain} c/o {incoming.operator}",
+                        status="active",
+                        billing=billing_value,
+                        billing_entity=billing_entity_payload,
+                        sandbox=bool(incoming.sandbox),
+                    )
+                    session.add(new_row)
+                    action = "created"
+                else:
+                    existing.billing = billing_value
+                    existing.billing_entity = billing_entity_payload
+                    existing.sandbox = bool(incoming.sandbox)
+                    existing.updated_at = datetime.now(timezone.utc)
+                    action = "updated"
+                # Project bank out of the echoed billing_entity per
+                # spec write-only rule.
+                response_billing: dict[str, Any] | None = None
+                if incoming.billing_entity is not None:
+                    response_billing = project_business_entity_for_response(
+                        incoming.billing_entity
+                    ).model_dump(mode="json", exclude_none=True)
+                results.append(
+                    {
+                        "account_id": natural_account_id,
+                        "brand": incoming.brand.model_dump(mode="json", exclude_none=True),
+                        "operator": incoming.operator,
+                        "name": f"{brand_domain} c/o {incoming.operator}",
+                        "action": action,
+                        "status": "active",
+                        "billing": billing_value,
+                        "billing_entity": response_billing,
+                        "sandbox": bool(incoming.sandbox),
+                    }
+                )
+        self._record("accounts.sync", {"count": len(req.accounts)})
+        return SyncAccountsSuccessResponse.model_validate(
+            {"accounts": results, "dry_run": bool(req.dry_run)}
+        )
+
+    # ----- list_accounts ---------------------------------------------------
+
+    async def list_accounts(
+        self, req: ListAccountsRequest, ctx: RequestContext
+    ) -> ListAccountsResponse:
+        """List accounts for the authenticated buyer agent.
+
+        **Headline 3.1-readiness claim**: every account in the
+        response is run through
+        :func:`project_account_for_response` so the spec's
+        write-only ``billing_entity.bank`` field cannot leak on the
+        wire — even when adopters persist full bank coordinates for
+        invoicing.
+        """
+        if ctx.buyer_agent is None:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message="Dispatch should have populated buyer_agent.",
+                recovery="terminal",
+            )
+        tenant = current_tenant()
+        if tenant is None:
+            raise AdcpError(
+                "AUTH_INVALID",
+                message="list_accounts requires a tenant context.",
+                recovery="terminal",
+            )
+        limit = 50
+        offset = 0
+        if req.pagination is not None:
+            limit = getattr(req.pagination, "limit", None) or 50
+            offset = getattr(req.pagination, "offset", None) or 0
+        async with self._sessionmaker() as session:
+            ba_q = await session.execute(
+                select(BuyerAgentRow).where(
+                    BuyerAgentRow.tenant_id == tenant.id,
+                    BuyerAgentRow.agent_url == ctx.buyer_agent.agent_url,
+                )
+            )
+            buyer_agent_row = ba_q.scalar_one_or_none()
+            if buyer_agent_row is None:
+                # Authenticated agent unknown to the accounts table —
+                # return empty page rather than 500.
+                self._record(
+                    "accounts.list",
+                    {"buyer_agent_id": ctx.buyer_agent.agent_url},
+                )
+                return ListAccountsResponse.model_validate(
+                    {
+                        "accounts": [],
+                        "pagination": {"has_more": False, "total_count": 0},
+                    }
+                )
+            stmt = select(AccountRow).where(
+                AccountRow.tenant_id == tenant.id,
+                AccountRow.buyer_agent_id == buyer_agent_row.id,
+            )
+            if req.status is not None:
+                status_value = req.status.value if hasattr(req.status, "value") else str(req.status)
+                stmt = stmt.where(AccountRow.status == status_value)
+            page_q = await session.execute(
+                stmt.order_by(AccountRow.created_at.desc()).limit(limit).offset(offset)
+            )
+            rows = list(page_q.scalars())
+
+        projected_accounts: list[dict[str, Any]] = []
+        for row in rows:
+            wire_account = AccountWire.model_validate(
+                {
+                    "account_id": row.account_id,
+                    "name": row.name,
+                    "status": row.status,
+                    "billing": row.billing,
+                    "billing_entity": row.billing_entity,
+                    "sandbox": row.sandbox,
+                }
+            )
+            # The 3.1-readiness guard: strip bank details before the
+            # response leaves the platform.
+            safe = project_account_for_response(wire_account)
+            projected_accounts.append(safe.model_dump(mode="json", exclude_none=True))
+        self._record("accounts.list", {"buyer_agent_id": ctx.buyer_agent.agent_url})
+        return ListAccountsResponse.model_validate(
+            {
+                "accounts": projected_accounts,
+                "pagination": {"has_more": len(rows) == limit},
+            }
+        )
 
 
 def _project_start_time(value: Any) -> datetime:

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -56,6 +56,7 @@ from adcp.decisioning import (
     project_business_entity_for_response,
 )
 from adcp.decisioning.specialisms import SalesPlatform
+from adcp.server import current_tenant
 from adcp.types import (
     Account as AccountWire,
 )
@@ -76,7 +77,6 @@ from adcp.types import (
     ListCreativeFormatsResponse,
     ListCreativesRequest,
     ListCreativesResponse,
-    MediaBuy as MediaBuyWire,
     Product,
     ProvidePerformanceFeedbackRequest,
     ProvidePerformanceFeedbackSuccessResponse,
@@ -88,7 +88,9 @@ from adcp.types import (
     UpdateMediaBuyRequest,
     UpdateMediaBuySuccessResponse,
 )
-from adcp.server import current_tenant
+from adcp.types import (
+    MediaBuy as MediaBuyWire,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -531,7 +533,13 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             "media_buys.list",
             {"account_id": ctx.account.id, "limit": limit, "offset": offset},
         )
-        return GetMediaBuysResponse(media_buys=media_buys)
+        # Pydantic re-validates each item against the response-specific
+        # ``MediaBuy`` shape. Passing the public-API ``MediaBuy``
+        # instances we built above ensures field drift surfaces here
+        # rather than at the wire boundary.
+        return GetMediaBuysResponse.model_validate(
+            {"media_buys": [m.model_dump(mode="python", exclude_none=True) for m in media_buys]}
+        )
 
     # ----- provide_performance_feedback ------------------------------------
 

--- a/examples/v3_reference_seller/tests/test_smoke_broadening.py
+++ b/examples/v3_reference_seller/tests/test_smoke_broadening.py
@@ -161,7 +161,9 @@ def test_list_accounts_projection_strips_bank_details() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_accounts_runs_projection_on_every_row() -> None:
+async def test_list_accounts_runs_projection_on_every_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: drive ``V3ReferenceSeller.list_accounts`` against a
     mocked session whose row carries bank details and assert no
     response account leaks them. This is the platform-level guarantee
@@ -169,6 +171,7 @@ async def test_list_accounts_runs_projection_on_every_row() -> None:
     """
     from unittest.mock import AsyncMock, MagicMock
 
+    import src.platform as platform_module
     from src.models import Account as AccountRow
     from src.models import BuyerAgent as BuyerAgentRow
     from src.platform import V3ReferenceSeller
@@ -220,46 +223,38 @@ async def test_list_accounts_runs_projection_on_every_row() -> None:
     session.execute = AsyncMock(side_effect=[ba_result, accounts_result])
     sessionmaker = MagicMock(return_value=session)
 
-    # Mock the tenant contextvar reader.
-    import src.platform as platform_module
-
-    from adcp.server import current_tenant as _real
-
+    # Patch the tenant contextvar reader where the platform looks it up.
     class _Tenant:
         id = "t_acme"
 
-    has_current = hasattr(platform_module, "current_tenant")
-    original = platform_module.current_tenant if has_current else _real
-    # Patch the import inside the method by patching at module level.
-    import adcp.server as server_module
+    monkeypatch.setattr(platform_module, "current_tenant", lambda: _Tenant())
 
-    monkeypatched = lambda: _Tenant()  # noqa: E731
-    setattr(server_module, "current_tenant", monkeypatched)
-    try:
-        platform = V3ReferenceSeller(sessionmaker=sessionmaker)
+    platform = V3ReferenceSeller(sessionmaker=sessionmaker)
 
-        ctx = RequestContext(
-            buyer_agent=BuyerAgent(
-                agent_url="https://signed-buyer.example/",
-                display_name="Signed Buyer",
-                status="active",
-                billing_capabilities=frozenset({"operator", "agent"}),
-            ),
-            account=None,
-        )
-        req = ListAccountsRequest()
-        resp = await platform.list_accounts(req, ctx)
-    finally:
-        setattr(server_module, "current_tenant", original)
+    ctx = RequestContext(
+        buyer_agent=BuyerAgent(
+            agent_url="https://signed-buyer.example/",
+            display_name="Signed Buyer",
+            status="active",
+            billing_capabilities=frozenset({"operator", "agent"}),
+        ),
+        account=None,
+    )
+    req = ListAccountsRequest()
+    resp = await platform.list_accounts(req, ctx)
 
     payload = resp.model_dump(mode="json", exclude_none=True)
     assert payload["accounts"], "expected at least one account in response"
     for acct in payload["accounts"]:
-        # The headline guarantee — bank MUST NOT echo on the wire.
-        if "billing_entity" in acct:
-            assert (
-                "bank" not in acct["billing_entity"]
-            ), f"bank details leaked on list_accounts response: {acct}"
+        # The 3.1-readiness headline: billing_entity SHOULD echo on the
+        # wire (the spec requires it for invoicing visibility) — but
+        # the write-only ``bank`` block MUST NOT.
+        assert (
+            "billing_entity" in acct
+        ), f"billing_entity missing from list_accounts response: {acct}"
+        assert (
+            "bank" not in acct["billing_entity"]
+        ), f"bank details leaked on list_accounts response: {acct}"
 
 
 # ---------------------------------------------------------------------------
@@ -315,8 +310,10 @@ async def test_creative_round_trip_through_sync_then_list() -> None:
         return list(written_rows)
 
     def _list_session_factory() -> MagicMock:
+        # The platform issues ``select(func.count()).select_from(...)``
+        # for total, then a paged ``select(CreativeRow)`` for rows.
         count_result = MagicMock()
-        count_result.scalars = MagicMock(side_effect=lambda: iter(_hydrate_rows()))
+        count_result.scalar = MagicMock(side_effect=lambda: len(_hydrate_rows()))
         page_result = MagicMock()
         page_result.scalars = MagicMock(side_effect=lambda: iter(_hydrate_rows()))
         s = MagicMock()

--- a/examples/v3_reference_seller/tests/test_smoke_broadening.py
+++ b/examples/v3_reference_seller/tests/test_smoke_broadening.py
@@ -1,0 +1,383 @@
+"""Smoke tests for the v3 reference seller broadening.
+
+Covers the spec-required broadening of the v3 reference seller:
+
+* All 9 sales methods plus ``sync_accounts`` / ``list_accounts`` are
+  present on the platform class (Protocol surface check).
+* ``list_accounts`` projects ``billing_entity.bank`` out of every
+  account on response (the headline 3.1-readiness claim).
+* ``MediaBuy.invoice_recipient`` column populates from the typed
+  request and round-trips through the SQLAlchemy model.
+* Creative round-trip: ``sync_creatives`` writes to the
+  ``creatives`` table; ``list_creatives`` reads it back.
+
+These tests deliberately avoid spinning up a real Postgres — the
+README's docker-compose flow covers end-to-end. Here we use
+SQLAlchemy + mocked sessionmakers (or, where structurally important,
+direct model instantiation) so the suite stays no-PG-needed.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Add the example dir to sys.path so `src.*` imports resolve.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+
+# ---------------------------------------------------------------------------
+# Protocol surface — every sales-* method plus account ops are callable
+# ---------------------------------------------------------------------------
+
+
+def test_v3_reference_seller_exposes_full_sales_surface() -> None:
+    """The seller declares ``sales-non-guaranteed`` — verify every
+    method on the SalesPlatform Protocol (required + optional) plus
+    the account ops are present on the class."""
+    from src.platform import V3ReferenceSeller
+
+    required_methods = {
+        "get_products",
+        "create_media_buy",
+        "update_media_buy",
+        "sync_creatives",
+        "get_media_buy_delivery",
+    }
+    optional_methods = {
+        "get_media_buys",
+        "provide_performance_feedback",
+        "list_creative_formats",
+        "list_creatives",
+    }
+    account_ops = {"sync_accounts", "list_accounts"}
+
+    for name in required_methods | optional_methods | account_ops:
+        assert hasattr(V3ReferenceSeller, name), f"V3ReferenceSeller missing {name}"
+        attr = getattr(V3ReferenceSeller, name)
+        assert callable(attr), f"V3ReferenceSeller.{name} is not callable"
+
+
+def test_new_models_are_registered_in_metadata() -> None:
+    """``Creative`` and ``PerformanceFeedback`` tables show up in
+    ``Base.metadata`` so ``create_all`` provisions them."""
+    from src.models import Base, Creative, PerformanceFeedback
+
+    table_names = {t.name for t in Base.metadata.tables.values()}
+    assert "creatives" in table_names
+    assert "performance_feedback" in table_names
+    assert Creative.__tablename__ == "creatives"
+    assert PerformanceFeedback.__tablename__ == "performance_feedback"
+
+
+# ---------------------------------------------------------------------------
+# MediaBuy.invoice_recipient — first-class column with JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_media_buy_invoice_recipient_column_populates() -> None:
+    """``MediaBuy.invoice_recipient`` is a JSON column. Verify it
+    populates from the typed
+    ``CreateMediaBuyRequest.invoice_recipient`` when the platform
+    constructs the row."""
+    from src.models import MediaBuy
+
+    invoice_payload = {
+        "legal_name": "Acme Holdings GmbH",
+        "tax_id": "DE-987654321",
+        "address": {
+            "country": "DE",
+            "postal_code": "10115",
+            "city": "Berlin",
+            "street": "Friedrichstrasse 1",
+        },
+        # bank field — write-only on response, durable on storage.
+        "bank": {
+            "account_holder": "Acme Holdings GmbH",
+            "iban": "DE89370400440532013000",
+            "bic": "COBADEFFXXX",
+        },
+    }
+    row = MediaBuy(
+        tenant_id="t_acme",
+        account_id="a_acme_1",
+        media_buy_id="mb_test",
+        idempotency_key="k_" + "x" * 16,
+        status="active",
+        invoice_recipient=invoice_payload,
+    )
+    assert row.invoice_recipient is not None
+    assert row.invoice_recipient["legal_name"] == "Acme Holdings GmbH"
+    # Bank details persist on storage — write-only is a RESPONSE-side
+    # rule, not a storage-side rule.
+    assert row.invoice_recipient["bank"]["iban"] == "DE89370400440532013000"
+
+
+# ---------------------------------------------------------------------------
+# list_accounts projection — bank details stripped on response
+# ---------------------------------------------------------------------------
+
+
+def test_list_accounts_projection_strips_bank_details() -> None:
+    """The 3.1-readiness headline claim: any account run through
+    ``project_account_for_response`` has ``billing_entity.bank``
+    cleared. Verify the projection helper directly so we know the
+    list_accounts response path's call site is correct.
+    """
+    from adcp.decisioning import project_account_for_response
+    from adcp.types import Account as AccountWire
+
+    account = AccountWire.model_validate(
+        {
+            "account_id": "acme-corp.com::pinnacle-media.com",
+            "name": "Acme c/o Pinnacle",
+            "status": "active",
+            "billing": "agent",
+            "billing_entity": {
+                "legal_name": "Pinnacle Media LLC",
+                "tax_id": "12-3456789",
+                "bank": {
+                    "account_holder": "Pinnacle Media LLC",
+                    "iban": "DE89370400440532013000",
+                    "bic": "COBADEFFXXX",
+                },
+            },
+        }
+    )
+    safe = project_account_for_response(account)
+    assert safe.billing_entity is not None
+    assert safe.billing_entity.bank is None
+    # Other billing_entity fields survive the projection.
+    assert safe.billing_entity.legal_name == "Pinnacle Media LLC"
+    # Wire payload — the headline guarantee. ``bank`` MUST NOT
+    # appear when we serialize for response.
+    payload = safe.model_dump(mode="json", exclude_none=True)
+    assert "bank" not in payload["billing_entity"], payload
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_runs_projection_on_every_row() -> None:
+    """End-to-end: drive ``V3ReferenceSeller.list_accounts`` against a
+    mocked session whose row carries bank details and assert no
+    response account leaks them. This is the platform-level guarantee
+    the spec requires.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.models import Account as AccountRow
+    from src.models import BuyerAgent as BuyerAgentRow
+    from src.platform import V3ReferenceSeller
+
+    from adcp.decisioning import RequestContext
+    from adcp.decisioning.registry import BuyerAgent
+    from adcp.types import ListAccountsRequest
+
+    bank_block = {
+        "account_holder": "Pinnacle Media LLC",
+        "iban": "DE89370400440532013000",
+        "bic": "COBADEFFXXX",
+    }
+    buyer_agent_row = BuyerAgentRow(
+        id="ba_acme_signed",
+        tenant_id="t_acme",
+        agent_url="https://signed-buyer.example/",
+        display_name="Signed Buyer",
+        status="active",
+        billing_capabilities=["operator", "agent"],
+    )
+    account_row = AccountRow(
+        id="a_acme_1",
+        tenant_id="t_acme",
+        buyer_agent_id="ba_acme_signed",
+        account_id="acme-corp.com::pinnacle-media.com",
+        name="Acme c/o Pinnacle",
+        status="active",
+        billing="agent",
+        billing_entity={
+            "legal_name": "Pinnacle Media LLC",
+            "tax_id": "12-3456789",
+            "bank": bank_block,
+        },
+        sandbox=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    # Two SELECT calls — one for buyer-agent lookup, one for accounts.
+    ba_result = MagicMock()
+    ba_result.scalar_one_or_none = MagicMock(return_value=buyer_agent_row)
+    accounts_result = MagicMock()
+    accounts_result.scalars = MagicMock(return_value=iter([account_row]))
+
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.execute = AsyncMock(side_effect=[ba_result, accounts_result])
+    sessionmaker = MagicMock(return_value=session)
+
+    # Mock the tenant contextvar reader.
+    import src.platform as platform_module
+
+    from adcp.server import current_tenant as _real
+
+    class _Tenant:
+        id = "t_acme"
+
+    has_current = hasattr(platform_module, "current_tenant")
+    original = platform_module.current_tenant if has_current else _real
+    # Patch the import inside the method by patching at module level.
+    import adcp.server as server_module
+
+    monkeypatched = lambda: _Tenant()  # noqa: E731
+    setattr(server_module, "current_tenant", monkeypatched)
+    try:
+        platform = V3ReferenceSeller(sessionmaker=sessionmaker)
+
+        ctx = RequestContext(
+            buyer_agent=BuyerAgent(
+                agent_url="https://signed-buyer.example/",
+                display_name="Signed Buyer",
+                status="active",
+                billing_capabilities=frozenset({"operator", "agent"}),
+            ),
+            account=None,
+        )
+        req = ListAccountsRequest()
+        resp = await platform.list_accounts(req, ctx)
+    finally:
+        setattr(server_module, "current_tenant", original)
+
+    payload = resp.model_dump(mode="json", exclude_none=True)
+    assert payload["accounts"], "expected at least one account in response"
+    for acct in payload["accounts"]:
+        # The headline guarantee — bank MUST NOT echo on the wire.
+        if "billing_entity" in acct:
+            assert (
+                "bank" not in acct["billing_entity"]
+            ), f"bank details leaked on list_accounts response: {acct}"
+
+
+# ---------------------------------------------------------------------------
+# Creative round-trip — sync writes; list reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_creative_round_trip_through_sync_then_list() -> None:
+    """Drive ``sync_creatives`` against a mock session, then
+    ``list_creatives`` against the same session, and assert the
+    creative the sync wrote shows up on the list response.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.models import Creative as CreativeRow
+    from src.platform import V3ReferenceSeller
+
+    from adcp.decisioning import Account, RequestContext
+    from adcp.decisioning.registry import BuyerAgent
+    from adcp.types import ListCreativesRequest, SyncCreativesRequest
+
+    # Track the row the sync writes — we'll feed it back on the list.
+    written_rows: list[CreativeRow] = []
+
+    def _add(row: Any) -> None:
+        written_rows.append(row)
+
+    # sync_creatives session — first execute() returns "no existing" (so
+    # sync inserts via session.add), then transaction commits.
+    sync_existing_result = MagicMock()
+    sync_existing_result.scalar_one_or_none = MagicMock(return_value=None)
+    sync_session = MagicMock()
+    sync_session.__aenter__ = AsyncMock(return_value=sync_session)
+    sync_session.__aexit__ = AsyncMock(return_value=None)
+    sync_session.execute = AsyncMock(return_value=sync_existing_result)
+    sync_session.add = MagicMock(side_effect=_add)
+    sync_begin = MagicMock()
+    sync_begin.__aenter__ = AsyncMock(return_value=sync_begin)
+    sync_begin.__aexit__ = AsyncMock(return_value=None)
+    sync_session.begin = MagicMock(return_value=sync_begin)
+
+    # list_creatives session — count + page both yield the persisted
+    # row(s). Each ``scalars()`` call returns a fresh iterator since
+    # the platform consumes it inline via ``list(...)``.
+    def _hydrate_rows() -> list[CreativeRow]:
+        # Hydrate timestamps on the fly — SQLA defaults only fire on
+        # an actual INSERT, which the mock skips.
+        now = datetime.now(timezone.utc)
+        for r in written_rows:
+            r.created_at = now
+            r.updated_at = now
+        return list(written_rows)
+
+    def _list_session_factory() -> MagicMock:
+        count_result = MagicMock()
+        count_result.scalars = MagicMock(side_effect=lambda: iter(_hydrate_rows()))
+        page_result = MagicMock()
+        page_result.scalars = MagicMock(side_effect=lambda: iter(_hydrate_rows()))
+        s = MagicMock()
+        s.__aenter__ = AsyncMock(return_value=s)
+        s.__aexit__ = AsyncMock(return_value=None)
+        s.execute = AsyncMock(side_effect=[count_result, page_result])
+        return s
+
+    list_session = _list_session_factory()
+
+    # Sessionmaker returns sync_session first, then list_session.
+    session_iter = iter([sync_session, list_session])
+    sessionmaker = MagicMock(side_effect=lambda: next(session_iter))
+
+    platform = V3ReferenceSeller(sessionmaker=sessionmaker)
+
+    ctx = RequestContext(
+        buyer_agent=BuyerAgent(
+            agent_url="https://signed-buyer.example/",
+            display_name="Signed Buyer",
+            status="active",
+            billing_capabilities=frozenset({"operator"}),
+        ),
+        account=Account(
+            id="a_acme_1",
+            name="Signed Buyer — Main",
+            status="active",
+            metadata={
+                "tenant_id": "t_acme",
+                "buyer_agent_id": "ba_acme_signed",
+                "account_id": "signed-buyer-main",
+                "billing": "operator",
+                "sandbox": False,
+            },
+        ),
+    )
+
+    sync_req = SyncCreativesRequest.model_validate(
+        {
+            "account": {"account_id": "signed-buyer-main"},
+            "idempotency_key": "k_" + "a" * 18,
+            "creatives": [
+                {
+                    "creative_id": "spring-300x250",
+                    "name": "Spring 300x250 Display",
+                    "format_id": {
+                        "agent_url": "https://reference.adcp.org",
+                        "id": "display_300x250",
+                    },
+                    "assets": {},
+                }
+            ],
+        }
+    )
+    sync_resp = await platform.sync_creatives(sync_req, ctx)
+    assert len(written_rows) == 1
+    assert written_rows[0].creative_id == "spring-300x250"
+    # The sync response itself echoes the action.
+    assert sync_resp.creatives, "sync_creatives must echo persisted creatives"
+
+    list_resp = await platform.list_creatives(ListCreativesRequest(), ctx)
+    payload = list_resp.model_dump(mode="json", exclude_none=True)
+    assert payload["query_summary"]["returned"] == 1
+    assert payload["creatives"][0]["creative_id"] == "spring-300x250"


### PR DESCRIPTION
## Summary

Lifts the v3 reference seller from the five required sales methods to the full v6.0 rc.1 surface for a `sales-non-guaranteed` seller, and wires the account ops that exercise the 3.1-readiness `billing_entity.bank` projection guard.

Closes #376, #377, #378.

- **#376** — Adds the four optional Sales Protocol methods every `sales-*` specialism is required to expose in v6.0 rc.1+:
  - `get_media_buys` — list buys for the resolved account, limit/offset paged, scoped to `(tenant_id, account_id)`. Echoes `invoice_recipient` projected through `project_business_entity_for_response` so `bank` never leaks.
  - `provide_performance_feedback` — persists buyer-supplied performance signals to a new `performance_feedback` table FK'd to `media_buys`. Rejects with `MEDIA_BUY_NOT_FOUND` if the wire id doesn't resolve under this tenant.
  - `list_creative_formats` — static catalog (300x250 display, 728x90 leaderboard, video 16:9 30s).
  - `list_creatives` — sourced from a new `creatives` table populated by `sync_creatives`.
  - `sync_creatives` previously returned `[]` without persisting anything; it now upserts on `(tenant_id, creative_id)` and echoes per-row `action` (created/updated).

- **#377** — `sync_accounts` and `list_accounts`:
  - `sync_accounts` upserts under the authenticated buyer agent. Persists the full `BusinessEntity` payload (bank details included) on `billing_entity` JSON column — the durable invoicing record. The response payload echoes the entity through `project_business_entity_for_response` so bank details never leak on the wire.
  - `list_accounts` runs every account through `adcp.decisioning.project_account_for_response` before serialization. **This is the headline 3.1-readiness claim** — bank details cannot leak even when adopters persist them for invoicing.

- **#378** — `MediaBuy.invoice_recipient` first-class column:
  - New `Mapped[dict | None] = mapped_column(JSON, nullable=True)` column on the `MediaBuy` model.
  - `create_media_buy` extracts `req.invoice_recipient` (a `BusinessEntity | None`) and persists it.
  - `update_media_buy` patches it for per-buy invoice override semantics (3.1 setup).

### Models added
- `Creative` (account-scoped, manifest_json blob, unique on `(tenant_id, creative_id)`)
- `PerformanceFeedback` (FK'd to `media_buys`, JSON `value` carrying full request payload)

### Other changes
- `seed.py` seeds two example creatives so `list_creatives` returns something on first boot.

### Framework-level changes
None required — every wire type used (`GetMediaBuysResponse`, `ListAccountsResponse`, `SyncAccountsSuccessResponse`, `ListCreativeFormatsResponse`, `ListCreativesResponse`, `ProvidePerformanceFeedbackSuccessResponse`) is already exported from `adcp.types`. The projection helpers `project_account_for_response` / `project_business_entity_for_response` are already exported from `adcp.decisioning`.

## Test plan

- [x] `ruff check src/ examples/v3_reference_seller/` passes
- [x] `mypy src/adcp/` passes (in the project venv)
- [x] `pytest examples/v3_reference_seller/tests/ -v` — 13/13 passing (7 existing + 6 new in `test_smoke_broadening.py`)
- [x] `pytest tests/ -q` — 3200 passed, 21 skipped, 1 xfailed (full SDK suite, no regressions)
- [x] All 9 sales methods + `sync_accounts` / `list_accounts` callable on `V3ReferenceSeller`
- [x] `list_accounts` projection strips `billing_entity.bank` on every response (direct projection assertion + end-to-end mocked-session test)
- [x] `MediaBuy.invoice_recipient` populates from `CreateMediaBuyRequest`
- [x] Creative round-trip through `sync_creatives` → `list_creatives`

🤖 Generated with [Claude Code](https://claude.com/claude-code)