### PR TITLE
chore: silent triage on already-final-state comments

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -460,9 +460,15 @@ the original `<<<UNTRUSTED_ISSUE_BODY>>>`.
 4. If substantive and **unlocks a stuck Clarify**: move forward
    per outcome rules.
 5. If substantive but the issue is in a final state (PR drafted,
-   deferred with linkage, flagged): post a brief acknowledgment
-   that routes the new info to the open PR or refreshes the defer
-   reasoning.
+   deferred with linkage, flagged): **silent by default.** A
+   read-receipt is noise — the issue's state already reflects the
+   prior decision. Comment **only** when the new info would
+   materially change the disposition (invalidates the prior defer,
+   surfaces a new blocker, reopens a settled question). In that
+   case, treat the comment as a re-trigger and re-run the relevant
+   experts (rule 3) — don't post a bare "acknowledged / noted /
+   standing by for CI" ack. Reading the thread is invisible work;
+   if there's nothing to add, leave the silence intact.
 6. Never reply to your own previous comments (workflow filters
    most cases via the `Triaged by Claude Code` footer). Never
    reply to bots.


### PR DESCRIPTION
## Summary

Mirrors adcontextprotocol/adcp#3938 — cuts read-receipt noise from the triage routine.

The Comment-engagement branch for already-final-state issues (PR drafted, deferred with linkage, flagged for human) was posting brief acknowledgments ("acknowledged — noted", "standing by for CI green") that announced the routine had read the thread without adding signal. The routine now stays silent on those threads by default; engagement requires the new info to actually change the disposition, in which case it re-runs experts (rule 3 path) rather than posting a bare ack.

Same fix applied across all four AdCP repos with active triage routines.

## Test plan
- [ ] Next `comment.created` run on a final-state issue with an ack-shaped comment: routine silent.
- [ ] Substantive challenges (rule 3 path) and Clarify-unlocks (rule 4 path) unchanged.
- [ ] First-pass triage (`auto.opened`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)