### PR TITLE
feat(server): createMediaBuyStore — opt-in targeting_overlay echo for property-lists / collection-lists sellers

### DIFF
--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -89,6 +89,10 @@ from adcp.decisioning.errors import (
     ValidationError,
 )
 from adcp.decisioning.helpers import ref_account_id
+from adcp.decisioning.media_buy_store import (
+    MediaBuyStore,
+    create_media_buy_store,
+)
 from adcp.decisioning.mock_ad_server import (
     InMemoryMockAdServer,
     MockAdServer,
@@ -274,6 +278,7 @@ __all__ = [
     "MEDIA_BUY_TRANSITIONS",
     "MaybeAsync",
     "MediaBuyNotFoundError",
+    "MediaBuyStore",
     "MockAdServer",
     "NoAuth",
     "OAuthCredential",
@@ -317,6 +322,7 @@ __all__ = [
     "bearer_only_registry",
     "compose_method",
     "create_adcp_server_from_platform",
+    "create_media_buy_store",
     "create_oauth_passthrough_resolver",
     "create_roster_account_store",
     "create_tenant_store",

--- a/src/adcp/decisioning/media_buy_store.py
+++ b/src/adcp/decisioning/media_buy_store.py
@@ -1,0 +1,194 @@
+"""``create_media_buy_store`` — opt-in framework wiring that gates
+``targeting_overlay`` echo on the seller's declared specialisms.
+
+The seller's spec contract on
+``schemas/cache/<v>/media-buy/get-media-buys-response.json`` requires
+that sellers claiming the ``property-lists`` or ``collection-lists``
+specialism echo persisted ``property_list`` / ``collection_list``
+references inside the ``packages[].targeting_overlay`` they return on
+``get_media_buys``. This factory lets adopters wire that contract once,
+at the framework boundary, instead of every adapter persisting +
+echoing by hand.
+
+Mirrors the JS-side ``createMediaBuyStore`` from ``@adcp/sdk@6.7``
+(commit ``dda2a77e``) with one shape change: the JS factory builds the
+persistence itself on top of an ``AdcpStateStore``. The Python SDK
+doesn't ship an ``AdcpStateStore`` Protocol, so adopters supply their
+own :class:`MediaBuyStore` implementation; this factory wraps it with
+specialism-aware gating. Adopters who want a reference impl can crib
+the in-memory pattern from the test suite.
+
+Usage::
+
+    from adcp.decisioning import create_media_buy_store
+
+    platform.media_buy_store = create_media_buy_store(
+        adopter_store, capabilities=platform.capabilities,
+    )
+
+Behavior:
+
+* Seller claims ``property-lists`` or ``collection-lists`` →
+  every method delegates to the adopter store.
+* Seller claims neither → ``persist_from_create`` and
+  ``merge_from_update`` are no-ops; ``backfill`` returns the response
+  unchanged. The adopter store is never invoked.
+
+The wrapper is always a fresh object so adopters can reason about
+identity at the assignment site without aliasing surprises.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from adcp.decisioning.platform import DecisioningCapabilities
+
+__all__ = [
+    "MediaBuyStore",
+    "create_media_buy_store",
+]
+
+#: Specialism slugs that require ``targeting_overlay`` echo on
+#: ``get_media_buys``. A seller claiming either MUST echo the persisted
+#: ``property_list`` / ``collection_list`` reference per
+#: ``schemas/cache/<v>/media-buy/get-media-buys-response.json``.
+_OVERLAY_ECHO_SPECIALISMS: frozenset[str] = frozenset({"property-lists", "collection-lists"})
+
+
+@runtime_checkable
+class MediaBuyStore(Protocol):
+    """Adopter-supplied persistence + echo for ``targeting_overlay``.
+
+    Three methods cover the full lifecycle of a per-package overlay:
+
+    * :meth:`persist_from_create` records overlays from a successful
+      ``create_media_buy``, joining the request's per-package overlay
+      with the response's seller-assigned ``package_id`` (or
+      ``buyer_ref`` when present).
+    * :meth:`merge_from_update` applies ``update_media_buy`` patches
+      with deep-merge semantics: keys absent from the patch keep prior
+      values, keys present with non-null values replace, keys present
+      and ``None`` clear.
+    * :meth:`backfill` fills in missing
+      ``packages[].targeting_overlay`` on a ``get_media_buys`` response
+      from the persisted store. Mutates the response in place; packages
+      the seller already echoed are left untouched.
+
+    Methods may be sync or async — the wrapper awaits at call time.
+    """
+
+    def persist_from_create(
+        self,
+        account_id: str,
+        request: Any,
+        result: Any,
+    ) -> Any: ...
+
+    def merge_from_update(
+        self,
+        account_id: str,
+        media_buy_id: str,
+        patch: Any,
+    ) -> Any: ...
+
+    def backfill(self, account_id: str, result: Any) -> Any: ...
+
+
+async def _await_maybe(value: Any) -> Any:
+    """Resolve a value that may be a coroutine OR a plain return.
+
+    Mirrors the helper in :mod:`adcp.decisioning.tenant_store`; adopter
+    callbacks are sync OR async and the wrapper keeps its own dispatch
+    uniform without forcing every adopter into ``async def``.
+    """
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+class _ActiveMediaBuyStore:
+    """Wrapper that delegates every method to the adopter store.
+
+    Constructed when the seller claims ``property-lists`` or
+    ``collection-lists``. Adds the sync/async normalization layer over
+    the adopter callbacks so the framework can ``await`` uniformly.
+    """
+
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: MediaBuyStore) -> None:
+        self._inner = inner
+
+    async def persist_from_create(self, account_id: str, request: Any, result: Any) -> None:
+        await _await_maybe(self._inner.persist_from_create(account_id, request, result))
+
+    async def merge_from_update(self, account_id: str, media_buy_id: str, patch: Any) -> None:
+        await _await_maybe(self._inner.merge_from_update(account_id, media_buy_id, patch))
+
+    async def backfill(self, account_id: str, result: Any) -> Any:
+        return await _await_maybe(self._inner.backfill(account_id, result))
+
+
+class _NoopMediaBuyStore:
+    """Pass-through wrapper for sellers not claiming the echo specialisms.
+
+    Holds a reference to the adopter store for parity with the active
+    path — adopters can swap their seller's ``capabilities`` between
+    builds without touching the wiring. The reference is kept private
+    (``_inner``) to discourage adopter code from reaching past the
+    wrapper to an unwrapped store.
+    """
+
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: MediaBuyStore) -> None:
+        self._inner = inner
+
+    async def persist_from_create(self, account_id: str, request: Any, result: Any) -> None:
+        del account_id, request, result  # no-op pass-through
+
+    async def merge_from_update(self, account_id: str, media_buy_id: str, patch: Any) -> None:
+        del account_id, media_buy_id, patch  # no-op pass-through
+
+    async def backfill(self, account_id: str, result: Any) -> Any:
+        del account_id
+        return result
+
+
+def create_media_buy_store(
+    adopter_store: MediaBuyStore,
+    *,
+    capabilities: DecisioningCapabilities,
+) -> MediaBuyStore:
+    """Wrap an adopter :class:`MediaBuyStore` with specialism-aware
+    ``targeting_overlay`` echo gating.
+
+    :param adopter_store: The persistence + echo implementation. Must
+        satisfy the :class:`MediaBuyStore` Protocol — three methods
+        (``persist_from_create``, ``merge_from_update``, ``backfill``)
+        sync or async.
+    :param capabilities: The seller's :class:`DecisioningCapabilities`.
+        Read once at construction to decide whether the wrapper
+        delegates or no-ops; not re-read per request, so adopters who
+        mutate ``capabilities.specialisms`` after building the store
+        won't see the change reflected. Build-time decision matches the
+        boot-time validation pattern used elsewhere
+        (``validate_platform``).
+
+    :returns: A :class:`MediaBuyStore` wrapper. When ``capabilities.specialisms``
+        intersects ``{property-lists, collection-lists}``, every method
+        delegates to ``adopter_store``. Otherwise every method is a
+        no-op pass-through and the adopter store is never invoked.
+
+    The returned object is always distinct from ``adopter_store`` — even
+    on the no-op path — so adopters can reason about identity at the
+    assignment site (``platform.media_buy_store = ...``) without
+    aliasing the underlying persistence layer.
+    """
+    claimed = set(capabilities.specialisms) & _OVERLAY_ECHO_SPECIALISMS
+    if claimed:
+        return _ActiveMediaBuyStore(adopter_store)
+    return _NoopMediaBuyStore(adopter_store)

--- a/tests/test_media_buy_store.py
+++ b/tests/test_media_buy_store.py
@@ -1,0 +1,401 @@
+"""Tests for :func:`create_media_buy_store` — opt-in wrapper that gates
+``targeting_overlay`` echo on the seller's declared specialisms.
+
+Mirrors the JS ``createMediaBuyStore`` test surface (commit ``dda2a77e``)
+adapted to Python's adopter-supplied :class:`MediaBuyStore`. The wrapper
+delegates persist / merge / backfill to the adopter's store when the
+seller claims ``property-lists`` or ``collection-lists``; for sellers
+not claiming those specialisms every method is a no-op pass-through.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    create_media_buy_store,
+)
+
+PROPERTY_LIST = {
+    "list_id": "acme_outdoor_allowlist_v1",
+    "agent_url": "https://lists.example.com",
+}
+COLLECTION_LIST = {
+    "list_id": "sports_collections_v3",
+    "agent_url": "https://lists.example.com",
+}
+
+
+class InMemoryMediaBuyStore:
+    """Adopter-side reference :class:`MediaBuyStore` impl.
+
+    Implements the persist / merge / backfill contract directly on a
+    nested ``{account_id: {media_buy_id: {package_id: overlay}}}`` dict.
+    Faithfully ports the JS reference behavior so wrapper tests focus on
+    the gate, not the underlying merge semantics.
+    """
+
+    def __init__(self) -> None:
+        self.records: dict[str, dict[str, dict[str, dict[str, Any]]]] = {}
+
+    async def persist_from_create(
+        self,
+        account_id: str,
+        request: dict[str, Any],
+        result: dict[str, Any],
+    ) -> None:
+        request_packages = request.get("packages") or []
+        response_packages = result.get("packages") or []
+        media_buy_id = result.get("media_buy_id")
+        if not request_packages or not media_buy_id:
+            return
+        persisted: dict[str, dict[str, Any]] = {}
+        for i, req_pkg in enumerate(request_packages):
+            overlay = req_pkg.get("targeting_overlay")
+            if not overlay:
+                continue
+            buyer_ref = req_pkg.get("buyer_ref")
+            matched = None
+            if buyer_ref:
+                matched = next(
+                    (p for p in response_packages if p.get("buyer_ref") == buyer_ref),
+                    None,
+                )
+            if matched is None and i < len(response_packages):
+                matched = response_packages[i]
+            package_id = matched.get("package_id") if matched else None
+            if not package_id:
+                continue
+            persisted[package_id] = (matched or {}).get("targeting_overlay") or overlay
+        if persisted:
+            self.records.setdefault(account_id, {})[media_buy_id] = persisted
+
+    async def merge_from_update(
+        self,
+        account_id: str,
+        media_buy_id: str,
+        patch: dict[str, Any],
+    ) -> None:
+        prior = self.records.setdefault(account_id, {}).setdefault(media_buy_id, {})
+        for pkg in patch.get("packages") or []:
+            package_id = pkg.get("package_id")
+            if not package_id:
+                continue
+            if "targeting_overlay" not in pkg:
+                continue
+            incoming = pkg["targeting_overlay"]
+            if incoming is None:
+                prior.pop(package_id, None)
+                continue
+            existing = prior.get(package_id, {})
+            merged = dict(existing)
+            for key, value in incoming.items():
+                if value is None:
+                    merged.pop(key, None)
+                else:
+                    merged[key] = value
+            prior[package_id] = merged
+        for pkg in patch.get("new_packages") or []:
+            package_id = pkg.get("package_id")
+            overlay = pkg.get("targeting_overlay")
+            if not package_id or not overlay:
+                continue
+            prior[package_id] = overlay
+        if not prior:
+            self.records[account_id].pop(media_buy_id, None)
+
+    async def backfill(self, account_id: str, result: dict[str, Any]) -> dict[str, Any]:
+        buys = result.get("media_buys")
+        if not buys:
+            return result
+        account_records = self.records.get(account_id, {})
+        for buy in buys:
+            media_buy_id = buy.get("media_buy_id")
+            if not media_buy_id:
+                continue
+            record = account_records.get(media_buy_id)
+            if not record:
+                continue
+            for pkg in buy.get("packages") or []:
+                package_id = pkg.get("package_id")
+                if not package_id or pkg.get("targeting_overlay") is not None:
+                    continue
+                persisted = record.get(package_id)
+                if persisted:
+                    pkg["targeting_overlay"] = persisted
+        return result
+
+
+def _capabilities(*specialisms: str) -> DecisioningCapabilities:
+    return DecisioningCapabilities(specialisms=list(specialisms))
+
+
+# -----------------------------
+# Active-wrapper path: seller claims property-lists / collection-lists
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_persists_and_echoes_targeting_overlay_when_property_lists_claimed() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("property-lists"))
+
+    await store.persist_from_create(
+        "acct_a",
+        {
+            "packages": [
+                {
+                    "buyer_ref": "pkg_a",
+                    "targeting_overlay": {
+                        "property_list": PROPERTY_LIST,
+                        "collection_list": COLLECTION_LIST,
+                    },
+                }
+            ]
+        },
+        {
+            "media_buy_id": "mb_1",
+            "packages": [{"package_id": "seller_pkg_001", "buyer_ref": "pkg_a"}],
+        },
+    )
+
+    result = await store.backfill(
+        "acct_a",
+        {"media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "seller_pkg_001"}]}]},
+    )
+
+    assert result["media_buys"][0]["packages"][0]["targeting_overlay"] == {
+        "property_list": PROPERTY_LIST,
+        "collection_list": COLLECTION_LIST,
+    }
+
+
+@pytest.mark.asyncio
+async def test_active_wrapper_echoes_for_collection_lists_specialism() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("collection-lists"))
+
+    overlay = {"collection_list": COLLECTION_LIST}
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg_a", "targeting_overlay": overlay}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg_a"}]},
+    )
+
+    result = await store.backfill(
+        "acct_a", {"media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "p1"}]}]}
+    )
+
+    assert result["media_buys"][0]["packages"][0]["targeting_overlay"] == {
+        "collection_list": COLLECTION_LIST
+    }
+
+
+@pytest.mark.asyncio
+async def test_active_wrapper_works_when_both_specialisms_claimed() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(
+        backing, capabilities=_capabilities("property-lists", "collection-lists")
+    )
+
+    overlay = {"property_list": PROPERTY_LIST}
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg_a", "targeting_overlay": overlay}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg_a"}]},
+    )
+    assert "mb_1" in backing.records["acct_a"]
+
+
+@pytest.mark.asyncio
+async def test_merge_from_update_preserves_prior_fields_when_patch_omits_them() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("property-lists"))
+
+    initial_overlay = {"property_list": PROPERTY_LIST}
+    patch_overlay = {"collection_list": COLLECTION_LIST}
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg_a", "targeting_overlay": initial_overlay}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg_a"}]},
+    )
+    await store.merge_from_update(
+        "acct_a",
+        "mb_1",
+        {"packages": [{"package_id": "p1", "targeting_overlay": patch_overlay}]},
+    )
+    result = await store.backfill(
+        "acct_a",
+        {"media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "p1"}]}]},
+    )
+    assert result["media_buys"][0]["packages"][0]["targeting_overlay"] == {
+        "property_list": PROPERTY_LIST,
+        "collection_list": COLLECTION_LIST,
+    }
+
+
+@pytest.mark.asyncio
+async def test_does_not_overwrite_targeting_overlay_seller_already_echoed() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("property-lists"))
+
+    overlay = {"property_list": PROPERTY_LIST}
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg_a", "targeting_overlay": overlay}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg_a"}]},
+    )
+
+    seller_echoed = {"geo_countries": ["US"]}
+    result = await store.backfill(
+        "acct_a",
+        {
+            "media_buys": [
+                {
+                    "media_buy_id": "mb_1",
+                    "packages": [{"package_id": "p1", "targeting_overlay": seller_echoed}],
+                }
+            ]
+        },
+    )
+    assert result["media_buys"][0]["packages"][0]["targeting_overlay"] is seller_echoed
+
+
+@pytest.mark.asyncio
+async def test_account_scopes_records_across_accounts() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("property-lists"))
+
+    overlay_a = {"property_list": PROPERTY_LIST}
+    overlay_b = {"collection_list": COLLECTION_LIST}
+
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg", "targeting_overlay": overlay_a}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg"}]},
+    )
+    await store.persist_from_create(
+        "acct_b",
+        {"packages": [{"buyer_ref": "pkg", "targeting_overlay": overlay_b}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg"}]},
+    )
+
+    a = await store.backfill(
+        "acct_a", {"media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "p1"}]}]}
+    )
+    b = await store.backfill(
+        "acct_b", {"media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "p1"}]}]}
+    )
+
+    assert a["media_buys"][0]["packages"][0]["targeting_overlay"] == overlay_a
+    assert b["media_buys"][0]["packages"][0]["targeting_overlay"] == overlay_b
+
+
+# -----------------------------
+# No-op pass-through path: seller claims neither specialism
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_noop_pass_through_when_neither_specialism_claimed() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("sales-non-guaranteed"))
+
+    overlay = {"property_list": PROPERTY_LIST}
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg_a", "targeting_overlay": overlay}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg_a"}]},
+    )
+    # Backing store was never touched — wrapper short-circuited.
+    assert backing.records == {}
+
+    # Backfill is a pure pass-through: response is returned unchanged.
+    response: dict[str, Any] = {
+        "media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "p1"}]}]
+    }
+    result = await store.backfill("acct_a", response)
+    assert result is response
+    assert "targeting_overlay" not in result["media_buys"][0]["packages"][0]
+
+
+@pytest.mark.asyncio
+async def test_noop_pass_through_with_empty_specialisms() -> None:
+    backing = InMemoryMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities())
+
+    await store.merge_from_update(
+        "acct_a",
+        "mb_1",
+        {"packages": [{"package_id": "p1", "targeting_overlay": {"property_list": PROPERTY_LIST}}]},
+    )
+    assert backing.records == {}
+
+
+# -----------------------------
+# Sync adopter callbacks
+# -----------------------------
+
+
+class SyncMediaBuyStore:
+    """Adopter store with sync (non-async) methods.
+
+    Mirrors the ``MaybeAsync`` shape used elsewhere — the wrapper must
+    accept either flavour without forcing adopters into ``async def``.
+    """
+
+    def __init__(self) -> None:
+        self.persisted: list[tuple[str, str]] = []
+        self.merged: list[tuple[str, str]] = []
+        self.backfilled: list[str] = []
+
+    def persist_from_create(
+        self, account_id: str, request: dict[str, Any], result: dict[str, Any]
+    ) -> None:
+        self.persisted.append((account_id, result["media_buy_id"]))
+
+    def merge_from_update(self, account_id: str, media_buy_id: str, patch: dict[str, Any]) -> None:
+        self.merged.append((account_id, media_buy_id))
+
+    def backfill(self, account_id: str, result: dict[str, Any]) -> dict[str, Any]:
+        self.backfilled.append(account_id)
+        return result
+
+
+@pytest.mark.asyncio
+async def test_wrapper_accepts_sync_adopter_callbacks() -> None:
+    backing = SyncMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_capabilities("property-lists"))
+
+    await store.persist_from_create(
+        "acct_a",
+        {"packages": [{"buyer_ref": "pkg", "targeting_overlay": {"property_list": PROPERTY_LIST}}]},
+        {"media_buy_id": "mb_1", "packages": [{"package_id": "p1", "buyer_ref": "pkg"}]},
+    )
+    await store.merge_from_update("acct_a", "mb_1", {"packages": []})
+    await store.backfill("acct_a", {"media_buys": []})
+
+    assert backing.persisted == [("acct_a", "mb_1")]
+    assert backing.merged == [("acct_a", "mb_1")]
+    assert backing.backfilled == ["acct_a"]
+
+
+# -----------------------------
+# Specialism gating semantics
+# -----------------------------
+
+
+def test_active_wrapper_returns_distinct_object_from_adopter_store() -> None:
+    """Wrapper is always a fresh object — never returns the adopter
+    store directly even on the no-op path. Lets adopters reason about
+    identity (e.g. assigning to ``platform.media_buy_store``) without
+    surprise aliasing of their persistence layer."""
+    backing = InMemoryMediaBuyStore()
+    active = create_media_buy_store(backing, capabilities=_capabilities("property-lists"))
+    noop = create_media_buy_store(backing, capabilities=_capabilities("sales-non-guaranteed"))
+    assert active is not backing
+    assert noop is not backing
+    assert active is not noop


