### PR TITLE
refactor(examples): v3 reference seller adopts upstream_for + mock-mode (Phase 3)

### DIFF
--- a/examples/v3_reference_seller/MIGRATION.md
+++ b/examples/v3_reference_seller/MIGRATION.md
@@ -5,6 +5,125 @@ Audience: maintainers of existing pre-v3 sales agents — Prebid's
 FreeWheel-fronting middleware, in-house seller adapters — who want to
 adopt the AdCP Python SDK without rewriting their ad-ops integration.
 
+## Migrating from a bespoke httpx upstream client (Phase 2 → Phase 3)
+
+If you've already started porting to v3 with a hand-rolled httpx wrapper
+on the platform class (the Phase 2 shape), here are the specific
+mechanical edits to land on the Phase 3 shape: SDK-owned
+`UpstreamHttpClient`, framework-resolved `upstream_for(ctx)`, and
+`Account.mode='mock'` for storyboard accounts.
+
+### Class field — drop the bespoke client, declare the URL + auth
+
+Before — bespoke httpx client constructed at platform-init:
+
+```python
+class MyAdServerSeller(SalesPlatform):
+    def __init__(self, *, sessionmaker, upstream_base_url, api_key):
+        self._sessionmaker = sessionmaker
+        self._upstream = MyHttpxClient(base_url=upstream_base_url, api_key=api_key)
+```
+
+After — production URL declared on the class, auth held as an instance
+attribute. The framework constructs (and pools) the `UpstreamHttpClient`
+on demand via `upstream_for(ctx)`:
+
+```python
+class MyAdServerSeller(DecisioningPlatform, SalesPlatform):
+    upstream_url = "https://prod.example/v1"
+
+    def __init__(self, *, sessionmaker, upstream_api_key):
+        self._sessionmaker = sessionmaker
+        self._upstream_auth = StaticBearer(token=upstream_api_key)
+```
+
+### Per-method usage — module-level helpers, not instance methods
+
+Before — bespoke client owns the helpers as instance methods:
+
+```python
+async def create_media_buy(self, req, ctx):
+    order = await self._upstream.create_order(advertiser_id=..., payload=...)
+```
+
+After — helpers are module-level functions taking the framework-resolved
+client plus per-call routing kwargs:
+
+```python
+async def create_media_buy(self, req, ctx):
+    client = self.upstream_for(ctx, auth=self._upstream_auth)
+    order = await create_order(
+        client,
+        network_code=ctx.account.metadata["network_code"],
+        payload=...,
+    )
+```
+
+### Account wiring — stamp `mode` and `mock_upstream_url`
+
+Before — account loaded as plain row, no routing context:
+
+```python
+account = Account(id="...", name=row.name, status="active")
+```
+
+After — explicit `mode` plus `mock_upstream_url` for storyboard /
+conformance accounts. Production accounts use `mode='live'`, your test
+infra uses `mode='sandbox'`, conformance / mock-fronted accounts use
+`mode='mock'` with the fixture URL on metadata:
+
+```python
+account = Account(
+    id="...",
+    name=row.name,
+    status="active",
+    mode="mock",
+    metadata={
+        "network_code": row.ext["network_code"],
+        "advertiser_id": row.ext["advertiser_id"],
+        "mock_upstream_url": os.environ["MOCK_AD_SERVER_URL"],
+    },
+    _mode_explicit=True,
+)
+```
+
+### Error handling — drop the custom translator
+
+Before — bespoke `UpstreamError` + a `_translate_upstream` helper that
+maps HTTP status to AdCP codes:
+
+```python
+try:
+    await self._upstream.create_order(...)
+except UpstreamError as exc:
+    raise self._translate_upstream(exc)
+```
+
+After — the SDK's `UpstreamHttpClient` already projects upstream
+non-2xx onto `AdcpError` with spec-conformant codes (401 →
+`AUTH_REQUIRED`, 403 → `PERMISSION_DENIED`, 404 → configurable
+`not_found_code`, 429 → `RATE_LIMITED`, 5xx → `SERVICE_UNAVAILABLE`,
+other 4xx → `INVALID_REQUEST` with `recovery='retry_with_changes'`).
+Drop the bespoke `UpstreamError` class, the `_translate_upstream`
+helper, and the surrounding try/except — let the helper raise.
+
+If a specific helper needs different per-call semantics (e.g.
+`ACCOUNT_NOT_FOUND` for a 404 on `list_products` instead of the default
+`MEDIA_BUY_NOT_FOUND`), pass `not_found_code='ACCOUNT_NOT_FOUND'` to
+the SDK helper rather than wrapping the call.
+
+### Tests — constructor takes `upstream_api_key` (not `upstream_base_url`)
+
+The platform constructor no longer takes the upstream base URL — that's
+on the class as `upstream_url`, and per-account routing comes from
+`account.metadata['mock_upstream_url']` for `mode='mock'` accounts.
+Update the constructor call in `tests/test_validate_platform_warnings.py`
+(and any other test that builds the platform directly) to pass
+`upstream_api_key=...` instead of `upstream_base_url=...`. Tests that
+build their own `Account` and inject it into `RequestContext` should
+stamp `mode='mock'` and `metadata['mock_upstream_url']` so
+`upstream_for(ctx)` resolves at the test fixture URL.
+
 ## Pre-v3 → v3 model/method mapping (Prebid salesagent porting checklist)
 
 This is a checklist for porting your existing AdCP 3.0.0-beta.2 sales
@@ -87,7 +206,7 @@ Common codes the translator emits:
 
 | Code | When to use | `recovery` |
 |---|---|---|
-| `INVALID_REQUEST` | Buyer sent a malformed request, or upstream rejected the translated payload (400). | `terminal` |
+| `INVALID_REQUEST` | Buyer sent a malformed request, or upstream rejected the translated payload (400). | `retry_with_changes` |
 | `MEDIA_BUY_NOT_FOUND` | Upstream 404 on a known-media-buy operation (`get_order`, `get_delivery`, `post_conversions`). | `terminal` |
 | `ACCOUNT_NOT_FOUND` | Upstream 404 on an account-scoped operation (`get_products`, `list_creatives`, `list_accounts`). | `terminal` |
 | `SERVICE_UNAVAILABLE` | Upstream 5xx, network timeout, JSON decode failure, server-side onboarding misconfig (account missing `ext.network_code`), or polling timeout on async approval. | `transient` |
@@ -97,6 +216,14 @@ Common codes the translator emits:
 | `UNSUPPORTED_FEATURE` | Method exists on the Protocol but this upstream doesn't support it (e.g. `update_media_buy` against an upstream with no order-update endpoint). | `terminal` |
 | `POLICY_VIOLATION` | Buyer's request fails a policy check upstream (brand-safety, traffic-quality). | `terminal` |
 | `CONFLICT` | Upstream 409 (e.g. duplicate idempotency_key with a different body). | `terminal` |
+
+These projections are SDK defaults from `UpstreamHttpClient` (see
+[`src/adcp/decisioning/upstream.py`](../../src/adcp/decisioning/upstream.py) —
+`_project_status`). Adopters who need different per-helper semantics
+(e.g. `recovery='terminal'` for a 400 that the upstream guarantees is
+unfixable, or `recovery='transient'` for a 400 that papers over an
+upstream race) override per-call by catching the `AdcpError` from the
+helper and re-raising with the desired code / recovery.
 
 **DO NOT raise on the wire**:
 

--- a/examples/v3_reference_seller/MIGRATION.md
+++ b/examples/v3_reference_seller/MIGRATION.md
@@ -201,30 +201,101 @@ The other modules (`models.py`, `tenant_router.py`, `buyer_registry.py`,
 `audit.py`, `app.py`) are reusable scaffolding — change them only if
 your tenant / RBAC / audit story differs.
 
-### 2. Replace `MockUpstreamClient` with your real upstream client
+### 2. Replace the upstream domain helpers with your real ad-server's API
 
