### PR TITLE
perf(server): lazy-load Pydantic schema generation to fix storyboard readiness flake

### DIFF
--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -1224,8 +1224,8 @@ def _generate_pydantic_schemas() -> dict[str, dict[str, Any]]:
     spec-accurate schemas with proper field types, descriptions,
     required fields, and nested ``$defs``.
 
-    The result is applied to ``ADCP_TOOL_DEFINITIONS`` at import time
-    by :func:`_apply_pydantic_schemas`. Any tool whose generation
+    The result is applied to ``ADCP_TOOL_DEFINITIONS`` lazily on first
+    ``tools/list`` call by :func:`_ensure_pydantic_schemas_applied`. Any tool whose generation
     fails (or whose request model has no mapping here) silently keeps
     its hand-crafted stub; ``tests/test_mcp_schema_drift.py`` guards
     against that regression by asserting every tool has an entry here.
@@ -1558,9 +1558,12 @@ def _generate_pydantic_output_schemas() -> dict[str, dict[str, Any]]:
     return schemas
 
 
-# Generate schemas once at import time
-_PYDANTIC_SCHEMAS = _generate_pydantic_schemas()
-_PYDANTIC_OUTPUT_SCHEMAS = _generate_pydantic_output_schemas()
+# Schemas are populated lazily on the first tools/list call to avoid
+# heavy Pydantic type imports at module import time. Use .update() so
+# external references bound before init (e.g. in tests) stay valid.
+_PYDANTIC_SCHEMAS: dict[str, dict[str, Any]] = {}
+_PYDANTIC_OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {}
+_schemas_applied = False
 
 
 def _apply_pydantic_schemas() -> None:
@@ -1580,7 +1583,22 @@ def _apply_pydantic_schemas() -> None:
             tool_def["outputSchema"] = _PYDANTIC_OUTPUT_SCHEMAS[name]
 
 
-_apply_pydantic_schemas()
+def _ensure_pydantic_schemas_applied() -> None:
+    """Lazily populate Pydantic schemas and apply them to tool definitions.
+
+    Safe to call multiple times — subsequent calls are no-ops. Called
+    automatically by :func:`get_tools_for_handler` on first invocation.
+    Tests that read :data:`_PYDANTIC_SCHEMAS` or ``ADCP_TOOL_DEFINITIONS``
+    schema fields directly should call this first (or use the session-scoped
+    conftest fixture that does so automatically).
+    """
+    global _schemas_applied
+    if _schemas_applied:
+        return
+    _PYDANTIC_SCHEMAS.update(_generate_pydantic_schemas())
+    _PYDANTIC_OUTPUT_SCHEMAS.update(_generate_pydantic_output_schemas())
+    _apply_pydantic_schemas()
+    _schemas_applied = True
 
 
 def _is_sdk_base_class(cls_name: str) -> bool:
