### PR TITLE
fix(ci): add --extra dev to pre-commit mypy hook to include types-protobuf stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: uv run mypy
+        entry: uv run --extra dev mypy  # --extra dev ensures types-protobuf stubs are present
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
Closes #411

Without `--extra dev`, `uv run mypy` does not activate `[project.optional-dependencies] dev`, which contains `types-protobuf`. The missing stubs cause 96 false-positive errors from `a2a`/`google.protobuf` imports in `client.py` and `protocols/a2a.py`. CI passes cleanly because it installs dev extras explicitly (`pip install -e ".[dev]"`). Adding `--extra dev` makes the pre-commit environment match CI so the hook no longer needs routine `SKIP=mypy` bypasses.

**What was tested:**
- `uv run --extra dev pytest tests/ -q` (excluding the pre-existing network-bound signing test `test_real_tls_handshake_still_validates_hostname`): **3188 passed, 26 skipped, 1 xfailed**
- Pre-existing signing-test failure confirmed on `main` before this change (unrelated: real TLS call to `example.com` returns 403 in the sandbox)
- YAML syntax validated

**Pre-PR review:**
- code-reviewer: approved — 1 nit: notes `types-protobuf` is duplicated in both `[project.optional-dependencies] dev` and `[dependency-groups] dev`; `--extra dev` is the correct flag to activate the former (where CI installs from)
- dx-expert: approved — nit: `--group dev` is the more semantically idiomatic uv flag since `uv add --dev` writes to `[dependency-groups]`; both flags work today because the stub is duplicated in both sections; inline comment is sufficient

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012s2eENfKoeaeeHUyV7Rd9y

---
_Generated by [Claude Code](https://claude.ai/code/session_012s2eENfKoeaeeHUyV7Rd9y)_