### PR DESCRIPTION
## Summary

Port of JS `@adcp/sdk@6.7`'s `createMediaBuyStore` (commit `dda2a77e`) to the Python SDK as `create_media_buy_store`.

- Wraps an adopter-supplied `MediaBuyStore` with specialism-aware gating: when the seller declares `property-lists` or `collection-lists` in `DecisioningCapabilities.specialisms`, every method delegates to the adopter store; otherwise every method is a no-op pass-through and the adopter store is never invoked.
- Defines the `MediaBuyStore` Protocol (three methods: `persist_from_create`, `merge_from_update`, `backfill`; sync or async).
- Closes the seller spec gap on `schemas/cache/<v>/media-buy/get-media-buys-response.json`'s mandated echo of persisted `property_list` / `collection_list` references for sellers claiming those specialisms.

## Design notes / divergences from JS

- **Adopter supplies the store, framework gates it.** The JS factory builds persistence itself on top of an `AdcpStateStore`. The Python SDK doesn't ship an `AdcpStateStore` Protocol, so this PR defines the `MediaBuyStore` Protocol the adopter implements; the factory wraps it. Adopters wanting a reference impl can crib the in-memory pattern from the test suite.
- **No-op path uses a wrapper, not a returned-as-is reference.** Even when the seller doesn't claim the echo specialisms, the wrapper is a fresh `_NoopMediaBuyStore` — not the adopter store directly. Lets adopters reason about identity at the assignment site without aliasing surprises.
- **Capabilities read at construction.** Mirrors the build-time-decision pattern used by `validate_platform`. Adopters who mutate `capabilities.specialisms` after building the store won't see the change reflected — rebuild instead.
- **Sync + async adopter callbacks both supported** via the `_await_maybe` shim, matching `tenant_store.py`'s pattern.

## Out of scope (deferred to framework PRs)

- Wiring `media_buy_store` into the `create_adcp_server_from_platform` dispatcher / handler layer (the Python equivalent of JS's `from-platform.ts` integration). Per the issue spec scope guard, framework-level interface changes are deferred.

Refs #462, #452.

## Test plan

- [x] Active path: persists + echoes overlay when `property-lists` claimed
- [x] Active path: persists + echoes overlay when `collection-lists` claimed
- [x] Active path: works when both specialisms claimed
- [x] Active path: merge preserves prior fields when patch omits them
- [x] Active path: does not overwrite seller-echoed overlay
- [x] Active path: account-scopes records across accounts
- [x] No-op path: backing store untouched when specialism not claimed
- [x] No-op path: works with empty specialisms list
- [x] Sync adopter callbacks accepted alongside async
- [x] Wrapper distinct from adopter store on both paths
- [x] `ruff check` clean on touched files
- [x] `mypy` clean on `media_buy_store.py`
- [x] Full regression: 3440 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)