### PR TITLE
feat(testing): storyboard runner matrix entry for v3 reference seller (#410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,3 +417,201 @@ jobs:
           name: storyboard-result-${{ github.run_attempt }}
           path: storyboard-result.json
           if-no-files-found: warn
+
+  storyboard-v3-reference-seller:
+    name: AdCP storyboard runner — examples/v3_reference_seller/src/app.py
+    runs-on: ubuntu-latest
+    # Non-blocking on first land. The v3 reference seller wires the
+    # full Tier 2 commercial-identity gate, subdomain tenant routing,
+    # validation in strict mode, and traffic counters — but it has
+    # never been exercised by the canonical storyboard runner, so any
+    # gap (auth shape, fixture mismatch, unimplemented sub-skill)
+    # surfaces here first. Promote to required once the
+    # sales-non-guaranteed bundle reports overall_status: passing.
+    continue-on-error: true
+
+    services:
+      postgres:
+        # CI-local ephemeral database. Same trust-auth pattern as
+        # ``pg-conformance`` above: GitHub's CI network is the trust
+        # boundary, and shipping a literal password here flags
+        # secret-scanners for no benefit.
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: adcp
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        # The v3 reference seller pulls in SQLAlchemy + asyncpg, which
+        # the SDK itself doesn't depend on. They're example-local
+        # deps, installed inline so the CI job doesn't bloat the
+        # SDK's own [dev] extra.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install "sqlalchemy[asyncio]>=2.0" asyncpg
+
+      - name: Add acme.localhost hosts entry
+        # SubdomainTenantMiddleware reads the ``Host`` header to pick
+        # the tenant. The seed plants ``acme.localhost`` as the tenant
+        # host, so the storyboard runner must reach the seller via
+        # that name — not 127.0.0.1. Ubuntu runners route ``*.localhost``
+        # via nss-myhostname today, but pinning the entry explicitly
+        # avoids depending on distro NSS behavior.
+        run: |
+          echo "127.0.0.1 acme.localhost" | sudo tee -a /etc/hosts
+          getent hosts acme.localhost
+
+      - name: Seed dev fixtures
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres@localhost:5432/adcp
+        run: |
+          cd examples/v3_reference_seller
+          python -m seed
+
+      - name: Start v3 reference seller
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres@localhost:5432/adcp
+          PORT: "3001"
+        run: |
+          cd examples/v3_reference_seller
+          python -m src.app &
+          AGENT_PID=$!
+          echo "AGENT_PID=$AGENT_PID" >> "$GITHUB_ENV"
+          for i in $(seq 1 60); do
+            # Hit the seller via the seeded tenant host so the
+            # SubdomainTenantMiddleware resolves ``acme.localhost`` →
+            # ``t_acme`` and the request progresses past the 404
+            # ``unknown-host`` early-return.
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
+              http://acme.localhost:3001/mcp 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" != "000" ] && [ "$HTTP_CODE" != "404" ]; then
+              echo "v3 reference seller ready (HTTP ${HTTP_CODE}, pid ${AGENT_PID})"
+              break
+            fi
+            if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+              echo "v3 reference seller process died during startup"
+              exit 1
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "v3 reference seller failed to start within 30s"
+              kill "$AGENT_PID" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+
+      - name: Run storyboard suite (sales-non-guaranteed)
+        timeout-minutes: 5
+        # The v3 reference seller declares the ``sales-non-guaranteed``
+        # specialism (``V3ReferenceSeller.capabilities.specialisms``).
+        # That bundle covers the nine sales-non-guaranteed methods the
+        # platform ships — the right contract surface to grade. The
+        # universal capability-discovery + error-compliance bundles
+        # are also exercised by the runner's default capability-driven
+        # selection, but pinning the bundle keeps the report focused.
+        #
+        # Bearer auth: ``seed.py`` plants ``dev-bearer-token-acme-1``
+        # for ``ba_acme_bearer``. The SDK's adopter-bearer middleware
+        # is not wired in ``app.py`` yet, so the runner reaches the
+        # platform via the no-auth code path the framework allows for
+        # dev seeds. If this proves insufficient (storyboard requires
+        # an authenticated identity for some skills) the run will fail
+        # here — that's the diagnostic signal to wire the bearer
+        # middleware as a follow-up.
+        run: |
+          npx -y -p @adcp/client@latest adcp storyboard run \
+            http://acme.localhost:3001/mcp sales-non-guaranteed \
+            --json --allow-http \
+            > storyboard-result.json
+
+      - name: Assert storyboard pass
+        run: |
+          python -c "
+          import json, sys, pathlib
+          p = pathlib.Path('storyboard-result.json')
+          if not p.exists() or p.stat().st_size == 0:
+              print('storyboard-result.json missing or empty — runner produced no output')
+              sys.exit(1)
+          with p.open() as f:
+              d = json.load(f)
+          if d.get('overall_status') != 'passing':
+              print(json.dumps(d, indent=2))
+              sys.exit(1)
+          "
+
+      - name: Assert anti-façade traffic counters non-zero
+        # PR #405 wired ``InMemoryMockAdServer`` + ``/_debug/traffic``
+        # so storyboard runs can prove the platform actually delegated
+        # to its upstream ad server, rather than fabricating responses
+        # in the dispatch layer. The seller's ``app.py`` opts in via
+        # ``enable_debug_endpoints=True`` (the production default is
+        # off). After the storyboard run, both ``media_buy.create``
+        # and ``creatives.upload`` counters must be > 0 — anything
+        # else means the storyboard didn't reach those skills, or
+        # the platform is short-circuiting.
+        run: |
+          # The debug endpoint is mounted as the OUTERMOST asgi
+          # middleware (see ``_prepend_debug_endpoint`` in
+          # ``adcp.server.serve``), so it runs before
+          # ``SubdomainTenantMiddleware`` and the host header doesn't
+          # need to match a seeded tenant. 127.0.0.1 is fine here.
+          curl -fsS http://127.0.0.1:3001/_debug/traffic > traffic.json
+          cat traffic.json
+          python -c "
+          import json, sys
+          with open('traffic.json') as f:
+              t = json.load(f)
+          # /_debug/traffic returns a flat dict of {method_name: count}
+          # — see DebugTrafficMiddleware in adcp.server.debug_endpoints.
+          # The reference seller's platform records ``media_buy.create``
+          # and ``creative.upload`` (singular — see ``_record`` calls in
+          # examples/v3_reference_seller/src/platform.py).
+          create = t.get('media_buy.create', 0)
+          upload = t.get('creative.upload', 0)
+          if create == 0:
+              print(f'media_buy.create counter is 0 — platform did not reach the mock ad server')
+              print(json.dumps(t, indent=2))
+              sys.exit(1)
+          if upload == 0:
+              print(f'creative.upload counter is 0 — platform did not reach the mock ad server')
+              print(json.dumps(t, indent=2))
+              sys.exit(1)
+          print(f'OK — media_buy.create={create}, creative.upload={upload}')
+          "
+
+      - name: Stop v3 reference seller
+        if: always()
+        run: |
+          if [ -n "${AGENT_PID:-}" ]; then
+            kill "$AGENT_PID" 2>/dev/null || true
+          fi
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storyboard-v3-result-${{ github.run_attempt }}
+          path: |
+            storyboard-result.json
+            traffic.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Adds a CI job that runs the AdCP storyboard runner against
`examples/v3_reference_seller/src/app.py` — the canonical multi-tenant
v3 seller that ships every Tier 2 / v3-supporting component the SDK
provides. Until now the storyboard CI job only targeted the simpler
`examples/seller_agent.py`, so the v3 ref seller's nine sales-non-guaranteed
methods, projection guard, strict schema validation, and anti-façade
traffic counters shipped unverified at the storyboard level.

## What the job does

- Spins up an ephemeral Postgres 16 service (same trust-auth pattern
  as the existing `pg-conformance` job).
- Installs SQLAlchemy + asyncpg inline (example-local deps, not in
  the SDK's `[dev]` extra).
- Pins `acme.localhost → 127.0.0.1` in `/etc/hosts` so the runner
  reaches the seller via the seeded tenant host that
  `SubdomainTenantMiddleware` resolves to `t_acme`.
- Runs `python -m seed` to plant the two-tenant / three-buyer-agent /
  two-account fixture set.
- Boots the seller via `python -m src.app` against the CI Postgres.
- Runs `adcp storyboard run … sales-non-guaranteed` — the specialism
  bundle matching `V3ReferenceSeller.capabilities.specialisms`.
- Asserts `overall_status: passing`.
- Polls `GET /_debug/traffic` and asserts both `media_buy.create`
  and `creative.upload` counters are non-zero (anti-façade contract
  from #405).

## Why `continue-on-error: true` on first land

The v3 reference seller has never been exercised by the canonical
runner, so any contract gap surfaces here first:

- **Auth shape** — `seed.py` plants `dev-bearer-token-acme-1` for the
  bearer agent, but `app.py` does not yet wire the bearer-extracting
  middleware. The runner reaches the platform via the framework's
  no-auth dev path; storyboards that require a bound `ctx.buyer_agent`
  for some skills may need explicit bearer auth wiring as a follow-up.
- **Bundle scope** — `sales-non-guaranteed` was chosen because it
  matches the platform's declared specialism. Storyboards in that
  bundle requiring features the ref seller doesn't implement (e.g.
  brand-rights, audience-sync) will surface as failures here.

The non-blocking mode lets the job ship in CI for visibility and
artifact upload while we close gaps; promote to required once the
bundle reports passing end-to-end.

## Storyboard / bundle choice

`V3ReferenceSeller` declares `sales-non-guaranteed` in
`capabilities.specialisms`. The storyboard runner ships a
`sales-non-guaranteed` specialism bundle (visible in
`adcp storyboard list --json`) — that's the right contract surface to
grade. The runner's default capability-driven selection would also
exercise universal bundles (capability-discovery, error-compliance,
schema-validation), but pinning to `sales-non-guaranteed` keeps the
report focused and the assertion clear.

## Traffic-counter assertion

The reference seller's platform records:

- `media_buy.create` — `examples/v3_reference_seller/src/platform.py:324`
- `creative.upload` (singular) — `examples/v3_reference_seller/src/platform.py:460`

The assertion asserts both counters are > 0 after the storyboard run.
Anything else means the storyboard didn't reach those skills, or the
platform is short-circuiting in the dispatch layer (the textbook
façade-adapter failure mode #405 was designed to catch).

## Test plan

- [ ] Job runs on this PR.
- [ ] If it passes: promote to required as a follow-up (drop
      `continue-on-error: true`).
- [ ] If it fails: the `storyboard-v3-result-*` artifact carries
      `storyboard-result.json` and `traffic.json` for diagnosis.
      File the gap as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)