### PR TITLE
feat(decisioning): createUpstreamHttpClient + createTranslationMap

### DIFF
--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -147,6 +147,10 @@ from adcp.decisioning.task_registry import (
     TaskRegistry,
     TaskState,
 )
+from adcp.decisioning.translation import (
+    TranslationMap,
+    create_translation_map,
+)
 from adcp.decisioning.types import (
     Account,
     AdcpError,
@@ -154,6 +158,16 @@ from adcp.decisioning.types import (
     SalesResult,
     TaskHandoff,
     WorkflowHandoff,
+)
+from adcp.decisioning.upstream import (
+    ApiKey,
+    AuthContext,
+    DynamicBearer,
+    NoAuth,
+    StaticBearer,
+    UpstreamAuth,
+    UpstreamHttpClient,
+    create_upstream_http_client,
 )
 
 # Conditional import: PgTaskRegistry needs the [pg] extra. Always expose
@@ -195,7 +209,9 @@ __all__ = [
     "AccountNotFoundError",
     "AccountStore",
     "AdcpError",
+    "ApiKey",
     "ApiKeyCredential",
+    "AuthContext",
     "AudiencePlatform",
     "AuditingBuyerAgentRegistry",
     "AuthInfo",
@@ -218,6 +234,7 @@ __all__ = [
     "CreativeBuilderPlatform",
     "DecisioningCapabilities",
     "DecisioningPlatform",
+    "DynamicBearer",
     "ExplicitAccounts",
     "Format",
     "FormatReferenceStructuredObject",
@@ -231,6 +248,7 @@ __all__ = [
     "MaybeAsync",
     "MediaBuyNotFoundError",
     "MockAdServer",
+    "NoAuth",
     "OAuthCredential",
     "PermissionDeniedError",
     "PgTaskRegistry",
@@ -249,11 +267,15 @@ __all__ = [
     "SignalsPlatform",
     "SingletonAccounts",
     "StateReader",
+    "StaticBearer",
     "TaskHandoff",
     "TaskHandoffContext",
     "TaskRegistry",
     "TaskState",
+    "TranslationMap",
     "UnsupportedFeatureError",
+    "UpstreamAuth",
+    "UpstreamHttpClient",
     "ValidationError",
     "WorkflowHandoff",
     "WorkflowObjectType",
@@ -262,6 +284,8 @@ __all__ = [
     "assert_media_buy_transition",
     "bearer_only_registry",
     "create_adcp_server_from_platform",
+    "create_translation_map",
+    "create_upstream_http_client",
     "mixed_registry",
     "project_account_for_response",
     "project_business_entity_for_response",

--- a/src/adcp/decisioning/translation.py
+++ b/src/adcp/decisioning/translation.py
@@ -1,0 +1,145 @@
+"""Bidirectional, type-safe key translation between AdCP and upstream values.
+
+Every translator-pattern adapter owes the framework two things: a thin
+HTTP client (see :mod:`adcp.decisioning.upstream`) and a set of small
+bidirectional key maps (AdCP ``"olv"`` ↔ upstream ``"video"``, AdCP
+``"guaranteed"`` ↔ upstream ``"GUARANTEED_AT_PRICE"``, …).
+:func:`create_translation_map` ships the map primitive so adapters
+declare the mapping once and the framework projects it both ways.
+
+Mirrors the JS ``createTranslationMap`` helper from
+``@adcp/sdk@6.7`` (``src/lib/server/upstream-helpers.ts``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Generic, TypeVar
+
+A = TypeVar("A")
+U = TypeVar("U")
+
+
+class TranslationMap(Generic[A, U]):
+    """Reversible mapping between AdCP wire values and upstream platform values.
+
+    Construct via :func:`create_translation_map`. Both lookup methods
+    raise :class:`KeyError` for unknown keys unless a default is
+    configured. Use the ``has_*`` predicates to guard a lookup, or
+    pass ``default_adcp`` / ``default_upstream`` for graceful
+    fallback.
+
+    Example::
+
+        channel_map = create_translation_map({
+            "olv": "video",
+            "ctv": "ctv",
+            "display": "display",
+            "streaming_audio": "audio",
+        })
+        channel_map.to_upstream("olv")     # "video"
+        channel_map.to_adcp("video")       # "olv"
+        channel_map.has_adcp("olv")        # True
+        channel_map.has_upstream("audio")  # True
+    """
+
+    __slots__ = ("_forward", "_reverse", "_default_adcp", "_default_upstream")
+
+    def __init__(
+        self,
+        adcp_to_upstream: Mapping[A, U],
+        *,
+        default_adcp: A | None = None,
+        default_upstream: U | None = None,
+    ) -> None:
+        self._forward: dict[A, U] = dict(adcp_to_upstream)
+        self._default_adcp = default_adcp
+        self._default_upstream = default_upstream
+
+        # Build reverse map and detect collisions in the same pass. Two
+        # AdCP keys mapping to the same upstream value would silently
+        # overwrite without this check — fail loud at construction so
+        # the bug is caught at boot, not on a request.
+        reverse: dict[U, A] = {}
+        for adcp_key, upstream_key in self._forward.items():
+            if upstream_key in reverse:
+                raise ValueError(
+                    f"translation collision: AdCP keys "
+                    f"{reverse[upstream_key]!r} and {adcp_key!r} both map to "
+                    f"upstream value {upstream_key!r}"
+                )
+            reverse[upstream_key] = adcp_key
+        self._reverse: dict[U, A] = reverse
+
+    def to_upstream(self, adcp_key: A) -> U:
+        """Translate an AdCP wire value to the upstream platform value.
+
+        :raises KeyError: when ``adcp_key`` isn't in the map and no
+            ``default_upstream`` was provided.
+        """
+        if adcp_key in self._forward:
+            return self._forward[adcp_key]
+        if self._default_upstream is not None:
+            return self._default_upstream
+        raise KeyError(f"unknown AdCP key: {adcp_key!r}")
+
+    def to_adcp(self, upstream_key: U) -> A:
+        """Translate an upstream platform value back to the AdCP wire value.
+
+        :raises KeyError: when ``upstream_key`` isn't in the map and
+            no ``default_adcp`` was provided.
+        """
+        if upstream_key in self._reverse:
+            return self._reverse[upstream_key]
+        if self._default_adcp is not None:
+            return self._default_adcp
+        raise KeyError(f"unknown upstream key: {upstream_key!r}")
+
+    def has_adcp(self, value: object) -> bool:
+        """True when ``value`` is a known AdCP-side key."""
+        return value in self._forward
+
+    def has_upstream(self, value: object) -> bool:
+        """True when ``value`` is a known upstream-side key."""
+        return value in self._reverse
+
+
+def create_translation_map(
+    adcp_to_upstream: Mapping[A, U],
+    *,
+    default_adcp: A | None = None,
+    default_upstream: U | None = None,
+) -> TranslationMap[A, U]:
+    """Build a bidirectional translation map from an AdCP→upstream record.
+
+    Keys on the left side are AdCP wire values; values on the right
+    are upstream platform values. Collisions in either direction (two
+    AdCP keys mapping to the same upstream value) are detected at
+    construction time and raise :class:`ValueError` — silent
+    overwrite would produce wrong-tenant routing in production.
+
+    :param adcp_to_upstream: ``{adcp_key: upstream_key}`` mapping.
+    :param default_adcp: Returned by :meth:`TranslationMap.to_adcp`
+        when the upstream key isn't in the map. ``None`` (default)
+        raises ``KeyError``.
+    :param default_upstream: Returned by
+        :meth:`TranslationMap.to_upstream` when the AdCP key isn't in
+        the map. ``None`` (default) raises ``KeyError``.
+
+    Example::
+
+        delivery_map = create_translation_map({
+            "guaranteed": "GUARANTEED_AT_PRICE",
+            "non_guaranteed": "STANDARD",
+        })
+        delivery_map.to_upstream("guaranteed")  # "GUARANTEED_AT_PRICE"
+        delivery_map.to_adcp("STANDARD")        # "non_guaranteed"
+    """
+    return TranslationMap(
+        adcp_to_upstream,
+        default_adcp=default_adcp,
+        default_upstream=default_upstream,
+    )
+
+
+__all__ = ["TranslationMap", "create_translation_map"]

--- a/src/adcp/decisioning/upstream.py
+++ b/src/adcp/decisioning/upstream.py
@@ -242,7 +242,7 @@ class UpstreamHttpClient:
         headers: Mapping[str, str] | None,
         auth_context: AuthContext | None,
         not_found_code: str,
-    ) -> dict[str, Any] | None:
+    ) -> Any:
         auth_header = await _resolve_auth_header(self._auth, auth_context)
         merged: dict[str, str] = {**self._default_headers, **auth_header}
         if headers:
@@ -268,7 +268,7 @@ class UpstreamHttpClient:
         )
         if response.status_code == 404 and self._treat_404_as_none:
             return None
-        if response.status_code >= 400:
+        if response.status_code >= 300:
             try:
                 body_text = response.text
             except Exception:  # pragma: no cover — defensive
@@ -282,7 +282,7 @@ class UpstreamHttpClient:
             )
         if response.status_code == 204 or not response.content:
             return {}
-        parsed: dict[str, Any] = response.json()
+        parsed: Any = response.json()
         return parsed
 
     async def get(
@@ -293,7 +293,7 @@ class UpstreamHttpClient:
         headers: Mapping[str, str] | None = None,
         auth_context: AuthContext | None = None,
         not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
-    ) -> dict[str, Any] | None:
+    ) -> Any:
         """``GET path``. Returns parsed JSON, or ``None`` on 404 when ``treat_404_as_none``."""
         return await self._request(
             "GET",
@@ -314,7 +314,7 @@ class UpstreamHttpClient:
         headers: Mapping[str, str] | None = None,
         auth_context: AuthContext | None = None,
         not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """``POST path`` with JSON body. Returns parsed JSON."""
         result = await self._request(
             "POST",
@@ -344,7 +344,7 @@ class UpstreamHttpClient:
         headers: Mapping[str, str] | None = None,
         auth_context: AuthContext | None = None,
         not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """``PUT path`` with JSON body. Returns parsed JSON."""
         result = await self._request(
             "PUT",
@@ -371,7 +371,7 @@ class UpstreamHttpClient:
         headers: Mapping[str, str] | None = None,
         auth_context: AuthContext | None = None,
         not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
-    ) -> dict[str, Any] | None:
+    ) -> Any:
         """``DELETE path``. Returns parsed JSON, or ``None`` on 404 when ``treat_404_as_none``."""
         return await self._request(
             "DELETE",

--- a/src/adcp/decisioning/upstream.py
+++ b/src/adcp/decisioning/upstream.py
@@ -1,0 +1,446 @@
+"""HTTP client primitives for AdCP translator adapters.
+
+Every translator-pattern seller (Prebid, GAM-shaped publishers, the v3
+reference seller) wires the same ~200 lines of httpx boilerplate: auth
+header injection, JSON parsing, 404→None for resource lookups, error
+projection to spec-conformant ``AdcpError`` codes. This module ships
+those primitives so adopters write only the upstream-specific bits.
+
+Mirrors the JS ``createUpstreamHttpClient`` helper from
+``@adcp/sdk@6.7`` (``src/lib/server/upstream-helpers.ts``). Python
+diverges from the JS shape in two places:
+
+* Methods return parsed JSON (``dict``) directly rather than a
+  ``{status, body}`` envelope. Within-2xx status distinction (201 vs
+  200) hasn't been a real-world need; we can add a ``raw_*`` variant
+  later if it does.
+* Non-2xx responses raise :class:`adcp.decisioning.types.AdcpError`
+  with a spec-conformant code (``AUTH_REQUIRED``, ``PERMISSION_DENIED``,
+  ``MEDIA_BUY_NOT_FOUND``, ``RATE_LIMITED``, ``SERVICE_UNAVAILABLE``,
+  ``INVALID_REQUEST``) rather than a generic ``Error``. Adopters can
+  override the 404 code per call via ``not_found_code`` for endpoints
+  whose missing-resource semantics aren't a media buy (e.g. creatives,
+  forecasts).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import httpx
+
+from adcp.decisioning.types import AdcpError
+
+#: Per-call routing context forwarded to :class:`DynamicBearer.get_token`.
+#:
+#: Adopters define their own shape. Common fields:
+#:
+#: * ``operator_id`` — resolved tenant id for per-operator credential lookup
+#: * ``network_code`` — multi-tenant routing key (matches AdCP
+#:   ``RequestContext.account.ext['network_code']``)
+#: * ``principal`` — pass-through of the caller's bearer token
+#:
+#: The SDK doesn't interpret this; it forwards it verbatim so the same
+#: client supports single-key tenant fan-out, per-operator credential
+#: lookup, and pass-through of the caller's principal without
+#: per-operator client construction.
+AuthContext = Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class StaticBearer:
+    """Fixed Bearer token injected into every request."""
+
+    token: str
+    kind: Literal["static_bearer"] = "static_bearer"
+
+
+@dataclass(frozen=True)
+class DynamicBearer:
+    """Async token factory called per-request.
+
+    ``get_token`` receives the optional ``auth_context`` passed to the
+    method call, so the same resolver can return a master key for
+    tenant fan-out, a per-operator key, or pass-through of the
+    caller's principal. OAuth client-credentials refresh is the
+    adopter's responsibility — typically a cached token with
+    expiry-driven refresh inside the closure.
+    """
+
+    get_token: Callable[[AuthContext | None], Awaitable[str]]
+    kind: Literal["dynamic_bearer"] = "dynamic_bearer"
+
+
+@dataclass(frozen=True)
+class ApiKey:
+    """Fixed key injected into a named header (e.g. ``X-Api-Key``)."""
+
+    header_name: str
+    key: str
+    kind: Literal["api_key"] = "api_key"
+
+
+@dataclass(frozen=True)
+class NoAuth:
+    """No authentication header injected. For unauthenticated services."""
+
+    kind: Literal["none"] = "none"
+
+
+#: Discriminated union of authentication strategies.
+UpstreamAuth = StaticBearer | DynamicBearer | ApiKey | NoAuth
+
+
+# Spec-conformant default mapping from upstream HTTP status to AdcpError code.
+# Per the AdCP error-code enum at schemas/cache/3.0.0/enums/error-code.json.
+# 404 is configurable per-call via ``not_found_code`` because the right
+# AdCP code depends on the resource being looked up.
+_DEFAULT_NOT_FOUND_CODE = "MEDIA_BUY_NOT_FOUND"
+
+
+def _project_status(
+    status_code: int,
+    *,
+    not_found_code: str,
+    method: str,
+    path: str,
+    body_text: str,
+) -> AdcpError:
+    """Project an upstream non-2xx status to a spec-conformant AdcpError."""
+    snippet = body_text[:200] if body_text else ""
+    suffix = f" — {snippet}" if snippet else ""
+    base = f"upstream {method} {path} failed: {status_code}{suffix}"
+    if status_code == 401:
+        return AdcpError(
+            "AUTH_REQUIRED",
+            message=base,
+            recovery="terminal",
+        )
+    if status_code == 403:
+        return AdcpError(
+            "PERMISSION_DENIED",
+            message=base,
+            recovery="terminal",
+        )
+    if status_code == 404:
+        return AdcpError(
+            not_found_code,
+            message=base,
+            recovery="terminal",
+        )
+    if status_code == 429:
+        return AdcpError(
+            "RATE_LIMITED",
+            message=base,
+            recovery="transient",
+        )
+    if status_code >= 500:
+        return AdcpError(
+            "SERVICE_UNAVAILABLE",
+            message=base,
+            recovery="transient",
+        )
+    # Any other 4xx → buyer-fixable.
+    return AdcpError(
+        "INVALID_REQUEST",
+        message=base,
+        recovery="retry_with_changes",
+    )
+
+
+async def _resolve_auth_header(
+    auth: UpstreamAuth,
+    auth_context: AuthContext | None,
+) -> dict[str, str]:
+    if isinstance(auth, StaticBearer):
+        return {"Authorization": f"Bearer {auth.token}"}
+    if isinstance(auth, DynamicBearer):
+        token = await auth.get_token(auth_context)
+        return {"Authorization": f"Bearer {token}"}
+    if isinstance(auth, ApiKey):
+        return {auth.header_name: auth.key}
+    if isinstance(auth, NoAuth):
+        return {}
+    # Exhaustive — kept as a guard against future additions.
+    raise TypeError(f"unknown UpstreamAuth variant: {type(auth).__name__}")
+
+
+class UpstreamHttpClient:
+    """Thin typed HTTP client over ``httpx.AsyncClient``.
+
+    Construct via :func:`create_upstream_http_client`. Connection
+    pooling is automatic (``max_keepalive_connections=10,
+    max_connections=20``) and the client reuses a single
+    ``httpx.AsyncClient`` across calls. Call :meth:`aclose` on shutdown
+    to release the pool, or use ``async with`` if your wiring supports
+    it.
+
+    Method signatures:
+
+    * :meth:`get` — returns parsed JSON ``dict``, or ``None`` on 404
+      when ``treat_404_as_none=True``.
+    * :meth:`post` / :meth:`put` — returns parsed JSON ``dict``.
+    * :meth:`delete` — returns parsed JSON ``dict``, or ``None`` on
+      404 when ``treat_404_as_none=True``.
+
+    All non-2xx responses raise :class:`AdcpError` with a
+    spec-conformant code. The 404 code is configurable per call via
+    ``not_found_code`` for endpoints whose missing-resource semantics
+    aren't a media buy.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        auth: UpstreamAuth,
+        default_headers: Mapping[str, str] | None = None,
+        timeout: float = 30.0,
+        treat_404_as_none: bool = True,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth = auth
+        self._default_headers: dict[str, str] = dict(default_headers or {})
+        self._timeout = timeout
+        self._treat_404_as_none = treat_404_as_none
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=self._timeout,
+                limits=httpx.Limits(
+                    max_keepalive_connections=10,
+                    max_connections=20,
+                ),
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        """Release the underlying ``httpx.AsyncClient`` connection pool."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> UpstreamHttpClient:
+        await self._get_client()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.aclose()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None,
+        json: Any,
+        headers: Mapping[str, str] | None,
+        auth_context: AuthContext | None,
+        not_found_code: str,
+    ) -> dict[str, Any] | None:
+        auth_header = await _resolve_auth_header(self._auth, auth_context)
+        merged: dict[str, str] = {**self._default_headers, **auth_header}
+        if headers:
+            merged.update(headers)
+        if json is not None:
+            # httpx adds Content-Type itself when ``json=`` is used, but
+            # set it explicitly so adopter middleware sees it pre-flight.
+            merged.setdefault("Content-Type", "application/json")
+
+        # Drop None query params — caller-friendly: pass kwargs through
+        # without filtering, matches the JS helper's behavior.
+        cleaned_params: dict[str, Any] | None = None
+        if params is not None:
+            cleaned_params = {k: v for k, v in params.items() if v is not None}
+
+        client = await self._get_client()
+        response = await client.request(
+            method,
+            path,
+            params=cleaned_params,
+            json=json,
+            headers=merged,
+        )
+        if response.status_code == 404 and self._treat_404_as_none:
+            return None
+        if response.status_code >= 400:
+            try:
+                body_text = response.text
+            except Exception:  # pragma: no cover — defensive
+                body_text = ""
+            raise _project_status(
+                response.status_code,
+                not_found_code=not_found_code,
+                method=method,
+                path=path,
+                body_text=body_text,
+            )
+        if response.status_code == 204 or not response.content:
+            return {}
+        parsed: dict[str, Any] = response.json()
+        return parsed
+
+    async def get(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        auth_context: AuthContext | None = None,
+        not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
+    ) -> dict[str, Any] | None:
+        """``GET path``. Returns parsed JSON, or ``None`` on 404 when ``treat_404_as_none``."""
+        return await self._request(
+            "GET",
+            path,
+            params=params,
+            json=None,
+            headers=headers,
+            auth_context=auth_context,
+            not_found_code=not_found_code,
+        )
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json: Any = None,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        auth_context: AuthContext | None = None,
+        not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
+    ) -> dict[str, Any]:
+        """``POST path`` with JSON body. Returns parsed JSON."""
+        result = await self._request(
+            "POST",
+            path,
+            params=params,
+            json=json,
+            headers=headers,
+            auth_context=auth_context,
+            not_found_code=not_found_code,
+        )
+        # POST 404 is unusual; treat_404_as_none still applies but
+        # callers don't expect None — surface as MEDIA_BUY_NOT_FOUND.
+        if result is None:
+            raise AdcpError(
+                not_found_code,
+                message=f"upstream POST {path} returned 404",
+                recovery="terminal",
+            )
+        return result
+
+    async def put(
+        self,
+        path: str,
+        *,
+        json: Any = None,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        auth_context: AuthContext | None = None,
+        not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
+    ) -> dict[str, Any]:
+        """``PUT path`` with JSON body. Returns parsed JSON."""
+        result = await self._request(
+            "PUT",
+            path,
+            params=params,
+            json=json,
+            headers=headers,
+            auth_context=auth_context,
+            not_found_code=not_found_code,
+        )
+        if result is None:
+            raise AdcpError(
+                not_found_code,
+                message=f"upstream PUT {path} returned 404",
+                recovery="terminal",
+            )
+        return result
+
+    async def delete(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        auth_context: AuthContext | None = None,
+        not_found_code: str = _DEFAULT_NOT_FOUND_CODE,
+    ) -> dict[str, Any] | None:
+        """``DELETE path``. Returns parsed JSON, or ``None`` on 404 when ``treat_404_as_none``."""
+        return await self._request(
+            "DELETE",
+            path,
+            params=params,
+            json=None,
+            headers=headers,
+            auth_context=auth_context,
+            not_found_code=not_found_code,
+        )
+
+
+def create_upstream_http_client(
+    base_url: str,
+    *,
+    auth: UpstreamAuth | None = None,
+    default_headers: Mapping[str, str] | None = None,
+    timeout: float = 30.0,
+    treat_404_as_none: bool = True,
+) -> UpstreamHttpClient:
+    """Create a thin typed HTTP client for an upstream platform API.
+
+    Handles auth injection, JSON serialization, 404→None translation,
+    and projection of non-2xx responses to spec-conformant
+    :class:`AdcpError` codes so adapters focus on domain logic.
+
+    :param base_url: Base URL of the upstream API. Trailing slashes
+        are stripped.
+    :param auth: Authentication strategy. Defaults to :class:`NoAuth`
+        for unauthenticated internal services.
+    :param default_headers: Headers included on every request
+        (e.g. tenant id, API version). Per-request headers passed to
+        individual method calls take precedence.
+    :param timeout: Per-request timeout in seconds. Default 30.0.
+    :param treat_404_as_none: When ``True`` (default), GET/DELETE 404
+        responses return ``None`` rather than raising. Set ``False``
+        to surface 404 as ``AdcpError(MEDIA_BUY_NOT_FOUND)``. POST and
+        PUT always raise on 404 — they're not lookups.
+
+    Example::
+
+        client = create_upstream_http_client(
+            "https://upstream.example.com",
+            auth=DynamicBearer(get_token=resolve_tenant_token),
+            default_headers={"X-API-Version": "2"},
+        )
+        order = await client.get(
+            f"/v1/orders/{order_id}",
+            auth_context={"network_code": ctx.account.ext["network_code"]},
+        )
+        if order is None:
+            raise AdcpError("MEDIA_BUY_NOT_FOUND", message=f"order {order_id}")
+    """
+    return UpstreamHttpClient(
+        base_url=base_url,
+        auth=auth or NoAuth(),
+        default_headers=default_headers,
+        timeout=timeout,
+        treat_404_as_none=treat_404_as_none,
+    )
+
+
+__all__ = [
+    "ApiKey",
+    "AuthContext",
+    "DynamicBearer",
+    "NoAuth",
+    "StaticBearer",
+    "UpstreamAuth",
+    "UpstreamHttpClient",
+    "create_upstream_http_client",
+]

--- a/tests/test_upstream_helpers.py
+++ b/tests/test_upstream_helpers.py
@@ -1,0 +1,429 @@
+"""Tests for the upstream HTTP client and translation map helpers.
+
+Mirrors the JS test/upstream-helpers.test.js coverage with two
+adaptations for the Python shape:
+
+* Methods return parsed JSON directly (``dict`` or ``None``), not a
+  ``{status, body}`` envelope.
+* Non-2xx responses raise :class:`AdcpError` with spec-conformant
+  codes (AUTH_REQUIRED / PERMISSION_DENIED / MEDIA_BUY_NOT_FOUND /
+  RATE_LIMITED / SERVICE_UNAVAILABLE / INVALID_REQUEST).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from adcp.decisioning import (
+    ApiKey,
+    DynamicBearer,
+    NoAuth,
+    StaticBearer,
+    TranslationMap,
+    UpstreamHttpClient,
+    create_translation_map,
+    create_upstream_http_client,
+)
+from adcp.decisioning.types import AdcpError
+
+BASE = "https://upstream.example.com"
+
+
+# ---------------------------------------------------------------------------
+# create_translation_map
+# ---------------------------------------------------------------------------
+
+
+class TestTranslationMap:
+    def setup_method(self) -> None:
+        self.channel_map: TranslationMap[str, str] = create_translation_map(
+            {
+                "olv": "video",
+                "ctv": "ctv",
+                "display": "display",
+                "streaming_audio": "audio",
+            }
+        )
+
+    def test_to_upstream_returns_b_side(self) -> None:
+        assert self.channel_map.to_upstream("olv") == "video"
+        assert self.channel_map.to_upstream("ctv") == "ctv"
+
+    def test_to_adcp_returns_a_side(self) -> None:
+        assert self.channel_map.to_adcp("video") == "olv"
+        assert self.channel_map.to_adcp("audio") == "streaming_audio"
+
+    def test_to_upstream_raises_on_unknown(self) -> None:
+        with pytest.raises(KeyError):
+            self.channel_map.to_upstream("unknown")
+
+    def test_to_adcp_raises_on_unknown(self) -> None:
+        with pytest.raises(KeyError):
+            self.channel_map.to_adcp("unknown_upstream")
+
+    def test_has_adcp(self) -> None:
+        assert self.channel_map.has_adcp("olv") is True
+        assert self.channel_map.has_adcp("video") is False
+        assert self.channel_map.has_adcp("missing") is False
+
+    def test_has_upstream(self) -> None:
+        assert self.channel_map.has_upstream("video") is True
+        assert self.channel_map.has_upstream("olv") is False
+        assert self.channel_map.has_upstream("missing") is False
+
+    def test_collision_detected_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="translation collision"):
+            create_translation_map({"a": "X", "b": "X"})
+
+    def test_default_upstream_fallback(self) -> None:
+        m: TranslationMap[str, str] = create_translation_map(
+            {"olv": "video"}, default_upstream="STANDARD"
+        )
+        assert m.to_upstream("olv") == "video"
+        assert m.to_upstream("unknown") == "STANDARD"
+
+    def test_default_adcp_fallback(self) -> None:
+        m: TranslationMap[str, str] = create_translation_map(
+            {"olv": "video"}, default_adcp="display"
+        )
+        assert m.to_adcp("video") == "olv"
+        assert m.to_adcp("unknown_upstream") == "display"
+
+
+# ---------------------------------------------------------------------------
+# create_upstream_http_client — happy paths and auth
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_returns_parsed_json_with_static_bearer() -> None:
+    route = respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={"ok": True}))
+    client = create_upstream_http_client(BASE, auth=StaticBearer(token="tok_123"))
+    result = await client.get("/items")
+    assert result == {"ok": True}
+    assert route.called
+    assert route.calls.last.request.headers["Authorization"] == "Bearer tok_123"
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_dynamic_bearer_called_per_request() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json=[]))
+    calls: list[object] = []
+
+    async def get_token(ctx: object) -> str:
+        calls.append(ctx)
+        return "fresh_token"
+
+    client = create_upstream_http_client(BASE, auth=DynamicBearer(get_token=get_token))
+    await client.get("/items")
+    assert calls == [None]
+    request = respx.calls.last.request
+    assert request.headers["Authorization"] == "Bearer fresh_token"
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_api_key_header_injected() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    client = create_upstream_http_client(
+        BASE, auth=ApiKey(header_name="X-Api-Key", key="secret_key")
+    )
+    await client.get("/items")
+    assert respx.calls.last.request.headers["X-Api-Key"] == "secret_key"
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_no_auth_sends_no_authorization_header() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    client = create_upstream_http_client(BASE, auth=NoAuth())
+    await client.get("/items")
+    assert "Authorization" not in respx.calls.last.request.headers
+    await client.aclose()
+
+
+@respx.mock
+async def test_default_auth_is_no_auth() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    client = create_upstream_http_client(BASE)  # no auth=
+    await client.get("/items")
+    assert "Authorization" not in respx.calls.last.request.headers
+    await client.aclose()
+
+
+@respx.mock
+async def test_query_params_serialized_and_none_dropped() -> None:
+    route = respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json=[]))
+    client = create_upstream_http_client(BASE)
+    await client.get("/items", params={"limit": 10, "q": "hello world", "skip_me": None})
+    assert route.called
+    url = str(respx.calls.last.request.url)
+    assert "limit=10" in url
+    # httpx URL-encodes the space as +
+    assert "q=hello+world" in url or "q=hello%20world" in url
+    assert "skip_me" not in url
+    await client.aclose()
+
+
+@respx.mock
+async def test_post_sends_json_body_and_default_headers() -> None:
+    route = respx.post(f"{BASE}/items").mock(return_value=httpx.Response(201, json={"id": "x"}))
+    client = create_upstream_http_client(
+        BASE,
+        auth=NoAuth(),
+        default_headers={"X-Tenant": "tenant_1"},
+    )
+    result = await client.post("/items", json={"name": "test"})
+    assert result == {"id": "x"}
+    assert route.called
+    request = respx.calls.last.request
+    assert request.method == "POST"
+    assert request.headers["X-Tenant"] == "tenant_1"
+    assert request.headers["Content-Type"] == "application/json"
+    assert json.loads(request.content) == {"name": "test"}
+    await client.aclose()
+
+
+@respx.mock
+async def test_put_sends_json_body() -> None:
+    respx.put(f"{BASE}/items/x").mock(
+        return_value=httpx.Response(200, json={"id": "x", "name": "updated"})
+    )
+    client = create_upstream_http_client(BASE)
+    result = await client.put("/items/x", json={"name": "updated"})
+    assert result == {"id": "x", "name": "updated"}
+    request = respx.calls.last.request
+    assert request.method == "PUT"
+    assert json.loads(request.content) == {"name": "updated"}
+    await client.aclose()
+
+
+@respx.mock
+async def test_delete_sends_correct_method() -> None:
+    respx.delete(f"{BASE}/items/1").mock(return_value=httpx.Response(204))
+    client = create_upstream_http_client(BASE)
+    result = await client.delete("/items/1")
+    assert result == {}  # 204 → empty dict
+    assert respx.calls.last.request.method == "DELETE"
+    await client.aclose()
+
+
+@respx.mock
+async def test_per_call_headers_override_defaults() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    client = create_upstream_http_client(
+        BASE, default_headers={"X-Tenant": "default", "X-Other": "stays"}
+    )
+    await client.get("/items", headers={"X-Tenant": "override"})
+    headers = respx.calls.last.request.headers
+    assert headers["X-Tenant"] == "override"
+    assert headers["X-Other"] == "stays"
+    await client.aclose()
+
+
+@respx.mock
+async def test_default_headers_merge_with_auth() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    client = create_upstream_http_client(
+        BASE,
+        auth=StaticBearer(token="abc"),
+        default_headers={"X-Tenant": "t1"},
+    )
+    await client.get("/items")
+    headers = respx.calls.last.request.headers
+    assert headers["Authorization"] == "Bearer abc"
+    assert headers["X-Tenant"] == "t1"
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# 404 → None vs MEDIA_BUY_NOT_FOUND
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_404_returns_none_when_treat_404_as_none_default() -> None:
+    respx.get(f"{BASE}/items/missing").mock(return_value=httpx.Response(404, text="not found"))
+    client = create_upstream_http_client(BASE)
+    result = await client.get("/items/missing")
+    assert result is None
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_404_raises_media_buy_not_found_when_disabled() -> None:
+    respx.get(f"{BASE}/items/missing").mock(return_value=httpx.Response(404, text="not found"))
+    client = create_upstream_http_client(BASE, treat_404_as_none=False)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/items/missing")
+    assert exc_info.value.code == "MEDIA_BUY_NOT_FOUND"
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_404_with_custom_not_found_code() -> None:
+    respx.get(f"{BASE}/creatives/x").mock(return_value=httpx.Response(404))
+    client = create_upstream_http_client(BASE, treat_404_as_none=False)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/creatives/x", not_found_code="CREATIVE_NOT_FOUND")
+    assert exc_info.value.code == "CREATIVE_NOT_FOUND"
+    await client.aclose()
+
+
+@respx.mock
+async def test_post_404_always_raises() -> None:
+    # POST is not a lookup; treat_404_as_none doesn't apply.
+    respx.post(f"{BASE}/items").mock(return_value=httpx.Response(404))
+    client = create_upstream_http_client(BASE)  # treat_404_as_none=True by default
+    with pytest.raises(AdcpError) as exc_info:
+        await client.post("/items", json={})
+    assert exc_info.value.code == "MEDIA_BUY_NOT_FOUND"
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Error projection — status → AdcpError code
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_401_raises_auth_required() -> None:
+    respx.get(f"{BASE}/x").mock(return_value=httpx.Response(401, text="unauthorized"))
+    client = create_upstream_http_client(BASE)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/x")
+    assert exc_info.value.code == "AUTH_REQUIRED"
+    assert exc_info.value.recovery == "terminal"
+    await client.aclose()
+
+
+@respx.mock
+async def test_403_raises_permission_denied() -> None:
+    respx.get(f"{BASE}/x").mock(return_value=httpx.Response(403, text="forbidden"))
+    client = create_upstream_http_client(BASE)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/x")
+    assert exc_info.value.code == "PERMISSION_DENIED"
+    await client.aclose()
+
+
+@respx.mock
+async def test_429_raises_rate_limited_transient() -> None:
+    respx.get(f"{BASE}/x").mock(return_value=httpx.Response(429, text="too many"))
+    client = create_upstream_http_client(BASE)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/x")
+    assert exc_info.value.code == "RATE_LIMITED"
+    assert exc_info.value.recovery == "transient"
+    await client.aclose()
+
+
+@respx.mock
+async def test_500_raises_service_unavailable() -> None:
+    respx.get(f"{BASE}/x").mock(return_value=httpx.Response(500, text="oops"))
+    client = create_upstream_http_client(BASE)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/x")
+    assert exc_info.value.code == "SERVICE_UNAVAILABLE"
+    assert exc_info.value.recovery == "transient"
+    await client.aclose()
+
+
+@respx.mock
+async def test_400_raises_invalid_request_correctable() -> None:
+    respx.get(f"{BASE}/x").mock(return_value=httpx.Response(400, text="bad"))
+    client = create_upstream_http_client(BASE)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/x")
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.recovery == "retry_with_changes"
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# auth_context passthrough
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_dynamic_bearer_receives_auth_context() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    captured: list[object] = []
+
+    async def get_token(ctx: object) -> str:
+        captured.append(ctx)
+        return "tok_for_acme"
+
+    client = create_upstream_http_client(BASE, auth=DynamicBearer(get_token=get_token))
+    await client.get("/items", auth_context={"operator_id": "acme"})
+    assert captured == [{"operator_id": "acme"}]
+    assert respx.calls.last.request.headers["Authorization"] == "Bearer tok_for_acme"
+    await client.aclose()
+
+
+@respx.mock
+async def test_dynamic_bearer_per_call_routing() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    respx.post(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+    keys = {"acme": "tok_acme", "globex": "tok_globex"}
+
+    async def get_token(ctx: object) -> str:
+        if isinstance(ctx, dict):
+            return keys.get(ctx.get("operator_id", ""), "master")
+        return "master"
+
+    client = create_upstream_http_client(BASE, auth=DynamicBearer(get_token=get_token))
+    await client.get("/items", auth_context={"operator_id": "acme"})
+    await client.post("/items", json={"x": 1}, auth_context={"operator_id": "globex"})
+    auths = [c.request.headers["Authorization"] for c in respx.calls]
+    assert auths == ["Bearer tok_acme", "Bearer tok_globex"]
+    await client.aclose()
+
+
+@respx.mock
+async def test_dynamic_bearer_principal_passthrough() -> None:
+    respx.get(f"{BASE}/items").mock(return_value=httpx.Response(200, json={}))
+
+    async def get_token(ctx: object) -> str:
+        if isinstance(ctx, dict):
+            principal = ctx.get("principal")
+            if isinstance(principal, str):
+                return principal
+        return "fallback"
+
+    client = create_upstream_http_client(BASE, auth=DynamicBearer(get_token=get_token))
+    await client.get("/items", auth_context={"principal": "caller_token_xyz"})
+    assert respx.calls.last.request.headers["Authorization"] == "Bearer caller_token_xyz"
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Pool reuse + context manager
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_async_context_manager_closes_client() -> None:
+    respx.get(f"{BASE}/x").mock(return_value=httpx.Response(200, json={}))
+    async with create_upstream_http_client(BASE) as client:
+        assert isinstance(client, UpstreamHttpClient)
+        await client.get("/x")
+        assert client._client is not None  # type: ignore[union-attr]
+    assert client._client is None  # type: ignore[union-attr]
+
+
+@respx.mock
+async def test_pool_reused_across_calls() -> None:
+    respx.get(f"{BASE}/a").mock(return_value=httpx.Response(200, json={}))
+    respx.get(f"{BASE}/b").mock(return_value=httpx.Response(200, json={}))
+    client = create_upstream_http_client(BASE)
+    await client.get("/a")
+    underlying = client._client  # type: ignore[union-attr]
+    await client.get("/b")
+    assert client._client is underlying  # type: ignore[union-attr]
+    await client.aclose()


### PR DESCRIPTION
## Summary

Ports the JS `@adcp/sdk@6.7` translator helpers (`createUpstreamHttpClient` + `createTranslationMap`) to Python so adapters stop hand-rolling the same ~200 lines of httpx boilerplate per upstream.

- **`create_upstream_http_client`** (`src/adcp/decisioning/upstream.py`): httpx-backed client with auth injection (`StaticBearer` / `DynamicBearer` / `ApiKey` / `NoAuth` as a discriminated dataclass union), default-header merge, query-string serialization, 404→`None` for GET/DELETE lookups (configurable via `treat_404_as_none`), and projection of non-2xx responses to spec-conformant `AdcpError` codes: 401→`AUTH_REQUIRED`, 403→`PERMISSION_DENIED`, 404→`MEDIA_BUY_NOT_FOUND` (overridable per call via `not_found_code`), 429→`RATE_LIMITED` (transient), 5xx→`SERVICE_UNAVAILABLE` (transient), 4xx→`INVALID_REQUEST` (retry_with_changes). `DynamicBearer.get_token` receives a per-call `auth_context` so a single client supports single-key tenant fan-out, per-operator credential lookup, and pass-through of the caller's principal without per-operator client construction. Connection-pooled `httpx.AsyncClient` reused across calls; `aclose()` and `async with` for cleanup.
- **`create_translation_map`** (`src/adcp/decisioning/translation.py`): bidirectional, type-safe AdCP↔upstream key mapping with `to_upstream` / `to_adcp` / `has_adcp` / `has_upstream`. Collisions in either direction (two AdCP keys → same upstream value) raise `ValueError` at construction so silent overwrite can't produce wrong-tenant routing. Optional `default_adcp` / `default_upstream` for graceful fallback; otherwise lookups raise `KeyError`.

## Why now

Every translator-pattern adopter (the v3 reference seller in #447, Prebid, GAM-shaped publishers) writes the same client from scratch. JS 6.7 ships these as canonical helpers. This PR delivers parity with one Python adaptation: methods return parsed JSON `dict` (or `None`) directly rather than the JS `{status, body}` envelope — within-2xx status distinction (201 vs 200) hasn't been a real-world need.

This PR ships only the primitives + tests. Refactoring `examples/v3_reference_seller/src/upstream.py` to use the helpers is a follow-up.

## Test plan

- [x] 34 tests pass (`tests/test_upstream_helpers.py`) — translation roundtrip, collision detection, default fallbacks; per-method happy paths; auth injection for all four kinds; per-call `auth_context` passthrough including the per-operator routing and principal-passthrough scenarios; 404→None vs `MEDIA_BUY_NOT_FOUND` toggle; status-code → AdcpError-code projection for 400/401/403/429/500; default-header merge + per-call header override; pool reuse and async-context-manager cleanup
- [x] `ruff check src/` clean
- [x] `mypy src/adcp/` clean (752 source files, strict mode)
- [x] Adjacent decisioning tests still pass (`test_decisioning_types.py`, `test_decisioning_specialisms.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)