### PR TITLE
feat(decisioning): credential-leak strip on every echo path + ctx_metadata guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,47 @@ All other source code should import from `adcp.types` (the public API).
 - Add specific `type: ignore` comments (e.g., `# type: ignore[no-any-return]`) rather than blanket ignores
 - Test type checking in CI across multiple Python versions (3.10+)
 
+## ctx_metadata: write-only credentials prohibited
+
+`RequestContext.metadata` (populated from the wire request's `context` extension)
+is **echoed back into responses** per the AdCP context-echo contract. Adopters who
+treat `metadata` as a generic KV bucket and store a credential there will discover
+it round-trips to the buyer — and lands in the idempotency replay cache.
+
+The dispatcher fail-closes on credential-shaped keys at `_build_request_context`.
+If you see a `ValueError` like `ctx_metadata may not contain credential-shaped
+keys`, migrate the value to `AuthInfo.credential` or a typed credential class.
+
+**Wrong** — credential stored in metadata, round-trips into response context:
+
+```python
+ctx = RequestContext(metadata={"upstream.api_token": secret})  # ValueError
+```
+
+**Right** — credential stored in the typed `AuthInfo.credential` field:
+
+```python
+auth = AuthInfo(
+    kind="api_key",
+    key_id="kid_1",
+    principal="agent.example.com",
+    credential=ApiKeyCredential(kind="api_key", key_id="kid_1"),
+)
+ctx = RequestContext(auth_info=auth, metadata={"correlation_id": "req_xyz"})
+```
+
+The credential-shaped key suffix list is in
+`adcp.decisioning.dispatch._CREDENTIAL_SHAPED_KEY_SUFFIXES` and matches
+case-insensitively at any nesting depth: `credential`, `credentials`, `token`,
+`secret`, `api_key`, `apikey`, `password`, `bearer`. Keys that don't match
+(`correlation_id`, `feature_flag.beta_pricing`, `trace_id`) pass through.
+
+For credentials the framework propagates to upstream calls (governance agents,
+signal providers, audience activations), use the typed credential classes from
+`adcp.decisioning`: `ApiKeyCredential`, `OAuthCredential`, `HttpSigCredential`.
+The framework dispatch threads these explicitly without going through the
+context-echo path.
+
 ## Testing Strategy
 
 **Mock at the Right Level**

--- a/src/adcp/decisioning/account_projection.py
+++ b/src/adcp/decisioning/account_projection.py
@@ -329,9 +329,118 @@ def to_wire_sync_governance_row(row: SyncGovernanceResultRow) -> dict[str, Any]:
     return wire
 
 
+# ---------------------------------------------------------------------------
+# Defense-in-depth scrubber — runs at every wire-emit boundary
+# ---------------------------------------------------------------------------
+
+
+#: Methods whose response payload may carry credential-shaped fields.
+#: The dispatcher gates the recursive scrubber on this set so unrelated
+#: tools (``get_products``, ``get_signals``) skip the walk entirely —
+#: the scrubber is O(n) in result size and not free for large catalogs.
+#:
+#: This set is intentionally broad: any tool whose response surfaces
+#: an ``Account`` envelope (``billing_entity``, ``governance_agents``)
+#: or a joined record carrying those keys belongs here.
+CREDENTIAL_BEARING_METHODS: frozenset[str] = frozenset(
+    {
+        "list_accounts",
+        "sync_accounts",
+        "sync_governance",
+        "create_media_buy",
+        "update_media_buy",
+        "get_media_buys",
+        "sync_creatives",
+        "list_creatives",
+    }
+)
+
+
+def _scrub_dict(value: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``value`` with credential-shaped fields stripped.
+
+    Strips:
+
+    * ``governance_agents[i].authentication`` — write-only credential.
+    * ``billing_entity.bank`` — write-only bank coordinates.
+
+    Walks recursively into nested dicts and lists. Returns a NEW dict —
+    the input is not mutated, so callers (idempotency replay cache,
+    middleware) can rely on input stability.
+    """
+    out: dict[str, Any] = {}
+    for key, sub in value.items():
+        if key == "governance_agents" and isinstance(sub, list):
+            out[key] = [_scrub_governance_agent_dict(a) if isinstance(a, dict) else a for a in sub]
+        elif key == "billing_entity" and isinstance(sub, dict):
+            out[key] = {k: v for k, v in _scrub_value(sub).items() if k != "bank"}
+        else:
+            out[key] = _scrub_value(sub)
+    return out
+
+
+def _scrub_governance_agent_dict(agent: dict[str, Any]) -> dict[str, Any]:
+    """Strip ``authentication`` from a governance-agent dict and recurse
+    into the remaining fields."""
+    return {k: _scrub_value(v) for k, v in agent.items() if k != "authentication"}
+
+
+def _scrub_value(value: Any) -> Any:
+    """Recurse into dicts / lists; return primitives unchanged."""
+    if isinstance(value, dict):
+        return _scrub_dict(value)
+    if isinstance(value, list):
+        return [_scrub_value(v) for v in value]
+    return value
+
+
+def strip_credentials_from_wire_result(method_name: str, result: Any) -> Any:
+    """Strip write-only credential fields from a wire-shape result.
+
+    Defense-in-depth boundary called by the dispatcher on every
+    response that may surface an :class:`Account` envelope. Removes
+    ``governance_agents[i].authentication`` and ``billing_entity.bank``
+    recursively — the same fields the typed projections
+    (:func:`to_wire_account`, :func:`to_wire_sync_governance_row`)
+    strip when the adopter returns the framework's typed dataclasses.
+
+    Adopters returning a loose dict (or a Pydantic model with
+    ``extra='allow'``) bypass the typed projections; this scrubber
+    catches them. Adopters returning the typed dataclasses get
+    double-stripped — the second pass is a no-op since the typed
+    projections already removed the fields.
+
+    Method gate: the scrubber is O(n) in result size; we only run it
+    on methods in :data:`CREDENTIAL_BEARING_METHODS`. Non-account
+    methods (``get_products``, ``get_signals``, ``activate_signal``)
+    skip the walk entirely and pass through unchanged.
+
+    The input is not mutated — returns a new value.
+    """
+    if method_name not in CREDENTIAL_BEARING_METHODS:
+        return result
+    if isinstance(result, dict):
+        return _scrub_dict(result)
+    if isinstance(result, list):
+        return [_scrub_value(v) for v in result]
+    # Typed Pydantic response models pass through unchanged — the
+    # response-side codegen'd shapes don't define ``authentication``
+    # on ``GovernanceAgent`` or ``bank`` on the response-side
+    # ``BusinessEntity``, so the schema enforces the strip
+    # structurally. Dumping-and-scrubbing a model would force
+    # downstream callers to lose typed-model identity for no
+    # security gain. The leak vector is loose dicts and Pydantic
+    # ``extra='allow'`` models that smuggle credentials past the
+    # codegen schema; both arrive as ``dict`` after the adopter's
+    # method returns or via the registry's ``model_dump`` path.
+    return result
+
+
 __all__ = [
+    "CREDENTIAL_BEARING_METHODS",
     "project_account_for_response",
     "project_business_entity_for_response",
+    "strip_credentials_from_wire_result",
     "to_wire_account",
     "to_wire_sync_accounts_row",
     "to_wire_sync_governance_row",

--- a/src/adcp/decisioning/dispatch.py
+++ b/src/adcp/decisioning/dispatch.py
@@ -44,6 +44,9 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
+from adcp.decisioning.account_projection import (
+    strip_credentials_from_wire_result,
+)
 from adcp.decisioning.platform import (
     GOVERNANCE_SPECIALISMS,
     DecisioningCapabilities,
@@ -393,10 +396,78 @@ def _strict_validate_platform() -> bool:
 # INTERNAL_ERROR breadcrumbs (Emma AudioStack P2)
 # ---------------------------------------------------------------------------
 
-#: Cap on the message+repr we expose to the wire. Long stack traces or
-#: secret-shaped repr (e.g., a ``Credential`` repr that includes the
-#: token) get truncated. Stack trace lives in server logs only.
-_INTERNAL_ERROR_DETAIL_CHARS = 200
+#: Substring suffixes that flag a ctx_metadata key as credential-shaped.
+#: Lowercased for case-insensitive matching against the user-supplied
+#: key. The list intentionally errs broad — a key like
+#: ``"upstream.api_key"`` belongs in :class:`AuthInfo.credential`, not
+#: ``ctx.metadata`` which round-trips into responses.
+#:
+#: Drift policy: when the spec or adopter conventions add a new
+#: credential-shaped suffix, append here. The gate is fail-closed by
+#: design — false positives require the adopter to rename the key, NOT
+#: silently echo the credential.
+_CREDENTIAL_SHAPED_KEY_SUFFIXES: tuple[str, ...] = (
+    "credential",
+    "credentials",
+    "token",
+    "secret",
+    "api_key",
+    "apikey",
+    "password",
+    "bearer",
+)
+
+
+def _validate_ctx_metadata_credentials(metadata: Any) -> None:
+    """Fail-closed gate: ctx.metadata must not carry credential-shaped
+    keys.
+
+    The framework projects buyer-supplied ``context`` extensions into
+    ``tool_ctx.metadata`` and echoes context back on responses per
+    the AdCP spec. An adopter who treats ``metadata`` as a generic
+    KV bucket can accidentally round-trip a credential to the buyer.
+    The ergonomic path for credentials is
+    :class:`AuthInfo.credential` / typed credential classes
+    (:class:`ApiKeyCredential`, :class:`OAuthCredential`,
+    :class:`HttpSigCredential`); ``ctx.metadata`` is for non-secret
+    request-scope hints (correlation ids, feature flags, trace ids).
+
+    Matches against any key whose lowercased form ends with one of
+    :data:`_CREDENTIAL_SHAPED_KEY_SUFFIXES`. Sub-keys at any nesting
+    depth count — a buyer-supplied
+    ``{"upstream": {"api_token": "..."}}`` is rejected the same as
+    a flat ``{"api_token": "..."}``.
+
+    :raises ValueError: when any credential-shaped key is found. The
+        exception message names the offending key path so the adopter
+        knows which field to migrate to ``AuthInfo.credential``.
+    """
+    if not metadata:
+        return
+    if not isinstance(metadata, dict):
+        return
+    for key, value in metadata.items():
+        if isinstance(key, str):
+            lower = key.lower()
+            for suffix in _CREDENTIAL_SHAPED_KEY_SUFFIXES:
+                if lower.endswith(suffix):
+                    raise ValueError(
+                        "ctx_metadata may not contain credential-shaped keys; "
+                        "use AuthInfo.credential (or a typed credential class "
+                        "like ApiKeyCredential / OAuthCredential / "
+                        "HttpSigCredential) instead. Found: "
+                        f"{key!r} (matched suffix {suffix!r}). "
+                        "ctx.metadata round-trips into response context per "
+                        "the AdCP spec; placing a credential here echoes it "
+                        "to the buyer."
+                    )
+        if isinstance(value, dict):
+            try:
+                _validate_ctx_metadata_credentials(value)
+            except ValueError as exc:
+                # Re-raise with the parent key prefixed so the diagnostic
+                # walks the adopter to the offending path.
+                raise ValueError(f"In ctx_metadata[{key!r}]: {exc}") from None
 
 
 def _internal_error_message(method_name: str, exc: BaseException) -> str:
@@ -415,15 +486,18 @@ def _internal_error_details(exc: BaseException) -> dict[str, Any]:
     """Build the wire-side ``details`` payload for an INTERNAL_ERROR
     wrap.
 
-    ``details.caused_by`` carries the exception class name + truncated
-    str — no traceback, no module path, no chained ``__cause__``.
-    The class name lets adopters distinguish ``AttributeError``
-    (typo-shaped) from ``KeyError`` (missing-config-shaped) from
-    ``ConnectionError`` (network-shaped) at a glance.
+    ``details.caused_by`` carries ONLY the exception class name —
+    ``"AttributeError"`` (typo-shaped), ``"KeyError"``
+    (missing-config-shaped), ``"ConnectionError"`` (network-shaped) —
+    enough for the seller dev to triage at a glance. The exception's
+    ``str()`` is deliberately omitted: any truncation length large
+    enough to be useful (200 chars) is also large enough to leak a
+    full OAuth client secret or bearer token if the adopter raised
+    on secret material. The full traceback (with message) lives in
+    the server log via ``logger.exception``; only the wire response
+    is sanitized to a class-name breadcrumb.
 
     **``caused_by.type`` is a debug breadcrumb, not a wire contract.**
-    The value is Python's exception class name verbatim
-    (``"AttributeError"``, ``"KeyError"``, ``"ValidationError"``).
     Buyers built against the JS SDK won't see Python-flavoured class
     names from JS sellers — only Python sellers leak Python types.
     Treat this field as "hint to the seller dev reading their own
@@ -434,11 +508,6 @@ def _internal_error_details(exc: BaseException) -> dict[str, Any]:
     structured retry/fix/abandon classification should read
     ``recovery`` (terminal/correctable/transient) which IS the
     cross-language contract.
-
-    Truncation is defense-in-depth against an adopter who throws on
-    secret material and ends up with a repr that includes the secret
-    value verbatim. The full traceback is in the server log via
-    ``logger.exception``; only the wire response is sanitized.
 
     **ValidationError special case** (Stability AI Emma P1 from the
     post-#340 matrix): when the platform method raises a pydantic
@@ -454,13 +523,9 @@ def _internal_error_details(exc: BaseException) -> dict[str, Any]:
     where a structured field list is meaningful, so we don't
     generalize this to other exception types.
     """
-    raw = str(exc)
-    if len(raw) > _INTERNAL_ERROR_DETAIL_CHARS:
-        raw = raw[: _INTERNAL_ERROR_DETAIL_CHARS - 3] + "..."
     details: dict[str, Any] = {
         "caused_by": {
             "type": type(exc).__name__,
-            "message": raw,
         }
     }
     # Try to import lazily so a future refactor that splits the
@@ -876,6 +941,19 @@ def _build_request_context(
 
     auth_principal = auth_info.principal if auth_info is not None else None
 
+    # ctx_metadata credential gate — fail-closed before any platform
+    # method sees the metadata. Buyers can populate ``context``
+    # extensions on the wire request that the framework projects into
+    # ``tool_ctx.metadata``; an adopter who treats ``metadata`` as a
+    # general-purpose KV bucket might shove a credential through it,
+    # only to discover the value round-trips into the response (the
+    # framework echoes context into responses per the AdCP spec).
+    # The ergonomic path for credentials is :class:`AuthInfo.credential`
+    # / typed credential classes; ``metadata`` is for non-secret
+    # request-scope hints. See the "ctx_metadata: write-only credentials
+    # prohibited" section in CLAUDE.md.
+    _validate_ctx_metadata_credentials(tool_ctx.metadata)
+
     # Composite cache scope key when store is supplied (production
     # path). Falls back to tool_ctx.caller_identity for test fixtures.
     caller_identity: str | None
@@ -1053,7 +1131,14 @@ async def _invoke_platform_method(
             registry=registry,
             executor=executor,
         )
-    return result
+
+    # Defense-in-depth credential strip on every sync return. The typed
+    # projections (:func:`to_wire_account` etc.) handle the case where
+    # the adopter returns the framework's typed dataclasses; this
+    # boundary catches loose dicts and Pydantic models with
+    # ``extra='allow'``. Method-gated to avoid walking large product
+    # / signal catalogs that can't carry credentials.
+    return strip_credentials_from_wire_result(method_name, result)
 
 
 async def _project_handoff(
@@ -1141,16 +1226,27 @@ async def _project_handoff(
 
         # Persist terminal artifact. Pydantic responses get
         # ``model_dump()``; dict responses pass through.
+        #
+        # Credential strip BEFORE persistence: durable registries
+        # (Postgres, Redis) write the artifact to disk; even in-memory,
+        # ``tasks/get`` returns it verbatim. A bearer credential
+        # surviving the typed projection (e.g., Pydantic
+        # ``extra='allow'`` model carrying ``governance_agents[i].
+        # authentication``) would land in the buyer's ``tasks/get``
+        # poll AND the idempotency replay cache. Method-gated so
+        # non-account methods skip the recursive walk.
         if hasattr(result, "model_dump"):
-            await registry.complete(task_id, result.model_dump())
+            persisted = result.model_dump()
         elif isinstance(result, dict):
-            await registry.complete(task_id, result)
+            persisted = result
         else:
             # Adopter returned an unexpected type (not Pydantic, not
             # dict). Best effort: stringify into a 'value' wrapper so
             # tasks/get returns something. Real impls always return
             # the typed Pydantic response.
-            await registry.complete(task_id, {"value": str(result)})
+            persisted = {"value": str(result)}
+        persisted = strip_credentials_from_wire_result(method_name, persisted)
+        await registry.complete(task_id, persisted)
 
     # ``asyncio.create_task`` only weak-refs the resulting Task — under
     # GC pressure or with no outer awaiter, the task can be collected

--- a/src/adcp/decisioning/dispatch.py
+++ b/src/adcp/decisioning/dispatch.py
@@ -468,6 +468,38 @@ def _validate_ctx_metadata_credentials(metadata: Any) -> None:
                 # Re-raise with the parent key prefixed so the diagnostic
                 # walks the adopter to the offending path.
                 raise ValueError(f"In ctx_metadata[{key!r}]: {exc}") from None
+        elif isinstance(value, list):
+            # Lists of dicts are a realistic shape (e.g.,
+            # ``{"upstream_configs": [{"api_token": "..."}]}``). Walk
+            # each item with the same recursion so a credential-shaped
+            # key buried in any list element fails the gate. Nested
+            # lists (``[[{"token": "x"}]]``) recurse via the same
+            # branch.
+            try:
+                _walk_ctx_metadata_list(value)
+            except ValueError as exc:
+                raise ValueError(f"In ctx_metadata[{key!r}]: {exc}") from None
+
+
+def _walk_ctx_metadata_list(items: list[Any]) -> None:
+    """Recurse into a list collected from ``ctx_metadata`` and reject
+    any credential-shaped key found in a dict element.
+
+    Nested lists are walked through this same function. Non-dict,
+    non-list items (strings, numbers, None) are ignored — only
+    container types can hide a credential-shaped key.
+    """
+    for index, item in enumerate(items):
+        if isinstance(item, dict):
+            try:
+                _validate_ctx_metadata_credentials(item)
+            except ValueError as exc:
+                raise ValueError(f"[{index}]: {exc}") from None
+        elif isinstance(item, list):
+            try:
+                _walk_ctx_metadata_list(item)
+            except ValueError as exc:
+                raise ValueError(f"[{index}]: {exc}") from None
 
 
 def _internal_error_message(method_name: str, exc: BaseException) -> str:

--- a/src/adcp/decisioning/task_registry.py
+++ b/src/adcp/decisioning/task_registry.py
@@ -389,16 +389,30 @@ class InMemoryTaskRegistry:
         task_id: str,
         result: dict[str, Any],
     ) -> None:
+        # Defense-in-depth credential strip at the persistence boundary.
+        # The dispatcher's TaskHandoff path also strips before calling
+        # complete() (see ``_project_handoff`` in dispatch.py); the
+        # WorkflowHandoff path does NOT (the adopter's external
+        # workflow calls ``registry.complete`` directly, off the
+        # framework's call stack). Stripping here closes that gap and
+        # protects custom registry consumers that bypass the dispatcher
+        # entirely. The strip is method-gated by ``record.task_type``
+        # (the wire verb name persisted at ``issue()``) and idempotent
+        # on already-stripped payloads, so the dispatcher-side double
+        # strip is a no-op.
+        from adcp.decisioning.account_projection import strip_credentials_from_wire_result
+
         async with self._lock:
             record = self._records.get(task_id)
             if record is None:
                 raise ValueError(f"Task {task_id!r} not found")
+            stripped = strip_credentials_from_wire_result(record.task_type, result)
             if record.state == "completed":
-                if record.result == result:
+                if record.result == stripped:
                     return  # idempotent
                 raise ValueError(f"Task {task_id!r} already completed with a different result")
             record.state = "completed"
-            record.result = dict(result)
+            record.result = dict(stripped) if isinstance(stripped, dict) else stripped
             record.updated_at = time.time()
 
     async def fail(

--- a/src/adcp/decisioning/webhook_emit.py
+++ b/src/adcp/decisioning/webhook_emit.py
@@ -45,6 +45,10 @@ import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from adcp.decisioning.account_projection import (
+    strip_credentials_from_wire_result,
+)
+
 if TYPE_CHECKING:
     from adcp.webhook_sender import WebhookSender
     from adcp.webhook_supervisor import WebhookDeliverySupervisor
@@ -261,6 +265,14 @@ def maybe_emit_sync_completion(
         if extracted is None:
             return
         url, token = extracted
+        # Defense-in-depth: strip credentials from the result BEFORE the
+        # webhook target sees it. The dispatcher already strips on the
+        # synchronous return path (:func:`_invoke_platform_method`);
+        # this is a second pass so the strip fires regardless of how
+        # the result reached this gate (direct adopter call, custom
+        # shim, future plumbing). Method-gated — non-account tools
+        # short-circuit without walking the result.
+        result = strip_credentials_from_wire_result(method_name, result)
         if method_name not in SPEC_WEBHOOK_TASK_TYPES:
             logger.warning(
                 "[adcp.decisioning] sync completion webhook for %s skipped — "

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -31,12 +31,75 @@ from adcp.server.helpers import valid_actions_for_status
 _logger = logging.getLogger("adcp.server")
 
 
+def _strip_write_only_fields(value: Any) -> Any:
+    """Recursively strip write-only credential fields from a wire dict.
+
+    Mirrors :func:`adcp.decisioning.account_projection._project_governance_agent`
+    at the response-builder layer. The decisioning dispatcher's strip
+    runs at ``_invoke_platform_method`` for platform methods; this
+    layer covers adopters who hand-build response payloads via the
+    ``adcp.server.responses`` builders without going through the
+    decisioning dispatcher.
+
+    Strips:
+
+    * ``governance_agents[i].authentication`` — write-only credential.
+    * ``billing_entity.bank`` — write-only bank coordinates.
+
+    Pydantic models are passed through unchanged — adopters using
+    typed response models are responsible for the strip via
+    :func:`adcp.decisioning.project_account_for_response` or
+    equivalent. Loose dicts (the more common case for hand-built
+    builder calls) get the recursive walk.
+    """
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, sub in value.items():
+            if key == "governance_agents" and isinstance(sub, list):
+                projected: list[Any] = []
+                for agent in sub:
+                    if isinstance(agent, dict):
+                        projected.append(
+                            {
+                                k: _strip_write_only_fields(v)
+                                for k, v in agent.items()
+                                if k != "authentication"
+                            }
+                        )
+                    else:
+                        projected.append(agent)
+                out[key] = projected
+            elif key == "billing_entity" and isinstance(sub, dict):
+                out[key] = {k: _strip_write_only_fields(v) for k, v in sub.items() if k != "bank"}
+            else:
+                out[key] = _strip_write_only_fields(sub)
+        return out
+    if isinstance(value, list):
+        return [_strip_write_only_fields(v) for v in value]
+    return value
+
+
 def _serialize(items: list[Any]) -> list[Any]:
-    """Serialize a list of dicts or Pydantic models to plain dicts."""
-    return [
-        p.model_dump(mode="json", exclude_none=True) if hasattr(p, "model_dump") else p
-        for p in items
-    ]
+    """Serialize a list of dicts or Pydantic models to plain dicts.
+
+    Loose-dict items (adopters returning ``{**db_record, ...}`` from
+    a hand-built response builder) get a recursive write-only-field
+    strip via :func:`_strip_write_only_fields` so
+    ``governance_agents[i].authentication`` and ``billing_entity.bank``
+    can't smuggle through. Pydantic models are passed through their
+    own ``model_dump`` — the typed projections at
+    :mod:`adcp.decisioning.account_projection` are responsible for
+    those.
+    """
+    out: list[Any] = []
+    for p in items:
+        if hasattr(p, "model_dump"):
+            out.append(p.model_dump(mode="json", exclude_none=True))
+        elif isinstance(p, dict):
+            out.append(_strip_write_only_fields(p))
+        else:
+            out.append(p)
+    return out
 
 
 # ============================================================================

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -211,8 +211,13 @@ def sync_accounts_response(
     action ("created"|"updated"), status ("active"|"pending_approval").
 
     Matches SyncAccountsResponse1 schema (field: "accounts").
+
+    Items pass through :func:`_serialize` so loose-dict adopters who
+    spread an input ``governance_agents`` (with ``authentication``)
+    or ``billing_entity`` (with ``bank``) onto the response get the
+    write-only credential strip.
     """
-    return {"accounts": accounts, "sandbox": sandbox}
+    return {"accounts": _serialize(accounts), "sandbox": sandbox}
 
 
 def sync_governance_response(
@@ -224,8 +229,12 @@ def sync_governance_response(
 
     Each account dict should include: account, status ("synced"),
     governance_agents ([{url, categories}]).
+
+    Items pass through :func:`_serialize` so loose-dict adopters who
+    spread an input ``governance_agents`` (with ``authentication``)
+    onto the response get the write-only credential strip.
     """
-    return {"accounts": accounts, "sandbox": sandbox}
+    return {"accounts": _serialize(accounts), "sandbox": sandbox}
 
 
 # ============================================================================

--- a/tests/test_credential_leak_strip.py
+++ b/tests/test_credential_leak_strip.py
@@ -383,6 +383,72 @@ async def test_task_registry_persists_stripped_artifact(
 
 
 # ---------------------------------------------------------------------------
+# H3b — WorkflowHandoff direct-complete path (adopter calls
+# ``registry.complete`` from external workflow, NOT through dispatcher)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_handoff_registry_complete_strips_credentials() -> None:
+    """``WorkflowHandoff`` enqueues to an external system; the adopter's
+    workflow later calls ``registry.complete(task_id, result)`` directly
+    — the framework is NOT on the call stack at that point, so the
+    dispatcher-level strip can't fire.
+
+    The strip must happen inside :meth:`TaskRegistry.complete` so a
+    credential-bearing dict written from the adopter's external workflow
+    can't survive into ``tasks/get``.
+    """
+    registry = InMemoryTaskRegistry()
+    task_id = await registry.issue(
+        account_id="acct_1",
+        task_type="sync_governance",
+    )
+
+    # Simulate the adopter's external workflow calling complete()
+    # directly with a credential-bearing result. No framework code is
+    # on the call stack here.
+    leaky_result = _governance_response_with_credentials()
+    await registry.complete(task_id, leaky_result)
+
+    persisted = await registry.get(task_id, expected_account_id="acct_1")
+    assert persisted is not None
+    assert persisted["state"] == "completed"
+    # Bearer MUST NOT survive into the persisted artifact — ``tasks/get``
+    # would otherwise echo it.
+    assert _BEARER not in str(persisted)
+    assert "authentication" not in str(persisted)
+    # Non-credential fields preserved.
+    agent = persisted["result"]["accounts"][0]["governance_agents"][0]
+    assert agent["url"] == "https://gov.example.com/"
+
+
+@pytest.mark.asyncio
+async def test_registry_complete_skips_strip_for_non_credential_method() -> None:
+    """The strip is method-gated by ``record.task_type``. A non-credential
+    method (``get_products``) skips the recursive walk — adopter-stashed
+    extra keys pass through unchanged."""
+    registry = InMemoryTaskRegistry()
+    task_id = await registry.issue(
+        account_id="acct_1",
+        task_type="get_products",
+    )
+    # A ``get_products`` task can't carry account credentials in the
+    # spec-shape result, so the gate skips the walk entirely. Confirm
+    # no over-eager scrubbing of unrelated keys.
+    big_payload: dict[str, Any] = {
+        "products": [{"id": "p1", "extra_metadata": {"authentication": "literal-string"}}],
+    }
+    await registry.complete(task_id, big_payload)
+    persisted = await registry.get(task_id, expected_account_id="acct_1")
+    assert persisted is not None
+    # ``authentication`` here is a product-level metadata field, not a
+    # governance-agent credential — must pass through unchanged.
+    product_auth = persisted["result"]["products"][0]["extra_metadata"]["authentication"]
+    assert product_auth == "literal-string"
+
+
+# ---------------------------------------------------------------------------
 # M1 — INTERNAL_ERROR caused_by omits exception str()
 # ---------------------------------------------------------------------------
 
@@ -491,9 +557,10 @@ def test_response_builder_strips_billing_entity_bank() -> None:
 
 def test_sync_governance_response_builder_round_trip_strip() -> None:
     """Cross-builder regression: the public ``sync_governance_response``
-    helper is what storyboards / hello-world adopters call. Verify
-    the strip fires when an adopter passes a credential-bearing
-    item dict through the public API."""
+    helper is what storyboards / hello-world adopters call. The
+    builder routes items through ``_serialize`` so a credential-bearing
+    item dict is scrubbed before the response leaves the seller.
+    """
     response = sync_governance_response(
         accounts=[
             {
@@ -511,16 +578,48 @@ def test_sync_governance_response_builder_round_trip_strip() -> None:
             }
         ],
     )
-    # Note: sync_governance_response returns ``{"accounts": [...]}``
-    # without going through ``_serialize`` — the items list is passed
-    # through as-is. This test pins that current behavior so a future
-    # refactor wiring the strip through this builder doesn't surprise.
-    # If the strip is added here, swap the assertion to negative.
-    leaked = _BEARER in str(response)
-    if leaked:
-        # Accept either path — the dispatcher-level strip still fires
-        # for any decisioning path. Pin the current builder behavior.
-        pass
+    assert _BEARER not in str(response)
+    agent = response["accounts"][0]["governance_agents"][0]
+    assert "authentication" not in agent
+    assert agent["url"] == "https://gov.example.com/"
+
+
+def test_sync_accounts_response_builder_round_trip_strip() -> None:
+    """Cross-builder regression: ``sync_accounts_response`` is the
+    other governance-adjacent builder that surfaces ``Account``
+    envelopes. Loose-dict adopters spreading ``billing_entity`` (with
+    ``bank``) onto the response must not leak bank coordinates."""
+    from adcp.server.responses import sync_accounts_response
+
+    response = sync_accounts_response(
+        accounts=[
+            {
+                "account_id": "acct_1",
+                "brand": "Acme",
+                "action": "created",
+                "status": "active",
+                "billing_entity": {
+                    "legal_name": "Acme Inc.",
+                    "bank": {"iban": _IBAN},
+                },
+                "governance_agents": [
+                    {
+                        "url": "https://gov.example.com/",
+                        "authentication": {
+                            "schemes": ["Bearer"],
+                            "credentials": _BEARER,
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+    serialized = response["accounts"][0]
+    assert _IBAN not in str(response)
+    assert _BEARER not in str(response)
+    assert "bank" not in serialized["billing_entity"]
+    assert "authentication" not in serialized["governance_agents"][0]
+    assert serialized["billing_entity"]["legal_name"] == "Acme Inc."
 
 
 # ---------------------------------------------------------------------------
@@ -599,3 +698,64 @@ def test_ctx_metadata_credential_suffix_match_is_case_insensitive(key: str) -> N
     tool_ctx = ToolContext(metadata={key: "value"})
     with pytest.raises(ValueError):
         _build_request_context(tool_ctx, Account(id="x"), None)
+
+
+def test_ctx_metadata_rejects_credentials_in_list_of_dicts() -> None:
+    """``ctx.metadata`` with a list of config dicts is a realistic
+    shape — adopters batch upstream client configs that way. The
+    gate must walk into list items so a credential buried in any
+    element trips the same rejection as a top-level key."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(
+        metadata={"upstream_configs": [{"name": "primary"}, {"api_token": "secret"}]}
+    )
+    with pytest.raises(ValueError) as exc_info:
+        _build_request_context(tool_ctx, Account(id="x"), None)
+    msg = str(exc_info.value)
+    assert "upstream_configs" in msg
+    assert "api_token" in msg
+
+
+def test_ctx_metadata_rejects_credentials_in_nested_lists() -> None:
+    """Nested lists (``[[{...}]]``) walk recursively — the gate is
+    not depth-limited, so an adversarial adopter shape can't smuggle a
+    credential past it via list-wrapping."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(metadata={"groups": [[{"client_secret": "leak"}]]})
+    with pytest.raises(ValueError) as exc_info:
+        _build_request_context(tool_ctx, Account(id="x"), None)
+    msg = str(exc_info.value)
+    assert "groups" in msg
+    assert "client_secret" in msg
+
+
+def test_ctx_metadata_allows_list_of_strings() -> None:
+    """A plain list of strings (tags, correlation chain) carries no
+    dict to inspect — the gate must not raise on a benign list shape."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(
+        metadata={"trace_chain": ["span_a", "span_b", "span_c"], "tags": ["beta"]}
+    )
+    ctx = _build_request_context(tool_ctx, Account(id="x"), None)
+    assert ctx.metadata["trace_chain"] == ["span_a", "span_b", "span_c"]
+
+
+def test_ctx_metadata_allows_list_of_benign_dicts() -> None:
+    """A list of dicts whose keys are NOT credential-shaped passes
+    through unchanged — adopters batch config dicts through metadata
+    without leaking credentials."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(
+        metadata={
+            "upstream_configs": [
+                {"name": "primary", "region": "us-east-1"},
+                {"name": "secondary", "region": "eu-west-1"},
+            ]
+        }
+    )
+    ctx = _build_request_context(tool_ctx, Account(id="x"), None)
+    assert ctx.metadata["upstream_configs"][0]["name"] == "primary"

--- a/tests/test_credential_leak_strip.py
+++ b/tests/test_credential_leak_strip.py
@@ -1,0 +1,601 @@
+"""Credential-leak strip — every wire-emit boundary scrubs.
+
+Audit findings #463 against PR #469: the typed projections
+(:func:`adcp.decisioning.to_wire_account` etc.) were public-API
+helpers but no framework code called them. This file is the regression
+suite that proves the strip is now load-bearing on every echo path:
+
+* H1 — synchronous return path through :func:`_invoke_platform_method`.
+* H2 — sync-completion webhook (``maybe_emit_sync_completion``).
+* H3 — :class:`TaskRegistry` persistence path (``registry.complete``
+  + ``tasks/get`` echo).
+* M1 — INTERNAL_ERROR ``caused_by`` omits exception ``str()`` so
+  bearer-shaped repr can't leak via the error wire.
+* M2 — ``adcp.server.responses._serialize`` strips loose-dict items
+  that bypass typed projections.
+* M3 — ``ctx_metadata`` fail-closed gate against credential-shaped
+  keys (round-trip risk via the AdCP context-echo contract).
+
+Each test exercises a distinct emit path so a regression in any one
+seam fires its own diagnostic.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from adcp.decisioning import (
+    Account,
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    InMemoryTaskRegistry,
+    SingletonAccounts,
+    TaskHandoffContext,
+)
+from adcp.decisioning.account_projection import (
+    CREDENTIAL_BEARING_METHODS,
+    strip_credentials_from_wire_result,
+)
+from adcp.decisioning.dispatch import (
+    _build_request_context,
+    _invoke_platform_method,
+)
+from adcp.decisioning.types import TaskHandoff
+from adcp.decisioning.webhook_emit import maybe_emit_sync_completion
+from adcp.server.base import ToolContext
+from adcp.server.responses import sync_governance_response
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def executor() -> Any:
+    pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="cred-leak-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+_BEARER = "super-secret-bearer-token-abcdefghij1234567890"
+_IBAN = "DE89370400440532013000"
+
+
+def _governance_response_with_credentials() -> dict[str, Any]:
+    """Wire-shape ``sync_governance`` response carrying credentials.
+
+    Realistic adopter footgun: ``return {"accounts": [{**entry, ...}]}``
+    spreads the input ``governance_agents`` (with ``authentication``)
+    onto the response. Pydantic ``extra='allow'`` would let this
+    through; the dispatcher must scrub regardless.
+    """
+    return {
+        "accounts": [
+            {
+                "account": {"account_id": "acct_1"},
+                "status": "synced",
+                "governance_agents": [
+                    {
+                        "url": "https://gov.example.com/",
+                        "categories": ["budget_authority"],
+                        "authentication": {
+                            "schemes": ["Bearer"],
+                            "credentials": _BEARER,
+                        },
+                    },
+                ],
+            },
+        ],
+        "sandbox": True,
+    }
+
+
+def _accounts_response_with_bank() -> dict[str, Any]:
+    """Wire-shape ``list_accounts`` response carrying bank coordinates."""
+    return {
+        "accounts": [
+            {
+                "account_id": "acct_1",
+                "name": "Acme",
+                "status": "active",
+                "billing_entity": {
+                    "legal_name": "Acme Inc.",
+                    "bank": {"account_holder": "Acme Inc.", "iban": _IBAN},
+                },
+            }
+        ],
+        "sandbox": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# H1 — synchronous return path through _invoke_platform_method
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_strips_governance_credentials_from_sync_return(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """End-to-end: a platform method returns a loose dict carrying
+    ``governance_agents[i].authentication.credentials``; the
+    dispatcher's strip layer removes them before the wire response
+    leaves the dispatcher.
+
+    Without this strip, every typed-projection helper in
+    :mod:`account_projection` is theatre — adopters returning
+    Pydantic ``extra='allow'`` models or plain dicts bypass the typed
+    path entirely.
+    """
+
+    class _LeakyPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct_1")
+
+        async def sync_governance(self, req: Any, ctx: Any) -> dict[str, Any]:
+            return _governance_response_with_credentials()
+
+    class _Req(BaseModel):
+        pass
+
+    ctx = _build_request_context(ToolContext(), Account(id="acct_1"), None)
+    result = await _invoke_platform_method(
+        _LeakyPlatform(),
+        "sync_governance",
+        _Req(),
+        ctx,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    # The bearer MUST NOT appear anywhere in the wire response.
+    assert _BEARER not in str(result)
+    assert "authentication" not in str(result)
+    # url + categories preserved.
+    agent = result["accounts"][0]["governance_agents"][0]
+    assert agent["url"] == "https://gov.example.com/"
+    assert agent["categories"] == ["budget_authority"]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_strips_billing_entity_bank_from_sync_return(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """Same posture as the governance test, for the second write-only
+    field the spec calls out: ``billing_entity.bank``."""
+
+    class _BankLeakingPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct_1")
+
+        async def list_accounts(self, req: Any, ctx: Any) -> dict[str, Any]:
+            return _accounts_response_with_bank()
+
+    class _Req(BaseModel):
+        pass
+
+    ctx = _build_request_context(ToolContext(), Account(id="acct_1"), None)
+    result = await _invoke_platform_method(
+        _BankLeakingPlatform(),
+        "list_accounts",
+        _Req(),
+        ctx,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    assert _IBAN not in str(result)
+    assert "bank" not in result["accounts"][0]["billing_entity"]
+    # legal_name preserved.
+    assert result["accounts"][0]["billing_entity"]["legal_name"] == "Acme Inc."
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_skip_strip_for_non_credential_methods(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """The strip is method-gated to avoid walking large product /
+    signal catalogs that can't carry credentials. ``get_products``
+    isn't in :data:`CREDENTIAL_BEARING_METHODS` — the result passes
+    through unchanged.
+
+    Defensive: confirms the gate doesn't accidentally include a
+    high-traffic method that would pay an O(n) walk on every call."""
+
+    assert "get_products" not in CREDENTIAL_BEARING_METHODS
+    assert "get_signals" not in CREDENTIAL_BEARING_METHODS
+
+    big_payload = {"products": [{"id": f"p{i}"} for i in range(1000)]}
+
+    class _BigPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct_1")
+
+        async def get_products(self, req: Any, ctx: Any) -> dict[str, Any]:
+            return big_payload
+
+    class _Req(BaseModel):
+        pass
+
+    ctx = _build_request_context(ToolContext(), Account(id="acct_1"), None)
+    result = await _invoke_platform_method(
+        _BigPlatform(),
+        "get_products",
+        _Req(),
+        ctx,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    # Pass-through (same object reference) when method is non-credential.
+    assert result is big_payload
+
+
+def test_strip_credentials_returns_input_unchanged_for_non_credential_method() -> None:
+    """The unit-level boundary: non-credential method names short-
+    circuit and return the original object reference (no defensive
+    copy on the hot path)."""
+    payload = {"products": [{"id": "p1"}]}
+    assert strip_credentials_from_wire_result("get_products", payload) is payload
+
+
+def test_strip_credentials_walks_recursively() -> None:
+    """The scrubber walks recursively — a deeply nested
+    ``governance_agents[i].authentication`` is stripped just as
+    a top-level one."""
+    nested = {
+        "accounts": [
+            {
+                "wrapper": {
+                    "deep": {
+                        "governance_agents": [
+                            {"url": "https://x", "authentication": {"credentials": _BEARER}},
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+    out = strip_credentials_from_wire_result("sync_governance", nested)
+    assert _BEARER not in str(out)
+    assert "authentication" not in str(out)
+
+
+# ---------------------------------------------------------------------------
+# H2 — sync-completion webhook
+# ---------------------------------------------------------------------------
+
+
+class _FakeWebhookSender:
+    """Captures the ``send_mcp`` payload so tests can assert on it."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def send_mcp(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_webhook_strips_credentials_before_buyer_callback() -> None:
+    """The webhook re-emits the response payload to a buyer-controlled
+    URL — :data:`SPEC_WEBHOOK_TASK_TYPES` includes ``sync_accounts``,
+    so a leaky response would echo the bearer to the buyer's webhook
+    server. Defense-in-depth: the strip runs in
+    :func:`maybe_emit_sync_completion` regardless of upstream
+    sanitization."""
+    import asyncio
+
+    sender = _FakeWebhookSender()
+
+    class _Params(BaseModel):
+        # Pydantic with arbitrary types so push_notification_config is
+        # a plain dict on the test fixture.
+        push_notification_config: dict[str, Any]
+
+    leaky_result = _governance_response_with_credentials()
+    params = _Params(
+        push_notification_config={
+            "url": "https://buyer.example.com/wh",
+            "token": "tok",
+        }
+    )
+
+    maybe_emit_sync_completion(
+        sender=sender,  # type: ignore[arg-type]
+        enabled=True,
+        method_name="sync_accounts",  # spec-eligible webhook task type
+        params=params,
+        result=leaky_result,
+    )
+    # Drain the fire-and-forget task.
+    await asyncio.sleep(0.01)
+    for _ in range(20):
+        if sender.calls:
+            break
+        await asyncio.sleep(0.01)
+
+    assert sender.calls, "webhook never fired"
+    payload = sender.calls[0]
+    assert _BEARER not in str(payload), "bearer leaked to buyer webhook"
+    assert "authentication" not in str(payload["result"])
+
+
+# ---------------------------------------------------------------------------
+# H3 — TaskRegistry persistence (durable + tasks/get echo)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_registry_persists_stripped_artifact(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """Durable registries (Postgres, Redis) write the artifact to disk
+    in plaintext; even in-memory, ``tasks/get`` returns it verbatim.
+    Strip BEFORE :meth:`TaskRegistry.complete` so the stored shape
+    never carries credentials."""
+
+    class _HandoffPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct_1")
+
+        async def sync_governance(self, req: Any, ctx: Any) -> Any:
+            async def _handoff(handoff_ctx: TaskHandoffContext) -> dict[str, Any]:
+                return _governance_response_with_credentials()
+
+            return TaskHandoff(_handoff)
+
+    class _Req(BaseModel):
+        pass
+
+    registry = InMemoryTaskRegistry()
+    ctx = _build_request_context(ToolContext(), Account(id="acct_1"), None)
+    submitted = await _invoke_platform_method(
+        _HandoffPlatform(),
+        "sync_governance",
+        _Req(),
+        ctx,
+        executor=executor,
+        registry=registry,
+    )
+    assert submitted["status"] == "submitted"
+    task_id = submitted["task_id"]
+
+    # Wait for the background handoff to complete.
+    import asyncio
+
+    persisted: dict[str, Any] | None = None
+    for _ in range(50):
+        persisted = await registry.get(task_id, expected_account_id="acct_1")
+        if persisted is not None and persisted["state"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+
+    assert persisted is not None
+    assert persisted["state"] == "completed"
+    # The persisted result MUST NOT carry credentials. ``tasks/get``
+    # returns the registry's ``to_dict()`` verbatim — what's persisted
+    # is what the buyer sees.
+    assert _BEARER not in str(persisted)
+    assert "authentication" not in str(persisted)
+
+
+# ---------------------------------------------------------------------------
+# M1 — INTERNAL_ERROR caused_by omits exception str()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_internal_error_caused_by_drops_message_field(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """An adopter exception whose ``str()`` carries a bearer-shaped
+    token must not leak through ``details.caused_by.message``. The
+    field is now omitted entirely; only ``caused_by.type`` (the
+    exception class name) survives — enough for triage, too narrow
+    to fit a credential."""
+
+    class _CredentialLeakingPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct_1")
+
+        async def get_products(self, req: Any, ctx: Any) -> Any:
+            # Realistic shape: an adopter's HTTP client wraps the
+            # request URL + Authorization header into the exception
+            # message on connection failure.
+            raise ConnectionError(f"POST upstream failed: Authorization=Bearer {_BEARER}")
+
+    class _Req(BaseModel):
+        pass
+
+    ctx = _build_request_context(ToolContext(), Account(id="acct_1"), None)
+    with pytest.raises(AdcpError) as exc_info:
+        await _invoke_platform_method(
+            _CredentialLeakingPlatform(),
+            "get_products",
+            _Req(),
+            ctx,
+            executor=executor,
+            registry=InMemoryTaskRegistry(),
+        )
+    err = exc_info.value
+    assert err.code == "INTERNAL_ERROR"
+    # caused_by carries ONLY ``type``.
+    assert err.details["caused_by"] == {"type": "ConnectionError"}
+    assert "message" not in err.details["caused_by"]
+    # Bearer must not appear ANYWHERE on the wire envelope. The wire
+    # ``message`` is propagated from the adopter exception class name
+    # only (`_internal_error_message` builds it), not the exception
+    # ``str()``.
+    assert _BEARER not in str(err.details)
+    assert _BEARER not in str(err.args[0] if err.args else "")
+
+
+# ---------------------------------------------------------------------------
+# M2 — adcp.server.responses._serialize strips loose dicts
+# ---------------------------------------------------------------------------
+
+
+def test_response_builder_strips_governance_credentials_from_loose_dicts() -> None:
+    """Adopters hand-building responses via
+    :mod:`adcp.server.responses` builders pass through ``_serialize``,
+    which previously short-circuited dict items unchanged. A loose
+    dict carrying ``governance_agents[i].authentication`` would
+    smuggle credentials through. The builder layer now scrubs these
+    keys recursively, mirroring the dispatcher-level strip."""
+    from adcp.server.responses import _serialize
+
+    items = [
+        {
+            "account": {"account_id": "acct_1"},
+            "status": "synced",
+            "governance_agents": [
+                {
+                    "url": "https://gov.example.com/",
+                    "authentication": {
+                        "schemes": ["Bearer"],
+                        "credentials": _BEARER,
+                    },
+                }
+            ],
+        }
+    ]
+    serialized = _serialize(items)
+    assert _BEARER not in str(serialized)
+    assert "authentication" not in str(serialized[0]["governance_agents"][0])
+    assert serialized[0]["governance_agents"][0]["url"] == "https://gov.example.com/"
+
+
+def test_response_builder_strips_billing_entity_bank() -> None:
+    """Bank coordinates the spec marks write-only must not echo via
+    builder output."""
+    from adcp.server.responses import _serialize
+
+    items = [
+        {
+            "account_id": "acct_1",
+            "name": "Acme",
+            "billing_entity": {
+                "legal_name": "Acme Inc.",
+                "bank": {"iban": _IBAN},
+            },
+        }
+    ]
+    serialized = _serialize(items)
+    assert _IBAN not in str(serialized)
+    assert "bank" not in serialized[0]["billing_entity"]
+    assert serialized[0]["billing_entity"]["legal_name"] == "Acme Inc."
+
+
+def test_sync_governance_response_builder_round_trip_strip() -> None:
+    """Cross-builder regression: the public ``sync_governance_response``
+    helper is what storyboards / hello-world adopters call. Verify
+    the strip fires when an adopter passes a credential-bearing
+    item dict through the public API."""
+    response = sync_governance_response(
+        accounts=[
+            {
+                "account": {"account_id": "acct_1"},
+                "status": "synced",
+                "governance_agents": [
+                    {
+                        "url": "https://gov.example.com/",
+                        "authentication": {
+                            "schemes": ["Bearer"],
+                            "credentials": _BEARER,
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+    # Note: sync_governance_response returns ``{"accounts": [...]}``
+    # without going through ``_serialize`` — the items list is passed
+    # through as-is. This test pins that current behavior so a future
+    # refactor wiring the strip through this builder doesn't surprise.
+    # If the strip is added here, swap the assertion to negative.
+    leaked = _BEARER in str(response)
+    if leaked:
+        # Accept either path — the dispatcher-level strip still fires
+        # for any decisioning path. Pin the current builder behavior.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# M3 — ctx_metadata fail-closed gate
+# ---------------------------------------------------------------------------
+
+
+def test_ctx_metadata_rejects_credential_shaped_keys() -> None:
+    """An adopter who shoves a credential into ``ctx.metadata`` would
+    discover the value round-trips into responses (the AdCP spec
+    echoes context). The gate fails fast at
+    :func:`_build_request_context` with a clear pointer to
+    :class:`AuthInfo.credential`."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(metadata={"upstream.api_token": "secret"})
+    with pytest.raises(ValueError) as exc_info:
+        _build_request_context(tool_ctx, Account(id="x"), None)
+    msg = str(exc_info.value)
+    assert "credential-shaped" in msg
+    assert "upstream.api_token" in msg
+    assert "AuthInfo.credential" in msg
+
+
+def test_ctx_metadata_rejects_nested_credential_keys() -> None:
+    """Sub-keys at any nesting depth count — a buyer-supplied
+    ``{"upstream": {"api_token": "..."}}`` is rejected the same as
+    a flat key. The diagnostic walks the adopter to the offending
+    path."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(metadata={"upstream": {"api_token": "secret"}})
+    with pytest.raises(ValueError) as exc_info:
+        _build_request_context(tool_ctx, Account(id="x"), None)
+    msg = str(exc_info.value)
+    assert "upstream" in msg
+    assert "api_token" in msg
+
+
+def test_ctx_metadata_allows_non_credential_keys() -> None:
+    """Non-credential keys (correlation ids, feature flags, trace
+    ids) pass through unchanged — the gate is targeted, not blanket
+    metadata blocking."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(
+        metadata={
+            "correlation_id": "req_abc123",
+            "feature_flag.beta_pricing": True,
+            "trace_id": "t_xyz",
+        }
+    )
+    ctx = _build_request_context(tool_ctx, Account(id="x"), None)
+    assert ctx.metadata["correlation_id"] == "req_abc123"
+    assert ctx.metadata["feature_flag.beta_pricing"] is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "credential",
+        "my.credentials",
+        "auth_token",
+        "client_secret",
+        "x.api_key",
+        "ApiKey",
+        "BEARER",
+        "user.password",
+    ],
+)
+def test_ctx_metadata_credential_suffix_match_is_case_insensitive(key: str) -> None:
+    """The suffix match handles common adopter naming variants —
+    ``ApiKey`` / ``API_KEY`` / ``api_key`` all trip the gate."""
+    from adcp.decisioning.dispatch import _build_request_context
+
+    tool_ctx = ToolContext(metadata={key: "value"})
+    with pytest.raises(ValueError):
+        _build_request_context(tool_ctx, Account(id="x"), None)

--- a/tests/test_decisioning_dispatch.py
+++ b/tests/test_decisioning_dispatch.py
@@ -649,27 +649,33 @@ async def test_invoke_wraps_unexpected_exceptions_to_internal_error(
     # P2: "An internal error occurred" was a dead end).
     assert "ValueError" in str(exc_info.value)
     assert "get_products" in str(exc_info.value)
-    # Wire ``details.caused_by`` carries the truncated message — full
-    # traceback stays in server logs only.
-    assert exc_info.value.details["caused_by"]["type"] == "ValueError"
-    assert "oops, internal-state bug" in exc_info.value.details["caused_by"]["message"]
+    # Wire ``details.caused_by`` carries ONLY the exception class —
+    # full str/traceback stays in server logs. The class name is the
+    # triage breadcrumb; the exception's str() is omitted on the wire
+    # because any truncation length useful for diagnostics also fits a
+    # full bearer token / OAuth secret.
+    assert exc_info.value.details["caused_by"] == {"type": "ValueError"}
+    assert "message" not in exc_info.value.details["caused_by"]
 
 
 @pytest.mark.asyncio
-async def test_invoke_internal_error_message_truncated_long_repr(
+async def test_invoke_internal_error_omits_exception_str(
     executor: ThreadPoolExecutor,
 ) -> None:
-    """Defense-in-depth: an exception whose ``str()`` is huge (or
-    contains secret material because the adopter's repr is sloppy)
-    is truncated on the wire so secret-shaped values don't leak via
-    ``details.caused_by.message``. Full repr stays in server logs."""
+    """Defense-in-depth: ``caused_by.message`` is omitted entirely.
+    Any truncation length useful for diagnostics also fits a full
+    OAuth client secret or bearer token, so the wire surfaces only
+    the exception class name. Full repr / traceback stays in server
+    logs via :func:`logger.exception`."""
 
     class _BlowupPlatform(DecisioningPlatform):
         capabilities = DecisioningCapabilities()
         accounts = SingletonAccounts(account_id="x")
 
         async def get_products(self, req, ctx):
-            raise RuntimeError("X" * 1000)
+            # Realistic credential-leak shape: an adopter raises with
+            # the bearer in the exception message.
+            raise RuntimeError("upstream call failed: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig")
 
     ctx = _build_request_context(ToolContext(), Account(id="x"), None)
     with pytest.raises(AdcpError) as exc_info:
@@ -681,9 +687,11 @@ async def test_invoke_internal_error_message_truncated_long_repr(
             executor=executor,
             registry=InMemoryTaskRegistry(),
         )
-    truncated = exc_info.value.details["caused_by"]["message"]
-    assert len(truncated) <= 200, f"got {len(truncated)} chars; expected ≤200"
-    assert truncated.endswith("...")
+    caused_by = exc_info.value.details["caused_by"]
+    assert caused_by == {"type": "RuntimeError"}
+    # The bearer-shaped string MUST NOT appear anywhere on the wire.
+    assert "Bearer" not in str(exc_info.value.details)
+    assert "eyJhbGciOiJIUzI1NiJ9" not in str(exc_info.value.details)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #469 shipped `to_wire_account` / `to_wire_sync_accounts_row` /
`to_wire_sync_governance_row` as public-API projection helpers, but
no framework code called them. The typed projections were public
library functions adopters _may_ call, with no load-bearing
protection — adopters returning loose dicts (or Pydantic
`extra='allow'` models) bypassed the strip entirely. This PR
completes the wiring its projections were missing, plus a couple
of related leak vectors the audit found.

Defense-in-depth strip now runs on every wire-emit boundary,
gated by method name to keep the hot path cheap on tools that
can't carry credentials (`get_products`, `get_signals`):

- **Synchronous return** through `_invoke_platform_method` —
  recursive scrubber removes
  `governance_agents[i].authentication` and `billing_entity.bank`
  from dict/list returns. Typed Pydantic responses pass through
  (the response-side codegen schema forbids `authentication`
  structurally).
- **TaskHandoff completion** through `_project_handoff` — strips
  before `await registry.complete(...)` so durable registries
  (Postgres / Redis) and in-memory `tasks/get` echoes never
  carry credentials.
- **Sync-completion webhook** through `maybe_emit_sync_completion` —
  strips `result` before the buyer-controlled URL sees it.
- **INTERNAL_ERROR wire envelope** — `caused_by.message` removed
  entirely. Any truncation length useful for diagnostics also fits
  a full OAuth client secret; the wire surfaces only the exception
  class name. Full traceback stays in server logs.
- **Hand-built response builder** through
  `adcp.server.responses._serialize` — recursive write-only-field
  strip on dict items so `{**db_record, ...}` patterns don't smuggle
  credentials.
- **`ctx_metadata` fail-closed gate** at `_build_request_context`
  — rejects keys matching credential-shaped suffixes
  (`token`, `secret`, `api_key`, `password`, `bearer`,
  `credential[s]`, `apikey`) at any nesting depth. The AdCP
  context-echo contract round-trips metadata into responses;
  credentials belong in `AuthInfo.credential` / typed credential
  classes. Documented in CLAUDE.md.

## Findings landed

| ID | Description | Status |
|----|-------------|--------|
| H1 | Wire credential strip into dispatcher | Landed (`strip_credentials_from_wire_result` in `_invoke_platform_method`) |
| H2 | Strip on sync-completion webhook payload | Landed (`maybe_emit_sync_completion`) |
| H3 | Strip before TaskRegistry persistence | Landed (`_project_handoff`) |
| M1 | Drop `_internal_error_details.caused_by.message` | Landed |
| M2 | Project `governance_agents` in `_serialize` | Landed (`_strip_write_only_fields`) |
| M3 | Validate `ctx_metadata` doesn't carry credentials | Landed (`_validate_ctx_metadata_credentials`) |
| Doc | `ctx_metadata` write-only-credentials section in CLAUDE.md | Landed |

## Findings deferred

- **L1** schema-drift test on `_project_governance_agent` allowlist —
  per the audit, defer.
- **L2** deep-copy in tenant_store — per the audit, defer.

## Notes on the audit's framing

The audit said "the dispatcher in `handler.py` and/or `dispatch.py`
builds responses for `list_accounts`, `sync_accounts`,
`sync_governance`. None of them call the projection helpers." In the
current source, `PlatformHandler` does not yet have shims for those
three account tools at all — they aren't in
`SPECIALISM_TO_ADVERTISED_TOOLS` and no code path calls
`platform.accounts.upsert` / `.list` / `.sync_governance`. Rather
than ship dispatcher shims for these tools (out of scope for a
credential-leak fix), this PR wires the strip at the universal
choke point (`_invoke_platform_method`) so the protection is
load-bearing for ANY future shim that surfaces these methods, AND
defends every existing method that may carry an `Account` envelope
(e.g., a `create_media_buy` response that joins an account record).

The integration test in `tests/test_credential_leak_strip.py`
exercises the strip end-to-end by routing a method-name-gated
credential-bearing dict through `_invoke_platform_method` and
asserting no leak — equivalent regression coverage to "mount the
default `_TenantStore` and invoke `sync_governance` through the
dispatcher" once those shims land in a follow-up PR.

## Refs

- Closes #463
- Refs #452
- Completes the wiring PR #469's projections were missing

## Test plan

- [x] `tests/test_credential_leak_strip.py` — 22 new tests, all pass
- [x] `tests/test_decisioning_dispatch.py` — updated for M1
  (`caused_by.message` removed)
- [x] Full regression suite (`pytest tests/`) — 3452 passed, 27
  skipped, 1 xfailed
- [x] `ruff check src/` — passed
- [x] `mypy src/adcp/` — passed (759 source files)
- [x] pre-commit hooks (black + ruff + mypy + bandit) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)