### PR TITLE
feat(decisioning): mock-mode upstream URL routing (Phase 2)

### DIFF
--- a/docs/handler-authoring.md
+++ b/docs/handler-authoring.md
@@ -689,6 +689,87 @@ For the full set of scope invariants — what each field means, how
 cache keys are composed, what leaks if you populate fields wrong — see
 [docs/multi-tenant-contract.md](./multi-tenant-contract.md).
 
+## Account modes and mock-mode upstream routing
+
+The framework recognizes three operationally distinct account modes
+([proposal](https://github.com/adcontextprotocol/adcp-client/blob/main/docs/proposals/lifecycle-state-and-sandbox-authority.md)):
+
+- `mode='live'` — production traffic. Adopter's upstream is truth.
+- `mode='sandbox'` — adopter's own test infrastructure (test DB, test
+  GAM tenant). Test-only surfaces (`comply_test_controller`) are
+  admitted; everything else flows through the adopter's normal code
+  path.
+- `mode='mock'` — points the adapter's HTTP client at a per-tenant
+  mock-server fixture URL. Adapter business logic runs unchanged;
+  only the upstream URL changes per request.
+
+Adopters mark accounts with their mode in `AccountStore.resolve`. The
+framework reads `account.mode` to gate test-only surfaces and route
+upstream HTTP.
+
+### Adapter URL contract
+
+Adapters declare their production upstream URL on the platform class.
+The URL is fixed per platform — credentials and per-tenant routing
+flow through `ctx.auth_info` and `ctx.account.metadata`, not through
+the URL.
+
+```python
+class GAMPlatform(DecisioningPlatform, SalesPlatform):
+    upstream_url = "https://googleads.googleapis.com"
+    ...
+
+    async def get_products(self, req, ctx):
+        client = self.upstream_for(ctx, auth=self._auth_for(ctx))
+        # client._base_url == upstream_url for mode='live'/'sandbox';
+        # client._base_url == account.metadata['mock_upstream_url']
+        # for mode='mock'.
+        data = await client.get("/v1/products")
+        ...
+```
+
+`upstream_for(ctx)` returns a cached `UpstreamHttpClient` keyed by
+`(base_url, id(auth))`. Connection pooling stays correct across
+requests; different tenants with different auth strategies get
+distinct clients.
+
+### Mock-mode account fixture URLs
+
+Mock-mode accounts populate `metadata['mock_upstream_url']` in their
+`AccountStore.resolve` return value:
+
+```python
+ExplicitAccounts(loader=lambda aid: Account(
+    id=aid,
+    mode="mock",
+    metadata={"mock_upstream_url": "http://localhost:4500"},
+))
+```
+
+The mock-server is per-specialism (`bin/adcp.js mock-server
+<specialism>`, default port 4500). Adopters or CI start it before
+running storyboards. The SDK does not manage the mock-server's
+lifecycle — it just points the adapter at the URL.
+
+### Fail-closed cases
+
+`upstream_for(ctx)` raises `AdcpError(code='CONFIGURATION_ERROR')`
+when:
+
+- `mode='mock'` and `metadata['mock_upstream_url']` is missing /
+  empty / non-string. Fix in `AccountStore.resolve`.
+- `mode='live'` / `mode='sandbox'` and `platform.upstream_url is
+  None`. Set the class attribute, or mark the account `mode='mock'`.
+
+`recovery='terminal'` — buyers can't fix this; only the adopter's
+deployment can.
+
+### Worked example
+
+See `examples/hello_mock_seller.py` for a single platform with four
+accounts demonstrating all four routes (live, sandbox, mock-A,
+mock-B).
+
 ## A2A transport
 
 `serve(MyAgent(), transport="a2a")` wires the same handler through the

--- a/examples/hello_mock_seller.py
+++ b/examples/hello_mock_seller.py
@@ -1,0 +1,257 @@
+"""Hello-mock-seller — mock-mode upstream URL routing demo.
+
+The shape adopters use to enable spec-conformance / agent-development
+without standing up a real upstream:
+
+- ``mode='live'`` / ``mode='sandbox'``: requests go to the adopter's
+  production URL (``HelloMockPlatform.upstream_url``). Sandbox is the
+  adopter's own test infra at the same URL with different credentials —
+  the adopter's ``DecisioningPlatform`` code path runs end-to-end.
+- ``mode='mock'``: requests go to ``account.metadata['mock_upstream_url']``.
+  The adapter code is unchanged; only the upstream URL changes per
+  request. Adopters point this at a per-specialism mock-server fixture
+  (e.g. ``bin/adcp.js mock-server sales-non-guaranteed`` on port 4500)
+  for spec-compliance storyboards or local agent development.
+
+The mock-server lifecycle is **not** managed by the SDK. Adopters or
+CI start it as needed (``bin/adcp.js mock-server <specialism>``) and
+populate the URL on the account's metadata in ``AccountStore.resolve``.
+
+Run::
+
+    uv run python examples/hello_mock_seller.py
+
+The example boots without hitting any of the four URLs — it's a code-
+shape demo. Production adapters call ``client.get(...)`` /
+``client.post(...)`` after :meth:`upstream_for`; here we just inspect
+the URL the framework selected so the four-account routing is visible
+on stdout.
+
+See ``docs/proposals/lifecycle-state-and-sandbox-authority.md`` for
+the three-mode design.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    ExplicitAccounts,
+    RequestContext,
+    SalesPlatform,
+    serve,
+)
+from adcp.decisioning.capabilities import (
+    Account as CapabilitiesAccount,
+)
+from adcp.decisioning.capabilities import (
+    Adcp,
+    IdempotencySupported,
+    MediaBuy,
+)
+from adcp.decisioning.types import Account
+
+# Pre-built account roster. Each Account demonstrates one routing case
+# the framework's upstream_for() enforces. Adopters in production load
+# accounts from a DB / config service via their AccountStore.resolve;
+# ExplicitAccounts(loader=...) is the simplest fit for a fixed roster.
+_ACCOUNTS: dict[str, Account[Any]] = {
+    "acct_live": Account(
+        id="acct_live",
+        mode="live",
+        name="Live tenant",
+        status="active",
+    ),
+    "acct_sandbox": Account(
+        id="acct_sandbox",
+        mode="sandbox",
+        name="Sandbox tenant",
+        status="active",
+    ),
+    "acct_mock_a": Account(
+        id="acct_mock_a",
+        mode="mock",
+        name="Mock fixture A",
+        status="active",
+        metadata={"mock_upstream_url": "http://localhost:4500"},
+    ),
+    "acct_mock_b": Account(
+        id="acct_mock_b",
+        mode="mock",
+        name="Mock fixture B",
+        status="active",
+        metadata={"mock_upstream_url": "http://localhost:4501"},
+    ),
+}
+
+
+def _load_account(account_id: str) -> Account[Any]:
+    from adcp.decisioning import AdcpError
+
+    if account_id not in _ACCOUNTS:
+        raise AdcpError(
+            "ACCOUNT_NOT_FOUND",
+            message=f"unknown account_id={account_id!r}",
+            recovery="terminal",
+            field="account.account_id",
+        )
+    return _ACCOUNTS[account_id]
+
+
+class HelloMockPlatform(DecisioningPlatform, SalesPlatform):
+    """Single platform demonstrating the four mock-mode routing cases.
+
+    All four accounts run through the same adapter code; the framework
+    selects the upstream URL at :meth:`upstream_for` time based on
+    ``ctx.account.mode``:
+
+    - acct_live    → ``HelloMockPlatform.upstream_url``
+    - acct_sandbox → ``HelloMockPlatform.upstream_url``
+    - acct_mock_a  → ``http://localhost:4500``
+    - acct_mock_b  → ``http://localhost:4501``
+
+    Production adapters (GAM, Kevel, FreeWheel, Prebid) declare
+    ``upstream_url`` as the canonical production URL — fixed per
+    platform. Per-tenant routing flows through ``ctx.auth_info`` and
+    ``ctx.account.metadata``, never through ``upstream_url``.
+    """
+
+    upstream_url = "https://example-ad-server.invalid/api"
+
+    capabilities = DecisioningCapabilities(
+        specialisms=["sales-non-guaranteed"],
+        adcp=Adcp(
+            major_versions=[3],
+            idempotency=IdempotencySupported(
+                supported=True,
+                replay_ttl_seconds=86400,
+            ),
+        ),
+        account=CapabilitiesAccount(supported_billing=["operator"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+    )
+    accounts = ExplicitAccounts(loader=_load_account)
+
+    def get_products(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        # The adapter's view of the world is identical across all four
+        # accounts — same upstream_for() call, same client API, same
+        # business logic. Only the resolved base_url differs.
+        client = self.upstream_for(ctx)
+
+        # Demo-only: surface the routed URL so the four-account routing
+        # is visible from a single tool call. Real adapters call
+        # ``await client.get('/v1/products', ...)`` here and project the
+        # upstream JSON onto the ``products`` schema.
+        return {
+            "products": [
+                {
+                    "product_id": "demo-product",
+                    "name": f"Mock-routed for {ctx.account.id}",
+                    "description": (
+                        f"Adapter pointed at {client._base_url} "
+                        f"(account.mode={ctx.account.mode})"
+                    ),
+                    "delivery_type": "non_guaranteed",
+                    "publisher_properties": [
+                        {"publisher_domain": "example.com", "selection_type": "all"},
+                    ],
+                    "format_ids": [
+                        {
+                            "agent_url": "https://creative.adcontextprotocol.org/",
+                            "id": "display_300x250",
+                        },
+                    ],
+                    "pricing_options": [
+                        {
+                            "pricing_option_id": "po-cpm-default",
+                            "pricing_model": "cpm",
+                            "floor_price": 5.0,
+                            "currency": "USD",
+                        },
+                    ],
+                    "reporting_capabilities": {
+                        "available_metrics": ["impressions"],
+                        "available_reporting_frequencies": ["daily"],
+                        "date_range_support": "date_range",
+                        "supports_webhooks": False,
+                        "expected_delay_minutes": 60,
+                        "timezone": "UTC",
+                    },
+                    "delivery_measurement": {"provider": "internal"},
+                },
+            ],
+        }
+
+    def create_media_buy(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        # Same routing behavior — the client points at the live URL for
+        # acct_live / acct_sandbox, and at the per-account mock URL
+        # for acct_mock_a / acct_mock_b.
+        _ = self.upstream_for(ctx)
+        return {
+            "media_buy_id": f"mb_{ctx.account.id}_demo",
+            "status": "active",
+            "packages": [],
+        }
+
+    def update_media_buy(
+        self,
+        media_buy_id: str,
+        patch: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        return {"media_buy_id": media_buy_id, "status": "active", "packages": []}
+
+    def sync_creatives(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        creatives = getattr(req, "creatives", None) or []
+        return {
+            "creatives": [
+                {
+                    "creative_id": (
+                        c.creative_id if hasattr(c, "creative_id") else c.get("creative_id")
+                    ),
+                    "approval_status": "approved",
+                }
+                for c in creatives
+            ],
+        }
+
+    def get_media_buy_delivery(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        return {
+            "media_buy_deliveries": [
+                {
+                    "media_buy_id": getattr(req, "media_buy_id", "mb_unknown"),
+                    "totals": {"impressions": 0, "spend": 0.0},
+                },
+            ],
+        }
+
+
+if __name__ == "__main__":
+    # Default port 3001. Buyers send ``account.account_id`` ∈
+    # {acct_live, acct_sandbox, acct_mock_a, acct_mock_b} on requests;
+    # the framework resolves through ExplicitAccounts.loader and threads
+    # the account onto ctx so upstream_for() picks the right URL.
+    serve(
+        HelloMockPlatform(),
+        name="hello-mock-seller",
+        port=3001,
+        auto_emit_completion_webhooks=False,
+    )

--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -53,6 +53,7 @@ from adcp.decisioning.account_mode import (
     AccountMode,
     assert_sandbox_account,
     get_account_mode,
+    get_mock_upstream_url,
     is_sandbox_or_mock_account,
 )
 from adcp.decisioning.account_projection import (
@@ -328,6 +329,7 @@ __all__ = [
     "assert_media_buy_transition",
     "assert_sandbox_account",
     "get_account_mode",
+    "get_mock_upstream_url",
     "is_sandbox_or_mock_account",
     "bearer_only_registry",
     "compose_method",

--- a/src/adcp/decisioning/account_mode.py
+++ b/src/adcp/decisioning/account_mode.py
@@ -8,9 +8,11 @@ env vars are operator-error-prone proxies for what is fundamentally an
 authority decision per principal.
 
 Mirrors the JS-side ``src/lib/server/account-mode.ts`` for cross-language
-parity. Phase 1 of the lifecycle-state-and-sandbox-authority proposal —
-ships the field, helpers, and dispatch gate. Mock-mode routing
-(Phase 2) is deferred.
+parity. Phase 1 of the lifecycle-state-and-sandbox-authority proposal
+ships the field, helpers, and dispatch gate; Phase 2 ships
+:func:`get_mock_upstream_url` and :meth:`DecisioningPlatform.upstream_for`
+so mock-mode accounts route HTTP requests at a per-tenant fixture URL
+without touching adapter business logic.
 
 See ``docs/proposals/lifecycle-state-and-sandbox-authority.md`` for the
 full three-mode design.
@@ -18,9 +20,10 @@ full three-mode design.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Literal, cast
 
-from adcp.decisioning.types import AdcpError
+from adcp.decisioning.types import Account, AdcpError
 
 #: Three operationally distinct account modes:
 #:
@@ -127,6 +130,38 @@ def assert_sandbox_account(
         recovery="terminal",
         details=details,
     )
+
+
+def get_mock_upstream_url(account: Account[Any]) -> str | None:
+    """Read ``account.metadata['mock_upstream_url']`` safely.
+
+    Adopters populate this in :meth:`AccountStore.resolve` for
+    ``mode='mock'`` accounts so the framework's
+    :meth:`DecisioningPlatform.upstream_for` knows which mock-server
+    fixture URL to point the adapter's :class:`UpstreamHttpClient` at.
+    The mock-server is per-specialism (``bin/adcp.js mock-server
+    <specialism>``); adopters or CI start it and supply the URL on the
+    account.
+
+    Returns ``None`` when:
+
+    - ``account.metadata`` is not a :class:`Mapping`.
+    - ``mock_upstream_url`` is absent.
+    - ``mock_upstream_url`` is empty / falsy / not a string.
+
+    The framework treats any of these as "no mock URL declared" and
+    fails closed at :meth:`DecisioningPlatform.upstream_for` rather
+    than silently routing to a live URL.
+    """
+    if account is None:
+        return None
+    metadata = getattr(account, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return None
+    url = metadata.get("mock_upstream_url")
+    if not isinstance(url, str) or not url:
+        return None
+    return url
 
 
 def _attr(obj: Any, name: str) -> Any:

--- a/src/adcp/decisioning/platform.py
+++ b/src/adcp/decisioning/platform.py
@@ -15,6 +15,13 @@ import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from adcp.decisioning.account_mode import get_account_mode, get_mock_upstream_url
+from adcp.decisioning.types import AdcpError
+from adcp.decisioning.upstream import (
+    NoAuth,
+    UpstreamAuth,
+    UpstreamHttpClient,
+)
 from adcp.types.capabilities import (
     Adcp,
     Brand,
@@ -34,6 +41,7 @@ from adcp.types.capabilities import (
 
 if TYPE_CHECKING:
     from adcp.decisioning.accounts import AccountStore
+    from adcp.decisioning.context import RequestContext
 
 
 @dataclass
@@ -362,3 +370,168 @@ class DecisioningPlatform:
     #: (different ``TMeta`` per adopter); ``validate_platform``
     #: confirms an :class:`AccountStore` instance is set.
     accounts: AccountStore[Any] = None  # type: ignore[assignment]
+
+    #: Optional: the adopter's production upstream API URL. Adapters
+    #: that talk to a real upstream (GAM, Kevel, FreeWheel, etc.) set
+    #: this to the canonical production endpoint
+    #: (``"https://googleads.googleapis.com"``,
+    #: ``"https://api.kevel.co"``, etc.). The value is fixed per
+    #: platform — credentials and per-tenant routing flow through
+    #: ``ctx.auth_info`` and ``ctx.account.metadata``, not through
+    #: this URL.
+    #:
+    #: Leave ``None`` for platforms that don't talk to an HTTP
+    #: upstream (pure in-process, in-memory, or composing via
+    #: framework-level resolvers only).
+    #:
+    #: When :attr:`upstream_url` is ``None``, :meth:`upstream_for`
+    #: refuses to construct a client for ``mode='live'`` /
+    #: ``mode='sandbox'`` accounts (raising ``CONFIGURATION_ERROR``).
+    #: ``mode='mock'`` accounts always read from
+    #: ``account.metadata['mock_upstream_url']`` and never consult
+    #: this attribute.
+    upstream_url: str | None = None
+
+    def upstream_for(
+        self,
+        ctx: RequestContext[Any],
+        *,
+        auth: UpstreamAuth | None = None,
+        default_headers: dict[str, str] | None = None,
+        timeout: float = 30.0,
+        treat_404_as_none: bool = True,
+    ) -> UpstreamHttpClient:
+        """Return an :class:`UpstreamHttpClient` pointed at the right URL
+        for this request's resolved account.
+
+        Routing rules:
+
+        - ``mode='live'`` / ``mode='sandbox'``: client at
+          :attr:`upstream_url`. The adopter's production upstream URL is
+          fixed per platform; only credentials vary per tenant (and flow
+          through ``auth`` / ``ctx.auth_info``).
+        - ``mode='mock'``: client at
+          ``ctx.account.metadata['mock_upstream_url']``. The adopter
+          populates this on mock-mode accounts; the framework points
+          the client at the per-tenant fixture URL. Adapter business
+          logic runs unchanged.
+
+        Clients are cached per-platform-instance keyed by
+        ``(base_url, id(auth))`` so repeated requests pool connections
+        through one ``httpx.AsyncClient``. Different auth strategies
+        get distinct clients (the auth is injected at construction
+        and can't be swapped per-request from a cached client).
+
+        :param ctx: The current request context. Required for
+            ``ctx.account.mode`` and ``ctx.account.metadata``.
+        :param auth: Auth strategy for the upstream. Defaults to
+            :class:`NoAuth` (no header injected). Adopters typically
+            pass a :class:`StaticBearer`, :class:`DynamicBearer`, or
+            :class:`ApiKey`. The same auth is used regardless of mode
+            — mock-mode fixtures usually accept any token, but adopters
+            may want their adapter to send identical headers in mock
+            and live so the wire shape matches end-to-end.
+        :param default_headers: Headers included on every request
+            (e.g. ``X-API-Version``).
+        :param timeout: Per-request timeout in seconds. Default 30.0.
+        :param treat_404_as_none: When ``True`` (default), GET/DELETE
+            404s return ``None`` rather than raising.
+
+        :raises AdcpError: ``CONFIGURATION_ERROR`` when:
+
+            - Account is ``mode='mock'`` but
+              ``account.metadata['mock_upstream_url']`` is missing,
+              empty, or non-string. Adopter must populate it on
+              mock-mode accounts in their ``AccountStore.resolve``.
+            - Account is ``mode='live'`` / ``mode='sandbox'`` but
+              ``self.upstream_url`` is ``None``. Adopter must declare
+              the production URL on their platform subclass.
+        """
+        account = ctx.account
+        mode = get_account_mode(account)
+
+        if mode == "mock":
+            base_url = get_mock_upstream_url(account)
+            if base_url is None:
+                raise AdcpError(
+                    "CONFIGURATION_ERROR",
+                    message=(
+                        "account is mode='mock' but no 'mock_upstream_url' "
+                        "string in metadata; populate it in "
+                        "AccountStore.resolve for mock-mode accounts. "
+                        "See docs/handler-authoring.md#mock-mode-upstream-routing."
+                    ),
+                    recovery="terminal",
+                    field="account.metadata.mock_upstream_url",
+                )
+        else:
+            # mode in {'live', 'sandbox'} — point at the platform's
+            # declared production URL. Sandbox is the adopter's own
+            # test infra; the URL is the same as live (credentials
+            # + tenant routing change, not the URL).
+            if self.upstream_url is None:
+                raise AdcpError(
+                    "CONFIGURATION_ERROR",
+                    message=(
+                        f"platform {type(self).__name__!s} has no "
+                        f"upstream_url declared but resolved account is "
+                        f"mode={mode!r}. Set the class attribute "
+                        "upstream_url to the production upstream API URL, "
+                        "or mark the account mode='mock' and populate "
+                        "metadata['mock_upstream_url']."
+                    ),
+                    recovery="terminal",
+                )
+            base_url = self.upstream_url
+
+        return self._cached_upstream_client(
+            base_url=base_url,
+            auth=auth or NoAuth(),
+            default_headers=default_headers,
+            timeout=timeout,
+            treat_404_as_none=treat_404_as_none,
+        )
+
+    def _cached_upstream_client(
+        self,
+        *,
+        base_url: str,
+        auth: UpstreamAuth,
+        default_headers: dict[str, str] | None,
+        timeout: float,
+        treat_404_as_none: bool,
+    ) -> UpstreamHttpClient:
+        """Per-instance cached :class:`UpstreamHttpClient` factory.
+
+        Cache key is ``(base_url, id(auth))``. Pooling correctness
+        requires keying on the auth instance — different ``DynamicBearer``
+        closures for different tenants need distinct clients so the
+        token resolver doesn't get accidentally shared, and the
+        ``UpstreamHttpClient`` itself owns the underlying
+        ``httpx.AsyncClient`` connection pool.
+
+        Cache lives on the platform instance (``__dict__`` lazy init);
+        multi-platform processes don't cross-pollute. Adopter code
+        does not mutate the cache; lifecycle is "create once, reuse
+        for the platform instance's lifetime."
+        """
+        cache: dict[tuple[str, int], UpstreamHttpClient] | None
+        cache = getattr(self, "_upstream_client_cache", None)
+        if cache is None:
+            cache = {}
+            self._upstream_client_cache = cache
+
+        key = (base_url, id(auth))
+        existing = cache.get(key)
+        if existing is not None:
+            return existing
+
+        client = UpstreamHttpClient(
+            base_url=base_url,
+            auth=auth,
+            default_headers=default_headers,
+            timeout=timeout,
+            treat_404_as_none=treat_404_as_none,
+        )
+        cache[key] = client
+        return client

--- a/src/adcp/decisioning/types.py
+++ b/src/adcp/decisioning/types.py
@@ -393,7 +393,17 @@ class Account(Generic[TMeta]):
         ``'active'``, ``'disabled'``, etc. Adopters consuming the
         ``account-status.json`` enum can use this directly.
     :param metadata: Adopter-defined typed metadata. Defaults to an
-        untyped dict for adopters who don't care.
+        untyped dict for adopters who don't care. Two framework-reserved
+        keys when ``metadata`` is a dict-shaped payload:
+
+        - ``mock_upstream_url`` (``str``): For ``mode='mock'`` accounts
+          only. Tells :meth:`DecisioningPlatform.upstream_for` which
+          mock-server fixture URL to point the adapter's
+          :class:`UpstreamHttpClient` at. Read via
+          :func:`get_mock_upstream_url`. The adopter populates this in
+          ``AccountStore.resolve`` for mock-mode accounts; the framework
+          fail-closes when missing.
+        - All other keys are adopter-defined.
     :param auth_info: The verified principal that authenticated this
         request, if any. Distinct from ``id`` because one principal
         can act on multiple accounts in 'explicit' resolution mode.

--- a/tests/test_error_code_conformance.py
+++ b/tests/test_error_code_conformance.py
@@ -73,6 +73,21 @@ KNOWN_NON_SPEC_CODES: dict[str, str] = {
         "Pre-canonical 3.1 split of AUTH_REQUIRED. Documented in the "
         "AUTH_REQUIRED enumDescription as a future spec change."
     ),
+    # TODO: track upstream addition to error-code.json enum.
+    # Server-side adopter-misconfiguration signal raised at framework
+    # seams where the platform's declared shape can't service the
+    # request — e.g., DecisioningPlatform.upstream_for() with no
+    # ``upstream_url`` and a non-mock account, or a mock-mode account
+    # whose ``metadata['mock_upstream_url']`` is missing/empty.
+    # Distinct from INVALID_REQUEST (buyer's payload bad) and
+    # SERVICE_UNAVAILABLE (transient upstream failure); buyers can't
+    # fix this — only the seller's deployment can. Surfaces with
+    # recovery=terminal so buyers don't retry.
+    "CONFIGURATION_ERROR": (
+        "Adopter-misconfiguration signal raised by "
+        "DecisioningPlatform.upstream_for. Distinct from INVALID_REQUEST "
+        "(buyer-fixable) and SERVICE_UNAVAILABLE (transient)."
+    ),
 }
 
 CANONICAL_CODES: frozenset[str] = frozenset(member.value for member in ErrorCode)

--- a/tests/test_upstream_for.py
+++ b/tests/test_upstream_for.py
@@ -1,0 +1,353 @@
+"""Phase 2 mock-mode upstream URL routing.
+
+Adapter code is unchanged across modes; the framework swaps the upstream
+URL the :class:`UpstreamHttpClient` points at based on
+``ctx.account.mode``:
+
+- ``mode='live'`` / ``mode='sandbox'``: ``platform.upstream_url``
+- ``mode='mock'``: ``account.metadata['mock_upstream_url']``
+
+Test matrix:
+
+- Routing (3): live, sandbox, mock — each routes to the right base URL.
+- Fail-closed (3): mock without metadata, mock with empty/None URL,
+  live without ``platform.upstream_url`` declared.
+- Cache (2): same key returns same client; different mock URLs don't
+  collide.
+- Auth threading (1): adopter-supplied ``UpstreamAuth`` flows through
+  to the constructed client.
+- ``get_mock_upstream_url`` helper (4): dict, missing, non-mapping,
+  non-string value.
+
+See ``docs/proposals/lifecycle-state-and-sandbox-authority.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    RequestContext,
+    StaticBearer,
+    UpstreamHttpClient,
+    get_mock_upstream_url,
+)
+from adcp.decisioning.types import Account
+from adcp.decisioning.upstream import NoAuth
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+PRODUCTION_URL = "https://upstream.example.invalid/api"
+MOCK_URL_A = "http://localhost:4500"
+MOCK_URL_B = "http://localhost:4501"
+
+
+class _Platform(DecisioningPlatform):
+    """Minimal platform instance — capabilities + upstream_url only.
+
+    Tests mutate ``upstream_url`` per-instance to exercise the
+    None-vs-string branches without subclassing for each.
+    """
+
+    capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+    upstream_url = PRODUCTION_URL
+
+
+def _ctx(
+    *,
+    mode: str = "live",
+    metadata: dict[str, Any] | None = None,
+) -> RequestContext[Any]:
+    """Build a RequestContext with an Account at the requested mode.
+
+    The test harness builds the context directly per the framework-only-
+    construction note on RequestContext — direct construction is
+    supported for tests.
+    """
+    account: Account[Any] = Account(
+        id="acct_test",
+        mode=mode,  # type: ignore[arg-type]
+        metadata=metadata if metadata is not None else {},
+    )
+    return RequestContext(account=account)
+
+
+# ---------------------------------------------------------------------------
+# Routing — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_live_mode_routes_to_platform_upstream_url() -> None:
+    platform = _Platform()
+    ctx = _ctx(mode="live")
+
+    client = platform.upstream_for(ctx)
+
+    assert isinstance(client, UpstreamHttpClient)
+    assert client._base_url == PRODUCTION_URL
+
+
+def test_sandbox_mode_routes_to_platform_upstream_url() -> None:
+    """Sandbox shares the production URL — adopter's test infra is reached
+    via the same endpoint with different credentials, not a different URL.
+    """
+    platform = _Platform()
+    ctx = _ctx(mode="sandbox")
+
+    client = platform.upstream_for(ctx)
+
+    assert client._base_url == PRODUCTION_URL
+
+
+def test_mock_mode_routes_to_account_metadata_url() -> None:
+    platform = _Platform()
+    ctx = _ctx(
+        mode="mock",
+        metadata={"mock_upstream_url": MOCK_URL_A},
+    )
+
+    client = platform.upstream_for(ctx)
+
+    assert client._base_url == MOCK_URL_A
+
+
+def test_two_mock_accounts_get_distinct_clients() -> None:
+    """Different mock URLs must not share a client (each one's
+    ``UpstreamHttpClient`` owns its own ``httpx.AsyncClient`` pool
+    pointed at a different host).
+    """
+    platform = _Platform()
+    ctx_a = _ctx(mode="mock", metadata={"mock_upstream_url": MOCK_URL_A})
+    ctx_b = _ctx(mode="mock", metadata={"mock_upstream_url": MOCK_URL_B})
+
+    client_a = platform.upstream_for(ctx_a)
+    client_b = platform.upstream_for(ctx_b)
+
+    assert client_a is not client_b
+    assert client_a._base_url == MOCK_URL_A
+    assert client_b._base_url == MOCK_URL_B
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed cases
+# ---------------------------------------------------------------------------
+
+
+def test_mock_mode_without_metadata_url_raises_configuration_error() -> None:
+    platform = _Platform()
+    ctx = _ctx(mode="mock", metadata={})
+
+    with pytest.raises(AdcpError) as excinfo:
+        platform.upstream_for(ctx)
+
+    assert excinfo.value.code == "CONFIGURATION_ERROR"
+    assert "mock_upstream_url" in str(excinfo.value)
+    assert excinfo.value.field == "account.metadata.mock_upstream_url"
+
+
+def test_mock_mode_with_empty_string_url_raises() -> None:
+    platform = _Platform()
+    ctx = _ctx(mode="mock", metadata={"mock_upstream_url": ""})
+
+    with pytest.raises(AdcpError) as excinfo:
+        platform.upstream_for(ctx)
+
+    assert excinfo.value.code == "CONFIGURATION_ERROR"
+
+
+def test_mock_mode_with_none_url_raises() -> None:
+    platform = _Platform()
+    ctx = _ctx(mode="mock", metadata={"mock_upstream_url": None})
+
+    with pytest.raises(AdcpError) as excinfo:
+        platform.upstream_for(ctx)
+
+    assert excinfo.value.code == "CONFIGURATION_ERROR"
+
+
+def test_mock_mode_with_non_string_url_raises() -> None:
+    """Non-string ``mock_upstream_url`` (int, dict, etc.) is rejected
+    — the helper requires a real URL string."""
+    platform = _Platform()
+    ctx = _ctx(mode="mock", metadata={"mock_upstream_url": 12345})
+
+    with pytest.raises(AdcpError) as excinfo:
+        platform.upstream_for(ctx)
+
+    assert excinfo.value.code == "CONFIGURATION_ERROR"
+
+
+def test_live_mode_without_platform_upstream_url_raises() -> None:
+    class _NoUpstreamPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        upstream_url = None
+
+    platform = _NoUpstreamPlatform()
+    ctx = _ctx(mode="live")
+
+    with pytest.raises(AdcpError) as excinfo:
+        platform.upstream_for(ctx)
+
+    assert excinfo.value.code == "CONFIGURATION_ERROR"
+    assert "upstream_url" in str(excinfo.value)
+    # Diagnostic includes the offending mode so adopters know to either
+    # set upstream_url or mark the account mock.
+    assert "live" in str(excinfo.value)
+
+
+def test_sandbox_mode_without_platform_upstream_url_raises() -> None:
+    class _NoUpstreamPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        upstream_url = None
+
+    platform = _NoUpstreamPlatform()
+    ctx = _ctx(mode="sandbox")
+
+    with pytest.raises(AdcpError) as excinfo:
+        platform.upstream_for(ctx)
+
+    assert excinfo.value.code == "CONFIGURATION_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Cache identity
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_call_same_url_returns_same_client_instance() -> None:
+    """Connection pooling correctness: the same (base_url, auth) must
+    reuse the same :class:`UpstreamHttpClient` across requests so one
+    ``httpx.AsyncClient`` pool fronts every call.
+    """
+    platform = _Platform()
+    auth = StaticBearer(token="t1")
+
+    client_1 = platform.upstream_for(_ctx(mode="live"), auth=auth)
+    client_2 = platform.upstream_for(_ctx(mode="live"), auth=auth)
+
+    assert client_1 is client_2
+
+
+def test_distinct_auth_strategies_get_distinct_clients() -> None:
+    """Different auth instances ⇒ different clients. The auth is
+    injected at construction; the framework can't swap it on a cached
+    instance, so cache key must include the auth identity.
+    """
+    platform = _Platform()
+    auth_1 = StaticBearer(token="t1")
+    auth_2 = StaticBearer(token="t2")
+
+    client_1 = platform.upstream_for(_ctx(mode="live"), auth=auth_1)
+    client_2 = platform.upstream_for(_ctx(mode="live"), auth=auth_2)
+
+    assert client_1 is not client_2
+
+
+def test_cache_is_per_platform_instance() -> None:
+    """Multi-platform processes (one DecisioningPlatform instance per
+    adapter) MUST NOT share an upstream-client cache. A leak across
+    platforms would let one adapter's auth headers ship on another
+    adapter's connection pool.
+    """
+    p1 = _Platform()
+    p2 = _Platform()
+
+    c1 = p1.upstream_for(_ctx(mode="live"))
+    c2 = p2.upstream_for(_ctx(mode="live"))
+
+    assert c1 is not c2
+
+
+# ---------------------------------------------------------------------------
+# Auth threading
+# ---------------------------------------------------------------------------
+
+
+def test_auth_strategy_flows_through_to_client_construction() -> None:
+    """Adopter-supplied :class:`UpstreamAuth` must reach the
+    :class:`UpstreamHttpClient`; the client carries it onto every
+    request and the auth resolver runs at request time.
+    """
+    platform = _Platform()
+    auth = StaticBearer(token="bearer-xyz")
+    ctx = _ctx(mode="live")
+
+    client = platform.upstream_for(ctx, auth=auth)
+
+    assert client._auth is auth
+
+
+def test_default_auth_is_no_auth() -> None:
+    """When the adopter doesn't supply auth, the framework defaults to
+    :class:`NoAuth` so the client construction succeeds; adopter
+    upstream calls without credentials work for unauthenticated dev /
+    fixture endpoints.
+    """
+    platform = _Platform()
+    client = platform.upstream_for(_ctx(mode="live"))
+
+    assert isinstance(client._auth, NoAuth)
+
+
+def test_default_headers_flow_through() -> None:
+    """Adopter-supplied default headers reach the constructed client."""
+    platform = _Platform()
+    client = platform.upstream_for(
+        _ctx(mode="live"),
+        default_headers={"X-API-Version": "2"},
+    )
+
+    assert client._default_headers == {"X-API-Version": "2"}
+
+
+# ---------------------------------------------------------------------------
+# get_mock_upstream_url helper
+# ---------------------------------------------------------------------------
+
+
+def test_get_mock_upstream_url_reads_dict_metadata() -> None:
+    account = Account(id="a", mode="mock", metadata={"mock_upstream_url": MOCK_URL_A})
+    assert get_mock_upstream_url(account) == MOCK_URL_A
+
+
+def test_get_mock_upstream_url_returns_none_when_absent() -> None:
+    account = Account(id="a", mode="mock", metadata={})
+    assert get_mock_upstream_url(account) is None
+
+
+def test_get_mock_upstream_url_returns_none_for_non_string() -> None:
+    account = Account(id="a", mode="mock", metadata={"mock_upstream_url": 12345})
+    assert get_mock_upstream_url(account) is None
+
+
+def test_get_mock_upstream_url_returns_none_for_empty_string() -> None:
+    account = Account(id="a", mode="mock", metadata={"mock_upstream_url": ""})
+    assert get_mock_upstream_url(account) is None
+
+
+def test_get_mock_upstream_url_returns_none_for_non_mapping_metadata() -> None:
+    """Pre-mode adopters whose ``metadata`` shape isn't a Mapping
+    (TypedDict subclasses ARE mappings; dataclass-shaped TMeta isn't)
+    read as ``None`` rather than raising — the framework's
+    fail-closed branch in :meth:`DecisioningPlatform.upstream_for`
+    surfaces ``CONFIGURATION_ERROR`` cleanly.
+    """
+
+    class _MetaDataclass:
+        # Intentionally NOT a Mapping
+        def __init__(self) -> None:
+            self.mock_upstream_url = MOCK_URL_A
+
+    account: Account[Any] = Account(id="a", mode="mock", metadata=_MetaDataclass())
+    assert get_mock_upstream_url(account) is None
+
+
+def test_get_mock_upstream_url_returns_none_for_none_account() -> None:
+    assert get_mock_upstream_url(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Phase 2 of the [lifecycle-state-and-sandbox-authority](https://github.com/adcontextprotocol/adcp-client/blob/main/docs/proposals/lifecycle-state-and-sandbox-authority.md) work. When a resolved `Account` has `mode='mock'`, the framework points the adapter's `UpstreamHttpClient` at the per-tenant mock-server fixture URL declared on `account.metadata['mock_upstream_url']`. Adapter business logic runs unchanged across all three modes; only the upstream URL changes per request.

**Reframe vs. earlier proposal sketches.** The proposal doc envisioned the SDK forwarding mock-mode tool calls out-of-process to a `bin/adcp.js mock-server` AdCP-MCP forwarder. The earlier agent on this work correctly determined that doesn't fit the existing mock-server (it's a **per-specialism upstream-API REST fixture**, not an MCP forwarder). The user (proposal author) confirmed the right model: the adapter knows its own production URL (GAM is always `googleads.googleapis.com`, Kevel is always `api.kevel.co`); mock-mode just swaps the upstream URL the adapter's HTTP client points at. Adapter code runs unchanged.

## Surface

- `DecisioningPlatform.upstream_url: str | None` — adopter declares the production upstream URL on their subclass (e.g. `"https://googleads.googleapis.com"`). `None` is allowed for pure in-process platforms.
- `DecisioningPlatform.upstream_for(ctx, *, auth=None, default_headers=None, timeout=30.0, treat_404_as_none=True) -> UpstreamHttpClient` — returns a cached client pointed at the right URL for `ctx.account.mode`. Fail-closes with `AdcpError(code='CONFIGURATION_ERROR', recovery='terminal')` when:
  - `mode='mock'` and `metadata['mock_upstream_url']` is missing/empty/non-string.
  - `mode='live'` / `mode='sandbox'` and `platform.upstream_url is None`.
- `get_mock_upstream_url(account) -> str | None` — type-safe accessor that handles dict, non-mapping, missing, empty, and non-string cases.

Cache key: `(base_url, id(auth))`, per-platform-instance. Different platform instances don't share clients (no cross-adapter auth-header leak); different auth strategies on the same platform get distinct clients (the auth is injected at construction and can't be swapped per-request from a cached client).

## What ships

| File | Change |
|---|---|
| `src/adcp/decisioning/account_mode.py` | Add `get_mock_upstream_url(account)` helper. |
| `src/adcp/decisioning/platform.py` | Add `upstream_url` class attr + `upstream_for(ctx)` method + per-instance cache. |
| `src/adcp/decisioning/types.py` | Document `metadata['mock_upstream_url']` contract on `Account` docstring. |
| `src/adcp/decisioning/__init__.py` | Export `get_mock_upstream_url`. |
| `tests/test_upstream_for.py` | 22 tests — routing, fail-closed, cache identity, auth threading. |
| `tests/test_error_code_conformance.py` | Allowlist `CONFIGURATION_ERROR` (server-side adopter-misconfig signal, distinct from `INVALID_REQUEST` and `SERVICE_UNAVAILABLE`). |
| `examples/hello_mock_seller.py` | Single platform with four accounts demonstrating live, sandbox, mock-A (port 4500), mock-B (port 4501). |
| `docs/handler-authoring.md` | New section: "Account modes and mock-mode upstream routing". |

## Hello-mock four-account example

```python
class HelloMockPlatform(DecisioningPlatform, SalesPlatform):
    upstream_url = "https://example-ad-server.invalid/api"

    accounts = ExplicitAccounts(loader=lambda aid: {
        "acct_live":    Account(id=aid, mode="live"),
        "acct_sandbox": Account(id=aid, mode="sandbox"),
        "acct_mock_a":  Account(id=aid, mode="mock",
                                metadata={"mock_upstream_url": "http://localhost:4500"}),
        "acct_mock_b":  Account(id=aid, mode="mock",
                                metadata={"mock_upstream_url": "http://localhost:4501"}),
    }[aid])

    async def get_products(self, req, ctx):
        client = self.upstream_for(ctx)  # base_url depends on ctx.account.mode
        ...
```

Mock-server lifecycle is **not** managed by the SDK. Adopters or CI start `bin/adcp.js mock-server <specialism>` and populate the URL on mock-mode accounts in their `AccountStore.resolve`.

## What's NOT in this PR

- Multi-platform routing (`PlatformRouter`) — separate work (#477).
- AdCP-MCP forwarder / `MockBackendClient` — doesn't fit the existing mock-server.
- `comply_test_controller` routing changes — Phase 1's gate stays as-is.
- Phase 3 composition / opt-out for adopters with bespoke sandbox needs.

## References

- Phase 1: #483 (Account.mode + comply-controller gate)
- JS umbrella: adcontextprotocol/adcp-client#1435
- Proposal: `docs/proposals/lifecycle-state-and-sandbox-authority.md`

## Test plan

- [x] `pytest tests/test_upstream_for.py -v` (22 tests pass)
- [x] `pytest tests/` full regression (3604 passed, 32 skipped, 0 failed)
- [x] `ruff check src/ tests/test_upstream_for.py examples/hello_mock_seller.py`
- [x] `mypy src/adcp/` (768 source files, 0 errors)
- [x] Boot `python examples/hello_mock_seller.py` — MCP listening on http://0.0.0.0:3001/mcp without errors
- [ ] Reviewer: confirm cache key shape `(base_url, id(auth))` matches expected pooling semantics
- [ ] Reviewer: confirm `CONFIGURATION_ERROR` allowlist entry is acceptable, or suggest spec-conformant alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)