-`src/upstream.py` is a thin httpx-based client over the JS mock-server.
-Replace it with your existing ad-server client:
+`src/upstream.py` is a set of module-level domain helpers mirroring
+the JS mock-server's openapi.yaml. Each helper takes a pooled
+`UpstreamHttpClient` (the SDK's httpx wrapper) plus per-call routing
+kwargs and returns the parsed upstream JSON:
 
 ```python
-# src/upstream.py — your version
-class MyAdServerClient:
-    def __init__(self, *, base_url: str, oauth_token: str) -> None:
-        ...
+# src/upstream.py — reference seller shape
+from adcp.decisioning import UpstreamHttpClient
 
-    async def list_orders(self, *, advertiser_id: str) -> list[Order]:
-        ...
 
-    async def create_order(self, *, payload: CreateOrderPayload) -> Order:
-        ...
+async def list_products(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    not_found_code: str = "ACCOUNT_NOT_FOUND",
+) -> dict[str, Any]:
+    return await client.get(
+        "/v1/products",
+        headers={"X-Network-Code": network_code},
+        not_found_code=not_found_code,
+    )
 
-    # ... mirrors of your existing API surface
+
+async def create_order(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    return await client.post(
+        "/v1/orders",
+        json=payload,
+        headers={"X-Network-Code": network_code},
+    )
 ```
 
-The shape doesn't have to match the JS mock's HTTP API — it has to
-match your real upstream. The shape that matters is what comes *out*
-of these methods (the data the platform translates into AdCP wire
-shapes).
+Adopters fork the helpers and replace the paths / payloads with their
+real upstream's API. The shape that matters is what comes *out* of
+these helpers (the data the platform translates onto AdCP wire shapes).
+
+The SDK's [`UpstreamHttpClient`](../../src/adcp/decisioning/upstream.py)
+handles:
+
+* **Connection pooling** — one `httpx.AsyncClient` per
+  `(base_url, auth)`; reused across calls.
+* **Auth injection** — `StaticBearer` (`Authorization: Bearer ...`),
+  `DynamicBearer` (per-call OAuth refresh), `ApiKey`
+  (custom header like `X-Api-Key: ...`), or `NoAuth`.
+* **Error projection** — non-2xx responses raise spec-conformant
+  `AdcpError` codes (401 → `AUTH_REQUIRED`, 403 → `PERMISSION_DENIED`,
+  404 → `not_found_code` (configurable per-call), 429 →
+  `RATE_LIMITED`, 5xx → `SERVICE_UNAVAILABLE`, other 4xx →
+  `INVALID_REQUEST`). Adopters who need richer 404 semantics
+  (e.g. `ACCOUNT_NOT_FOUND` for product lookups) override per-call.
+* **204 / empty body handling** — returns `{}` instead of crashing
+  on empty responses.
+
+### 2a. Wire `upstream_url` and `upstream_for(ctx)`
+
+Declare your production upstream URL on the platform class:
+
+```python
+class MyAdServerSeller(DecisioningPlatform, SalesPlatform):
+    upstream_url = "https://my-real-adserver.example.com/v1"
+
+    def __init__(self, *, sessionmaker, upstream_api_key: str) -> None:
+        self._sessionmaker = sessionmaker
+        # Single auth instance shared across upstream_for() calls;
+        # the framework's client cache keys on (base_url, id(auth)).
+        self._upstream_auth = StaticBearer(token=upstream_api_key)
+        self.accounts = _make_account_store(...)
+
+    async def get_products(self, req, ctx):
+        client = self.upstream_for(ctx, auth=self._upstream_auth)
+        payload = await upstream_helpers.list_products(
+            client, network_code=ctx.account.metadata["network_code"]
+        )
+        # ... project to AdCP shapes
+```
+
+The framework's `upstream_for(ctx)` picks the URL based on
+`ctx.account.mode`:
+
+| `account.mode` | Upstream URL |
+|---|---|
+| `live` | `MyAdServerSeller.upstream_url` (production) |
+| `sandbox` | `MyAdServerSeller.upstream_url` (your test infra at the same URL with different credentials) |
+| `mock` | `account.metadata["mock_upstream_url"]` (per-account fixture URL — the SDK routes to your mock-server) |
+
+The same adapter code path runs against all three modes. Sellers
+running this code today serve `live` traffic; the same code serves
+conformance / storyboard buyers when their account is marked
+`mock` — no per-call branching.
 
 ### 3. Reseed the BuyerAgent / Account tables with your tenant config
 
@@ -250,7 +321,36 @@ Account(
 ```
 
 The platform's `_make_account_store` reads `ext` onto
-`ctx.account.metadata`, where every translator method picks it up.
+`ctx.account.metadata`, where every translator method picks it up. It
+also stamps each resolved account with `mode` so `upstream_for(ctx)`
+knows where to route:
+
+```python
+return Account(
+    id=row.id,
+    name=row.name,
+    status=row.status,
+    # Branch on the row's lifecycle. Production accounts: 'live'.
+    # Your own test infra: 'sandbox'. Conformance / storyboard
+    # accounts: 'mock' (with mock_upstream_url populated).
+    mode="live",
+    metadata={
+        "network_code": row.ext["network_code"],
+        "advertiser_id": row.ext["advertiser_id"],
+        # Only populated for mode='mock' accounts; framework reads
+        # this in upstream_for() to route at the fixture URL.
+        # "mock_upstream_url": "http://127.0.0.1:4503",
+    },
+    _mode_explicit=True,
+)
+```
+
+**Resolver discipline.** The mode is a security-relevant flag — it
+gates the sandbox-authority enforcement on test-only surfaces
+(comply controller, `force_*`, `simulate_*`). Source `mode` from a
+trusted store keyed by the authenticated principal; never from
+request data. A buyer who can self-promote to `mode='sandbox'` can
+unlock test-only surfaces on a live principal.
 
 ### 4. Translate your upstream onto the `SalesPlatform` Protocol
 
@@ -258,16 +358,28 @@ The platform's `_make_account_store` reads `ext` onto
 
 ```python
 class MyAdServerSeller(DecisioningPlatform, SalesPlatform):
+    upstream_url = "https://my-real-adserver.example.com/v1"
+
     async def get_products(self, req, ctx):
-        upstream_payload = await self._upstream.list_products(
-            advertiser_id=ctx.account.metadata["advertiser_id"],
+        # Resolve the pooled UpstreamHttpClient via the framework.
+        # Routes at upstream_url for live/sandbox accounts, at
+        # account.metadata['mock_upstream_url'] for mock accounts.
+        client = self.upstream_for(ctx, auth=self._upstream_auth)
+        upstream_payload = await upstream_helpers.list_products(
+            client,
+            network_code=ctx.account.metadata["network_code"],
         )
         # translate to AdCP Product[]
         return GetProductsResponse(products=[...])
 
     async def create_media_buy(self, req, ctx):
-        order = await self._upstream.create_order(...)
-        if order.status == "pending_approval":
+        client = self.upstream_for(ctx, auth=self._upstream_auth)
+        order = await upstream_helpers.create_order(
+            client,
+            network_code=ctx.account.metadata["network_code"],
+            payload=...,
+        )
+        if order["status"] == "pending_approval":
             # async approval path — return a Submitted envelope
             # and poll the upstream in the background
             return ctx.handoff_to_task(self._poll_until_approved)

--- a/examples/v3_reference_seller/README.md
+++ b/examples/v3_reference_seller/README.md
@@ -16,7 +16,7 @@ salesagent), see [MIGRATION.md](MIGRATION.md).
 
 | Component | Module | Source |
 |---|---|---|
-| Upstream HTTP client (translator seam) | `src/upstream.py` | `httpx.AsyncClient` |
+| Upstream HTTP client (translator seam) | `src/upstream.py` + `DecisioningPlatform.upstream_for` | `adcp.decisioning.UpstreamHttpClient` |
 | Tier 2 commercial-identity gate | `src/buyer_registry.py` | `adcp.decisioning.BuyerAgentRegistry` |
 | Subdomain tenant routing | `src/tenant_router.py` + `src/app.py` | `adcp.server.SubdomainTenantMiddleware` |
 | Account v3 storage (bank-details column) | `src/models.py` | `Account.billing_entity` JSON column |
@@ -115,10 +115,50 @@ data lives upstream.
 
 ### Upstream client (`src/upstream.py`)
 
-`MockUpstreamClient` is an httpx-based client mirroring the JS mock-
-server's openapi.yaml 1:1. Adopters fork this and replace the URL,
-auth, and method bodies with their real ad-server's API. The shape
-of the methods (signatures + return types) is what stays stable.
+`src/upstream.py` is a set of module-level **domain helpers** mirroring
+the JS mock-server's openapi.yaml 1:1 (`list_products`, `create_order`,
+`get_delivery`, etc.). Each helper takes a pooled
+[`UpstreamHttpClient`](../../src/adcp/decisioning/upstream.py)
+(the SDK's httpx wrapper handling auth + 4xx/5xx → `AdcpError`
+projection) plus the per-call `network_code`, and returns the parsed
+upstream JSON. Adopters fork the helpers and replace the URL paths /
+payload shapes with their real ad-server's API; the SDK client handles
+the boilerplate.
+
+Auth and routing flow through `DecisioningPlatform.upstream_for(ctx)`:
+
+```python
+class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
+    # Adopters with a real production upstream replace this URL.
+    upstream_url = "https://sales-guaranteed.example.invalid/v1"
+
+    async def get_products(self, req, ctx):
+        client = self.upstream_for(ctx, auth=self._upstream_auth)
+        payload = await upstream_helpers.list_products(
+            client, network_code=ctx.account.metadata["network_code"]
+        )
+        # ... project to AdCP shapes
+```
+
+The framework picks the URL from `ctx.account.mode`:
+
+| `account.mode` | Upstream URL source |
+|---|---|
+| `live` / `sandbox` | `V3ReferenceSeller.upstream_url` (production) |
+| `mock` | `account.metadata["mock_upstream_url"]` (per-account fixture URL) |
+
+The reference seller is **mock-mode by design** — its only upstream
+is the JS mock-server fixture, so `_make_account_store` stamps every
+resolved account with `mode="mock"` and
+`metadata["mock_upstream_url"]` (sourced from the
+`MOCK_AD_SERVER_URL` env). Adopters with a real production upstream:
+
+* Declare `upstream_url` on their `V3ReferenceSeller` subclass to the
+  production URL.
+* Default new accounts to `mode="live"` in `AccountStore.resolve`.
+* Reserve `mode="mock"` (with `mock_upstream_url`) for conformance /
+  storyboard accounts only — the same adapter code path runs against
+  either URL with no per-call branching.
 
 ### Platform (`src/platform.py`)
 
@@ -283,15 +323,25 @@ DATABASE_URL=postgresql+asyncpg://postgres@localhost/adcp_test \
 
 Adopters typically change:
 
-1. **`src/upstream.py`** — replace with your real ad-server's
-   HTTP client.
-2. **`src/platform.py`** — adjust the AdCP ↔ upstream translation
-   (mostly type-mapping). The structure of each method stays
-   identical; you change what it sends and how it projects the
-   response.
-3. **`src/audit.py`** — extend `details` with adopter-specific
+1. **`src/upstream.py`** — fork the per-endpoint domain helpers and
+   replace the paths / payloads with your real ad server's API. Keep
+   the helpers as functions taking `UpstreamHttpClient` + per-call
+   routing kwargs; the SDK client handles pooling, auth injection,
+   and `AdcpError` projection.
+2. **`V3ReferenceSeller.upstream_url`** — replace the placeholder with
+   your production upstream URL once you migrate accounts to
+   `mode="live"`.
+3. **`src/platform.py::_make_account_store`** — branch on the row's
+   lifecycle to set `mode`: `live` for production accounts, `sandbox`
+   for your own test infra, `mock` (with `mock_upstream_url`) for
+   conformance / storyboard accounts only.
+4. **`src/platform.py`** method bodies — adjust the AdCP ↔ upstream
+   translation (mostly type-mapping). The structure of each method
+   stays identical (resolve client via `upstream_for`, call domain
+   helper, project upstream JSON onto AdCP shapes).
+5. **`src/audit.py`** — extend `details` with adopter-specific
    fields (decision flags, fraud scores, A/B variant ids).
-4. **Auth wiring in `src/app.py`** — wire your verifier middleware
+6. **Auth wiring in `src/app.py`** — wire your verifier middleware
    that constructs `AuthInfo`.
 
 Adopters typically *don't* change:

--- a/examples/v3_reference_seller/src/app.py
+++ b/examples/v3_reference_seller/src/app.py
@@ -7,7 +7,12 @@ Boot sequence:
 
 1. Connect SQLAlchemy async engine + sessionmaker.
 2. Create schema (idempotent ``Base.metadata.create_all``).
-3. Connect the upstream HTTP client (:class:`MockUpstreamClient`).
+3. Wire the upstream HTTP client. The platform calls
+   :meth:`adcp.decisioning.DecisioningPlatform.upstream_for` per
+   request, which builds a pooled :class:`UpstreamHttpClient` from the
+   resolved account's ``mode`` (``mock`` here) +
+   ``metadata['mock_upstream_url']`` (sourced from
+   ``MOCK_AD_SERVER_URL``).
 4. Build the framework wiring:
 
    * :class:`SqlSubdomainTenantRouter` for ``Host`` → tenant
@@ -19,8 +24,12 @@ Boot sequence:
    — single binary serving MCP at ``/mcp`` and A2A at ``/`` with
    :class:`SubdomainTenantMiddleware` layered on the outer HTTP app.
 
-Adopters fork this file and replace :class:`MockUpstreamClient` with
-their own ad-server HTTP client. Everything else stays.
+Adopters fork this file and replace the per-specialism mock-server
+boot with their own ad-server URL: declare ``upstream_url`` on the
+:class:`V3ReferenceSeller` subclass and have ``AccountStore.resolve``
+return ``mode='live'`` (or ``'sandbox'``) accounts. Everything else
+stays — the framework's ``upstream_for`` routes the same adapter
+code path against either URL.
 
 ::
 
@@ -59,7 +68,6 @@ from .buyer_registry import make_registry as make_buyer_registry
 from .models import Base
 from .platform import V3ReferenceSeller
 from .tenant_router import SqlSubdomainTenantRouter
-from .upstream import MockUpstreamClient
 
 if TYPE_CHECKING:
     from adcp.server import RequestMetadata
@@ -123,11 +131,6 @@ def main() -> None:
 
     asyncio.run(_bootstrap_schema(engine))
 
-    upstream = MockUpstreamClient(
-        base_url=upstream_url,
-        api_key=upstream_api_key,
-    )
-
     router = SqlSubdomainTenantRouter(sessionmaker=sessionmaker)
     audit_sink = make_audit_sink(sessionmaker)
     # The buyer registry composes cache + rate-limit + audit around
@@ -142,9 +145,18 @@ def main() -> None:
     # ``GET /_debug/traffic``. Production adopters omit both kwargs;
     # the endpoint stays closed and the recorder is a no-op.
     mock_ad_server = InMemoryMockAdServer()
+    # The reference seller is mock-mode by design: every Account its
+    # ``AccountStore.resolve`` returns is ``mode='mock'`` and carries
+    # ``MOCK_AD_SERVER_URL`` in ``account.metadata['mock_upstream_url']``.
+    # The framework's ``upstream_for(ctx)`` reads that URL to point
+    # the pooled :class:`UpstreamHttpClient` at the JS mock-server.
+    # Adopters with a real production upstream replace ``mode='mock'``
+    # with ``mode='live'`` in their ``AccountStore.resolve`` and declare
+    # :attr:`V3ReferenceSeller.upstream_url` to their production URL.
     platform = V3ReferenceSeller(
         sessionmaker=sessionmaker,
-        upstream=upstream,
+        upstream_api_key=upstream_api_key,
+        mock_upstream_url=upstream_url,
         mock_ad_server=mock_ad_server,
     )
 
@@ -152,7 +164,7 @@ def main() -> None:
         "v3 reference seller booting on port=%d (transport=both, MCP at /mcp, A2A at /)",
         port,
     )
