### PR TITLE
feat(decisioning): composeMethod + security composer helpers

### DIFF
--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -59,6 +59,13 @@ from adcp.decisioning.accounts import (
     FromAuthAccounts,
     SingletonAccounts,
 )
+from adcp.decisioning.compose import (
+    ShortCircuit,
+    compose_method,
+    require_account_match,
+    require_advertiser_match,
+    require_org_scope,
+)
 from adcp.decisioning.context import (
     AuthInfo,
     RequestContext,
@@ -280,12 +287,17 @@ __all__ = [
     "WorkflowHandoff",
     "WorkflowObjectType",
     "WorkflowStep",
+    "ShortCircuit",
     "assert_creative_transition",
     "assert_media_buy_transition",
     "bearer_only_registry",
+    "compose_method",
     "create_adcp_server_from_platform",
     "create_translation_map",
     "create_upstream_http_client",
+    "require_account_match",
+    "require_advertiser_match",
+    "require_org_scope",
     "mixed_registry",
     "project_account_for_response",
     "project_business_entity_for_response",

--- a/src/adcp/decisioning/compose.py
+++ b/src/adcp/decisioning/compose.py
@@ -1,0 +1,360 @@
+"""Method-level composition for :class:`DecisioningPlatform` adopters.
+
+Provides :func:`compose_method` for wrapping a single platform method
+with typed ``before`` / ``after`` hooks, plus three pre-built
+``BeforeHook`` factories — :func:`require_account_match`,
+:func:`require_advertiser_match`, :func:`require_org_scope` — for
+common authorization gates.
+
+Mirrors the JS-side ``composeMethod`` helper at
+``src/lib/server/decisioning/compose.ts``. Adopters layer cross-cutting
+concerns (security gates, audit, enrichment, caching) on individual
+methods of an existing platform without re-typing every method by hand.
+
+``before`` returning ``None`` falls through to the wrapped method.
+Returning :class:`ShortCircuit` wraps the value to short-circuit;
+``after`` (if any) still runs on the short-circuit value before it
+flows back to the caller. The discriminated wrapper avoids the
+``None``-as-sentinel footgun: adopters who forget the wrapper and
+return a bare value get a :class:`TypeError` at runtime, not silent
+short-circuit-with-``None``.
+
+``after`` runs BEFORE response-schema validation — decorations must
+satisfy the wire schema. Vendor-specific data goes under ``ext``
+(the spec's typed extension surface), not at the top level.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeAlias
+
+from typing_extensions import TypeVar
+
+from adcp.decisioning.context import RequestContext
+from adcp.decisioning.types import AdcpError
+
+#: Request type — Pydantic request model the platform method accepts.
+Req = TypeVar("Req")
+
+#: Response type — Pydantic response model the platform method returns.
+Res = TypeVar("Res")
+
+#: Generic value type for :class:`ShortCircuit`.
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ShortCircuit(Generic[T]):
+    """Wrapper a ``before`` hook returns to skip the inner method.
+
+    Returning ``ShortCircuit(value=...)`` from a
+    :data:`BeforeHook` skips the wrapped inner method and feeds the
+    wrapped value through ``after`` (if any) back to the caller.
+    Returning ``None`` falls through to the inner method.
+
+    Discriminated wrapper rather than a sentinel ``None``: adopters
+    who omit the wrapper and return a bare value get a
+    :class:`TypeError` at runtime rather than silent
+    short-circuit-with-``None`` behavior — the most common footgun
+    when porting middleware between languages.
+
+    :param value: The result to return in place of calling the inner
+        method. Must satisfy the wire schema (any decoration via
+        ``after`` runs before response-schema validation).
+    """
+
+    value: T
+
+
+#: Platform-method signature — ``async (params, ctx) -> result``.
+#:
+#: All composed methods are async. Adopter platforms whose underlying
+#: implementations are sync should wrap them in a thin
+#: ``async def`` shim before passing to :func:`compose_method`.
+PlatformMethod: TypeAlias = Callable[[Req, RequestContext[Any]], Awaitable[Res]]
+
+#: Before-hook signature — ``async (params, ctx) -> ShortCircuit[Res] | None``.
+#:
+#: Returning ``None`` falls through to the inner method. Returning
+#: :class:`ShortCircuit` wraps the value to short-circuit.
+BeforeHook: TypeAlias = Callable[
+    [Req, RequestContext[Any]],
+    Awaitable[ShortCircuit[Res] | None],
+]
+
+#: After-hook signature — ``async (result, params, ctx) -> Res``.
+#:
+#: Runs whether the result came from the inner method or from a
+#: ``before`` short-circuit. Receives the original ``params`` and
+#: ``ctx`` for context-dependent enrichment.
+AfterHook: TypeAlias = Callable[
+    [Res, Req, RequestContext[Any]],
+    Awaitable[Res],
+]
+
+
+def compose_method(
+    inner: Callable[[Req, RequestContext[Any]], Awaitable[Res]],
+    *,
+    before: (
+        Callable[
+            [Req, RequestContext[Any]],
+            Awaitable[ShortCircuit[Res] | None],
+        ]
+        | None
+    ) = None,
+    after: (
+        Callable[
+            [Res, Req, RequestContext[Any]],
+            Awaitable[Res],
+        ]
+        | None
+    ) = None,
+) -> Callable[[Req, RequestContext[Any]], Awaitable[Res]]:
+    """Wrap a platform method with typed ``before`` / ``after`` hooks.
+
+    Type-preserving: the returned callable has the same
+    ``async (params, ctx) -> Res`` signature as ``inner`` so it slots
+    into a typed :class:`DecisioningPlatform` shape without casts.
+
+    Validates ``inner`` is callable eagerly at wrap time so adopters
+    who reference an optional method that wasn't implemented on the
+    underlying platform get a clear :class:`TypeError` at module load
+    rather than at first traffic.
+
+    Example::
+
+        from adcp.decisioning.compose import compose_method, ShortCircuit
+
+        async def before_hook(req, ctx):
+            if req.optimization == "price":
+                return ShortCircuit(value=cached_price_opt)
+            return None
+
+        async def after_hook(result, req, ctx):
+            return result.model_copy(
+                update={
+                    "ext": {
+                        **(result.ext or {}),
+                        "carbon_grams_per_impression": await score(result),
+                    }
+                }
+            )
+
+        wrapped = compose_method(
+            base_platform.get_media_buy_delivery,
+            before=before_hook,
+            after=after_hook,
+        )
+
+    :param inner: The platform method to wrap. Must be callable;
+        non-callables raise :class:`TypeError` immediately.
+    :param before: Optional pre-call hook. Returning
+        :class:`ShortCircuit` skips the inner method and feeds the
+        wrapped value through ``after``. Returning ``None`` falls
+        through. Returning a bare non-:class:`ShortCircuit` non-``None``
+        value raises :class:`TypeError`.
+    :param after: Optional post-call hook. Runs whether the result
+        came from ``inner`` or from a ``before`` short-circuit, and
+        BEFORE response-schema validation. Decorations must satisfy
+        the wire schema; vendor-specific data goes under ``ext``.
+    :returns: A wrapper with the same signature as ``inner``.
+    :raises TypeError: when ``inner`` is not callable.
+    """
+    if not callable(inner):
+        raise TypeError(
+            f"compose_method: 'inner' must be callable, got "
+            f"{type(inner).__name__}. Did you reference an optional "
+            f"method that wasn't implemented on the platform?"
+        )
+
+    async def wrapper(req: Req, ctx: RequestContext[Any]) -> Res:
+        result: Res
+        if before is not None:
+            early = await before(req, ctx)
+            if early is None:
+                result = await inner(req, ctx)
+            elif isinstance(early, ShortCircuit):
+                result = early.value
+            else:
+                raise TypeError(
+                    f"compose_method: before hook returned "
+                    f"{type(early).__name__}; expected None or "
+                    f"ShortCircuit. Wrap the value: "
+                    f"`return ShortCircuit(value=...)`."
+                )
+        else:
+            result = await inner(req, ctx)
+        if after is not None:
+            result = await after(result, req, ctx)
+        return result
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Security composer helpers
+# ---------------------------------------------------------------------------
+
+# Generic message used on every denial path. Adopters who need
+# custom messaging should write their own ``BeforeHook`` rather than
+# parameterizing this — the framework's default keeps the message
+# from being a side channel that leaks how each gate identified the
+# mismatch.
+_DENIED_MESSAGE = (
+    "Caller is not authorized for this resource. The request's account "
+    "scope does not match the authenticated principal's scope."
+)
+
+
+def _read_field(obj: Any, name: str) -> Any:
+    """Read ``name`` off ``obj``. Pydantic models, dataclasses, dicts
+    all supported. Missing field raises :class:`AdcpError` with
+    ``PERMISSION_DENIED`` rather than ``AttributeError`` — a buyer
+    referencing a non-existent field is denied uniformly with a
+    field-mismatch, not crashed.
+    """
+    if isinstance(obj, dict):
+        if name not in obj:
+            raise AdcpError(
+                "PERMISSION_DENIED",
+                message=_DENIED_MESSAGE,
+                recovery="terminal",
+            )
+        return obj[name]
+    try:
+        return getattr(obj, name)
+    except AttributeError as exc:
+        raise AdcpError(
+            "PERMISSION_DENIED",
+            message=_DENIED_MESSAGE,
+            recovery="terminal",
+        ) from exc
+
+
+def _read_metadata_field(metadata: Any, name: str) -> Any:
+    """Read ``name`` off the account metadata. Supports TypedDict /
+    plain dict and adopter-defined dataclasses / Pydantic models
+    uniformly. Missing field raises :class:`AdcpError`."""
+    if metadata is None:
+        raise AdcpError(
+            "PERMISSION_DENIED",
+            message=_DENIED_MESSAGE,
+            recovery="terminal",
+        )
+    return _read_field(metadata, name)
+
+
+def require_account_match(
+    expected_account_field: str = "account_id",
+) -> BeforeHook[Any, Any]:
+    """Build a :data:`BeforeHook` that requires the request's account
+    field equal ``ctx.account.id``.
+
+    The most common security composer — gates a method so a buyer
+    can only operate on their own account. Apply via
+    :func:`compose_method`::
+
+        wrapped = compose_method(
+            base.get_media_buy_delivery,
+            before=require_account_match(),
+        )
+
+    :param expected_account_field: Name of the field on the request
+        Pydantic model carrying the buyer-supplied account id.
+        Default ``"account_id"`` matches the AdCP wire convention.
+    :returns: A :data:`BeforeHook` that raises :class:`AdcpError`
+        with ``PERMISSION_DENIED`` on mismatch (or missing field) and
+        falls through (returns ``None``) on match.
+    """
+
+    async def hook(req: Any, ctx: RequestContext[Any]) -> ShortCircuit[Any] | None:
+        requested = _read_field(req, expected_account_field)
+        if requested != ctx.account.id:
+            raise AdcpError(
+                "PERMISSION_DENIED",
+                message=_DENIED_MESSAGE,
+                recovery="terminal",
+            )
+        return None
+
+    return hook
+
+
+def require_advertiser_match(
+    expected_advertiser_field: str = "advertiser_id",
+) -> BeforeHook[Any, Any]:
+    """Build a :data:`BeforeHook` that requires the request's
+    advertiser field equal ``ctx.account.metadata['advertiser_id']``.
+
+    Use for per-advertiser scope below the account level — adopters
+    who run multi-advertiser accounts and need to prevent cross-
+    advertiser access within an account.
+
+    :param expected_advertiser_field: Name of the field on the request
+        Pydantic model carrying the buyer-supplied advertiser id.
+        Default ``"advertiser_id"`` matches the AdCP wire convention.
+    :returns: A :data:`BeforeHook` that raises :class:`AdcpError`
+        with ``PERMISSION_DENIED`` on mismatch (or missing
+        ``advertiser_id`` in metadata) and falls through on match.
+    """
+
+    async def hook(req: Any, ctx: RequestContext[Any]) -> ShortCircuit[Any] | None:
+        requested = _read_field(req, expected_advertiser_field)
+        scoped = _read_metadata_field(ctx.account.metadata, "advertiser_id")
+        if requested != scoped:
+            raise AdcpError(
+                "PERMISSION_DENIED",
+                message=_DENIED_MESSAGE,
+                recovery="terminal",
+            )
+        return None
+
+    return hook
+
+
+def require_org_scope(
+    expected_org_field: str = "organization_id",
+) -> BeforeHook[Any, Any]:
+    """Build a :data:`BeforeHook` that requires the request's
+    organization field equal ``ctx.account.metadata['organization_id']``.
+
+    Use for org-level multi-tenancy where a single org owns multiple
+    accounts and the authorization decision is at the org level
+    (not the per-account level).
+
+    :param expected_org_field: Name of the field on the request
+        Pydantic model carrying the buyer-supplied organization id.
+        Default ``"organization_id"`` matches the AdCP wire
+        convention.
+    :returns: A :data:`BeforeHook` that raises :class:`AdcpError`
+        with ``PERMISSION_DENIED`` on mismatch (or missing
+        ``organization_id`` in metadata) and falls through on match.
+    """
+
+    async def hook(req: Any, ctx: RequestContext[Any]) -> ShortCircuit[Any] | None:
+        requested = _read_field(req, expected_org_field)
+        scoped = _read_metadata_field(ctx.account.metadata, "organization_id")
+        if requested != scoped:
+            raise AdcpError(
+                "PERMISSION_DENIED",
+                message=_DENIED_MESSAGE,
+                recovery="terminal",
+            )
+        return None
+
+    return hook
+
+
+__all__ = [
+    "AfterHook",
+    "BeforeHook",
+    "PlatformMethod",
+    "ShortCircuit",
+    "compose_method",
+    "require_account_match",
+    "require_advertiser_match",
+    "require_org_scope",
+]

--- a/src/adcp/decisioning/compose.py
+++ b/src/adcp/decisioning/compose.py
@@ -221,7 +221,7 @@ def _read_field(obj: Any, name: str) -> Any:
             raise AdcpError(
                 "PERMISSION_DENIED",
                 message=_DENIED_MESSAGE,
-                recovery="terminal",
+                recovery="correctable",
             )
         return obj[name]
     try:
@@ -230,7 +230,7 @@ def _read_field(obj: Any, name: str) -> Any:
         raise AdcpError(
             "PERMISSION_DENIED",
             message=_DENIED_MESSAGE,
-            recovery="terminal",
+            recovery="correctable",
         ) from exc
 
 
@@ -242,7 +242,7 @@ def _read_metadata_field(metadata: Any, name: str) -> Any:
         raise AdcpError(
             "PERMISSION_DENIED",
             message=_DENIED_MESSAGE,
-            recovery="terminal",
+            recovery="correctable",
         )
     return _read_field(metadata, name)
 
@@ -276,7 +276,7 @@ def require_account_match(
             raise AdcpError(
                 "PERMISSION_DENIED",
                 message=_DENIED_MESSAGE,
-                recovery="terminal",
+                recovery="correctable",
             )
         return None
 
@@ -308,7 +308,7 @@ def require_advertiser_match(
             raise AdcpError(
                 "PERMISSION_DENIED",
                 message=_DENIED_MESSAGE,
-                recovery="terminal",
+                recovery="correctable",
             )
         return None
 
@@ -341,7 +341,7 @@ def require_org_scope(
             raise AdcpError(
                 "PERMISSION_DENIED",
                 message=_DENIED_MESSAGE,
-                recovery="terminal",
+                recovery="correctable",
             )
         return None
 

--- a/tests/test_compose_method.py
+++ b/tests/test_compose_method.py
@@ -1,0 +1,404 @@
+"""Tests for :mod:`adcp.decisioning.compose`.
+
+Covers:
+
+* ``before`` returning ``None`` falls through to the inner method.
+* ``before`` returning :class:`ShortCircuit` short-circuits; inner
+  is not called.
+* ``after`` runs on the inner result.
+* ``after`` runs on the short-circuit result with original
+  ``params`` + ``ctx`` available.
+* ``after`` wraps both paths uniformly.
+* :class:`TypeError` when ``inner`` is not callable at wrap time.
+* :class:`TypeError` when ``before`` returns a bare non-
+  :class:`ShortCircuit` value.
+* :func:`require_account_match` raises :class:`AdcpError`
+  ``PERMISSION_DENIED`` on mismatch, falls through on match.
+* :func:`require_advertiser_match` similar.
+* :func:`require_org_scope` similar.
+* Composing three security hooks chains correctly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from adcp.decisioning.compose import (
+    ShortCircuit,
+    compose_method,
+    require_account_match,
+    require_advertiser_match,
+    require_org_scope,
+)
+from adcp.decisioning.context import RequestContext
+from adcp.decisioning.types import Account, AdcpError
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Req:
+    """Stand-in for a Pydantic request model — adopters' real platform
+    methods take :class:`adcp.types.GetProductsRequest` etc.; tests
+    use a plain dataclass to keep the fixture surface minimal."""
+
+    account_id: str = "acct_1"
+    advertiser_id: str = "adv_1"
+    organization_id: str = "org_1"
+    payload: str = "p"
+
+
+@dataclass
+class _Res:
+    value: str = "inner-result"
+
+
+def _make_ctx(
+    account_id: str = "acct_1",
+    metadata: dict[str, Any] | None = None,
+) -> RequestContext[dict[str, Any]]:
+    """Build a :class:`RequestContext` with a typed :class:`Account`
+    for security-hook tests. Production code receives ``ctx`` from
+    the dispatch hydration helper; tests construct directly."""
+    if metadata is None:
+        metadata = {"advertiser_id": "adv_1", "organization_id": "org_1"}
+    return RequestContext(
+        account=Account(id=account_id, metadata=metadata),
+    )
+
+
+# ---------------------------------------------------------------------------
+# compose_method — core semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_before_returns_none_falls_through_to_inner() -> None:
+    """``before`` returning ``None`` runs the inner method
+    unchanged."""
+    inner_calls: list[_Req] = []
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        inner_calls.append(req)
+        return _Res(value="from-inner")
+
+    async def before(req: _Req, ctx: RequestContext[Any]) -> None:
+        return None
+
+    wrapped = compose_method(inner, before=before)
+    result = await wrapped(_Req(), _make_ctx())
+
+    assert result.value == "from-inner"
+    assert len(inner_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_before_short_circuit_skips_inner() -> None:
+    """``before`` returning :class:`ShortCircuit` skips the inner
+    method entirely; the wrapped value is returned to the caller."""
+    inner_calls: list[_Req] = []
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        inner_calls.append(req)
+        return _Res(value="from-inner")
+
+    async def before(req: _Req, ctx: RequestContext[Any]) -> ShortCircuit[_Res] | None:
+        return ShortCircuit(value=_Res(value="short-circuited"))
+
+    wrapped = compose_method(inner, before=before)
+    result = await wrapped(_Req(), _make_ctx())
+
+    assert result.value == "short-circuited"
+    assert inner_calls == []
+
+
+@pytest.mark.asyncio
+async def test_after_runs_on_inner_result() -> None:
+    """``after`` wraps the inner method's return value."""
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        return _Res(value="raw")
+
+    async def after(result: _Res, req: _Req, ctx: RequestContext[Any]) -> _Res:
+        return _Res(value=f"wrapped:{result.value}")
+
+    wrapped = compose_method(inner, after=after)
+    result = await wrapped(_Req(), _make_ctx())
+
+    assert result.value == "wrapped:raw"
+
+
+@pytest.mark.asyncio
+async def test_after_runs_on_short_circuit_with_original_params_and_ctx() -> None:
+    """``after`` runs even when ``before`` short-circuits, and sees
+    the original ``params`` and ``ctx`` (not the short-circuit
+    payload)."""
+    seen: dict[str, Any] = {}
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        raise AssertionError("inner must not be called on short-circuit")
+
+    async def before(req: _Req, ctx: RequestContext[Any]) -> ShortCircuit[_Res] | None:
+        return ShortCircuit(value=_Res(value="cached"))
+
+    async def after(result: _Res, req: _Req, ctx: RequestContext[Any]) -> _Res:
+        seen["result"] = result.value
+        seen["req_payload"] = req.payload
+        seen["account_id"] = ctx.account.id
+        return _Res(value=f"after:{result.value}")
+
+    wrapped = compose_method(inner, before=before, after=after)
+    result = await wrapped(_Req(payload="ping"), _make_ctx(account_id="acct_x"))
+
+    assert result.value == "after:cached"
+    assert seen == {
+        "result": "cached",
+        "req_payload": "ping",
+        "account_id": "acct_x",
+    }
+
+
+@pytest.mark.asyncio
+async def test_after_wraps_both_paths_uniformly() -> None:
+    """A single ``after`` hook wraps both the inner-result path and
+    the short-circuit path identically — adopters wire enrichment
+    once and it covers cache-hit + cache-miss without branching."""
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        return _Res(value="inner")
+
+    async def before(req: _Req, ctx: RequestContext[Any]) -> ShortCircuit[_Res] | None:
+        if req.payload == "skip":
+            return ShortCircuit(value=_Res(value="cached"))
+        return None
+
+    async def after(result: _Res, req: _Req, ctx: RequestContext[Any]) -> _Res:
+        return _Res(value=f"wrapped:{result.value}")
+
+    wrapped = compose_method(inner, before=before, after=after)
+
+    inner_path = await wrapped(_Req(payload="run"), _make_ctx())
+    short_path = await wrapped(_Req(payload="skip"), _make_ctx())
+
+    assert inner_path.value == "wrapped:inner"
+    assert short_path.value == "wrapped:cached"
+
+
+def test_typeerror_when_inner_not_callable() -> None:
+    """Wrap-time validation: passing a non-callable ``inner`` raises
+    immediately so adopters who reference an optional method that
+    wasn't implemented on the platform fail at module load, not at
+    first traffic."""
+    with pytest.raises(TypeError, match="must be callable"):
+        compose_method(None)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="must be callable"):
+        compose_method("not a function")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_typeerror_when_before_returns_bare_value() -> None:
+    """The discriminated :class:`ShortCircuit` wrapper catches the
+    ``None``-as-sentinel footgun: an adopter who returns a bare value
+    (forgetting the wrapper) gets a clear :class:`TypeError`, not
+    silent short-circuit-with-bare-value."""
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        return _Res(value="inner")
+
+    async def before(req: _Req, ctx: RequestContext[Any]) -> Any:
+        return _Res(value="bare-not-wrapped")
+
+    wrapped = compose_method(inner, before=before)
+    with pytest.raises(TypeError, match="ShortCircuit"):
+        await wrapped(_Req(), _make_ctx())
+
+
+# ---------------------------------------------------------------------------
+# Security composer helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_require_account_match_falls_through_on_match() -> None:
+    """When ``ctx.account.id`` matches the request's ``account_id``,
+    the hook returns ``None`` (fall through) so the inner method
+    runs."""
+    hook = require_account_match()
+    result = await hook(_Req(account_id="acct_1"), _make_ctx(account_id="acct_1"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_require_account_match_raises_on_mismatch() -> None:
+    """When ``ctx.account.id`` does not match the request's
+    ``account_id``, the hook raises :class:`AdcpError` with
+    ``PERMISSION_DENIED``."""
+    hook = require_account_match()
+    with pytest.raises(AdcpError) as excinfo:
+        await hook(
+            _Req(account_id="acct_other"),
+            _make_ctx(account_id="acct_1"),
+        )
+    assert excinfo.value.code == "PERMISSION_DENIED"
+
+
+@pytest.mark.asyncio
+async def test_require_account_match_custom_field() -> None:
+    """The factory accepts a custom field name for non-default
+    request shapes."""
+
+    @dataclass
+    class _CustomReq:
+        tenant_id: str
+
+    hook = require_account_match(expected_account_field="tenant_id")
+    assert await hook(_CustomReq(tenant_id="acct_1"), _make_ctx(account_id="acct_1")) is None
+    with pytest.raises(AdcpError):
+        await hook(_CustomReq(tenant_id="other"), _make_ctx(account_id="acct_1"))
+
+
+@pytest.mark.asyncio
+async def test_require_advertiser_match_falls_through_on_match() -> None:
+    """When ``ctx.account.metadata['advertiser_id']`` equals the
+    request's ``advertiser_id``, the hook returns ``None``."""
+    hook = require_advertiser_match()
+    result = await hook(
+        _Req(advertiser_id="adv_1"),
+        _make_ctx(metadata={"advertiser_id": "adv_1"}),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_require_advertiser_match_raises_on_mismatch() -> None:
+    """When the request's advertiser does not match the metadata
+    scope, the hook raises :class:`AdcpError`."""
+    hook = require_advertiser_match()
+    with pytest.raises(AdcpError) as excinfo:
+        await hook(
+            _Req(advertiser_id="adv_other"),
+            _make_ctx(metadata={"advertiser_id": "adv_1"}),
+        )
+    assert excinfo.value.code == "PERMISSION_DENIED"
+
+
+@pytest.mark.asyncio
+async def test_require_advertiser_match_raises_on_missing_metadata() -> None:
+    """When ``ctx.account.metadata`` lacks ``advertiser_id``, the
+    hook denies — adopters who claim per-advertiser scope must wire
+    ``advertiser_id`` into the metadata; missing it is a
+    misconfiguration that defaults to deny."""
+    hook = require_advertiser_match()
+    with pytest.raises(AdcpError):
+        await hook(_Req(advertiser_id="adv_1"), _make_ctx(metadata={}))
+
+
+@pytest.mark.asyncio
+async def test_require_org_scope_falls_through_on_match() -> None:
+    """When ``ctx.account.metadata['organization_id']`` equals the
+    request's ``organization_id``, the hook returns ``None``."""
+    hook = require_org_scope()
+    result = await hook(
+        _Req(organization_id="org_1"),
+        _make_ctx(metadata={"organization_id": "org_1"}),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_require_org_scope_raises_on_mismatch() -> None:
+    """When the request's org does not match the metadata scope, the
+    hook raises :class:`AdcpError`."""
+    hook = require_org_scope()
+    with pytest.raises(AdcpError) as excinfo:
+        await hook(
+            _Req(organization_id="org_other"),
+            _make_ctx(metadata={"organization_id": "org_1"}),
+        )
+    assert excinfo.value.code == "PERMISSION_DENIED"
+
+
+# ---------------------------------------------------------------------------
+# Composing security hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chained_security_hooks_pass_when_all_match() -> None:
+    """Adopters chain multiple security composers by routing through
+    a single ``before`` that calls each in turn. Inner runs only when
+    every hook falls through."""
+    inner_calls: list[_Req] = []
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        inner_calls.append(req)
+        return _Res(value="ok")
+
+    account_hook = require_account_match()
+    advertiser_hook = require_advertiser_match()
+    org_hook = require_org_scope()
+
+    async def chained(req: _Req, ctx: RequestContext[Any]) -> ShortCircuit[_Res] | None:
+        for hook in (account_hook, advertiser_hook, org_hook):
+            early = await hook(req, ctx)
+            if early is not None:
+                return early
+        return None
+
+    wrapped = compose_method(inner, before=chained)
+    result = await wrapped(
+        _Req(account_id="acct_1", advertiser_id="adv_1", organization_id="org_1"),
+        _make_ctx(
+            account_id="acct_1",
+            metadata={"advertiser_id": "adv_1", "organization_id": "org_1"},
+        ),
+    )
+
+    assert result.value == "ok"
+    assert len(inner_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_chained_security_hooks_deny_at_first_failure() -> None:
+    """When chained, the first failing hook raises and short-
+    circuits the chain — subsequent hooks and the inner method don't
+    run."""
+    inner_calls: list[_Req] = []
+    advertiser_hook_calls: list[_Req] = []
+
+    async def inner(req: _Req, ctx: RequestContext[Any]) -> _Res:
+        inner_calls.append(req)
+        return _Res(value="ok")
+
+    account_hook = require_account_match()
+
+    async def tracking_advertiser_hook(
+        req: _Req, ctx: RequestContext[Any]
+    ) -> ShortCircuit[_Res] | None:
+        advertiser_hook_calls.append(req)
+        return await require_advertiser_match()(req, ctx)
+
+    async def chained(req: _Req, ctx: RequestContext[Any]) -> ShortCircuit[_Res] | None:
+        for hook in (account_hook, tracking_advertiser_hook):
+            early = await hook(req, ctx)
+            if early is not None:
+                return early
+        return None
+
+    wrapped = compose_method(inner, before=chained)
+
+    with pytest.raises(AdcpError) as excinfo:
+        await wrapped(
+            _Req(account_id="acct_other"),
+            _make_ctx(account_id="acct_1"),
+        )
+
+    assert excinfo.value.code == "PERMISSION_DENIED"
+    assert advertiser_hook_calls == []
+    assert inner_calls == []


### PR DESCRIPTION
## Summary

Port JS @adcp/sdk@6.7's typed before/after hook factory to Python. Adopters layer cross-cutting concerns (security gates, audit, enrichment, caching) on individual platform methods without re-typing every method.

New module `adcp.decisioning.compose`:

- `compose_method(inner, *, before, after)` — wraps a platform method with typed hooks. Validates `inner` is callable at wrap time (catches typos referencing optional methods at module load, not first traffic). `after` runs whether the result came from `inner` or a `before` short-circuit, BEFORE response-schema validation.
- `ShortCircuit[T]` — frozen dataclass discriminator. A `before` hook returns `ShortCircuit(value=...)` to skip `inner`; returns `None` to fall through. The discriminated wrapper avoids the `None`-as-sentinel footgun — bare-value returns raise `TypeError` rather than silently short-circuiting with `None`.
- `require_account_match` / `require_advertiser_match` / `require_org_scope` — pre-built `BeforeHook`s for the three common authorization patterns. Stackable via a small chain helper.

Mirrors `src/lib/server/decisioning/compose.ts` from the JS SDK; the `.changeset/compose-method-helper.md` rationale applies verbatim.

This ships the primitives only — existing platform methods are not refactored to use them.

## Test plan

- [x] 17 tests in `tests/test_compose_method.py` cover: before-fall-through, before-short-circuit-skips-inner, after-on-inner, after-on-short-circuit-with-original-params-and-ctx, after-uniform-on-both-paths, TypeError on non-callable inner, TypeError on bare-value before return, each security helper (match falls through / mismatch raises PERMISSION_DENIED / missing metadata denies / custom field name), and three-hook chained composition (success + first-failure).
- [x] `ruff check src/` clean
- [x] `mypy src/adcp/` clean (751 source files)
- [x] `pytest tests/test_compose_method.py -v` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)