### PR TITLE
docs(adcp): document git worktree isolation pattern for parallel agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ agent an isolated checkout.
 > **Note:** Conductor worktrees handle this automatically via `.conductor.json`
 > (runs `setup_conductor_env.py` + `pre-commit install` on create). Use the
 > manual steps below only for raw `git worktree` outside of Conductor.
+> See `CONDUCTOR.md` for Conductor-specific setup and troubleshooting.
 
 **Create a worktree:**
 
@@ -169,7 +170,7 @@ git worktree add /tmp/claude-issue-<N>-<slug> -b claude/issue-<N>-<slug> main
 
 ```bash
 cd /tmp/claude-issue-<N>-<slug>
-cp /path/to/repo-root/.env .env   # .env is not inherited; copy from repo root
+cp "$(git rev-parse --git-common-dir)/../.env" .env   # .env is not inherited
 pre-commit install                 # hooks are not inherited from parent worktree
 pip install -e .[dev]              # install in this worktree's context
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,41 @@ pytest tests/ -v          # Tests
 
 All three must pass. CI runs them across Python 3.10–3.13; locally running on your current version catches most issues.
 
+## Parallel Agent Isolation (git worktrees)
+
+When multiple agents work in the same checkout simultaneously, they clobber each other's
+branches — there is no error, the work is silently lost. Use `git worktree` to give each
+agent an isolated checkout.
+
+> **Note:** Conductor worktrees handle this automatically via `.conductor.json`
+> (runs `setup_conductor_env.py` + `pre-commit install` on create). Use the
+> manual steps below only for raw `git worktree` outside of Conductor.
+
+**Create a worktree:**
+
+```bash
+git worktree add /tmp/claude-issue-<N>-<slug> -b claude/issue-<N>-<slug> main
+```
+
+**Setup checklist (run inside the new worktree):**
+
+```bash
+cd /tmp/claude-issue-<N>-<slug>
+cp /path/to/repo-root/.env .env   # .env is not inherited; copy from repo root
+pre-commit install                 # hooks are not inherited from parent worktree
+pip install -e .[dev]              # install in this worktree's context
+```
+
+**Teardown (after branch is merged):**
+
+```bash
+git worktree remove /tmp/claude-issue-<N>-<slug>
+# or: git worktree prune   # removes all stale worktrees at once
+```
+
+**Branch naming:** always follow `claude/issue-<N>-<short-slug>` — branch-protection
+rules enforce this pattern and PRs from non-conforming names may be rejected.
+
 ## Additional Important Reminders
 
 **NEVER**:


### PR DESCRIPTION
Closes #418

Adds a "Parallel Agent Isolation (git worktrees)" section to `CLAUDE.md` documenting the `git worktree add /tmp/<branch>` pattern that prevents parallel agents from clobbering each other's branches. The section covers: why isolation is needed (silent branch collision), the create command with the correct `claude/issue-<N>-<slug>` branch naming, a setup checklist (`.env` copy via `git rev-parse --git-common-dir`, `pre-commit install`, `pip install -e .[dev]`), teardown, and a pointer to `CONDUCTOR.md` for Conductor-managed worktrees.

**What was tested:**
- Docs-only change (`CLAUDE.md`); no Python source touched — build/pytest gate skipped per triage-prompt rule for markdown-only diffs
- `git rev-parse --git-common-dir` verified to resolve to main worktree `.git` dir in linked-worktree context
- All commands verified for correct syntax (`git worktree add <path> -b <branch> <commit>` confirmed valid per man page)

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit: `cp` could note missing-file case (cosmetic)
- docs-expert: approved — no blockers; nit: `cd` in checklist is redundant with the "run inside the new worktree" label (cosmetic)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017TUh8WYUoUWzdxDQMPLM5t

---
_Generated by [Claude Code](https://claude.ai/code/session_017TUh8WYUoUWzdxDQMPLM5t)_