-    logger.info("Translator upstream: %s (api_key=%s...)", upstream_url, upstream_api_key[:4])
+    logger.info("Mock-mode upstream: %s (api_key=%s...)", upstream_url, upstream_api_key[:4])
     logger.info("Audit sink wired: %s. Tenant router cache: 256 hosts.", type(audit_sink).__name__)
 
     serve(

--- a/examples/v3_reference_seller/src/models.py
+++ b/examples/v3_reference_seller/src/models.py
@@ -276,9 +276,10 @@ class Account(Base):
     sandbox: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     #: Translator-pattern routing — ``{"network_code": "...",
-    #: "advertiser_id": "..."}``. Read by
-    #: :class:`upstream.MockUpstreamClient` to scope upstream calls
-    #: to the right tenant on the JS mock-server.
+    #: "advertiser_id": "..."}``. Read onto ``ctx.account.metadata``
+    #: by :func:`platform._make_account_store` so platform method
+    #: bodies pass ``network_code`` to :mod:`upstream` helpers without
+    #: a second query.
     ext: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -35,8 +35,26 @@ Account ops (3.1-readiness anchor — local Postgres):
   :func:`adcp.decisioning.project_account_for_response` so bank
   details never leak on response.
 
-Adopters fork this file and replace :class:`upstream.MockUpstreamClient`
-with their real ad server's HTTP client. Method bodies stay
+Upstream HTTP routing — adopter migration template
+--------------------------------------------------
+
+Every sales-* method body resolves the upstream client via
+:meth:`DecisioningPlatform.upstream_for`. The framework picks the URL
+based on the resolved account's ``mode``:
+
+* ``mode='live'`` / ``mode='sandbox'`` → :attr:`upstream_url` (the
+  adopter's production URL declared on the platform class).
+* ``mode='mock'`` → ``account.metadata['mock_upstream_url']``.
+
+The reference seller's only upstream is the JS mock-server fixture, so
+every account it ships is ``mode='mock'`` (see :func:`_make_account_store`
+which sets ``mock_upstream_url`` from the ``MOCK_AD_SERVER_URL`` env on
+every Account it returns). Adopters with a real production upstream
+declare :attr:`upstream_url` to that production URL and mark only their
+test/conformance accounts ``mode='mock'``.
+
+Adopters fork this file and replace the upstream payload helpers
+(:mod:`upstream`) with their real ad server's API. Method bodies stay
 shape-compatible — only the upstream URL / auth / payload mapping
 changes.
 """
@@ -58,6 +76,8 @@ from adcp.decisioning import (
     DecisioningPlatform,
     ExplicitAccounts,
     MockAdServer,
+    StaticBearer,
+    UpstreamHttpClient,
     project_account_for_response,
     project_business_entity_for_response,
 )
@@ -103,7 +123,7 @@ from adcp.types import (
     UpdateMediaBuySuccessResponse,
 )
 
-from .upstream import MockUpstreamClient, UpstreamError
+from . import upstream as upstream_helpers
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -121,13 +141,32 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _make_account_store(sessionmaker: async_sessionmaker) -> ExplicitAccounts:
-    """Adopter ``AccountStore`` — resolves
-    ``request.account.account_id`` against the ``accounts`` table.
+def _make_account_store(
+    sessionmaker: async_sessionmaker,
+    *,
+    mock_upstream_url: str,
+) -> ExplicitAccounts:
+    """Adopter ``AccountStore`` — resolves ``request.account.account_id``
+    against the ``accounts`` table.
 
     Reads ``ext`` (the upstream routing payload, ``{"network_code":
     ..., "advertiser_id": ...}``) onto :attr:`Account.metadata` so
     platform methods can pluck them out without a second query.
+
+    Every account the reference seller resolves runs in ``mode='mock'``
+    — the seller's only upstream is the per-specialism mock-server
+    fixture (see module docstring). ``mock_upstream_url`` is sourced
+    from the ``MOCK_AD_SERVER_URL`` env var (set in :func:`app.main`)
+    and stamped onto every Account; the framework's
+    :meth:`DecisioningPlatform.upstream_for` reads it to point the
+    :class:`UpstreamHttpClient` at the fixture.
+
+    Adopters with a real production upstream:
+
+    * Declare :attr:`V3ReferenceSeller.upstream_url` to their production URL.
+    * Default new accounts to ``mode='live'`` here.
+    * Reserve ``mode='mock'`` (with ``mock_upstream_url``) for
+      conformance / storyboard accounts only.
     """
 
     async def loader(account_id: str) -> Account[dict[str, Any]]:
@@ -174,10 +213,17 @@ def _make_account_store(sessionmaker: async_sessionmaker) -> ExplicitAccounts:
                 ),
                 recovery="transient",
             )
+        # Reference seller is mock-mode by design — its only upstream
+        # is the per-specialism mock-server fixture. Adopters with a
+        # real production upstream branch on the row's lifecycle to
+        # decide ``mode``: live for production accounts, sandbox for
+        # the adopter's own test infra, mock only for conformance /
+        # storyboard accounts.
         return Account(
             id=row.id,
             name=row.name,
             status=row.status,
+            mode="mock",
             metadata={
                 "tenant_id": row.tenant_id,
                 "buyer_agent_id": row.buyer_agent_id,
@@ -186,7 +232,13 @@ def _make_account_store(sessionmaker: async_sessionmaker) -> ExplicitAccounts:
                 "sandbox": row.sandbox,
                 "network_code": network_code,
                 "advertiser_id": advertiser_id,
+                # Framework-reserved key — read by ``upstream_for`` to
+                # route the UpstreamHttpClient at the mock-server.
+                "mock_upstream_url": mock_upstream_url,
             },
+            # Mark the mode as deliberately set so the framework's
+            # observed-modes tracker counts the account correctly.
+            _mode_explicit=True,
         )
 
     return ExplicitAccounts(loader=loader)
@@ -213,11 +265,27 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
     """Translator-pattern seller against the JS mock-server upstream.
 
     Every method body reads :attr:`RequestContext.account` for the
-    upstream routing (``network_code`` + ``advertiser_id``) and calls
-    :class:`upstream.MockUpstreamClient` over HTTP. The local
+    upstream routing (``network_code`` + ``advertiser_id``) and resolves
+    an :class:`UpstreamHttpClient` via :meth:`upstream_for`. The local
     Postgres is consulted only for the commercial-identity layer
     (account resolution + ``sync_accounts`` / ``list_accounts``).
+
+    The reference seller's only upstream is a mock-server fixture, so
+    every account it serves is ``mode='mock'`` and the upstream URL
+    comes from ``account.metadata['mock_upstream_url']`` (sourced from
+    the ``MOCK_AD_SERVER_URL`` env). :attr:`upstream_url` carries a
+    placeholder URL that adopters forking this template replace with
+    their real production URL when they migrate accounts to
+    ``mode='live'``.
     """
+
+    #: Production upstream URL placeholder. The reference seller is
+    #: mock-mode by design, so this URL is never resolved at runtime —
+    #: every account is ``mode='mock'`` and the upstream URL comes from
+    #: ``account.metadata['mock_upstream_url']``. Adopters forking this
+    #: template replace this value with their real production ad-server
+    #: URL when migrating accounts to ``mode='live'``.
+    upstream_url = "https://sales-guaranteed.example.invalid/v1"
 
     capabilities = DecisioningCapabilities(
         # Real GAM-shaped publishers sell BOTH guaranteed (IO-driven)
@@ -244,17 +312,76 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         self,
         *,
         sessionmaker: async_sessionmaker,
-        upstream: MockUpstreamClient,
+        upstream_api_key: str,
+        mock_upstream_url: str | None = None,
         mock_ad_server: MockAdServer | None = None,
         approval_poll_interval_s: float = 1.0,
         approval_poll_max_iterations: int = 60,
     ) -> None:
+        """Construct the reference seller.
+
+        :param sessionmaker: Async SQLAlchemy sessionmaker for the
+            commercial-identity tables (tenants / buyer_agents /
+            accounts).
+        :param upstream_api_key: API key the upstream expects in the
+            ``Authorization: Bearer ...`` header. Wired into a
+            :class:`adcp.decisioning.StaticBearer` and threaded through
+            every :meth:`upstream_for` call.
+        :param mock_upstream_url: Where the JS mock-server is listening.
+            When set, every Account this platform resolves is
+            ``mode='mock'`` and carries this URL in
+            ``account.metadata['mock_upstream_url']``. When ``None``,
+            accounts are still ``mode='mock'`` (the reference seller has
+            no real production upstream) but the URL is not stamped —
+            tests construct Accounts directly with their own
+            ``mock_upstream_url``. :func:`app.main` always sets this
+            from the ``MOCK_AD_SERVER_URL`` env.
+        :param mock_ad_server: Optional anti-façade traffic recorder.
+        :param approval_poll_interval_s: Base sleep between polls of
+            ``/v1/tasks/{id}`` during async order approval.
+        :param approval_poll_max_iterations: Maximum polls before
+            raising ``SERVICE_UNAVAILABLE`` (transient).
+        """
         self._sessionmaker = sessionmaker
-        self._upstream = upstream
+        # Single auth instance shared across every upstream_for() call.
+        # The framework's client cache keys on (base_url, id(auth)),
+        # so a stable instance means one pooled httpx client per URL.
+        self._upstream_auth = StaticBearer(token=upstream_api_key)
         self._mock_ad_server = mock_ad_server
         self._approval_poll_interval_s = approval_poll_interval_s
         self._approval_poll_max_iterations = approval_poll_max_iterations
