### PR TITLE
fix(testing): make a2a_compat_shim resilient to wrong a2a-sdk in /tmp worktrees

### DIFF
--- a/tests/a2a_compat_shim.py
+++ b/tests/a2a_compat_shim.py
@@ -25,6 +25,7 @@ behavior the adapter or wire serializer could silently depend on.
 from __future__ import annotations
 
 import sys
+import warnings
 from typing import Any
 
 from a2a import types as pb
@@ -62,26 +63,45 @@ __all__ = [
 ]
 
 
+def _proto_alias(cls: Any, src: str, dst: str) -> None:
+    """Set cls.dst = cls.src, warning independently per alias if src is absent.
+
+    Guarding each alias independently avoids partial-patch state: if one
+    source attribute is missing the rest still land, and each missing
+    attribute gets its own actionable warning rather than a group abort.
+    """
+    if not hasattr(cls, src):
+        warnings.warn(
+            f"a2a_compat_shim: {cls.__name__}.{src} not found — "
+            "verify a2a-sdk>=1.0.1,<1.0.2 is installed. "
+            "Run: pip install 'a2a-sdk>=1.0.1,<1.0.2'. A2A tests may fail.",
+            RuntimeWarning,
+            stacklevel=1,
+        )
+        return
+    setattr(cls, dst, getattr(cls, src))
+
+
 # --- Role enum backwards-compat aliases (attribute-level monkey-patch) ---
 # ``Role.user`` / ``Role.agent`` didn't exist on the proto enum; tests
 # referenced them verbatim. Adding them once here means every call site
 # (``role=Role.user``) keeps compiling without per-file edits.
-pb.Role.user = pb.Role.ROLE_USER  # type: ignore[attr-defined]
-pb.Role.agent = pb.Role.ROLE_AGENT  # type: ignore[attr-defined]
+_proto_alias(pb.Role, "ROLE_USER", "user")
+_proto_alias(pb.Role, "ROLE_AGENT", "agent")
 
 
 # --- TaskState backwards-compat aliases ---
 # Tests reference ``TaskState.working`` / ``TaskState.completed`` / etc.
 # Proto enums don't have these symbol-shaped attributes; shim them in.
-pb.TaskState.completed = pb.TaskState.TASK_STATE_COMPLETED  # type: ignore[attr-defined]
-pb.TaskState.failed = pb.TaskState.TASK_STATE_FAILED  # type: ignore[attr-defined]
-pb.TaskState.working = pb.TaskState.TASK_STATE_WORKING  # type: ignore[attr-defined]
-pb.TaskState.submitted = pb.TaskState.TASK_STATE_SUBMITTED  # type: ignore[attr-defined]
-pb.TaskState.input_required = pb.TaskState.TASK_STATE_INPUT_REQUIRED  # type: ignore[attr-defined]
-pb.TaskState.auth_required = pb.TaskState.TASK_STATE_AUTH_REQUIRED  # type: ignore[attr-defined]
-pb.TaskState.canceled = pb.TaskState.TASK_STATE_CANCELED  # type: ignore[attr-defined]
-pb.TaskState.rejected = pb.TaskState.TASK_STATE_REJECTED  # type: ignore[attr-defined]
-pb.TaskState.unknown = pb.TaskState.TASK_STATE_UNSPECIFIED  # type: ignore[attr-defined]
+_proto_alias(pb.TaskState, "TASK_STATE_COMPLETED", "completed")
+_proto_alias(pb.TaskState, "TASK_STATE_FAILED", "failed")
+_proto_alias(pb.TaskState, "TASK_STATE_WORKING", "working")
+_proto_alias(pb.TaskState, "TASK_STATE_SUBMITTED", "submitted")
+_proto_alias(pb.TaskState, "TASK_STATE_INPUT_REQUIRED", "input_required")
+_proto_alias(pb.TaskState, "TASK_STATE_AUTH_REQUIRED", "auth_required")
+_proto_alias(pb.TaskState, "TASK_STATE_CANCELED", "canceled")
+_proto_alias(pb.TaskState, "TASK_STATE_REJECTED", "rejected")
+_proto_alias(pb.TaskState, "TASK_STATE_UNSPECIFIED", "unknown")
 
 
 Role = pb.Role

--- a/tests/a2a_compat_shim.py
+++ b/tests/a2a_compat_shim.py
@@ -76,7 +76,7 @@ def _proto_alias(cls: Any, src: str, dst: str) -> None:
             "verify a2a-sdk>=1.0.1,<1.0.2 is installed. "
             "Run: pip install 'a2a-sdk>=1.0.1,<1.0.2'. A2A tests may fail.",
             RuntimeWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
         return
     setattr(cls, dst, getattr(cls, src))
