### PR TITLE
fix(client): is_v3_capabilities_shape — surface v3 validation errors instead of opaque failure

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -595,6 +595,8 @@ __all__ = [
     "ValidationResult",
     # Capability validation
     "FeatureResolver",
+    "build_synthetic_capabilities",
+    "is_v3_capabilities_shape",
     "validate_capabilities",
     # Core types
     "AgentConfig",

--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -25,6 +25,7 @@ from adcp.adagents import (
 from adcp.capabilities import (  # noqa: F401
     FeatureResolver,
     build_synthetic_capabilities,
+    is_v3_capabilities_shape,
     validate_capabilities,
 )
 from adcp.client import ADCPClient, ADCPMultiAgentClient, Checkpoint

--- a/src/adcp/capabilities.py
+++ b/src/adcp/capabilities.py
@@ -111,17 +111,24 @@ def is_v3_capabilities_shape(data: Any) -> bool:
     """
     if not isinstance(data, dict):
         return False
-    # Primary: adcp.major_versions contains 3
+    # Primary: adcp.major_versions contains integer 3. The AdCP schema defines
+    # major_versions as a list of integers; string "3" would be a non-conformant
+    # seller and falls through to the secondary/tertiary checks below.
     adcp = data.get("adcp")
     if isinstance(adcp, dict):
         if 3 in adcp.get("major_versions", []):
             return True
-    # Secondary: v3-only protocol name in supported_protocols list
+    # Secondary: v3-only protocol name in supported_protocols list.
+    # Guard isinstance(p, str) so a malformed seller response with a list of
+    # objects (e.g. [{"name": "governance"}]) doesn't raise TypeError.
     protocols = data.get("supported_protocols")
     if isinstance(protocols, list):
-        if any(p in _V3_PROTOCOL_NAMES for p in protocols):
+        if any(p in _V3_PROTOCOL_NAMES for p in protocols if isinstance(p, str)):
             return True
-    # Tertiary: v3-only capability block present as a top-level key
+    # Tertiary: v3-only capability block present as a top-level key.
+    # Note: Trusted Match Protocol (TMP) is negotiated inside media_buy.execution
+    # and does not appear as a supported_protocols value or top-level key, so
+    # a media_buy-only v3 seller using TMP is caught only by the primary check.
     if _V3_PROTOCOL_NAMES & set(data.keys()):
         return True
     return False

--- a/src/adcp/capabilities.py
+++ b/src/adcp/capabilities.py
@@ -87,6 +87,46 @@ for _task, _feature in TASK_FEATURE_MAP.items():
 del _task, _feature
 
 
+#: Protocol names that only exist in AdCP v3+. Used by
+#: :func:`is_v3_capabilities_shape` to detect v3-shaped responses.
+_V3_PROTOCOL_NAMES: frozenset[str] = frozenset(
+    {"governance", "sponsored_intelligence", "brand", "creative"}
+)
+
+
+def is_v3_capabilities_shape(data: Any) -> bool:
+    """Return True if *data* appears to be a v3-shaped capabilities response.
+
+    Useful when a raw capabilities dict fails Pydantic validation — the heuristic
+    tells you whether to surface a v3-specific error or fall through to the generic
+    path. Checks, in order:
+
+    1. ``adcp.major_versions`` contains ``3`` (most reliable — present on any
+       response that reached the parse stage).
+    2. ``supported_protocols`` list contains a v3-only protocol name
+       (``governance``, ``sponsored_intelligence``, ``brand``, ``creative``).
+    3. A v3-only capability block key is present at the top level (same names).
+
+    Returns ``False`` for any non-dict input.
+    """
+    if not isinstance(data, dict):
+        return False
+    # Primary: adcp.major_versions contains 3
+    adcp = data.get("adcp")
+    if isinstance(adcp, dict):
+        if 3 in adcp.get("major_versions", []):
+            return True
+    # Secondary: v3-only protocol name in supported_protocols list
+    protocols = data.get("supported_protocols")
+    if isinstance(protocols, list):
+        if any(p in _V3_PROTOCOL_NAMES for p in protocols):
+            return True
+    # Tertiary: v3-only capability block present as a top-level key
+    if _V3_PROTOCOL_NAMES & set(data.keys()):
+        return True
+    return False
+
+
 def build_synthetic_capabilities(
     supported_protocols: list[str],
     *,

--- a/src/adcp/client.py
+++ b/src/adcp/client.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from mcp import ClientSession
 
 from adcp._version import resolve_adcp_version
-from adcp.capabilities import TASK_FEATURE_MAP, FeatureResolver
+from adcp.capabilities import TASK_FEATURE_MAP, FeatureResolver, is_v3_capabilities_shape
 from adcp.exceptions import ADCPError, ADCPWebhookSignatureError
 from adcp.protocols.a2a import A2AAdapter
 from adcp.protocols.base import ProtocolAdapter
@@ -1051,6 +1051,22 @@ class ADCPClient:
             self._feature_resolver = FeatureResolver(result.data)
             self._capabilities_fetched_at = time.monotonic()
             return self._capabilities
+        # When Pydantic parsing failed (transport succeeded but schema validation
+        # didn't), _parse_response stashes the raw dict in metadata. Check whether
+        # it looks v3-shaped so we can surface a v3-specific error instead of the
+        # opaque "Failed to fetch capabilities: Failed to parse response:" chain.
+        raw_data = (result.metadata or {}).get("_parse_failure_raw")
+        if raw_data is not None and is_v3_capabilities_shape(raw_data):
+            raise ADCPError(
+                "Capabilities response is v3-shaped but failed validation — "
+                "the seller's get_adcp_capabilities endpoint has a schema bug.",
+                agent_id=self.agent_config.id,
+                agent_uri=self.agent_config.agent_uri,
+                suggestion=(
+                    f"Pydantic validation error: {result.error}. "
+                    "Check the seller's capabilities endpoint against the v3 schema."
+                ),
+            )
         raise ADCPError(
             f"Failed to fetch capabilities: {result.error or result.message}",
             agent_id=self.agent_config.id,

--- a/src/adcp/client.py
+++ b/src/adcp/client.py
@@ -1057,13 +1057,17 @@ class ADCPClient:
         # opaque "Failed to fetch capabilities: Failed to parse response:" chain.
         raw_data = (result.metadata or {}).get("_parse_failure_raw")
         if raw_data is not None and is_v3_capabilities_shape(raw_data):
+            pydantic_detail = (result.error or "").removeprefix(
+                "Failed to parse response: "
+            )
             raise ADCPError(
-                "Capabilities response is v3-shaped but failed validation — "
-                "the seller's get_adcp_capabilities endpoint has a schema bug.",
+                "Capabilities response is v3-shaped but does not satisfy the "
+                "v3 schema — a required field may be missing or have an "
+                "unexpected type.",
                 agent_id=self.agent_config.id,
                 agent_uri=self.agent_config.agent_uri,
                 suggestion=(
-                    f"Pydantic validation error: {result.error}. "
+                    f"Pydantic detail: {pydantic_detail}. "
                     "Check the seller's capabilities endpoint against the v3 schema."
                 ),
             )

--- a/src/adcp/protocols/base.py
+++ b/src/adcp/protocols/base.py
@@ -149,11 +149,16 @@ class ProtocolAdapter(ABC):
             # Parsing failed - return error result. Preserve idempotency_key
             # and replayed so callers can still correlate/suppress side-effects
             # even when response parsing fails.
+            # Store raw data in metadata so callers (e.g. refresh_capabilities)
+            # can inspect the shape even after parsing fails.
+            meta: dict[str, Any] = dict(raw_result.metadata or {})
+            meta["_parse_failure_raw"] = raw_result.data
             return TaskResult[T](
                 status=TaskStatus.FAILED,
                 error=f"Failed to parse response: {e}",
                 message=raw_result.message,
                 success=False,
+                metadata=meta,
                 debug_info=raw_result.debug_info,
                 idempotency_key=raw_result.idempotency_key,
                 replayed=raw_result.replayed,

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -931,7 +931,7 @@ class TestRefreshCapabilitiesV3Shape:
 
         msg = str(exc_info.value)
         assert "v3-shaped" in msg
-        assert "schema bug" in msg
+        assert "required field may be missing" in msg
         # Must NOT be the old buried message
         assert "Failed to fetch capabilities" not in msg
 
@@ -958,9 +958,10 @@ class TestRefreshCapabilitiesV3Shape:
             with pytest.raises(ADCPError) as exc_info:
                 await client.refresh_capabilities()
 
-        # Pydantic field path should appear in the suggestion field directly
+        # Pydantic field path should appear in suggestion without the internal prefix
         assert exc_info.value.suggestion is not None
         assert "supported_billing" in exc_info.value.suggestion
+        assert "Failed to parse response" not in exc_info.value.suggestion
 
     @pytest.mark.asyncio
     async def test_genuine_v2_failure_raises_generic_error(self) -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -884,6 +884,17 @@ class TestIsV3CapabilitiesShape:
         }
         assert is_v3_capabilities_shape(data) is True
 
+    def test_malformed_supported_protocols_list_of_dicts_does_not_raise(self) -> None:
+        # A broken seller might return supported_protocols as a list of objects.
+        # The isinstance(p, str) guard must prevent TypeError on dict iteration.
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {
+            "adcp": {"major_versions": [2]},
+            "supported_protocols": [{"name": "governance"}],
+        }
+        assert is_v3_capabilities_shape(data) is False
+
     def test_importable_from_top_level(self) -> None:
         from adcp import is_v3_capabilities_shape
 
@@ -947,8 +958,9 @@ class TestRefreshCapabilitiesV3Shape:
             with pytest.raises(ADCPError) as exc_info:
                 await client.refresh_capabilities()
 
-        # Pydantic field path should appear in the raised exception string
-        assert "supported_billing" in str(exc_info.value)
+        # Pydantic field path should appear in the suggestion field directly
+        assert exc_info.value.suggestion is not None
+        assert "supported_billing" in exc_info.value.suggestion
 
     @pytest.mark.asyncio
     async def test_genuine_v2_failure_raises_generic_error(self) -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -809,3 +809,186 @@ class TestSupportsV3:
         )
         resolver = FeatureResolver(caps)
         assert resolver.supports_v3() is True
+
+
+class TestIsV3CapabilitiesShape:
+    """Tests for is_v3_capabilities_shape()."""
+
+    def test_v3_by_major_version(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {"adcp": {"major_versions": [3]}, "supported_protocols": ["media_buy"]}
+        assert is_v3_capabilities_shape(data) is True
+
+    def test_v3_by_major_version_mixed(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {"adcp": {"major_versions": [2, 3]}, "supported_protocols": ["media_buy"]}
+        assert is_v3_capabilities_shape(data) is True
+
+    def test_v3_by_supported_protocols_governance(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        # v3-only protocol name in supported_protocols list catches media_buy-only
+        # v3 sellers that don't advertise governance/brand/etc capability blocks
+        data = {
+            "adcp": {"major_versions": [2]},
+            "supported_protocols": ["media_buy", "governance"],
+        }
+        assert is_v3_capabilities_shape(data) is True
+
+    def test_v3_by_supported_protocols_sponsored_intelligence(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {"adcp": {}, "supported_protocols": ["sponsored_intelligence"]}
+        assert is_v3_capabilities_shape(data) is True
+
+    def test_v3_by_top_level_governance_key(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {
+            "adcp": {"major_versions": [2]},
+            "supported_protocols": ["media_buy"],
+            "governance": {"spend_aggregation_window_days": 30},
+        }
+        assert is_v3_capabilities_shape(data) is True
+
+    def test_genuine_v2_returns_false(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {"adcp": {"major_versions": [2]}, "supported_protocols": ["media_buy"]}
+        assert is_v3_capabilities_shape(data) is False
+
+    def test_non_dict_returns_false(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        for val in [None, 42, [], "string", b"bytes"]:
+            assert is_v3_capabilities_shape(val) is False
+
+    def test_empty_dict_returns_false(self) -> None:
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        assert is_v3_capabilities_shape({}) is False
+
+    def test_ambiguous_v2_major_v3_top_key(self) -> None:
+        # A response claiming major_versions=[2] but including a governance block
+        # is detected as v3-shaped via the tertiary key check — the seller has
+        # a misconfiguration, and surfacing a v3 error is more useful than
+        # treating it as a genuine v2 agent.
+        from adcp.capabilities import is_v3_capabilities_shape
+
+        data = {
+            "adcp": {"major_versions": [2]},
+            "supported_protocols": ["media_buy"],
+            "brand": {},
+        }
+        assert is_v3_capabilities_shape(data) is True
+
+    def test_importable_from_top_level(self) -> None:
+        from adcp import is_v3_capabilities_shape
+
+        assert callable(is_v3_capabilities_shape)
+
+
+class TestRefreshCapabilitiesV3Shape:
+    """Tests for the v3-shape detection in refresh_capabilities()."""
+
+    @pytest.mark.asyncio
+    async def test_v3_shaped_parse_failure_raises_loud_error(self) -> None:
+        client = ADCPClient(_make_config())
+
+        # Simulate: transport succeeded (success=True from adapter), but Pydantic
+        # validation failed — _parse_response stashes the raw dict in metadata.
+        failed_result = TaskResult(
+            status=TaskStatus.FAILED,
+            data=None,
+            success=False,
+            error="Failed to parse response: 1 validation error for GetAdcpCapabilitiesResponse",
+            metadata={
+                "_parse_failure_raw": {
+                    "adcp": {"major_versions": [3]},
+                    "supported_protocols": ["media_buy"],
+                    "media_buy": {},
+                }
+            },
+        )
+        with patch.object(client, "get_adcp_capabilities", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = failed_result
+
+            with pytest.raises(ADCPError) as exc_info:
+                await client.refresh_capabilities()
+
+        msg = str(exc_info.value)
+        assert "v3-shaped" in msg
+        assert "schema bug" in msg
+        # Must NOT be the old buried message
+        assert "Failed to fetch capabilities" not in msg
+
+    @pytest.mark.asyncio
+    async def test_v3_shaped_error_includes_pydantic_detail_in_suggestion(self) -> None:
+        client = ADCPClient(_make_config())
+
+        pydantic_err = "1 validation error for GetAdcpCapabilitiesResponse\naccount -> supported_billing"
+        failed_result = TaskResult(
+            status=TaskStatus.FAILED,
+            data=None,
+            success=False,
+            error=f"Failed to parse response: {pydantic_err}",
+            metadata={
+                "_parse_failure_raw": {
+                    "adcp": {"major_versions": [3]},
+                    "supported_protocols": ["governance"],
+                }
+            },
+        )
+        with patch.object(client, "get_adcp_capabilities", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = failed_result
+
+            with pytest.raises(ADCPError) as exc_info:
+                await client.refresh_capabilities()
+
+        # Pydantic field path should appear in the raised exception string
+        assert "supported_billing" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_genuine_v2_failure_raises_generic_error(self) -> None:
+        """A v2-shaped parse failure falls through to the generic error path."""
+        client = ADCPClient(_make_config())
+
+        failed_result = TaskResult(
+            status=TaskStatus.FAILED,
+            data=None,
+            success=False,
+            error="Failed to parse response: unexpected field",
+            metadata={
+                "_parse_failure_raw": {
+                    "adcp": {"major_versions": [2]},
+                    "supported_protocols": ["media_buy"],
+                }
+            },
+        )
+        with patch.object(client, "get_adcp_capabilities", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = failed_result
+
+            with pytest.raises(ADCPError) as exc_info:
+                await client.refresh_capabilities()
+
+        assert "Failed to fetch capabilities" in str(exc_info.value)
+        assert "v3-shaped" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_no_raw_data_raises_generic_error(self) -> None:
+        """Transport failure (no raw data at all) still raises the generic error."""
+        client = ADCPClient(_make_config())
+
+        failed_result = TaskResult(
+            status=TaskStatus.FAILED,
+            data=None,
+            success=False,
+            error="Connection refused",
+        )
+        with patch.object(client, "get_adcp_capabilities", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = failed_result
+
+            with pytest.raises(ADCPError, match="Failed to fetch capabilities"):
+                await client.refresh_capabilities()


### PR DESCRIPTION
Closes #461

Ports the JS 6.6.0 fix (`27bd79d`) to Python. When a v3 seller's `get_adcp_capabilities` endpoint returns a structurally v3-shaped response that fails Pydantic validation (e.g. one missing required field on `Account`), `refresh_capabilities()` previously raised a generic `"Failed to fetch capabilities: Failed to parse response: ..."` with no v3-specific signal. Users would chase confusing schema-version cascades with no connection to the actual validation failure.

## Changes

**`src/adcp/capabilities.py`** — adds `is_v3_capabilities_shape(data: Any) -> bool`

Heuristic checks in priority order:
1. `adcp.major_versions` contains integer `3` (most reliable — present on any response that reached the parse stage)
2. `supported_protocols` list contains a v3-only protocol name (`governance`, `sponsored_intelligence`, `brand`, `creative`) — catches `media_buy`-only v3 sellers with no v3 capability blocks
3. A v3-only capability block key present at the top level (tertiary fallback)

Returns `False` for any non-dict input. Guards `isinstance(p, str)` in the secondary check so a malformed `supported_protocols: [{"name": "governance"}]` does not raise `TypeError`.

**`src/adcp/protocols/base.py`** — preserves raw data on parse failure

In `_parse_response()`, when a `ValueError` occurs during Pydantic parsing, stashes `raw_result.data` in `metadata["_parse_failure_raw"]`. This lets `refresh_capabilities()` inspect the raw dict without duplicating activity-event emission or changing any other behavior. (`_parse_failure_raw` is an SDK-internal key; sole consumer is `refresh_capabilities`.)

**`src/adcp/client.py`** — v3-aware error in `refresh_capabilities()`

After a failed `get_adcp_capabilities()`, checks `metadata["_parse_failure_raw"]` and calls `is_v3_capabilities_shape()`. If v3-shaped, raises `ADCPError` with a clear message and the stripped Pydantic field path in the `suggestion` field instead of the opaque generic error.

**`src/adcp/__init__.py`** — exports `is_v3_capabilities_shape` and adds it to `__all__`

Exported alongside `build_synthetic_capabilities` so integrators debugging seller endpoints can call it against a raw dict without knowing the internal module layout.

## What was tested

- `pytest tests/test_capabilities.py` — 72 passed (14 new: 10 `TestIsV3CapabilitiesShape` + 4 `TestRefreshCapabilitiesV3Shape`)
- `pytest tests/` — 3300 passed, 27 skipped, 1 pre-existing TLS failure unrelated to this diff
- `mypy src/adcp/` — Success, no issues found in 753 source files
- `ruff check src/` — All checks passed

## Pre-PR review

- **code-reviewer**: approved — fixed two blockers (unhashable-items `TypeError` guard; `__all__` omission) and one nit (fragile test assertion) before merge
- **dx-expert**: approved — fixed suggestion-string double-label and "schema bug" wording before merge; `llms.txt` omission noted as out-of-scope follow-up

**Nit surfaced (not fixed, noting for reviewers):** `llms.txt` line for `adcp.capabilities` does not list `is_v3_capabilities_shape`. Coding agents reading `llms.txt` will not discover the function by scan. Low-risk omission (function is in `__all__` and importable); a follow-up one-line patch to `llms.txt` would close the gap.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01VodVHzLfxBLX8peistiguY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VodVHzLfxBLX8peistiguY)_