-        self.accounts = _make_account_store(sessionmaker)
+        # AccountStore is always wired. ``app.main`` passes the
+        # MOCK_AD_SERVER_URL env so resolved accounts route at the JS
+        # mock-server fixture. Tests that bypass the AccountStore (by
+        # passing ``Account`` objects directly into ``RequestContext``)
+        # still need a non-None ``accounts`` attribute for
+        # ``validate_platform`` — they pass ``mock_upstream_url=None``
+        # and the store is built with a placeholder; the loader is
+        # never invoked in those tests.
+        self.accounts = _make_account_store(
+            sessionmaker,
+            mock_upstream_url=mock_upstream_url or "http://mock-upstream-not-configured.invalid",
+        )
+
+    def _client(self, ctx: RequestContext) -> UpstreamHttpClient:
+        """Resolve the pooled :class:`UpstreamHttpClient` for this
+        request via the framework's :meth:`upstream_for`.
+
+        The framework picks the URL from ``ctx.account.mode``:
+
+        * ``mode='mock'`` → ``account.metadata['mock_upstream_url']``
+          (the JS mock-server fixture for this specialism).
+        * ``mode='live'`` / ``mode='sandbox'`` → :attr:`upstream_url`.
+
+        ``treat_404_as_none=False`` — the reference seller wants 404s
+        to surface as :class:`AdcpError` (with per-callsite override of
+        the AdCP error code) rather than be papered over to ``None``.
+        """
+        return self.upstream_for(
+            ctx,
+            auth=self._upstream_auth,
+            treat_404_as_none=False,
+        )
 
     def _record(self, method: str, args: dict[str, Any]) -> None:
         """Record an outbound upstream call on the wired
@@ -292,19 +419,13 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         # into upstream targeting json here. The reference seller keeps
         # it minimal — pass the targeting as a JSON string when
         # provided so the upstream can perturb supply.
-        try:
-            payload = await self._upstream.list_products(network_code=network_code)
-        except UpstreamError as exc:
-            raise self._translate_upstream(
-                exc,
-                default_code="SERVICE_UNAVAILABLE",
-                not_found_code="ACCOUNT_NOT_FOUND",
-            ) from exc
+        client = self._client(ctx)
+        payload = await upstream_helpers.list_products(client, network_code=network_code)
         self._record("products.list", {"network_code": network_code})
         agent_url = "https://reference.adcp.org"
         products: list[Product] = []
-        for upstream in payload.get("products", []):
-            pricing = upstream.get("pricing", {})
+        for upstream_row in payload.get("products", []):
+            pricing = upstream_row.get("pricing", {})
             pricing_model = pricing.get("model", "cpm")
             # The seller's ``pricing_models`` capability declares ``cpm``
             # only; skip upstream rows that price on any other model
@@ -315,7 +436,7 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             if pricing_model != "cpm":
                 logger.debug(
                     "Skipping product %r — pricing model %r not in seller's capability set",
-                    upstream.get("product_id"),
+                    upstream_row.get("product_id"),
                     pricing_model,
                 )
                 continue
@@ -323,7 +444,7 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             cpm = pricing.get("cpm")
             min_spend = pricing.get("min_spend")
             pricing_option: dict[str, Any] = {
-                "pricing_option_id": f"{upstream['product_id']}-{pricing_model}",
+                "pricing_option_id": f"{upstream_row['product_id']}-{pricing_model}",
                 "pricing_model": "cpm",
                 "currency": currency,
             }
@@ -336,22 +457,22 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             # at ``reference.adcp.org`` — adopters whose upstream uses a
             # different format namespace (their own publisher domain)
             # rewrite ``agent_url`` here.
-            upstream_formats = upstream.get("format_ids") or []
+            upstream_formats = upstream_row.get("format_ids") or []
             format_ids = [{"agent_url": agent_url, "id": fid} for fid in upstream_formats]
             if not format_ids:
                 # Spec requires at least one format on the response.
                 # Fall back to the channel-default — adopters with
                 # richer per-product format tables wire the lookup here.
-                channel = upstream.get("channel", "display")
+                channel = upstream_row.get("channel", "display")
                 fallback_id = "display_300x250" if channel == "display" else "video_16x9_30s"
                 format_ids = [{"agent_url": agent_url, "id": fallback_id}]
             products.append(
                 Product.model_validate(
                     {
-                        "product_id": upstream["product_id"],
-                        "name": upstream["name"],
-                        "description": upstream.get("name", ""),
-                        "delivery_type": upstream.get("delivery_type", "non_guaranteed"),
+                        "product_id": upstream_row["product_id"],
+                        "name": upstream_row["name"],
+                        "description": upstream_row.get("name", ""),
+                        "delivery_type": upstream_row.get("delivery_type", "non_guaranteed"),
                         "publisher_properties": [
                             # The reference seller is a single-publisher
                             # demo; ``selection_type='all'`` matches the
@@ -416,13 +537,10 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             "budget": float(budget_amount),
             "client_request_id": req.idempotency_key,
         }
-        try:
-            order = await self._upstream.create_order(
-                network_code=network_code,
-                payload=order_payload,
-            )
-        except UpstreamError as exc:
-            raise self._translate_upstream(exc, default_code="SERVICE_UNAVAILABLE") from exc
+        client = self._client(ctx)
+        order = await upstream_helpers.create_order(
+            client, network_code=network_code, payload=order_payload
+        )
         self._record(
             "media_buy.create",
             {
@@ -444,7 +562,9 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         # still pending. Refetch once and project from current status;
         # don't enter a polling loop we have no signal to drive.
         if approval_task_id is None:
-            current = await self._upstream.get_order(network_code=network_code, order_id=order_id)
+            current = await upstream_helpers.get_order(
+                client, network_code=network_code, order_id=order_id
+            )
             self._record(
                 "media_buy.confirm",
                 {"order_id": order_id, "status": current.get("status")},
@@ -466,8 +586,8 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         async def _poll_until_approved(task_handoff_ctx: Any) -> CreateMediaBuySuccessResponse:
             del task_handoff_ctx
             for _ in range(self._approval_poll_max_iterations):
-                task = await self._upstream.get_task(
-                    network_code=network_code, task_id=bound_task_id
+                task = await upstream_helpers.get_task(
+                    client, network_code=network_code, task_id=bound_task_id
                 )
                 self._record(
                     "task.poll",
@@ -491,7 +611,7 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 # Jitter the poll interval so concurrent buys don't
                 # synchronize their upstream calls. Honoring an upstream
                 # ``Retry-After`` is a follow-up — it requires plumbing
-                # the response headers through ``UpstreamError``.
+                # the response headers through the SDK client.
                 jitter = random.uniform(0.5, 1.5)
                 await asyncio.sleep(self._approval_poll_interval_s * jitter)
             else:
@@ -510,8 +630,8 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 )
             # Refetch the order; project from the actual current status
             # rather than assume the broken-out loop saw a green light.
-            approved_order = await self._upstream.get_order(
-                network_code=network_code, order_id=order_id
+            approved_order = await upstream_helpers.get_order(
+                client, network_code=network_code, order_id=order_id
             )
             self._record(
                 "media_buy.confirm",
@@ -635,6 +755,7 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         network_code = ctx.account.metadata["network_code"]
         advertiser_id = ctx.account.metadata["advertiser_id"]
         results: list[SyncCreativeResult] = []
+        client = self._client(ctx)
         for creative in req.creatives:
             # The upstream's ``format_id`` is a string; the AdCP
             # ``format_id`` is a structured ``{agent_url, id}`` object.
@@ -651,10 +772,9 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             snippet = getattr(creative, "snippet", None)
             if snippet is not None:
                 payload["snippet"] = str(snippet)
-            try:
-                await self._upstream.upload_creative(network_code=network_code, payload=payload)
-            except UpstreamError as exc:
-                raise self._translate_upstream(exc, default_code="SERVICE_UNAVAILABLE") from exc
+            await upstream_helpers.upload_creative(
+                client, network_code=network_code, payload=payload
+            )
             results.append(
                 SyncCreativeResult.model_validate(
                     {
@@ -695,38 +815,41 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         report_currency = "USD"
         report_period: dict[str, Any] | None = None
         delivery_rows: list[dict[str, Any]] = []
+        client = self._client(ctx)
         for order_id in media_buy_ids:
             try:
-                upstream = await self._upstream.get_delivery(
-                    network_code=network_code, order_id=order_id
+                upstream_row = await upstream_helpers.get_delivery(
+                    client, network_code=network_code, order_id=order_id
                 )
-            except UpstreamError as exc:
-                if exc.status_code == 404:
+            except AdcpError as exc:
+                # 404 on delivery → skip this buy (the spec allows
+                # partial responses). Other errors propagate.
+                if exc.code == "MEDIA_BUY_NOT_FOUND":
                     continue
-                raise self._translate_upstream(exc, default_code="SERVICE_UNAVAILABLE") from exc
+                raise
             # The mock's DeliveryReport schema doesn't carry order
             # status (see openapi.yaml § DeliveryReport). Double-fetch
             # the order so we project the correct AdCP MediaBuyStatus
             # — completed / canceled / rejected buys would otherwise
             # all surface as 'active' to the buyer.
             try:
-                order_meta = await self._upstream.get_order(
-                    network_code=network_code, order_id=order_id
+                order_meta = await upstream_helpers.get_order(
+                    client, network_code=network_code, order_id=order_id
                 )
                 upstream_status = order_meta.get("status", "")
-            except UpstreamError as exc:
-                if exc.status_code == 404:
+            except AdcpError as exc:
+                if exc.code == "MEDIA_BUY_NOT_FOUND":
                     # Delivery row exists but order is gone — odd,
                     # surface as 'active' so the row is at least
                     # well-formed; the operator's audit log will catch it.
                     upstream_status = ""
                 else:
-                    raise self._translate_upstream(exc, default_code="SERVICE_UNAVAILABLE") from exc
+                    raise
             wire_status = _DELIVERY_STATUS_MAP.get(upstream_status, "active")
-            totals = upstream.get("totals", {})
-            report_currency = upstream.get("currency", report_currency)
-            if report_period is None and upstream.get("reporting_period"):
-                report_period = upstream["reporting_period"]
+            totals = upstream_row.get("totals", {})
+            report_currency = upstream_row.get("currency", report_currency)
+            if report_period is None and upstream_row.get("reporting_period"):
+                report_period = upstream_row["reporting_period"]
             delivery_rows.append(
                 {
                     "media_buy_id": order_id,
@@ -785,10 +908,8 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         if req.pagination is not None:
             limit = getattr(req.pagination, "limit", None) or 50
             offset = getattr(req.pagination, "offset", None) or 0
-        try:
-            payload = await self._upstream.list_orders(network_code=network_code)
-        except UpstreamError as exc:
-            raise self._translate_upstream(exc, default_code="SERVICE_UNAVAILABLE") from exc
+        client = self._client(ctx)
+        payload = await upstream_helpers.list_orders(client, network_code=network_code)
         # Filter to this advertiser_id (the upstream is per-network,
         # but a single network can host multiple advertisers under the
         # same network_code — our AdCP account maps to one of them).
@@ -886,21 +1007,13 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 }
             ],
         }
-        try:
-            await self._upstream.post_conversions(
-                network_code=network_code,
-                order_id=req.media_buy_id,
-                payload=payload,
-            )
-        except UpstreamError as exc:
-            if exc.status_code == 404:
-                raise AdcpError(
-                    "MEDIA_BUY_NOT_FOUND",
-                    message=f"No media buy {req.media_buy_id!r} on the upstream.",
-                    recovery="terminal",
-                    field="media_buy_id",
-                ) from exc
-            raise self._translate_upstream(exc, default_code="SERVICE_UNAVAILABLE") from exc
+        client = self._client(ctx)
+        await upstream_helpers.post_conversions(
+            client,
+            network_code=network_code,
+            order_id=req.media_buy_id,
+            payload=payload,
+        )
         self._record(
             "performance.feedback",
             {"media_buy_id": req.media_buy_id, "metric_type": metric_type},
@@ -968,14 +1081,8 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         if req.pagination is not None:
             limit = getattr(req.pagination, "limit", None) or 50
             offset = getattr(req.pagination, "offset", None) or 0
-        try:
-            payload = await self._upstream.list_creatives(network_code=network_code)
-        except UpstreamError as exc:
-            raise self._translate_upstream(
-                exc,
-                default_code="SERVICE_UNAVAILABLE",
-                not_found_code="ACCOUNT_NOT_FOUND",
-            ) from exc
+        client = self._client(ctx)
+        payload = await upstream_helpers.list_creatives(client, network_code=network_code)
         upstream_creatives = [
             c for c in payload.get("creatives", []) if c.get("advertiser_id") == advertiser_id
         ]
@@ -1199,74 +1306,6 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 "accounts": projected_accounts,
                 "pagination": {"has_more": has_more, "total_count": total_count},
             }
-        )
-
-    # ----- helpers ---------------------------------------------------------
-
-    @staticmethod
-    def _translate_upstream(
-        exc: UpstreamError,
-        default_code: str,
-        *,
-        not_found_code: str = "MEDIA_BUY_NOT_FOUND",
-    ) -> AdcpError:
-        """Project an upstream error onto an AdCP wire error.
-
-        Maps common HTTP statuses to spec-conformant codes from the
-        canonical ``ErrorCode`` enum; unknown statuses fall through to
-        ``default_code`` (typically ``SERVICE_UNAVAILABLE``) so the
-        dispatcher gets a structured error envelope rather than a 500.
-
-        ``not_found_code`` lets callsites override the 404 mapping —
-        ``get_products`` / ``list_creatives`` / ``list_accounts`` 404s
-        mean an unknown network / account, not a missing media buy.
-        """
-        upstream_code = exc.payload.get("code")
-        upstream_message = exc.payload.get("message", "")
-        if exc.status_code == 400:
-            # The mock returns 400 ``invalid_request`` for malformed
-            # payloads — surface as terminal ``INVALID_REQUEST`` so
-            # buyers know to fix the request rather than retry.
-            return AdcpError(
-                "INVALID_REQUEST",
-                message=f"Upstream rejected the translated payload: {upstream_message}",
-                recovery="terminal",
-                details={"upstream_code": upstream_code, "upstream_message": upstream_message},
-            )
-        if exc.status_code == 401:
-            return AdcpError(
-                "AUTH_REQUIRED",
-                message=f"Upstream rejected credentials: {upstream_message}",
-                recovery="terminal",
-            )
-        if exc.status_code == 403:
-            return AdcpError(
-                "PERMISSION_DENIED",
-                message=f"Upstream forbade request: {upstream_message}",
-                recovery="terminal",
-            )
-        if exc.status_code == 404:
-            return AdcpError(
-                not_found_code,
-                message=f"Upstream resource not found: {upstream_message}",
-                recovery="terminal",
-            )
-        if exc.status_code == 409:
-            return AdcpError(
-                "CONFLICT",
-                message=f"Upstream conflict: {upstream_message}",
-                recovery="terminal",
-            )
-        if exc.status_code == 429:
-            return AdcpError(
-                "RATE_LIMITED",
-                message=f"Upstream rate-limited: {upstream_message}",
-                recovery="transient",
-            )
-        return AdcpError(
-            default_code,
-            message=f"Upstream error {exc.status_code}: {upstream_message}",
-            recovery="transient",
         )
 
 

--- a/examples/v3_reference_seller/src/platform.py
+++ b/examples/v3_reference_seller/src/platform.py
@@ -144,7 +144,7 @@ logger = logging.getLogger(__name__)
 def _make_account_store(
     sessionmaker: async_sessionmaker,
     *,
-    mock_upstream_url: str,
+    mock_upstream_url: str | None,
 ) -> ExplicitAccounts:
     """Adopter ``AccountStore`` — resolves ``request.account.account_id``
     against the ``accounts`` table.