@@ -145,6 +145,12 @@ def Message(  # noqa: N802 (0.3 fixture shim)
     return pb.Message(**kwargs)
 
 
+# Note: this dict accesses pb.TaskState.TASK_STATE_* directly (no _proto_alias guard).
+# Any AttributeError here propagates out of the module, but conftest.py's
+# `except (ImportError, AttributeError)` catches it and sets _a2a_compat_shim=None,
+# so collection still succeeds. _proto_alias guards only the setattr side-effects;
+# this dict is purely read-only at construction and is only reached when pb.TaskState
+# has the correct 1.0 shape.
 _STATE_STRING_MAP: dict[str, pb.TaskState.ValueType] = {
     "completed": pb.TaskState.TASK_STATE_COMPLETED,
     "failed": pb.TaskState.TASK_STATE_FAILED,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings as _warnings
 from pathlib import Path
 from types import UnionType
 from typing import Any
@@ -10,7 +11,18 @@ from pydantic import TypeAdapter
 # Import the a2a-sdk 1.0 compat shim early so monkey-patches like
 # ``Role.user = ROLE_USER`` and ``TaskStatus.__init__`` string coercion
 # land before any test module constructs those proto types.
-from tests import a2a_compat_shim as _a2a_compat_shim  # noqa: F401
+# Guard with try/except so a missing or wrong-version a2a-sdk doesn't
+# break collection — only A2A tests that actually use the shim will fail.
+try:
+    from tests import a2a_compat_shim as _a2a_compat_shim
+except (ImportError, AttributeError) as _shim_exc:
+    _warnings.warn(
+        f"a2a_compat_shim unavailable ({_shim_exc}); "
+        "run: pip install 'a2a-sdk>=1.0.1,<1.0.2'. A2A tests may fail.",
+        RuntimeWarning,
+        stacklevel=1,
+    )
+    _a2a_compat_shim = None  # type: ignore[assignment]
 
 _INTEGRATION_DIR = (Path(__file__).parent / "integration").resolve()
 
@@ -48,7 +60,7 @@ def _a2a_compat_send_and_aggregate(
     a real a2a-sdk server and must NOT be shimmed — they rely on the
     genuine async-generator contract.
     """
-    if _is_integration_test(request):
+    if _a2a_compat_shim is None or _is_integration_test(request):
         return
     _a2a_compat_shim.patch_send_and_aggregate(monkeypatch)
 


### PR DESCRIPTION
Closes #419

## Summary

`tests/a2a_compat_shim.py` assigned `pb.Role.user = pb.Role.ROLE_USER` (and 9 similar aliases) at module scope with no guard. When `a2a-sdk` is absent or at the wrong version in a fresh `/tmp` worktree, these raise `AttributeError` at import time; `conftest.py`'s top-level `from tests import a2a_compat_shim` propagated that error to pytest collection, aborting all test gathering.

Two changes:

- **`tests/a2a_compat_shim.py`**: introduce `_proto_alias(cls, src, dst)` that guards each alias independently via `hasattr`. Each missing attribute emits a `RuntimeWarning` with the exact install command (`pip install 'a2a-sdk>=1.0.1,<1.0.2'`) and `stacklevel=2` so the warning points at the `_proto_alias(pb.Role, ...)` call site in the module body. A comment at `_STATE_STRING_MAP` documents that any `AttributeError` there is caught upstream by conftest's import guard (the asymmetric guard pattern is intentional — that dict is purely read-only at construction and only reachable once `pb.TaskState` has the correct 1.0 shape).

- **`tests/conftest.py`**: wrap the shim import in `except (ImportError, AttributeError)` — `RuntimeError` is intentionally *not* caught so the shim's pytest-process guard still fires loudly for non-test callers. Falls back to `_a2a_compat_shim = None`; the autouse fixture no-ops when `None` rather than `pytest.skip`-ing everything (that would mark ~3000 non-A2A unit tests as skipped, which is incorrect).

**Note on degraded-env behavior:** when the shim is `None`, `A2AAdapter._send_and_aggregate` is not patched and unit tests that mock `send_message` as `AsyncMock(return_value=...)` will fail at runtime rather than at collection time. This is the correct trade-off — collection always succeeds; only A2A tests fail, and they fail with informative errors rather than a global abort.

## What tested

- `pytest tests/test_a2a_server.py tests/test_protocols.py tests/test_backward_compat.py -x -q` → **143 passed, 1 xfailed**
- `pytest tests/test_client.py tests/test_capabilities.py tests/test_type_aliases.py tests/test_public_api.py -x -q` → **171 passed**
- `mypy src/adcp/` → **Success: no issues found in 749 source files**
- `ruff check tests/a2a_compat_shim.py tests/conftest.py` → **All checks passed**

## Pre-PR review

- **code-reviewer**: approved — no blockers; `stacklevel=2` nit addressed; `_STATE_STRING_MAP` asymmetry documented per reviewer request
- **dx-expert**: approved — ship with `stacklevel=2` fix applied; autouse no-op design (vs. `pytest.skip`) confirmed correct; other nits (`state_to_pb` KeyError message, `_taskstatus_init` silent timestamp drop) are pre-existing and out of scope for this fix

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01AnL37fUet4e3yXt9YBxd7a

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnL37fUet4e3yXt9YBxd7a)_