### PR TITLE
ci: promote v3 reference seller storyboard to required (@adcp/sdk@6.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,10 +482,9 @@ jobs:
   storyboard-v3-reference-seller:
     name: AdCP storyboard runner — v3 reference seller (translator)
     runs-on: ubuntu-latest
-    # Non-blocking until storyboard tooling settles for the translator
-    # pattern. Promote to required once the JS mock-server's
-    # sales-guaranteed surface is canonical.
-    continue-on-error: true
+    # Required as of @adcp/sdk@6.7.0 (sales-guaranteed mock-server
+    # canonicalized; closes #449). Storyboard run + traffic-counter
+    # assertions gate every PR's translator-pattern conformance.
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,6 +528,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,pg]"
+          # Example-local deps: the v3 reference seller imports
+          # sqlalchemy + asyncpg (async Postgres driver) which aren't
+          # in the SDK's [dev,pg] extras. Install inline rather than
+          # adding an example-only optional-dependencies group.
+          pip install "sqlalchemy>=2.0" "asyncpg>=0.29" "respx>=0.20"
 
       - name: Pre-install @adcp/sdk (once, then call binary directly)
         run: |


### PR DESCRIPTION
## Summary

`@adcp/sdk@6.7.0` published with the `sales-guaranteed` mock-server (closes #449). The v3 reference seller's translator pattern can now run end-to-end in CI:

- JS mock-server upstream (`adcp mock-server sales-guaranteed`)
- Postgres + Python seller boot
- Storyboard runner against the seller
- `/_debug/traffic` counter assertions (anti-façade contract)

This PR drops `continue-on-error: true` from the storyboard job so spec-conformance regressions gate every future PR.

## Validation

The PR's own CI run is the validation — if the storyboard job passes here, we know the full stack works against `@adcp/sdk@6.7.0`. If it fails, this PR doesn't merge.

## Closes

- #449 — `@adcp/sdk@6.7` publish blocks v3 storyboard promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)