### PR TITLE
fix(ci): add concurrency group to cancel superseded runs on force-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Closes #413. Force-pushes did not retrigger the Test Python matrix because the previous run's lightweight jobs (conventional-commits, IPR) still held the free-tier runner slots; the matrix for the new SHA was queued but never scheduled. Required \`gh pr close && gh pr reopen\` to work around.

This adds a per-ref concurrency group with \`cancel-in-progress: true\`, so a new \`synchronize\` event cancels the superseded run and frees the runner slots immediately.

## Test plan

- [ ] Force-push to a branch in this PR; observe that the previous CI run is auto-canceled and the Test Python matrix re-runs against the new SHA.
- [ ] Normal first-push still runs the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)