@@ -161,6 +161,14 @@ def _make_account_store(
     :meth:`DecisioningPlatform.upstream_for` reads it to point the
     :class:`UpstreamHttpClient` at the fixture.
 
+    When ``mock_upstream_url`` is ``None`` the loader fails-fast with
+    ``CONFIGURATION_ERROR`` — there is no URL to stamp onto a
+    ``mode='mock'`` Account, so resolving here would only defer the
+    failure to a downstream :class:`httpx.ConnectError` that the SDK's
+    :class:`UpstreamHttpClient` does not project. ``None`` is only legal
+    when callers bypass the AccountStore by constructing ``Account``
+    objects directly into ``RequestContext`` (the unit-test pattern).
+
     Adopters with a real production upstream:
 
     * Declare :attr:`V3ReferenceSeller.upstream_url` to their production URL.
@@ -170,6 +178,26 @@ def _make_account_store(
     """
 
     async def loader(account_id: str) -> Account[dict[str, Any]]:
+        if mock_upstream_url is None:
+            # Reference seller is mock-mode by design — every Account
+            # this loader returns will have ``mode='mock'`` and rely on
+            # ``metadata['mock_upstream_url']`` for upstream routing. If
+            # the platform was constructed without a mock_upstream_url,
+            # there is no URL to stamp; resolving here would produce an
+            # Account that ``upstream_for(ctx)`` cannot route. Fail loud
+            # at the resolution boundary rather than letting the
+            # placeholder cascade into an httpx ConnectError downstream.
+            raise AdcpError(
+                "CONFIGURATION_ERROR",
+                message=(
+                    "V3ReferenceSeller account loader was invoked without a "
+                    "mock_upstream_url. Pass mock_upstream_url to "
+                    "V3ReferenceSeller(...) (sourced from the MOCK_AD_SERVER_URL "
+                    "env in app.main), or override the AccountStore in tests "
+                    "that construct Account objects directly."
+                ),
+                recovery="terminal",
+            )
         tenant = current_tenant()
         if tenant is None:
             raise AdcpError(
@@ -328,14 +356,14 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
             :class:`adcp.decisioning.StaticBearer` and threaded through
             every :meth:`upstream_for` call.
         :param mock_upstream_url: Where the JS mock-server is listening.
-            When set, every Account this platform resolves is
-            ``mode='mock'`` and carries this URL in
-            ``account.metadata['mock_upstream_url']``. When ``None``,
-            accounts are still ``mode='mock'`` (the reference seller has
-            no real production upstream) but the URL is not stamped —
-            tests construct Accounts directly with their own
-            ``mock_upstream_url``. :func:`app.main` always sets this
-            from the ``MOCK_AD_SERVER_URL`` env.
+            When set, every Account the loader resolves is ``mode='mock'``
+            and carries this URL in ``account.metadata['mock_upstream_url']``.
+            When ``None``, the loader fails-fast with ``CONFIGURATION_ERROR``
+            if anything ever resolves through it — only legal when callers
+            bypass the AccountStore by constructing ``Account`` objects
+            directly into ``RequestContext`` (the unit-test pattern).
+            :func:`app.main` always sets this from the ``MOCK_AD_SERVER_URL``
+            env.
         :param mock_ad_server: Optional anti-façade traffic recorder.
         :param approval_poll_interval_s: Base sleep between polls of
             ``/v1/tasks/{id}`` during async order approval.
@@ -356,11 +384,11 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
         # passing ``Account`` objects directly into ``RequestContext``)
         # still need a non-None ``accounts`` attribute for
         # ``validate_platform`` — they pass ``mock_upstream_url=None``
-        # and the store is built with a placeholder; the loader is
-        # never invoked in those tests.
+        # and the loader fails-fast with CONFIGURATION_ERROR if anything
+        # ever resolves through it.
         self.accounts = _make_account_store(
             sessionmaker,
-            mock_upstream_url=mock_upstream_url or "http://mock-upstream-not-configured.invalid",
+            mock_upstream_url=mock_upstream_url,
         )
 
     def _client(self, ctx: RequestContext) -> UpstreamHttpClient:
@@ -413,12 +441,6 @@ class V3ReferenceSeller(DecisioningPlatform, SalesPlatform):
                 recovery="transient",
             )
         network_code = ctx.account.metadata["network_code"]
-        # Forward optional filtering hints to the upstream.
-        # ``GetProductsRequest.brief`` / ``targeting`` are AdCP-shaped;
-        # adopters with their own upstream translate the AdCP brief
-        # into upstream targeting json here. The reference seller keeps
-        # it minimal — pass the targeting as a JSON string when
-        # provided so the upstream can perturb supply.
         client = self._client(ctx)
         payload = await upstream_helpers.list_products(client, network_code=network_code)
         self._record("products.list", {"network_code": network_code})

--- a/examples/v3_reference_seller/src/upstream.py
+++ b/examples/v3_reference_seller/src/upstream.py
@@ -1,284 +1,273 @@
-"""HTTP client for the JS mock ad-server upstream.
+"""Domain helpers for the JS mock ad-server upstream.
 
-The reference seller is a **translator**: AdCP wire on the inside,
-this client over HTTP on the outside. The mock-server ships in
+The reference seller is a **translator**: AdCP wire on the inside, this
+upstream's HTTP API on the outside. The mock-server ships in
 ``@adcp/client`` — boot it via::
 
     npx -y -p @adcp/client@latest \\
         adcp mock-server sales-guaranteed --port 4503 --api-key test-key
 
 The full upstream surface is documented in the mock's openapi.yaml
-(under ``src/lib/mock-server/sales-guaranteed/`` in the JS repo).
-This client mirrors that surface 1:1 — translation from AdCP shapes
-to upstream shapes happens in :mod:`platform`, not here.
+(under ``src/lib/mock-server/sales-guaranteed/`` in the JS repo). The
+helpers in this module mirror that surface 1:1 — translation from AdCP
+shapes to upstream shapes happens in :mod:`platform`, not here.
+
+Each helper takes an :class:`adcp.decisioning.UpstreamHttpClient` (the
+SDK's pooled httpx wrapper handling auth + 4xx/5xx → ``AdcpError``
+projection) and a ``network_code`` (the upstream's per-call routing key,
+sent as the ``X-Network-Code`` header). The SDK projects upstream
+non-2xx responses onto :class:`adcp.decisioning.AdcpError` with
+spec-conformant codes (401 → ``AUTH_REQUIRED``, 403 →
+``PERMISSION_DENIED``, 404 → ``not_found_code`` (default
+``MEDIA_BUY_NOT_FOUND``, override per-call), 429 → ``RATE_LIMITED``,
+5xx → ``SERVICE_UNAVAILABLE``, other 4xx → ``INVALID_REQUEST``).
 
 Adopters fork this module and replace the URL / auth / methods with
-their real ad server's API. The shape of the methods (signatures and
+their real ad server's API. The shape of the helpers (signatures and
 return types) is what stays stable; what's inside the request body
 and response parsing is whatever the adopter's upstream returns.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-import httpx
-
-logger = logging.getLogger(__name__)
+from adcp.decisioning import UpstreamHttpClient
 
 
-class UpstreamError(Exception):
-    """Raised when the upstream returns a non-2xx status.
-
-    Carries the upstream's structured error payload (``{code, message}``
-    per the mock's openapi.yaml ``Error`` schema) plus the HTTP status
-    code. The platform layer decides whether to project this onto an
-    AdCP wire error (typically ``UPSTREAM_FAILURE`` /
-    ``MEDIA_BUY_NOT_FOUND``) or to retry / fail terminal.
+def _network_headers(network_code: str) -> dict[str, str]:
+    """``X-Network-Code`` header for the per-call routing the mock-server
+    expects. Auth (``Authorization: Bearer ...``) is injected by the
+    :class:`UpstreamHttpClient`'s :class:`StaticBearer` and is not set
+    here.
     """
-
-    def __init__(self, status_code: int, payload: dict[str, Any] | None) -> None:
-        self.status_code = status_code
-        self.payload = payload or {}
-        message = self.payload.get("message") or f"upstream {status_code}"
-        super().__init__(message)
+    return {"X-Network-Code": network_code}
 
 
-class MockUpstreamClient:
-    """httpx-based client for the sales-guaranteed mock upstream.
+# ----- products / inventory / forecast -----------------------------------
 
-    Connection-pooled via ``httpx.AsyncClient``. The client carries a
-    customer-level API key (constructor) and per-call routing via
-    ``X-Network-Code`` (from ``ctx.account.ext['network_code']`` —
-    each platform method passes the network_code through).
 
-    ::
+async def list_products(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    delivery_type: str | None = None,
+    channel: str | None = None,
+    targeting: str | None = None,
+    flight_start: str | None = None,
+    flight_end: str | None = None,
+    budget: float | None = None,
+    not_found_code: str = "ACCOUNT_NOT_FOUND",
+) -> dict[str, Any]:
+    """``GET /v1/products``.
 
-        client = MockUpstreamClient(
-            base_url="http://127.0.0.1:4503",
-            api_key="test-key",
-        )
-        products = await client.list_products(
-            network_code="net_premium_us",
-            delivery_type="guaranteed",
-        )
+    Query params drive per-product forecast decoration upstream
+    (see openapi.yaml). Returns the raw upstream payload — translation
+    to AdCP ``Product[]`` happens in
+    :meth:`platform.V3ReferenceSeller.get_products`.
+
+    A 404 here means the network/account is unknown — pass
+    ``not_found_code='ACCOUNT_NOT_FOUND'`` (default) so the buyer
+    receives the right spec code.
     """
-
-    def __init__(
-        self,
-        *,
-        base_url: str,
-        api_key: str,
-        timeout: float = 30.0,
-    ) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._api_key = api_key
-        self._timeout = timeout
-        self._client: httpx.AsyncClient | None = None
-
-    async def _get_client(self) -> httpx.AsyncClient:
-        if self._client is None:
-            self._client = httpx.AsyncClient(
-                base_url=self._base_url,
-                timeout=self._timeout,
-                limits=httpx.Limits(
-                    max_keepalive_connections=10,
-                    max_connections=20,
-                ),
-            )
-        return self._client
-
-    async def aclose(self) -> None:
-        if self._client is not None:
-            await self._client.aclose()
-            self._client = None
-
-    def _headers(self, network_code: str) -> dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self._api_key}",
-            "X-Network-Code": network_code,
-            "Content-Type": "application/json",
-        }
-
-    async def _request(
-        self,
-        method: str,
-        path: str,
-        *,
-        network_code: str,
-        params: dict[str, Any] | None = None,
-        json: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        client = await self._get_client()
-        response = await client.request(
-            method,
-            path,
-            params=params,
-            json=json,
-            headers=self._headers(network_code),
-        )
-        if response.status_code >= 400:
-            try:
-                payload = response.json()
-            except ValueError:
-                payload = None
-            raise UpstreamError(response.status_code, payload)
-        if response.status_code == 204 or not response.content:
-            return {}
-        return response.json()  # type: ignore[no-any-return]
-
-    # ----- products / inventory / forecast --------------------------------
-
-    async def list_products(
-        self,
-        *,
-        network_code: str,
-        delivery_type: str | None = None,
-        channel: str | None = None,
-        targeting: str | None = None,
-        flight_start: str | None = None,
-        flight_end: str | None = None,
-        budget: float | None = None,
-    ) -> dict[str, Any]:
-        """``GET /v1/products``.
-
-        Query params drive per-product forecast decoration upstream
-        (see openapi.yaml). Returns the raw upstream payload —
-        translation to AdCP ``Product[]`` happens in
-        :meth:`platform.V3ReferenceSeller.get_products`.
-        """
-        params: dict[str, Any] = {}
-        if delivery_type is not None:
-            params["delivery_type"] = delivery_type
-        if channel is not None:
-            params["channel"] = channel
-        if targeting is not None:
-            params["targeting"] = targeting
-        if flight_start is not None:
-            params["flight_start"] = flight_start
-        if flight_end is not None:
-            params["flight_end"] = flight_end
-        if budget is not None:
-            params["budget"] = budget
-        return await self._request("GET", "/v1/products", network_code=network_code, params=params)
-
-    async def get_forecast(
-        self,
-        *,
-        network_code: str,
-        payload: dict[str, Any],
-    ) -> dict[str, Any]:
-        """``POST /v1/forecast`` — single-product delivery forecast."""
-        return await self._request("POST", "/v1/forecast", network_code=network_code, json=payload)
-
-    # ----- orders ---------------------------------------------------------
-
-    async def list_orders(self, *, network_code: str) -> dict[str, Any]:
-        """``GET /v1/orders``."""
-        return await self._request("GET", "/v1/orders", network_code=network_code)
-
-    async def create_order(
-        self,
-        *,
-        network_code: str,
-        payload: dict[str, Any],
-    ) -> dict[str, Any]:
-        """``POST /v1/orders`` — returns ``Order`` in
-        ``pending_approval`` status with an ``approval_task_id``."""
-        return await self._request("POST", "/v1/orders", network_code=network_code, json=payload)
-
-    async def get_order(self, *, network_code: str, order_id: str) -> dict[str, Any]:
-        """``GET /v1/orders/{order_id}``."""
-        return await self._request("GET", f"/v1/orders/{order_id}", network_code=network_code)
-
-    async def add_line_item(
-        self,
-        *,
-        network_code: str,
-        order_id: str,
-        payload: dict[str, Any],
-    ) -> dict[str, Any]:
-        """``POST /v1/orders/{order_id}/lineitems``."""
-        return await self._request(
-            "POST",
-            f"/v1/orders/{order_id}/lineitems",
-            network_code=network_code,
-            json=payload,
-        )
-
-    async def attach_creative(
-        self,
-        *,
-        network_code: str,
-        order_id: str,
-        line_item_id: str,
-        creative_id: str,
-    ) -> dict[str, Any]:
-        """``POST /v1/orders/{order_id}/lineitems/{li}/creative-attach``."""
-        return await self._request(
-            "POST",
-            f"/v1/orders/{order_id}/lineitems/{line_item_id}/creative-attach",
-            network_code=network_code,
-            json={"creative_id": creative_id},
-        )
-
-    async def get_delivery(
-        self,
-        *,
-        network_code: str,
-        order_id: str,
-        start: str | None = None,
-        end: str | None = None,
-    ) -> dict[str, Any]:
-        """``GET /v1/orders/{order_id}/delivery``."""
-        params: dict[str, Any] = {}
-        if start is not None:
-            params["start"] = start
-        if end is not None:
-            params["end"] = end
-        return await self._request(
-            "GET",
-            f"/v1/orders/{order_id}/delivery",
-            network_code=network_code,
-            params=params,
-        )
-
-    async def post_conversions(
-        self,
-        *,
-        network_code: str,
-        order_id: str,
-        payload: dict[str, Any],
-    ) -> dict[str, Any]:
-        """``POST /v1/orders/{order_id}/conversions`` (CAPI)."""
-        return await self._request(
-            "POST",
-            f"/v1/orders/{order_id}/conversions",
-            network_code=network_code,
-            json=payload,
-        )
-
-    # ----- creatives ------------------------------------------------------
-
-    async def list_creatives(self, *, network_code: str) -> dict[str, Any]:
-        """``GET /v1/creatives``."""
-        return await self._request("GET", "/v1/creatives", network_code=network_code)
-
-    async def upload_creative(
-        self,
-        *,
-        network_code: str,
-        payload: dict[str, Any],
-    ) -> dict[str, Any]:
-        """``POST /v1/creatives``."""
-        return await self._request("POST", "/v1/creatives", network_code=network_code, json=payload)
-
-    # ----- async approval task --------------------------------------------
-
-    async def get_task(self, *, network_code: str, task_id: str) -> dict[str, Any]:
-        """``GET /v1/tasks/{task_id}`` — poll an approval task."""
-        return await self._request("GET", f"/v1/tasks/{task_id}", network_code=network_code)
+    params: dict[str, Any] = {
+        "delivery_type": delivery_type,
+        "channel": channel,
+        "targeting": targeting,
+        "flight_start": flight_start,
+        "flight_end": flight_end,
+        "budget": budget,
+    }
+    return await client.get(  # type: ignore[no-any-return]
+        "/v1/products",
+        params=params,
+        headers=_network_headers(network_code),
+        not_found_code=not_found_code,
+    )
 
 
-__all__ = ["MockUpstreamClient", "UpstreamError"]
+async def get_forecast(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``POST /v1/forecast`` — single-product delivery forecast."""
+    return await client.post(  # type: ignore[no-any-return]
+        "/v1/forecast",
+        json=payload,
+        headers=_network_headers(network_code),
+    )
+
+
+# ----- orders ------------------------------------------------------------
+
+
+async def list_orders(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+) -> dict[str, Any]:
+    """``GET /v1/orders``."""
+    return await client.get(  # type: ignore[no-any-return]
+        "/v1/orders",
+        headers=_network_headers(network_code),
+    )
+
+
+async def create_order(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``POST /v1/orders`` — returns ``Order`` in ``pending_approval``
+    status with an ``approval_task_id``.
+    """
+    return await client.post(  # type: ignore[no-any-return]
+        "/v1/orders",
+        json=payload,
+        headers=_network_headers(network_code),
+    )
+
+
+async def get_order(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    order_id: str,
+) -> dict[str, Any]:
+    """``GET /v1/orders/{order_id}``."""
+    return await client.get(  # type: ignore[no-any-return]
+        f"/v1/orders/{order_id}",
+        headers=_network_headers(network_code),
+    )
+
+
+async def add_line_item(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    order_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``POST /v1/orders/{order_id}/lineitems``."""
+    return await client.post(  # type: ignore[no-any-return]
+        f"/v1/orders/{order_id}/lineitems",
+        json=payload,
+        headers=_network_headers(network_code),
+    )
+
+
+async def attach_creative(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    order_id: str,
+    line_item_id: str,
+    creative_id: str,
+) -> dict[str, Any]:
+    """``POST /v1/orders/{order_id}/lineitems/{li}/creative-attach``."""
+    return await client.post(  # type: ignore[no-any-return]
+        f"/v1/orders/{order_id}/lineitems/{line_item_id}/creative-attach",
+        json={"creative_id": creative_id},
+        headers=_network_headers(network_code),
+    )
+
+
+async def get_delivery(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    order_id: str,
+    start: str | None = None,
+    end: str | None = None,
+) -> dict[str, Any]:
+    """``GET /v1/orders/{order_id}/delivery``."""
+    return await client.get(  # type: ignore[no-any-return]
+        f"/v1/orders/{order_id}/delivery",
+        params={"start": start, "end": end},
+        headers=_network_headers(network_code),
+    )
+
+
+async def post_conversions(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    order_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``POST /v1/orders/{order_id}/conversions`` (CAPI)."""
+    return await client.post(  # type: ignore[no-any-return]
+        f"/v1/orders/{order_id}/conversions",
+        json=payload,
+        headers=_network_headers(network_code),
+    )
+
+
+# ----- creatives ---------------------------------------------------------
+
+
+async def list_creatives(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    not_found_code: str = "ACCOUNT_NOT_FOUND",
+) -> dict[str, Any]:
+    """``GET /v1/creatives``.
+
+    A 404 here means the network/account is unknown (no creatives ever
+    existed under it) — surface as ``ACCOUNT_NOT_FOUND``.
+    """
+    return await client.get(  # type: ignore[no-any-return]
+        "/v1/creatives",
+        headers=_network_headers(network_code),
+        not_found_code=not_found_code,
+    )
+
+
+async def upload_creative(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``POST /v1/creatives``."""
+    return await client.post(  # type: ignore[no-any-return]
+        "/v1/creatives",
+        json=payload,
+        headers=_network_headers(network_code),
+    )
+
+
+# ----- async approval task ----------------------------------------------
+
+
+async def get_task(
+    client: UpstreamHttpClient,
+    *,
+    network_code: str,
+    task_id: str,
+) -> dict[str, Any]:
+    """``GET /v1/tasks/{task_id}`` — poll an approval task."""
+    return await client.get(  # type: ignore[no-any-return]
+        f"/v1/tasks/{task_id}",
+        headers=_network_headers(network_code),
+    )
+
+
+__all__ = [
+    "add_line_item",
+    "attach_creative",
+    "create_order",
+    "get_delivery",
+    "get_forecast",
+    "get_order",
+    "get_task",
+    "list_creatives",
+    "list_orders",
+    "list_products",
+    "post_conversions",
+    "upload_creative",
+]

--- a/examples/v3_reference_seller/tests/test_smoke_broadening.py
+++ b/examples/v3_reference_seller/tests/test_smoke_broadening.py
@@ -1229,7 +1229,10 @@ async def test_create_media_buy_raises_when_polling_times_out(
     handoff = await platform.create_media_buy(req, ctx)
     # Drive the handoff fn directly — the framework would wrap it in
     # background dispatch. We assert it raises rather than fabricates.
-    fn = handoff._fn  # type: ignore[attr-defined]
+    # ``TaskHandoff`` exposes no public driver — the framework dispatches
+    # via the private ``_fn`` attr; reach for it here so the test can
+    # observe the AdcpError the coroutine would raise into the registry.
+    fn = handoff._fn  # type: ignore[attr-defined]  # noqa: SLF001
     with pytest.raises(AdcpError) as excinfo:
         await fn(None)
     assert excinfo.value.code == "SERVICE_UNAVAILABLE"
@@ -1301,7 +1304,9 @@ async def test_create_media_buy_raises_when_task_rejected(respx_mock: Any) -> No
         }
     )
     handoff = await platform.create_media_buy(req, ctx)
-    fn = handoff._fn  # type: ignore[attr-defined]
+    # See ``test_create_media_buy_raises_when_polling_times_out`` above
+    # for why the test reaches for the private ``_fn`` attr.
+    fn = handoff._fn  # type: ignore[attr-defined]  # noqa: SLF001
     with pytest.raises(AdcpError) as excinfo:
         await fn(None)
     assert excinfo.value.code == "POLICY_VIOLATION"

--- a/examples/v3_reference_seller/tests/test_smoke_broadening.py
+++ b/examples/v3_reference_seller/tests/test_smoke_broadening.py
@@ -9,6 +9,12 @@ Covers:
 * Translator pattern: the platform calls the upstream over HTTP for
   ad-ops data (products, orders, creatives, delivery, conversions)
   and uses local Postgres only for the commercial-identity layer.
+* Phase 3 wiring: the platform resolves its upstream client via the
+  framework's :meth:`DecisioningPlatform.upstream_for`. Account is
+  ``mode='mock'`` with ``metadata['mock_upstream_url']`` pointing at
+  the respx-intercepted base URL; the SDK's
+  :class:`UpstreamHttpClient` carries the auth header and projects
+  upstream non-2xx onto :class:`AdcpError` codes.
 
 Tests deliberately avoid spinning up a real Postgres or the JS mock-
 server — Postgres I/O is mocked via SQLAlchemy session mocks, and
@@ -78,6 +84,19 @@ def test_capabilities_claim_both_sales_specialisms() -> None:
     assert {"sales-non-guaranteed", "sales-guaranteed"} == specialisms
 
 
+def test_platform_declares_upstream_url() -> None:
+    """Phase 3 — the platform declares ``upstream_url`` so the
+    framework's ``upstream_for`` can route ``mode='live'`` /
+    ``'sandbox'`` accounts. The reference seller is mock-mode by
+    design, so the value is a placeholder adopters replace; what
+    matters is that the attribute exists for the migration template."""
+    from src.platform import V3ReferenceSeller
+
+    assert V3ReferenceSeller.upstream_url is not None
+    assert isinstance(V3ReferenceSeller.upstream_url, str)
+    assert V3ReferenceSeller.upstream_url.startswith(("http://", "https://"))
+
+
 # ---------------------------------------------------------------------------
 # list_accounts projection — bank details stripped on response
 # ---------------------------------------------------------------------------
@@ -128,7 +147,6 @@ async def test_list_accounts_runs_projection_on_every_row(
     from src.models import Account as AccountRow
     from src.models import BuyerAgent as BuyerAgentRow
     from src.platform import V3ReferenceSeller
-    from src.upstream import MockUpstreamClient
 
     from adcp.decisioning import RequestContext
     from adcp.decisioning.registry import BuyerAgent
@@ -185,8 +203,10 @@ async def test_list_accounts_runs_projection_on_every_row(
 
     monkeypatch.setattr(platform_module, "current_tenant", lambda: _Tenant())
 
-    upstream = MockUpstreamClient(base_url="http://up", api_key="k")
-    platform = V3ReferenceSeller(sessionmaker=sessionmaker, upstream=upstream)
+    platform = V3ReferenceSeller(
+        sessionmaker=sessionmaker,
+        upstream_api_key="test-key",
+    )
 
     ctx = RequestContext(
         buyer_agent=BuyerAgent(
@@ -212,8 +232,11 @@ async def test_list_accounts_runs_projection_on_every_row(
 
 
 # ---------------------------------------------------------------------------
-# Translator-pattern HTTP plumbing — upstream is called over httpx
+# Translator-pattern HTTP plumbing — upstream is called via upstream_for()
 # ---------------------------------------------------------------------------
+
+
+_RESPX_BASE_URL = "http://up.test"
 
 
 def _build_account_metadata(network_code: str = "net_premium_us") -> dict[str, Any]:
@@ -225,12 +248,21 @@ def _build_account_metadata(network_code: str = "net_premium_us") -> dict[str, A
         "sandbox": False,
         "network_code": network_code,
         "advertiser_id": "adv_volta_motors",
+        # Phase 2 framework-reserved key — read by ``upstream_for`` to
+        # point the pooled UpstreamHttpClient at the respx fixture.
+        "mock_upstream_url": _RESPX_BASE_URL,
     }
 
 
 def _build_ctx() -> Any:
-    """Build a RequestContext with an Account that carries upstream
-    routing in metadata. Used by every translator-pattern test."""
+    """Build a RequestContext with a ``mode='mock'`` Account whose
+    metadata carries the upstream routing (``network_code`` /
+    ``advertiser_id``) and the framework-reserved ``mock_upstream_url``.
+
+    The framework's ``upstream_for(ctx)`` reads ``mock_upstream_url``
+    to build a pooled :class:`UpstreamHttpClient` pointed at the
+    respx-intercepted fixture URL.
+    """
     from adcp.decisioning import Account, RequestContext
     from adcp.decisioning.registry import BuyerAgent
 
@@ -245,27 +277,29 @@ def _build_ctx() -> Any:
             id="a_acme_1",
             name="Signed Buyer — Main",
             status="active",
+            mode="mock",
             metadata=_build_account_metadata(),
         ),
     )
 
 
-def _platform_with_upstream(
-    base_url: str = "http://up.test",
-) -> Any:
-    """Construct a V3ReferenceSeller with a fresh httpx-based upstream
-    client. The respx fixture (per-test) intercepts all outbound calls.
+def _platform_with_upstream() -> Any:
+    """Construct a :class:`V3ReferenceSeller` for translator-pattern
+    tests. The platform builds its :class:`UpstreamHttpClient` lazily
+    via :meth:`upstream_for`; the per-test respx fixture intercepts
+    every outbound HTTP call against ``http://up.test``.
     """
     from src.platform import V3ReferenceSeller
-    from src.upstream import MockUpstreamClient
 
-    upstream = MockUpstreamClient(base_url=base_url, api_key="test-key")
     sessionmaker = MagicMock()
-    return V3ReferenceSeller(sessionmaker=sessionmaker, upstream=upstream)
+    return V3ReferenceSeller(
+        sessionmaker=sessionmaker,
+        upstream_api_key="test-key",
+    )
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_products_translates_upstream_to_adcp(respx_mock: Any) -> None:
     """The platform calls ``GET /v1/products`` and projects the
     upstream's ``pricing.cpm`` + ``min_spend`` onto an AdCP
@@ -314,26 +348,24 @@ async def test_get_products_translates_upstream_to_adcp(respx_mock: Any) -> None
     assert cpm.fixed_price == 35.0
     assert cpm.currency == "USD"
     assert cpm.min_spend_per_package == 25_000.0
-    # Upstream call carried the X-Network-Code header.
+    # The SDK's UpstreamHttpClient carried StaticBearer for auth;
+    # the upstream helper added the X-Network-Code per-call header.
     sent_request = respx_mock.calls.last.request
     assert sent_request.headers.get("X-Network-Code") == "net_premium_us"
     assert sent_request.headers.get("Authorization") == "Bearer test-key"
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_create_media_buy_returns_task_handoff_on_pending_approval(
     respx_mock: Any,
 ) -> None:
     """When the upstream returns ``pending_approval`` + ``approval_task_id``,
     the platform returns a :class:`TaskHandoff` so the framework
     surfaces the wire ``Submitted`` envelope to the buyer."""
-    from src.upstream import MockUpstreamClient
-
     from adcp.decisioning.types import TaskHandoff
     from adcp.types import CreateMediaBuyRequest
 
-    del MockUpstreamClient  # imported for side-effect docs
     respx_mock.post("/v1/orders").mock(
         return_value=httpx.Response(
             201,
@@ -387,7 +419,7 @@ async def test_create_media_buy_returns_task_handoff_on_pending_approval(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_create_media_buy_sync_fast_path_when_upstream_already_approved(
     respx_mock: Any,
 ) -> None:
@@ -464,7 +496,7 @@ async def test_update_media_buy_raises_unsupported_feature() -> None:
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_sync_creatives_uploads_each_creative_to_upstream(
     respx_mock: Any,
 ) -> None:
@@ -515,7 +547,7 @@ async def test_sync_creatives_uploads_each_creative_to_upstream(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_media_buys_filters_by_advertiser_id(respx_mock: Any) -> None:
     """The upstream's ``GET /v1/orders`` is per-network; we filter to
     this AdCP account's ``advertiser_id`` so a misrouted buyer can't
@@ -563,7 +595,7 @@ async def test_get_media_buys_filters_by_advertiser_id(respx_mock: Any) -> None:
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_media_buy_delivery_translates_upstream_report(
     respx_mock: Any,
 ) -> None:
@@ -619,7 +651,7 @@ async def test_get_media_buy_delivery_translates_upstream_report(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_provide_performance_feedback_posts_capi_conversion(
     respx_mock: Any,
 ) -> None:
@@ -666,7 +698,7 @@ async def test_provide_performance_feedback_rejects_non_conversion_rate_metric()
     from adcp.decisioning import AdcpError
     from adcp.types import ProvidePerformanceFeedbackRequest
 
-    with respx.mock(base_url="http://up.test") as respx_mock:
+    with respx.mock(base_url=_RESPX_BASE_URL) as respx_mock:
         platform = _platform_with_upstream()
         ctx = _build_ctx()
         req = ProvidePerformanceFeedbackRequest.model_validate(
@@ -689,12 +721,14 @@ async def test_provide_performance_feedback_rejects_non_conversion_rate_metric()
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_provide_performance_feedback_404_translates_to_media_buy_not_found(
     respx_mock: Any,
 ) -> None:
     """Upstream 404 on the order routes to the spec-conformant
-    ``MEDIA_BUY_NOT_FOUND`` AdCP error code, not a generic 500."""
+    ``MEDIA_BUY_NOT_FOUND`` AdCP error code, not a generic 500. The
+    SDK's :class:`UpstreamHttpClient` projects POST 404 → the
+    default ``not_found_code`` (``MEDIA_BUY_NOT_FOUND``)."""
     from adcp.decisioning import AdcpError
     from adcp.types import ProvidePerformanceFeedbackRequest
 
@@ -721,7 +755,7 @@ async def test_provide_performance_feedback_404_translates_to_media_buy_not_foun
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_list_creatives_filters_to_account_advertiser(respx_mock: Any) -> None:
     """``GET /v1/creatives`` returns the upstream catalog; we project
     onto AdCP shape and filter to this AdCP account's advertiser_id."""
@@ -766,7 +800,7 @@ async def test_list_creative_formats_is_static_no_upstream_call() -> None:
     static catalog. The test asserts no upstream call is made."""
     from adcp.types import ListCreativeFormatsRequest
 
-    with respx.mock(base_url="http://up.test") as respx_mock:
+    with respx.mock(base_url=_RESPX_BASE_URL) as respx_mock:
         platform = _platform_with_upstream()
         ctx = _build_ctx()
         resp = await platform.list_creative_formats(ListCreativeFormatsRequest(), ctx)
@@ -813,103 +847,58 @@ async def test_account_loader_rejects_account_missing_upstream_routing(
 
     monkeypatch.setattr(platform_module, "current_tenant", lambda: _Tenant())
 
-    store = _make_account_store(sessionmaker)
+    store = _make_account_store(sessionmaker, mock_upstream_url="http://up.test")
     with pytest.raises(AdcpError) as excinfo:
         await store.resolve({"account_id": "bad-acct"})
     assert excinfo.value.code == "SERVICE_UNAVAILABLE"
     assert excinfo.value.recovery == "transient"
 
 
-# ---------------------------------------------------------------------------
-# _translate_upstream — HTTP status → spec error code projection
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_account_loader_returns_mock_mode_with_upstream_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 3 wiring: the AccountStore stamps every Account it
+    resolves with ``mode='mock'`` and ``metadata['mock_upstream_url']``
+    so the framework's ``upstream_for(ctx)`` routes the adapter at the
+    mock-server fixture URL.
+    """
+    import src.platform as platform_module
+    from src.models import Account as AccountRow
+    from src.platform import _make_account_store
 
-
-def test_translate_upstream_400_projects_to_invalid_request() -> None:
-    """The mock returns 400 for malformed payloads; surface as terminal
-    ``INVALID_REQUEST`` (the canonical spec code) so buyers know to fix
-    the request rather than retry transiently."""
-    from src.platform import V3ReferenceSeller
-    from src.upstream import UpstreamError
-
-    err = V3ReferenceSeller._translate_upstream(
-        UpstreamError(400, {"code": "invalid_request", "message": "bad budget"}),
-        default_code="SERVICE_UNAVAILABLE",
+    good_row = AccountRow(
+        id="a_good",
+        tenant_id="t_acme",
+        buyer_agent_id="ba_x",
+        account_id="good-acct",
+        name="Good Account",
+        status="active",
+        billing="operator",
+        sandbox=False,
+        ext={"network_code": "net_premium_us", "advertiser_id": "adv_volta_motors"},
     )
-    assert err.code == "INVALID_REQUEST"
-    assert err.recovery == "terminal"
-    assert err.details["upstream_code"] == "invalid_request"
-    assert err.details["upstream_message"] == "bad budget"
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=good_row)
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.execute = AsyncMock(return_value=result)
+    sessionmaker = MagicMock(return_value=session)
 
+    class _Tenant:
+        id = "t_acme"
 
-def test_translate_upstream_401_projects_to_auth_required() -> None:
-    """Upstream 401 surfaces as the canonical spec code ``AUTH_REQUIRED``."""
-    from src.platform import V3ReferenceSeller
-    from src.upstream import UpstreamError
+    monkeypatch.setattr(platform_module, "current_tenant", lambda: _Tenant())
 
-    err = V3ReferenceSeller._translate_upstream(
-        UpstreamError(401, {"message": "bad bearer"}),
-        default_code="SERVICE_UNAVAILABLE",
-    )
-    assert err.code == "AUTH_REQUIRED"
-    assert err.recovery == "terminal"
-
-
-def test_translate_upstream_500_projects_to_default_code_transient() -> None:
-    """Unknown upstream statuses fall through to the caller's
-    ``default_code`` with ``recovery='transient'`` — never the legacy
-    ``recovery='retry'`` string (which isn't in the AdCP enum)."""
-    from src.platform import V3ReferenceSeller
-    from src.upstream import UpstreamError
-
-    err = V3ReferenceSeller._translate_upstream(
-        UpstreamError(500, {"message": "boom"}),
-        default_code="SERVICE_UNAVAILABLE",
-    )
-    assert err.code == "SERVICE_UNAVAILABLE"
-    assert err.recovery == "transient"
-
-
-def test_translate_upstream_429_projects_to_rate_limited() -> None:
-    """Upstream 429 surfaces as the canonical spec code ``RATE_LIMITED``."""
-    from src.platform import V3ReferenceSeller
-    from src.upstream import UpstreamError
-
-    err = V3ReferenceSeller._translate_upstream(
-        UpstreamError(429, {"message": "slow down"}),
-        default_code="SERVICE_UNAVAILABLE",
-    )
-    assert err.code == "RATE_LIMITED"
-    assert err.recovery == "transient"
-
-
-def test_translate_upstream_404_default_is_media_buy_not_found() -> None:
-    """Default 404 mapping surfaces ``MEDIA_BUY_NOT_FOUND`` — used by
-    get_order / get_delivery / post_conversions callsites where 404
-    genuinely means the media buy is gone."""
-    from src.platform import V3ReferenceSeller
-    from src.upstream import UpstreamError
-
-    err = V3ReferenceSeller._translate_upstream(
-        UpstreamError(404, {"message": "no order"}),
-        default_code="SERVICE_UNAVAILABLE",
-    )
-    assert err.code == "MEDIA_BUY_NOT_FOUND"
-
-
-def test_translate_upstream_404_account_callsite_overrides_to_account_not_found() -> None:
-    """get_products / list_creatives 404s mean the network/account is
-    unknown — pass ``not_found_code='ACCOUNT_NOT_FOUND'`` so buyers
-    don't see a misleading ``MEDIA_BUY_NOT_FOUND``."""
-    from src.platform import V3ReferenceSeller
-    from src.upstream import UpstreamError
-
-    err = V3ReferenceSeller._translate_upstream(
-        UpstreamError(404, {"message": "no network"}),
-        default_code="SERVICE_UNAVAILABLE",
-        not_found_code="ACCOUNT_NOT_FOUND",
-    )
-    assert err.code == "ACCOUNT_NOT_FOUND"
+    store = _make_account_store(sessionmaker, mock_upstream_url="http://127.0.0.1:4503")
+    account = await store.resolve({"account_id": "good-acct"})
+    assert account.mode == "mock"
+    assert account.metadata["mock_upstream_url"] == "http://127.0.0.1:4503"
+    # Routing data still flows through metadata so platform methods
+    # pluck network_code / advertiser_id directly.
+    assert account.metadata["network_code"] == "net_premium_us"
+    assert account.metadata["advertiser_id"] == "adv_volta_motors"
 
 
 # ---------------------------------------------------------------------------
@@ -919,10 +908,10 @@ def test_translate_upstream_404_account_callsite_overrides_to_account_not_found(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_products_401_translates_to_auth_required(respx_mock: Any) -> None:
     """A 401 from the upstream surfaces as the spec code
-    ``AUTH_REQUIRED`` (post-fix-pack-1; was ``AUTH_INVALID``)."""
+    ``AUTH_REQUIRED`` via the SDK's UpstreamHttpClient projection."""
     from adcp.decisioning import AdcpError
     from adcp.types import GetProductsRequest
 
@@ -940,7 +929,7 @@ async def test_get_products_401_translates_to_auth_required(respx_mock: Any) -> 
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_products_500_translates_to_service_unavailable(respx_mock: Any) -> None:
     """A 500 surfaces as ``SERVICE_UNAVAILABLE`` with
     ``recovery='transient'`` so buyers retry."""
@@ -959,7 +948,7 @@ async def test_get_products_500_translates_to_service_unavailable(respx_mock: An
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_products_429_translates_to_rate_limited(respx_mock: Any) -> None:
     """A 429 surfaces as ``RATE_LIMITED`` (transient)."""
     from adcp.decisioning import AdcpError
@@ -978,10 +967,12 @@ async def test_get_products_429_translates_to_rate_limited(respx_mock: Any) -> N
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_products_404_translates_to_account_not_found(respx_mock: Any) -> None:
     """A 404 from get_products means an unknown network/account, not a
-    missing media buy — verify the per-callsite override."""
+    missing media buy. The :mod:`upstream` helper passes
+    ``not_found_code='ACCOUNT_NOT_FOUND'`` to the SDK client so the
+    spec-correct AdCP code surfaces on the wire."""
     from adcp.decisioning import AdcpError
     from adcp.types import GetProductsRequest
 
@@ -998,7 +989,7 @@ async def test_get_products_404_translates_to_account_not_found(respx_mock: Any)
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_upstream_malformed_json_raises_clean_error(respx_mock: Any) -> None:
     """A non-JSON response body on a 5xx upstream still produces a
     structured ``AdcpError`` rather than leaking a ``ValueError``."""
@@ -1014,8 +1005,6 @@ async def test_upstream_malformed_json_raises_clean_error(respx_mock: Any) -> No
         await platform.get_products(
             GetProductsRequest.model_validate({"buying_mode": "wholesale"}), ctx
         )
-    # Falls through to default_code on the 5xx path — payload is empty
-    # because JSON decode failed.
     assert excinfo.value.code == "SERVICE_UNAVAILABLE"
 
 
@@ -1026,7 +1015,7 @@ async def test_upstream_malformed_json_raises_clean_error(respx_mock: Any) -> No
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_create_media_buy_no_task_id_path_refetches_and_projects(
     respx_mock: Any,
 ) -> None:
@@ -1097,7 +1086,7 @@ async def test_create_media_buy_no_task_id_path_refetches_and_projects(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_create_media_buy_no_task_id_path_raises_on_pending(
     respx_mock: Any,
 ) -> None:
@@ -1166,7 +1155,7 @@ async def test_create_media_buy_no_task_id_path_raises_on_pending(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_create_media_buy_raises_when_polling_times_out(
     respx_mock: Any,
 ) -> None:
@@ -1175,7 +1164,6 @@ async def test_create_media_buy_raises_when_polling_times_out(
     (transient). The framework projects this as a wire-shaped task
     failure — never a fabricated success."""
     from src.platform import V3ReferenceSeller
-    from src.upstream import MockUpstreamClient
 
     from adcp.decisioning import AdcpError
     from adcp.types import CreateMediaBuyRequest
@@ -1209,12 +1197,11 @@ async def test_create_media_buy_raises_when_polling_times_out(
             },
         )
     )
-    upstream = MockUpstreamClient(base_url="http://up.test", api_key="test-key")
     sessionmaker = MagicMock()
     # Tighten polling so the test finishes fast — 2 iterations × 0.001s.
     platform = V3ReferenceSeller(
         sessionmaker=sessionmaker,
-        upstream=upstream,
+        upstream_api_key="test-key",
         approval_poll_interval_s=0.001,
         approval_poll_max_iterations=2,
     )
@@ -1250,7 +1237,7 @@ async def test_create_media_buy_raises_when_polling_times_out(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_create_media_buy_raises_when_task_rejected(respx_mock: Any) -> None:
     """When the upstream approval task completes with
     ``outcome='rejected'``, the polling coroutine raises
@@ -1327,7 +1314,7 @@ async def test_create_media_buy_raises_when_task_rejected(respx_mock: Any) -> No
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_media_buy_delivery_projects_completed_status(
     respx_mock: Any,
 ) -> None:
@@ -1375,7 +1362,7 @@ async def test_get_media_buy_delivery_projects_completed_status(
 
 
 @pytest.mark.asyncio
-@respx.mock(base_url="http://up.test")
+@respx.mock(base_url=_RESPX_BASE_URL)
 async def test_get_media_buy_delivery_projects_canceled_status(
     respx_mock: Any,
 ) -> None:

--- a/tests/test_validate_platform_warnings.py
+++ b/tests/test_validate_platform_warnings.py
@@ -259,9 +259,12 @@ def test_v3_reference_seller_passes_with_no_warnings(
     UserWarnings. If this test fails, PR #408 has regressed.
 
     The seller's ``__init__`` requires a SQLAlchemy ``async_sessionmaker``
-    and an optional ``MockAdServer``; we build the instance with a sentinel
-    sessionmaker because ``validate_platform`` only walks attributes —
-    it never executes the methods, so the sessionmaker is never touched.
+    plus the upstream API key (Phase 3 of the lifecycle-state-and-
+    sandbox-authority work — the platform builds its
+    :class:`UpstreamHttpClient` lazily via :meth:`upstream_for`). We
+    build the instance with a sentinel sessionmaker because
+    ``validate_platform`` only walks attributes — it never executes
+    the methods, so the sessionmaker is never touched.
     """
 
     v3_platform = pytest.importorskip("examples.v3_reference_seller.src.platform")
@@ -272,7 +275,10 @@ def test_v3_reference_seller_passes_with_no_warnings(
         def __call__(self, *args, **kwargs):
             raise RuntimeError("validate_platform must not open a session")
 
-    seller = seller_cls(sessionmaker=_StubSessionmaker())
+    seller = seller_cls(
+        sessionmaker=_StubSessionmaker(),
+        upstream_api_key="test-key",
+    )
 
     monkeypatch.delenv("ADCP_DECISIONING_STRICT_VALIDATE_PLATFORM", raising=False)
     with warnings.catch_warnings(record=True) as caught:


### PR DESCRIPTION
## Summary

Phase 3 of the lifecycle-state-and-sandbox-authority work: refactor the v3 reference seller to use the SDK's `UpstreamHttpClient` + `DecisioningPlatform.upstream_for` mock-mode routing shipped in Phase 2 (#487). The reference seller is the canonical adopter migration template — what salesagent and other translator-pattern adopters mirror when they migrate.

- **Bespoke httpx client gone.** `MockUpstreamClient` (httpx pooling + ApiKey auth + bespoke `UpstreamError` projection) replaced with module-level domain helpers (`list_products`, `create_order`, `get_delivery`, ...) taking the SDK's `UpstreamHttpClient`. ~285 LoC of HTTP boilerplate gone, ~270 LoC of focused upstream-shape helpers stay.
- **`upstream_url` + `upstream_for(ctx)` wiring.** The platform declares `upstream_url = "https://sales-guaranteed.example.invalid/v1"` (placeholder adopters replace with their production URL). Each method body resolves the pooled client via `self.upstream_for(ctx, auth=self._upstream_auth)` — the framework picks `upstream_url` for `mode='live'`/`'sandbox'` and `account.metadata['mock_upstream_url']` for `mode='mock'`. Same adapter code path against either URL.
- **AccountStore stamps `mode='mock'`.** Every resolved account is `mode='mock'` + `metadata['mock_upstream_url']` (sourced from the existing `MOCK_AD_SERVER_URL` env). Adopters with a real production upstream branch on row lifecycle to set `mode='live'` for production accounts and reserve `mode='mock'` for conformance / storyboard accounts only.
- **Auth: `StaticBearer`.** `Authorization: Bearer <api_key>` flows through the SDK's `StaticBearer`; per-call `X-Network-Code` flows as a per-call header on each upstream-helper invocation. Single `StaticBearer` instance shared across `upstream_for()` calls means the framework's client cache pools one `httpx.AsyncClient` per base URL.
- **Error handling: SDK projection.** Bespoke `_translate_upstream` helper deleted — the SDK's `UpstreamHttpClient` already projects every status code we cared about (401 → `AUTH_REQUIRED`, 403 → `PERMISSION_DENIED`, 404 → `not_found_code` (configurable per-call), 429 → `RATE_LIMITED`, 5xx → `SERVICE_UNAVAILABLE`, other 4xx → `INVALID_REQUEST`). Upstream helpers pass `not_found_code='ACCOUNT_NOT_FOUND'` for `list_products` / `list_creatives` so the right AdCP code surfaces.
- **Env contract preserved.** `MOCK_AD_SERVER_URL` / `MOCK_AD_SERVER_API_KEY` still drive the wiring; storyboard CI needs no workflow changes.
- **MIGRATION.md / README.md** updated to walk adopters through the new pattern (declare `upstream_url`, branch `account.mode` in `AccountStore.resolve`, use `upstream_for` in method bodies).

## Test plan

- [x] `ruff check examples/v3_reference_seller/` — clean
- [x] `mypy examples/v3_reference_seller/src/` — same 17 pre-existing errors as before the refactor (none introduced by this change)
- [x] `pytest examples/v3_reference_seller/tests/test_smoke.py examples/v3_reference_seller/tests/test_smoke_broadening.py` — 38 passed
- [x] `pytest tests/` (broad SDK regression) — 3616 passed, 31 skipped
- [x] End-to-end smoke via respx: a `mode='mock'` Account with `metadata['mock_upstream_url']='http://up.smoke'` correctly routes the platform's `get_products` at the fixture URL with `Authorization: Bearer test-key` + `X-Network-Code: net_smoke` headers intact
- [ ] Live mock-server smoke — couldn't run locally (the `npx -p @adcp/client adcp mock-server <specialism>` sub-command isn't accessible via the published `@adcp/client` CLI from this checkout). Storyboard CI is the load-bearing regression gate and will catch any wire-level drift.

## What this is for

This PR is the canonical adopter migration template. Salesagent maintainers (and other translator-pattern adopters — Prebid, GAM-fronting middleware, FreeWheel-fronting middleware) read this PR as the diff they mirror when they migrate to the Phase 2 mock-mode routing. The MIGRATION.md updates are the load-bearing documentation; the code is the reference.

## Refs

- Phase 1: #483 (Account.mode + sandbox-authority gate)
- Phase 2: #487 (Account.metadata['mock_upstream_url'] + DecisioningPlatform.upstream_for)
- Phase 3 (this PR): adopter wiring template

🤖 Generated with [Claude Code](https://claude.com/claude-code)