@@ -1718,6 +1736,7 @@ def get_tools_for_handler(
     Returns:
         Filtered list of tool definitions.
     """
+    _ensure_pydantic_schemas_applied()
     cls = handler if isinstance(handler, type) else type(handler)
     instance = handler if not isinstance(handler, type) else None
 

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -1586,11 +1586,12 @@ def _apply_pydantic_schemas() -> None:
 def _ensure_pydantic_schemas_applied() -> None:
     """Lazily populate Pydantic schemas and apply them to tool definitions.
 
-    Safe to call multiple times — subsequent calls are no-ops. Called
-    automatically by :func:`get_tools_for_handler` on first invocation.
-    Tests that read :data:`_PYDANTIC_SCHEMAS` or ``ADCP_TOOL_DEFINITIONS``
-    schema fields directly should call this first (or use the session-scoped
-    conftest fixture that does so automatically).
+    Mutates :data:`ADCP_TOOL_DEFINITIONS` in-place, replacing each tool's
+    ``inputSchema`` with the Pydantic-generated schema and adding
+    ``outputSchema``. Safe to call multiple times — subsequent calls are
+    no-ops. Called automatically by :func:`create_mcp_tools` /
+    :func:`get_tools_for_handler`; callers outside those paths (e.g. tests
+    or doc generators) must invoke this before reading schema fields.
     """
     global _schemas_applied
     if _schemas_applied:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,15 @@ from tests import a2a_compat_shim as _a2a_compat_shim  # noqa: F401
 _INTEGRATION_DIR = (Path(__file__).parent / "integration").resolve()
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _ensure_pydantic_schemas() -> None:
+    """Trigger lazy Pydantic schema init so ADCP_TOOL_DEFINITIONS has
+    inputSchema/outputSchema populated for any test that reads them directly."""
+    from adcp.server.mcp_tools import _ensure_pydantic_schemas_applied
+
+    _ensure_pydantic_schemas_applied()
+
+
 def _is_integration_test(request: pytest.FixtureRequest) -> bool:
     """Is this test under ``tests/integration/``?
 

--- a/tests/test_mcp_schema_drift.py
+++ b/tests/test_mcp_schema_drift.py
@@ -2,8 +2,8 @@
 
 The MCP tool registry exposes ``inputSchema`` for every ADCP tool via
 ``tools/list``. These schemas are auto-generated from the corresponding
-Pydantic request models in ``adcp.types`` at import time
-(:func:`adcp.server.mcp_tools._generate_pydantic_schemas`).
+Pydantic request models in ``adcp.types`` on first ``tools/list`` call
+(:func:`adcp.server.mcp_tools._ensure_pydantic_schemas_applied`).
 
 This module protects the generation path from regressions:
 
@@ -59,7 +59,7 @@ def test_input_schemas_match_pydantic_generation() -> None:
 
     assert not mismatches, (
         "ADCP_TOOL_DEFINITIONS has stale inputSchemas — "
-        "`_apply_pydantic_schemas()` must run at import time:\n"
+        "call `_ensure_pydantic_schemas_applied()` (or `create_mcp_tools()`) first:\n"
         + "\n".join(f"  - {name}" for name in mismatches)
     )
 

--- a/tests/test_spec_coverage.py
+++ b/tests/test_spec_coverage.py
@@ -213,8 +213,9 @@ def test_mcp_tool_input_schema_matches_pydantic_models():
 
     assert drift == [], (
         "MCP tool inputSchema fields have drifted from Pydantic models.\n"
-        "The inputSchema is auto-generated from the request model at\n"
-        "import time; this drift shouldn't be possible unless schema\n"
-        "generation is broken. See tests/test_mcp_schema_drift.py.\n"
+        "The inputSchema is auto-generated from the request model on first\n"
+        "tools/list call (_ensure_pydantic_schemas_applied()); this drift\n"
+        "shouldn't be possible unless schema generation is broken.\n"
+        "See tests/test_mcp_schema_drift.py.\n"
         + "\n".join(f"  - {d}" for d in drift)
     )

--- a/tests/test_spec_coverage.py
+++ b/tests/test_spec_coverage.py
@@ -173,8 +173,8 @@ def test_tool_filtering_by_handler_type():
 def test_mcp_tool_input_schema_matches_pydantic_models():
     """MCP tool inputSchemas are generated from Pydantic request models.
 
-    The ``ADCP_TOOL_DEFINITIONS[*].inputSchema`` is overwritten at import
-    time by ``_apply_pydantic_schemas()`` with the output of
+    The ``ADCP_TOOL_DEFINITIONS[*].inputSchema`` is overwritten on first
+    ``tools/list`` call by ``_ensure_pydantic_schemas_applied()`` with the output of
     ``model_json_schema()`` on the corresponding ``<ToolName>Request``
     model. This test is a coarse guard that every tool with a mapped
     request model carries a schema advertising every field of that


### PR DESCRIPTION
Closes #412

## Summary

`_generate_pydantic_schemas()`, `_generate_pydantic_output_schemas()`, and `_apply_pydantic_schemas()` previously ran at module import time, causing ~4.5s of Pydantic type-import and schema-generation work to race with the storyboard readiness probe. This produced "Agent unreachable" failures across PRs #391, #405, #406, #407.

Schema generation is now deferred to the first `get_tools_for_handler()` call, which fires during `create_mcp_tools()` at server construction — after the process is ready but before any wire request arrives. `_PYDANTIC_SCHEMAS` and `_PYDANTIC_OUTPUT_SCHEMAS` start as empty `{}` dicts and are populated via `.update()` so any external references (test files importing those symbols) stay valid. A `_schemas_applied` sentinel makes subsequent calls no-ops (~0ms on the hot path).

## What tested

- `pytest tests/test_mcp_schema_drift.py tests/test_tools_list_output_schema.py tests/test_spec_coverage.py tests/test_server_dx.py` — 78 passed
- `pytest tests/` (excluding integration/conformance) — **2816 passed, 17 skipped, 1 xfailed**
- `mypy src/adcp/` — no issues (749 source files)
- `ruff check src/` — all checks passed
- Import-time delta measured: ~4.5s of schema generation moved out of `import adcp.server` onto first `create_mcp_tools()` call

## Test infrastructure change

`tests/conftest.py` gains a `scope="session"` autouse fixture that calls `_ensure_pydantic_schemas_applied()` before any test body runs. This ensures tests that import `_PYDANTIC_SCHEMAS` or read `ADCP_TOOL_DEFINITIONS["inputSchema"]`/`["outputSchema"]` directly continue to see the Pydantic-generated schemas rather than the hand-crafted stubs.

## Nits (not fixed — noted for awareness)

- `_schemas_applied` has no type annotation (mypy infers `bool` correctly from the global rebinding)
- No `logger.warning` if generation raises — exception propagates to `create_mcp_tools()` caller, same as old import-time crash behavior; per-tool failures still produce `logger.debug` as before

## Pre-PR review

- **code-reviewer**: approved — call site in `get_tools_for_handler` is correct; schemas are applied before `_register_handler_tools` reads `outputSchema` from returned dicts; `.update()` mutation is safe; no blockers
- **dx-expert**: approved (1 blocker fixed — stale "at import time" in `test_spec_coverage.py` assertion message; fixed in follow-up commit); 3 nits noted above

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01NnoQN3c6Wi5LY5DEUBp8W2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnoQN3c6Wi5LY5DEUBp8W2)_