### PR TITLE
feat(decisioning): PlatformRouter + multi-platform proof (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,7 +727,7 @@ jobs:
           adcp storyboard run \
             http://tenant-a.localhost:3001/mcp media_buy_seller \
             --json --allow-http \
-            > tenant-a-storyboard.json || true
+            > tenant-a-storyboard.json
           cat tenant-a-storyboard.json | head -50
 
       - name: Run storyboard — tenant-b (sales-non-guaranteed)
@@ -736,7 +736,7 @@ jobs:
           adcp storyboard run \
             http://tenant-b.localhost:3001/mcp media_buy_seller \
             --json --allow-http \
-            > tenant-b-storyboard.json || true
+            > tenant-b-storyboard.json
           cat tenant-b-storyboard.json | head -50
 
       - if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,3 +646,104 @@ jobs:
           name: v3-storyboard-result-${{ github.run_attempt }}
           path: examples/v3_reference_seller/v3-storyboard-result.json
           if-no-files-found: warn
+
+  storyboard-multi-platform-seller:
+    name: AdCP storyboard runner — examples/multi_platform_seller (PlatformRouter)
+    runs-on: ubuntu-latest
+    # Multi-tenant proof: one process, two tenants, one router. Each
+    # tenant's storyboard runs against its own subdomain
+    # (tenant-a.localhost / tenant-b.localhost). Non-blocking until
+    # the storyboard reaches passing — same posture as the
+    # examples/seller_agent.py job above.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache ~/.npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-adcp-sdk
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Pre-install @adcp/sdk
+        run: |
+          npm install -g @adcp/sdk@latest
+          adcp --version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Map tenant subdomains to localhost
+        run: |
+          # The storyboard runner connects to ``tenant-x.localhost`` —
+          # /etc/hosts gives those names a 127.0.0.1 mapping so the
+          # subdomain middleware on the seller process resolves the
+          # right tenant from the Host header.
+          echo "127.0.0.1 tenant-a.localhost tenant-b.localhost" \
+            | sudo tee -a /etc/hosts
+
+      - name: Boot multi-platform seller
+        run: |
+          ADCP_PORT=3001 python -m examples.multi_platform_seller.src.app &
+          SELLER_PID=$!
+          echo "SELLER_PID=$SELLER_PID" >> "$GITHUB_ENV"
+          for i in $(seq 1 60); do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
+              http://127.0.0.1:3001/mcp 2>/dev/null) || HTTP_CODE="000"
+            if [ "$HTTP_CODE" != "000" ]; then
+              echo "Seller ready (HTTP ${HTTP_CODE}, pid ${SELLER_PID})"
+              break
+            fi
+            if ! kill -0 "$SELLER_PID" 2>/dev/null; then
+              echo "Seller process died during startup"
+              exit 1
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Seller failed to start within 30s"
+              kill "$SELLER_PID" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+
+      - name: Run storyboard — tenant-a (sales-guaranteed)
+        timeout-minutes: 5
+        run: |
+          adcp storyboard run \
+            http://tenant-a.localhost:3001/mcp media_buy_seller \
+            --json --allow-http \
+            > tenant-a-storyboard.json || true
+          cat tenant-a-storyboard.json | head -50
+
+      - name: Run storyboard — tenant-b (sales-non-guaranteed)
+        timeout-minutes: 5
+        run: |
+          adcp storyboard run \
+            http://tenant-b.localhost:3001/mcp media_buy_seller \
+            --json --allow-http \
+            > tenant-b-storyboard.json || true
+          cat tenant-b-storyboard.json | head -50
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-platform-storyboards-${{ github.run_attempt }}
+          path: |
+            tenant-a-storyboard.json
+            tenant-b-storyboard.json
+          if-no-files-found: warn

--- a/examples/multi_platform_seller/README.md
+++ b/examples/multi_platform_seller/README.md
@@ -12,8 +12,8 @@ shape) maintain a registry like
 
 ```python
 ADAPTER_REGISTRY: dict[str, Type[AdServerAdapter]] = {
-    "gam": GAMAdapter,
-    "kevel": KevelAdapter,
+    "adserver_a": AdServerAAdapter,
+    "adserver_b": AdServerBAdapter,
     "mock": MockAdapter,
     ...
 }
@@ -117,14 +117,14 @@ tenants DO support, breaking the "one URL → many tenants" model.
 
 ## Migration target — `ADAPTER_REGISTRY` adopters
 
-A separate `MIGRATION_FROM_ADAPTER_REGISTRY.md` (companion PR) walks
-through the salesagent translation step-by-step. The short version:
+A separate [`MIGRATION_FROM_ADAPTER_REGISTRY.md`](./MIGRATION_FROM_ADAPTER_REGISTRY.md)
+walks through the salesagent translation step-by-step. The short version:
 
 ```python
 # Before — runtime adapter instantiation per tenant
 ADAPTER_REGISTRY: dict[str, Type[AdServerAdapter]] = {
-    "gam": GAMAdapter,
-    "kevel": KevelAdapter,
+    "adserver_a": AdServerAAdapter,
+    "adserver_b": AdServerBAdapter,
 }
 adapter = ADAPTER_REGISTRY[tenant.backend](tenant.config, principal)
 result = adapter.create_media_buy(request)

--- a/examples/multi_platform_seller/README.md
+++ b/examples/multi_platform_seller/README.md
@@ -1,0 +1,158 @@
+# multi_platform_seller — N tenants, N platforms, one process
+
+A worked example of the multi-tenant pattern: one `serve()` call hosts
+two tenants, each backed by a different `DecisioningPlatform`
+subclass, dispatched by `PlatformRouter` based on the request's
+resolved tenant.
+
+## Why this exists
+
+Multi-tenant SaaS sales agents (Prebid `salesagent` and adopters in its
+shape) maintain a registry like
+
+```python
+ADAPTER_REGISTRY: dict[str, Type[AdServerAdapter]] = {
+    "gam": GAMAdapter,
+    "kevel": KevelAdapter,
+    "mock": MockAdapter,
+    ...
+}
+```
+
+…and instantiate the right adapter per-request based on the tenant's
+configured backend. The `DecisioningPlatform` framework supports the
+same shape via `PlatformRouter`: preload one platform per tenant,
+let the router pick by `ctx.account.metadata['tenant_id']`. The
+adopter swaps a runtime `dict[str, Type[Adapter]]` lookup for a
+construction-time `dict[str, DecisioningPlatform]` injection — same
+mental model, framework-managed dispatch.
+
+## What it ships
+
+| File | Role |
+|---|---|
+| `src/mock_guaranteed.py` | `sales-guaranteed` mock — fixed-CPM, capacity-bounded inventory, `pending_creatives → pending_start → active → completed` lifecycle. |
+| `src/mock_non_guaranteed.py` | `sales-non-guaranteed` mock — programmatic remnant, always accepts, delivery scales with budget. |
+| `src/account_store.py` | `MultiTenantAccountStore` — resolves wire account refs to `Account` instances with `metadata['tenant_id']` populated. Reads either the `Host`-header-set tenant contextvar or the wire `account.account_id` prefix (`tenant-a:...`). |
+| `src/app.py` | Boot script. Constructs both platforms, the account store, the `PlatformRouter`, wires `SubdomainTenantMiddleware`, calls `serve()`. |
+
+## Running locally
+
+```bash
+# 1. (Optional) Map the tenant subdomains to localhost:
+echo "127.0.0.1 tenant-a.localhost tenant-b.localhost" | sudo tee -a /etc/hosts
+
+# 2. Boot the seller:
+python -m examples.multi_platform_seller.src.app
+
+# 3. Hit either tenant via subdomain:
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Host: tenant-a.localhost:3001" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  http://127.0.0.1:3001/mcp
+
+# 4. Or send an explicit account ref (storyboard convention):
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+    "name":"get_products",
+    "arguments":{"buying_mode":"brief","brief":"display","account":{"account_id":"tenant-a:demo"}}
+  }}' \
+  http://127.0.0.1:3001/mcp
+```
+
+## How tenant routing works
+
+```
+   ┌──────────────────────┐     SubdomainTenantMiddleware reads
+   │  POST /mcp           │ ──► the Host header, sets the tenant
+   │  Host: tenant-a...   │     contextvar.
+   └──────────┬───────────┘
+              │
+              ▼
+   ┌──────────────────────┐     MultiTenantAccountStore.resolve()
+   │  PlatformRouter      │ ──► reads the contextvar (or the wire
+   │  (DecisioningPlatform│     ref's tenant prefix) and stamps
+   │   subclass)          │     metadata['tenant_id'] onto the
+   └──────────┬───────────┘     resolved Account.
+              │
+              ▼
+   ┌──────────────────────┐     Synthesized delegation for every
+   │  router.get_products │ ──► specialism method looks up the
+   │  router.create_…     │     child by tenant_id and forwards
+   └──────────┬───────────┘     the call verbatim.
+              │
+              ▼
+   ┌──────────────────────────────┐
+   │ MockGuaranteedPlatform OR    │
+   │ MockNonGuaranteedPlatform    │
+   └──────────────────────────────┘
+```
+
+## Capabilities — union, not intersection
+
+The router's `capabilities.specialisms` is the **union** of every
+child platform's specialisms. `tools/list` advertises every tool any
+child serves; calls to a tool the resolved tenant doesn't implement
+raise a structured `UNSUPPORTED_FEATURE` error per spec.
+
+Intersection-based capabilities would silently hide tools that some
+tenants DO support, breaking the "one URL → many tenants" model.
+
+## Adding a third tenant
+
+1. Write a new `DecisioningPlatform` subclass for the new tenant's
+   backend (or reuse one of the mocks).
+2. Add `"tenant-c": NewPlatform()` to the `platforms=` mapping in
+   `app.py`.
+3. Add the new tenant to `MultiTenantAccountStore(tenants=...)` and to
+   the `SubdomainTenantMiddleware` router.
+4. If the new tenant adds a specialism (e.g. `audience-sync`), extend
+   the router's `capabilities.specialisms` accordingly. The router's
+   synthesized delegation already covers every framework-known
+   specialism method — you don't have to update the router itself.
+
+## Migration target — `ADAPTER_REGISTRY` adopters
+
+A separate `MIGRATION_FROM_ADAPTER_REGISTRY.md` (companion PR) walks
+through the salesagent translation step-by-step. The short version:
+
+```python
+# Before — runtime adapter instantiation per tenant
+ADAPTER_REGISTRY: dict[str, Type[AdServerAdapter]] = {
+    "gam": GAMAdapter,
+    "kevel": KevelAdapter,
+}
+adapter = ADAPTER_REGISTRY[tenant.backend](tenant.config, principal)
+result = adapter.create_media_buy(request)
+
+# After — boot-time platform construction, framework-managed dispatch
+router = PlatformRouter(
+    accounts=tenant_routing_account_store,
+    platforms={
+        tenant_id: build_platform_for(tenant)
+        for tenant_id, tenant in load_tenants().items()
+    },
+    capabilities=DecisioningCapabilities(
+        specialisms=union_of_tenant_specialisms(),
+        ...,
+    ),
+)
+serve(router, asgi_middleware=[(SubdomainTenantMiddleware, {...})])
+```
+
+## What this example deliberately leaves out
+
+- **Real upstream HTTP.** Both mocks set `upstream_url = None` and
+  serve in-process. Production adopters set `upstream_url` on each
+  child platform and let `DecisioningPlatform.upstream_for(ctx)`
+  thread the per-request client.
+- **Multi-protocol fan-out.** Each request resolves to exactly one
+  tenant. Fan-out (one buyer call → multiple sellers) is a different
+  pattern and out of scope.
+- **Cross-tenant state.** Each tenant is an island — its own
+  inventory, its own buys, its own auth. The router never aggregates
+  across tenants.

--- a/examples/multi_platform_seller/src/__init__.py
+++ b/examples/multi_platform_seller/src/__init__.py
@@ -1,0 +1,25 @@
+"""Multi-platform seller example — N tenants, N platforms, one process.
+
+See the README for the wiring story; this package exposes:
+
+* :class:`MockGuaranteedPlatform` — fixed-allocation, capacity-bounded
+  inventory (the canonical guaranteed-buy shape).
+* :class:`MockNonGuaranteedPlatform` — programmatic remnant, always
+  accepts, delivery scales with budget.
+* :class:`MultiTenantAccountStore` — resolves wire account refs to
+  Account[TenantMeta] with ``metadata['tenant_id']`` populated.
+* :func:`build_router` — assembles the :class:`PlatformRouter` from the
+  per-tenant platforms.
+"""
+
+from __future__ import annotations
+
+from .account_store import MultiTenantAccountStore
+from .mock_guaranteed import MockGuaranteedPlatform
+from .mock_non_guaranteed import MockNonGuaranteedPlatform
+
+__all__ = [
+    "MockGuaranteedPlatform",
+    "MockNonGuaranteedPlatform",
+    "MultiTenantAccountStore",
+]

--- a/examples/multi_platform_seller/src/account_store.py
+++ b/examples/multi_platform_seller/src/account_store.py
@@ -20,7 +20,7 @@ against the same boot.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from adcp.decisioning import AdcpError
 from adcp.decisioning.accounts import AccountStore
@@ -117,9 +117,14 @@ def _auth_info_to_dict(auth_info: AuthInfo | None) -> dict[str, Any] | None:
 
 
 # Static-type assertion: the store satisfies the AccountStore Protocol.
-# Mypy reads this at type-check time; runtime uses isinstance via the
-# Protocol's @runtime_checkable decorator.
-_ASSERT: AccountStore[dict[str, Any]] = MultiTenantAccountStore(tenants=frozenset({"_assertion"}))
+# TYPE_CHECKING-only so the assertion has zero runtime cost and never
+# exposes a dummy "_assertion" tenant via the registry. Mypy still
+# reads it; runtime callers use isinstance via the Protocol's
+# @runtime_checkable decorator.
+if TYPE_CHECKING:
+    _ASSERT: AccountStore[dict[str, Any]] = MultiTenantAccountStore(
+        tenants=frozenset({"_assertion"})
+    )
 
 
 __all__ = ["MultiTenantAccountStore"]

--- a/examples/multi_platform_seller/src/account_store.py
+++ b/examples/multi_platform_seller/src/account_store.py
@@ -1,0 +1,125 @@
+"""Multi-tenant account store — resolves wire account refs to accounts
+that carry ``metadata['tenant_id']`` for :class:`PlatformRouter` dispatch.
+
+Two resolution paths share the same store:
+
+1. **Subdomain-routed** (production-ish): the ASGI middleware
+   :class:`adcp.server.SubdomainTenantMiddleware` extracts the tenant
+   from the ``Host`` header and stashes it on the
+   :func:`adcp.server.current_tenant` contextvar. The store reads that
+   contextvar to stamp the tenant id onto the resolved account.
+2. **Explicit ref** (storyboard / dev): the wire request carries
+   ``account.account_id`` like ``tenant-a:acct_demo``. The store splits
+   on ``:`` and uses the prefix as the tenant id.
+
+In production adopters typically use one path or the other. The
+example accepts both so the storyboard runner (which sends explicit
+account refs) and a subdomain-aware buyer (which doesn't) both work
+against the same boot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from adcp.decisioning import AdcpError
+from adcp.decisioning.accounts import AccountStore
+from adcp.decisioning.context import AuthInfo
+from adcp.decisioning.types import Account
+from adcp.server import current_tenant
+
+
+class MultiTenantAccountStore:
+    """:class:`AccountStore` impl that wires tenant routing to
+    :class:`PlatformRouter`.
+
+    :param tenants: The set of recognized tenant ids. Resolution refuses
+        anything outside this set with ``ACCOUNT_NOT_FOUND``.
+    """
+
+    resolution: Literal["explicit"] = "explicit"
+
+    def __init__(self, *, tenants: frozenset[str]) -> None:
+        if not tenants:
+            raise ValueError("MultiTenantAccountStore requires non-empty tenants")
+        self._tenants = tenants
+
+    def resolve(
+        self,
+        ref: dict[str, Any] | None = None,
+        auth_info: AuthInfo | None = None,
+    ) -> Account[dict[str, Any]]:
+        """Resolve a wire ref + auth context to a tenant-scoped Account.
+
+        Resolution order:
+
+        1. Subdomain-set contextvar (set by
+           :class:`SubdomainTenantMiddleware`) — production path.
+        2. Account ref prefix ``tenant-a:acct_demo`` — storyboard/dev.
+        3. Reject with ``ACCOUNT_NOT_FOUND``.
+        """
+        tenant_id = self._tenant_from_subdomain() or self._tenant_from_ref(ref)
+        if tenant_id is None or tenant_id not in self._tenants:
+            raise AdcpError(
+                "ACCOUNT_NOT_FOUND",
+                message=(
+                    "Could not resolve a tenant for this request. Either "
+                    "send via the tenant subdomain (e.g. "
+                    "tenant-a.localhost) or pass account.account_id with "
+                    "a 'tenant-x:' prefix. Recognized tenants: "
+                    f"{sorted(self._tenants)}."
+                ),
+                recovery="terminal",
+                field="account",
+            )
+
+        account_id = (ref or {}).get("account_id") if isinstance(ref, dict) else None
+        if not account_id:
+            account_id = f"{tenant_id}:default"
+
+        return Account(
+            id=account_id,
+            metadata={"tenant_id": tenant_id},
+            auth_info=_auth_info_to_dict(auth_info),
+        )
+
+    # ----- internals --------------------------------------------------
+
+    def _tenant_from_subdomain(self) -> str | None:
+        tenant = current_tenant()
+        if tenant is None:
+            return None
+        return tenant.id
+
+    def _tenant_from_ref(self, ref: dict[str, Any] | None) -> str | None:
+        if not ref:
+            return None
+        account_id = ref.get("account_id") if isinstance(ref, dict) else None
+        if not account_id or not isinstance(account_id, str):
+            return None
+        if ":" not in account_id:
+            # Storyboard convention is ``tenant:rest``. Bare account ids
+            # without a prefix don't carry tenant information.
+            return None
+        prefix, _ = account_id.split(":", 1)
+        return prefix
+
+
+def _auth_info_to_dict(auth_info: AuthInfo | None) -> dict[str, Any] | None:
+    if auth_info is None:
+        return None
+    return {
+        "kind": auth_info.kind,
+        "key_id": auth_info.key_id,
+        "principal": auth_info.principal,
+        "scopes": list(auth_info.scopes),
+    }
+
+
+# Static-type assertion: the store satisfies the AccountStore Protocol.
+# Mypy reads this at type-check time; runtime uses isinstance via the
+# Protocol's @runtime_checkable decorator.
+_ASSERT: AccountStore[dict[str, Any]] = MultiTenantAccountStore(tenants=frozenset({"_assertion"}))
+
+
+__all__ = ["MultiTenantAccountStore"]

--- a/examples/multi_platform_seller/src/app.py
+++ b/examples/multi_platform_seller/src/app.py
@@ -1,0 +1,157 @@
+"""Boot a multi-platform seller — N tenants behind one process.
+
+Wires:
+
+* :class:`MockGuaranteedPlatform` for ``tenant-a`` (sales-guaranteed).
+* :class:`MockNonGuaranteedPlatform` for ``tenant-b`` (sales-non-guaranteed).
+* :class:`PlatformRouter` over both, with a union capabilities
+  declaration so ``tools/list`` advertises every method either platform
+  serves.
+* :class:`SubdomainTenantMiddleware` so requests to ``tenant-a.localhost``
+  vs ``tenant-b.localhost`` resolve to the right tenant via the
+  ``Host`` header.
+
+Run::
+
+    python -m examples.multi_platform_seller.src.app
+
+For local subdomain routing, add to ``/etc/hosts``::
+
+    127.0.0.1 tenant-a.localhost tenant-b.localhost
+
+Then connect any AdCP MCP buyer to::
+
+    http://tenant-a.localhost:3001/mcp
+    http://tenant-b.localhost:3001/mcp
+
+The storyboard runner sends explicit ``account.account_id`` like
+``tenant-a:storyboard-account``; both routing paths work against the
+same boot.
+"""
+
+from __future__ import annotations
+
+import os
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    PlatformRouter,
+    serve,
+)
+from adcp.decisioning.capabilities import Account as CapabilitiesAccount
+from adcp.decisioning.capabilities import (
+    Adcp,
+    IdempotencySupported,
+    MediaBuy,
+    SupportedProtocol,
+)
+from adcp.server import (
+    InMemorySubdomainTenantRouter,
+    SubdomainTenantMiddleware,
+    Tenant,
+)
+
+# Examples are not a package on PYTHONPATH; the ``-m`` invocation
+# requires this module to live under ``examples.multi_platform_seller.src``
+# which already gives the right qualified imports.
+from examples.multi_platform_seller.src.account_store import MultiTenantAccountStore
+from examples.multi_platform_seller.src.mock_guaranteed import MockGuaranteedPlatform
+from examples.multi_platform_seller.src.mock_non_guaranteed import (
+    MockNonGuaranteedPlatform,
+)
+
+PORT = int(os.environ.get("ADCP_PORT") or os.environ.get("PORT") or 3001)
+
+
+def build_router() -> PlatformRouter:
+    """Construct the :class:`PlatformRouter` over the two mock tenants."""
+    tenants = frozenset({"tenant-a", "tenant-b"})
+    accounts = MultiTenantAccountStore(tenants=tenants)
+
+    # Union capabilities: the router advertises every specialism either
+    # platform serves. Per-tool dispatch goes to whichever tenant the
+    # request resolves to; calls that the resolved tenant doesn't
+    # implement raise UNSUPPORTED_FEATURE.
+    capabilities = DecisioningCapabilities(
+        specialisms=["sales-guaranteed", "sales-non-guaranteed"],
+        adcp=Adcp(
+            major_versions=[3],
+            idempotency=IdempotencySupported(supported=True, replay_ttl_seconds=86400),
+        ),
+        account=CapabilitiesAccount(supported_billing=["operator"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+        supported_protocols=[SupportedProtocol.media_buy],
+    )
+
+    return PlatformRouter(
+        accounts=accounts,
+        platforms={
+            "tenant-a": MockGuaranteedPlatform(),
+            "tenant-b": MockNonGuaranteedPlatform(),
+        },
+        capabilities=capabilities,
+    )
+
+
+def build_subdomain_middleware() -> tuple[type, dict[str, object]]:
+    """Build the ``SubdomainTenantMiddleware`` registration tuple.
+
+    Returns ``(middleware_class, kwargs)`` matching the framework's
+    ``asgi_middleware=`` shape so ``serve()`` adds it to the Starlette
+    stack with the right router.
+    """
+    subdomain_router = InMemorySubdomainTenantRouter(
+        tenants={
+            f"tenant-a.localhost:{PORT}": Tenant(
+                id="tenant-a", display_name="Mock Guaranteed Tenant"
+            ),
+            f"tenant-b.localhost:{PORT}": Tenant(
+                id="tenant-b", display_name="Mock Non-Guaranteed Tenant"
+            ),
+            # The middleware strips the port suffix before lookup, so
+            # the entries above also match ``tenant-a.localhost`` /
+            # ``tenant-b.localhost`` without the explicit port. Adding
+            # the port-suffixed keys is belt-and-braces in case the
+            # normalization changes.
+            "tenant-a.localhost": Tenant(id="tenant-a", display_name="Mock Guaranteed Tenant"),
+            "tenant-b.localhost": Tenant(id="tenant-b", display_name="Mock Non-Guaranteed Tenant"),
+        }
+    )
+    return SubdomainTenantMiddleware, {"router": subdomain_router}
+
+
+def _allowed_hosts() -> list[str]:
+    """The TransportSecurityMiddleware host allowlist.
+
+    FastMCP's DNS-rebinding-protection default only accepts loopback
+    patterns; the tenant subdomains have to be added explicitly. Both
+    bare hosts and ``host:*`` (any-port) wildcards work; using
+    ``host:*`` keeps the example port-agnostic for adopters who change
+    ``ADCP_PORT``.
+    """
+    return [
+        "tenant-a.localhost",
+        "tenant-a.localhost:*",
+        "tenant-b.localhost",
+        "tenant-b.localhost:*",
+    ]
+
+
+if __name__ == "__main__":
+    router = build_router()
+    middleware_class, middleware_kwargs = build_subdomain_middleware()
+
+    serve(
+        router,
+        name="multi-platform-seller",
+        port=PORT,
+        auto_emit_completion_webhooks=False,
+        # ``serve()`` forwards extra kwargs to ``adcp.server.serve``;
+        # the underlying transport accepts a Starlette middleware list.
+        asgi_middleware=[(middleware_class, middleware_kwargs)],
+        # Extend FastMCP's host allowlist to include the tenant
+        # subdomains. Without this the transport returns 421 on every
+        # ``Host: tenant-x.localhost`` request before the subdomain
+        # router gets a chance to resolve.
+        allowed_hosts=_allowed_hosts(),
+    )

--- a/examples/multi_platform_seller/src/app.py
+++ b/examples/multi_platform_seller/src/app.py
@@ -100,19 +100,13 @@ def build_subdomain_middleware() -> tuple[type, dict[str, object]]:
     ``asgi_middleware=`` shape so ``serve()`` adds it to the Starlette
     stack with the right router.
     """
+    # The router's ``_normalize_host`` (see
+    # ``adcp.server.tenant_router._normalize_host``) lower-cases the
+    # host and strips any ``:port`` suffix at construction AND at
+    # lookup, so ``tenant-a.localhost:3001`` and ``tenant-a.localhost``
+    # resolve identically. Register the bare host once.
     subdomain_router = InMemorySubdomainTenantRouter(
         tenants={
-            f"tenant-a.localhost:{PORT}": Tenant(
-                id="tenant-a", display_name="Mock Guaranteed Tenant"
-            ),
-            f"tenant-b.localhost:{PORT}": Tenant(
-                id="tenant-b", display_name="Mock Non-Guaranteed Tenant"
-            ),
-            # The middleware strips the port suffix before lookup, so
-            # the entries above also match ``tenant-a.localhost`` /
-            # ``tenant-b.localhost`` without the explicit port. Adding
-            # the port-suffixed keys is belt-and-braces in case the
-            # normalization changes.
             "tenant-a.localhost": Tenant(id="tenant-a", display_name="Mock Guaranteed Tenant"),
             "tenant-b.localhost": Tenant(id="tenant-b", display_name="Mock Non-Guaranteed Tenant"),
         }

--- a/examples/multi_platform_seller/src/mock_guaranteed.py
+++ b/examples/multi_platform_seller/src/mock_guaranteed.py
@@ -166,7 +166,7 @@ class MockGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
         req: Any,
         ctx: RequestContext[Any],
     ) -> dict[str, Any]:
-        """Reserve capacity. Rejects ``INVENTORY_UNAVAILABLE`` when the
+        """Reserve capacity. Rejects ``PRODUCT_UNAVAILABLE`` when the
         requested impressions exceed remaining capacity for ANY of the
         requested products. Atomic per-call: either every package
         reserves or none does.

--- a/examples/multi_platform_seller/src/mock_guaranteed.py
+++ b/examples/multi_platform_seller/src/mock_guaranteed.py
@@ -1,0 +1,524 @@
+"""In-process mock guaranteed-inventory platform.
+
+Models the canonical ``sales-guaranteed`` shape: pre-bookable
+inventory, fixed CPM, capacity-bounded, exposes the four-state
+lifecycle ``pending_creatives → pending_start → active → completed``.
+
+Pure Python — no upstream HTTP, no external deps. The point is to
+demonstrate how an adopter writes a :class:`DecisioningPlatform`
+subclass that satisfies the ``sales-guaranteed`` Protocol; the
+business logic is intentionally minimal so the platform-shape and
+router-integration story stay legible.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from adcp.decisioning import (
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    RequestContext,
+    SalesPlatform,
+    assert_media_buy_transition,
+)
+from adcp.decisioning.capabilities import Account as CapabilitiesAccount
+from adcp.decisioning.capabilities import (
+    Adcp,
+    IdempotencySupported,
+    MediaBuy,
+    SupportedProtocol,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory inventory + buy state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Product:
+    """One sellable inventory product."""
+
+    product_id: str
+    name: str
+    description: str
+    cpm_usd: float
+    capacity_impressions: int
+
+
+@dataclass
+class _MediaBuy:
+    """One pre-booked media buy reserving capacity from a product."""
+
+    media_buy_id: str
+    buyer_ref: str
+    product_id: str
+    impressions_reserved: int
+    total_budget_usd: float
+    start_time: datetime
+    end_time: datetime
+    status: str = "pending_creatives"
+    creatives_attached: int = 0
+
+
+# Catalog defaults — the full storyboard runs against these. Adopters
+# in production load from their own datastore; here a frozen list is
+# more legible than a CMS round trip.
+_DEFAULT_CATALOG: list[_Product] = [
+    _Product(
+        product_id="guaranteed-homepage-takeover",
+        name="Guaranteed Homepage Takeover",
+        description="Premium 970x250 above-the-fold inventory, fixed CPM.",
+        cpm_usd=25.00,
+        capacity_impressions=10_000_000,
+    ),
+    _Product(
+        product_id="guaranteed-mobile-interstitial",
+        name="Guaranteed Mobile Interstitial",
+        description="Full-screen interstitial on owned mobile properties.",
+        cpm_usd=18.00,
+        capacity_impressions=5_000_000,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# The platform
+# ---------------------------------------------------------------------------
+
+
+class MockGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
+    """In-process ``sales-guaranteed`` platform.
+
+    Each call resolves through ``ctx.account`` like any
+    :class:`DecisioningPlatform` — the multi-tenant routing is the
+    router's concern; this platform just serves the requests it
+    receives. The ``accounts`` attribute is set by the example's
+    ``app.py`` boot to a no-op store; the framework's
+    :func:`validate_platform` requires every platform to carry one,
+    even when (as in router-fronted deployments) the router's store
+    is the active resolver.
+
+    :attr:`upstream_url` is ``None`` — no real upstream. Adapter HTTP
+    routing flows through :meth:`upstream_for` for live/sandbox, but
+    here every storyboard step is satisfied in-process.
+    """
+
+    upstream_url = None
+
+    capabilities = DecisioningCapabilities(
+        specialisms=["sales-guaranteed"],
+        adcp=Adcp(
+            major_versions=[3],
+            idempotency=IdempotencySupported(supported=True, replay_ttl_seconds=86400),
+        ),
+        account=CapabilitiesAccount(supported_billing=["operator"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+        supported_protocols=[SupportedProtocol.media_buy],
+    )
+
+    def __init__(
+        self,
+        *,
+        catalog: list[_Product] | None = None,
+    ) -> None:
+        self._lock = threading.Lock()
+        # The catalog is per-instance: tenants get their own product
+        # list, capacity, and reservations. Multi-tenant adopters scale
+        # this by giving each tenant its own MockGuaranteedPlatform
+        # instance — exactly the router-fronted topology.
+        self._catalog: dict[str, _Product] = {
+            p.product_id: p for p in (catalog or list(_DEFAULT_CATALOG))
+        }
+        self._capacity: dict[str, int] = {
+            p.product_id: p.capacity_impressions for p in self._catalog.values()
+        }
+        self._buys: dict[str, _MediaBuy] = {}
+
+    # The router's AccountStore is what runtime dispatch threads
+    # ctx.account through; this attribute exists only to satisfy
+    # validate_platform's "accounts must be set" gate. The router never
+    # consults it.
+    accounts: Any = None  # type: ignore[assignment]
+
+    # ----- sales-guaranteed required methods --------------------------
+
+    def get_products(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Sync catalog read. Returns the full product list."""
+        return {
+            "products": [
+                _project_product_to_wire(p, self._capacity[p.product_id])
+                for p in self._catalog.values()
+            ]
+        }
+
+    def create_media_buy(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Reserve capacity. Rejects ``INVENTORY_UNAVAILABLE`` when the
+        requested impressions exceed remaining capacity for ANY of the
+        requested products. Atomic per-call: either every package
+        reserves or none does.
+        """
+        # Wire shape: req.packages = [{buyer_ref, products, budget, ...}]
+        packages = _read_packages(req)
+        if not packages:
+            raise AdcpError(
+                "INVALID_REQUEST",
+                message="create_media_buy requires at least one package.",
+                recovery="correctable",
+                field="packages",
+            )
+
+        with self._lock:
+            # Pre-flight every package's capacity ask before mutating
+            # state. Two-phase reserve avoids partial writes when the
+            # last package in the list trips capacity.
+            reservations: list[tuple[str, int, float]] = []
+            for pkg in packages:
+                product_id, impressions, budget = _resolve_package_capacity(pkg, self._catalog)
+                remaining = self._capacity.get(product_id, 0)
+                if impressions > remaining:
+                    raise AdcpError(
+                        "PRODUCT_UNAVAILABLE",
+                        message=(
+                            f"product {product_id!r} has {remaining} "
+                            f"impressions remaining; package requested "
+                            f"{impressions}."
+                        ),
+                        recovery="correctable",
+                        field="packages",
+                        details={
+                            "product_id": product_id,
+                            "remaining": remaining,
+                            "requested": impressions,
+                        },
+                    )
+                reservations.append((product_id, impressions, budget))
+
+            # Commit phase — capacity already validated.
+            media_buy_id = f"mb_g_{uuid.uuid4().hex[:12]}"
+            total_impressions = 0
+            total_budget = 0.0
+            for product_id, impressions, budget in reservations:
+                self._capacity[product_id] -= impressions
+                total_impressions += impressions
+                total_budget += budget
+
+            buyer_ref = _read_buyer_ref(req)
+            start_time, end_time = _read_window(req)
+            self._buys[media_buy_id] = _MediaBuy(
+                media_buy_id=media_buy_id,
+                buyer_ref=buyer_ref,
+                product_id=reservations[0][0],
+                impressions_reserved=total_impressions,
+                total_budget_usd=total_budget,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+        return {
+            "media_buy_id": media_buy_id,
+            "buyer_ref": buyer_ref,
+            "status": "pending_creatives",
+            "packages": [
+                {
+                    "package_id": f"pkg_{i}",
+                    "buyer_ref": _read_pkg_buyer_ref(pkg, i),
+                    "status": "pending_creatives",
+                }
+                for i, pkg in enumerate(packages)
+            ],
+        }
+
+    def update_media_buy(
+        self,
+        media_buy_id: str,
+        patch: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Drive the lifecycle: pause / resume / cancel. The state
+        machine helper enforces legal transitions and raises
+        ``INVALID_STATE`` otherwise."""
+        with self._lock:
+            buy = self._buys.get(media_buy_id)
+            if buy is None:
+                raise AdcpError(
+                    "MEDIA_BUY_NOT_FOUND",
+                    message=f"unknown media_buy_id={media_buy_id!r}",
+                    recovery="terminal",
+                    field="media_buy_id",
+                )
+
+            new_state = _read_target_state(patch)
+            if new_state is not None:
+                assert_media_buy_transition(buy.status, new_state, media_buy_id=media_buy_id)
+                buy.status = new_state
+
+        return {
+            "media_buy_id": media_buy_id,
+            "buyer_ref": buy.buyer_ref,
+            "status": buy.status,
+            "packages": [],
+        }
+
+    def sync_creatives(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Auto-approve every submitted creative and advance the buy
+        from ``pending_creatives → pending_start`` once any creatives
+        are attached. Real adopters route to standards-and-practices
+        review; the mock skips that to keep the storyboard straight-
+        through.
+        """
+        creatives = _read_creatives(req)
+        media_buy_id = _read_media_buy_id(req)
+
+        with self._lock:
+            buy = self._buys.get(media_buy_id) if media_buy_id else None
+            if buy is not None and creatives:
+                buy.creatives_attached += len(creatives)
+                if buy.status == "pending_creatives":
+                    assert_media_buy_transition(
+                        buy.status, "pending_start", media_buy_id=media_buy_id
+                    )
+                    buy.status = "pending_start"
+
+        return {
+            "creatives": [
+                {
+                    "creative_id": _creative_id(c, i),
+                    "approval_status": "approved",
+                }
+                for i, c in enumerate(creatives)
+            ],
+        }
+
+    def get_media_buy_delivery(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Synthesize delivery proportional to elapsed flight time.
+
+        Real adopters read from their reporting pipeline; the mock
+        scales delivery linearly between ``start_time`` and
+        ``end_time`` so storyboard assertions on a non-zero delivery
+        response have something to bite on.
+        """
+        media_buy_id = _read_media_buy_id(req)
+        with self._lock:
+            buy = self._buys.get(media_buy_id) if media_buy_id else None
+
+        if buy is None:
+            return {"media_buy_deliveries": []}
+
+        now = datetime.now(timezone.utc)
+        if buy.status not in ("active", "paused", "completed"):
+            served = 0
+            spend = 0.0
+        else:
+            elapsed = (now - buy.start_time).total_seconds()
+            window = max(1.0, (buy.end_time - buy.start_time).total_seconds())
+            ratio = max(0.0, min(1.0, elapsed / window))
+            served = int(buy.impressions_reserved * ratio)
+            spend = buy.total_budget_usd * ratio
+
+        return {
+            "media_buy_deliveries": [
+                {
+                    "media_buy_id": media_buy_id,
+                    "totals": {
+                        "impressions": served,
+                        "spend": round(spend, 2),
+                    },
+                },
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Wire-shape projections (pure helpers)
+# ---------------------------------------------------------------------------
+
+
+def _project_product_to_wire(
+    product: _Product,
+    remaining_impressions: int,
+) -> dict[str, Any]:
+    """Project a :class:`_Product` to the AdCP product wire shape."""
+    return {
+        "product_id": product.product_id,
+        "name": product.name,
+        "description": product.description,
+        "delivery_type": "guaranteed",
+        "publisher_properties": [
+            {"publisher_domain": "example.com", "selection_type": "all"},
+        ],
+        "format_ids": [
+            {
+                "agent_url": "https://creative.adcontextprotocol.org/",
+                "id": "display_300x250",
+            },
+        ],
+        "pricing_options": [
+            {
+                "pricing_option_id": "po-cpm-fixed",
+                "pricing_model": "cpm",
+                "fixed_price": product.cpm_usd,
+                "currency": "USD",
+            },
+        ],
+        "reporting_capabilities": {
+            "available_metrics": ["impressions", "spend"],
+            "available_reporting_frequencies": ["daily"],
+            "date_range_support": "date_range",
+            "supports_webhooks": False,
+            "expected_delay_minutes": 60,
+            "timezone": "UTC",
+        },
+        "delivery_measurement": {"provider": "internal"},
+        "available_inventory_impressions": remaining_impressions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wire-shape readers — accept either typed Pydantic or dict-shaped input
+# ---------------------------------------------------------------------------
+
+
+def _attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Read ``name`` from a Pydantic model OR a dict, with default."""
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _read_packages(req: Any) -> list[Any]:
+    raw = _attr(req, "packages", [])
+    return list(raw) if raw else []
+
+
+def _read_buyer_ref(req: Any) -> str:
+    return str(_attr(req, "buyer_ref", "buyer_unknown"))
+
+
+def _read_window(req: Any) -> tuple[datetime, datetime]:
+    start = _attr(req, "start_time")
+    end = _attr(req, "end_time")
+    if isinstance(start, str):
+        start = _parse_iso(start)
+    if isinstance(end, str):
+        end = _parse_iso(end)
+    if not isinstance(start, datetime):
+        start = datetime.now(timezone.utc)
+    if not isinstance(end, datetime):
+        end = start
+    return start, end
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse a wire-shape ISO-8601 timestamp.
+
+    Accepts both ``Z`` and explicit offset suffixes; falls back to the
+    current time on parse failure (the buyer-side validator catches
+    truly malformed timestamps before they reach the platform).
+    """
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return datetime.now(timezone.utc)
+
+
+def _read_pkg_buyer_ref(pkg: Any, idx: int) -> str:
+    return str(_attr(pkg, "buyer_ref", f"pkg-{idx}"))
+
+
+def _resolve_package_capacity(
+    pkg: Any,
+    catalog: dict[str, _Product],
+) -> tuple[str, int, float]:
+    """Resolve a package to ``(product_id, impressions, budget_usd)``."""
+    products = _attr(pkg, "products", []) or []
+    if not products:
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message="package.products is empty",
+            recovery="correctable",
+            field="packages[].products",
+        )
+    product_id = str(products[0])
+    if product_id not in catalog:
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message=f"unknown product {product_id!r}",
+            recovery="correctable",
+            field="packages[].products",
+        )
+
+    budget = _attr(pkg, "budget", {}) or {}
+    total_budget = float(_attr(budget, "total", 0.0) or 0.0)
+    cpm = catalog[product_id].cpm_usd
+    if cpm <= 0:
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=f"product {product_id!r} has non-positive CPM",
+            recovery="terminal",
+        )
+    # Impressions = (budget / CPM) * 1000.
+    impressions = int(total_budget / cpm * 1000)
+    return product_id, impressions, total_budget
+
+
+def _read_target_state(patch: Any) -> str | None:
+    """Project an ``UpdateMediaBuyRequest`` onto a target lifecycle state."""
+    if patch is None:
+        return None
+    active = _attr(patch, "active", None)
+    if active is True:
+        return "active"
+    if active is False:
+        return "paused"
+    status = _attr(patch, "status", None)
+    if isinstance(status, str):
+        return status
+    return None
+
+
+def _read_creatives(req: Any) -> list[Any]:
+    raw = _attr(req, "creatives", []) or []
+    return list(raw)
+
+
+def _read_media_buy_id(req: Any) -> str | None:
+    raw = _attr(req, "media_buy_id", None)
+    if raw is not None:
+        return str(raw)
+    # Some shapes nest under ``media_buy_ids[0]`` for batch reads.
+    ids = _attr(req, "media_buy_ids", None)
+    if isinstance(ids, list) and ids:
+        return str(ids[0])
+    return None
+
+
+def _creative_id(creative: Any, idx: int) -> str:
+    raw = _attr(creative, "creative_id", None)
+    if raw:
+        return str(raw)
+    return f"cr_{idx}"
+
+
+__all__ = ["MockGuaranteedPlatform"]

--- a/examples/multi_platform_seller/src/mock_non_guaranteed.py
+++ b/examples/multi_platform_seller/src/mock_non_guaranteed.py
@@ -1,0 +1,413 @@
+"""In-process mock non-guaranteed (programmatic remnant) platform.
+
+Models the canonical ``sales-non-guaranteed`` shape: every
+``create_media_buy`` succeeds, delivery scales with budget, status
+starts ``active``. No capacity reservation — the auction-time
+allocation runs at delivery, not at booking. Variable CPM with a
+floor.
+
+Pure Python — no upstream HTTP. Sibling to
+:class:`MockGuaranteedPlatform`; the contrast between the two
+illustrates why a multi-tenant seller needs a router (different
+business model per tenant) rather than a single ``DecisioningPlatform``
+that branches internally.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from adcp.decisioning import (
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    RequestContext,
+    SalesPlatform,
+    assert_media_buy_transition,
+)
+from adcp.decisioning.capabilities import Account as CapabilitiesAccount
+from adcp.decisioning.capabilities import (
+    Adcp,
+    IdempotencySupported,
+    MediaBuy,
+    SupportedProtocol,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Product:
+    """One programmatic-remnant inventory product."""
+
+    product_id: str
+    name: str
+    description: str
+    floor_cpm_usd: float
+
+
+@dataclass
+class _MediaBuy:
+    media_buy_id: str
+    buyer_ref: str
+    total_budget_usd: float
+    start_time: datetime
+    end_time: datetime
+    status: str = "active"
+    creatives_attached: int = 0
+
+
+_DEFAULT_CATALOG: list[_Product] = [
+    _Product(
+        product_id="remnant-display-network",
+        name="Programmatic Display Network",
+        description="Run-of-network 300x250 with auction-time pricing.",
+        floor_cpm_usd=2.00,
+    ),
+    _Product(
+        product_id="remnant-video-rotation",
+        name="Programmatic Video Rotation",
+        description="Pre-roll 15s/30s with floor-based clearing.",
+        floor_cpm_usd=8.00,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# The platform
+# ---------------------------------------------------------------------------
+
+
+class MockNonGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
+    """In-process ``sales-non-guaranteed`` platform.
+
+    Always accepts ``create_media_buy``; the auction at serving time
+    decides which impressions clear at the variable CPM. Delivery
+    scales with budget instead of fixed reservations.
+
+    :attr:`upstream_url` is ``None`` — the mock runs entirely in
+    process.
+    """
+
+    upstream_url = None
+
+    capabilities = DecisioningCapabilities(
+        specialisms=["sales-non-guaranteed"],
+        adcp=Adcp(
+            major_versions=[3],
+            idempotency=IdempotencySupported(supported=True, replay_ttl_seconds=86400),
+        ),
+        account=CapabilitiesAccount(supported_billing=["operator"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+        supported_protocols=[SupportedProtocol.media_buy],
+    )
+
+    def __init__(
+        self,
+        *,
+        catalog: list[_Product] | None = None,
+        clearing_multiplier: float = 1.4,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._catalog: dict[str, _Product] = {
+            p.product_id: p for p in (catalog or list(_DEFAULT_CATALOG))
+        }
+        # Multiplier on the floor CPM to simulate clearing prices in
+        # the synthetic delivery projection. Real adopters read from
+        # their auction logs; the mock uses a fixed multiplier so the
+        # storyboard's delivery assertions stay deterministic.
+        self._clearing_multiplier = clearing_multiplier
+        self._buys: dict[str, _MediaBuy] = {}
+
+    accounts: Any = None  # type: ignore[assignment]
+
+    # ----- sales-non-guaranteed required methods ----------------------
+
+    def get_products(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        return {"products": [_project_product_to_wire(p) for p in self._catalog.values()]}
+
+    def create_media_buy(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Always succeed. No capacity reservation; auction at serving
+        time decides clearing. The buy goes straight to ``active``."""
+        packages = _read_packages(req)
+        if not packages:
+            raise AdcpError(
+                "INVALID_REQUEST",
+                message="create_media_buy requires at least one package.",
+                recovery="correctable",
+                field="packages",
+            )
+
+        # Validate referenced products exist before issuing the buy.
+        # PRODUCT_NOT_FOUND is the spec error code for this case.
+        total_budget = 0.0
+        for pkg in packages:
+            products = _attr(pkg, "products", []) or []
+            for product_id in products:
+                if str(product_id) not in self._catalog:
+                    raise AdcpError(
+                        "PRODUCT_NOT_FOUND",
+                        message=f"unknown product {product_id!r}",
+                        recovery="correctable",
+                        field="packages[].products",
+                    )
+            budget = _attr(pkg, "budget", {}) or {}
+            total_budget += float(_attr(budget, "total", 0.0) or 0.0)
+
+        media_buy_id = f"mb_n_{uuid.uuid4().hex[:12]}"
+        buyer_ref = _read_buyer_ref(req)
+        start_time, end_time = _read_window(req)
+
+        with self._lock:
+            self._buys[media_buy_id] = _MediaBuy(
+                media_buy_id=media_buy_id,
+                buyer_ref=buyer_ref,
+                total_budget_usd=total_budget,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+        return {
+            "media_buy_id": media_buy_id,
+            "buyer_ref": buyer_ref,
+            "status": "active",
+            "packages": [
+                {
+                    "package_id": f"pkg_{i}",
+                    "buyer_ref": _read_pkg_buyer_ref(pkg, i),
+                    "status": "active",
+                }
+                for i, pkg in enumerate(packages)
+            ],
+        }
+
+    def update_media_buy(
+        self,
+        media_buy_id: str,
+        patch: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        with self._lock:
+            buy = self._buys.get(media_buy_id)
+            if buy is None:
+                raise AdcpError(
+                    "MEDIA_BUY_NOT_FOUND",
+                    message=f"unknown media_buy_id={media_buy_id!r}",
+                    recovery="terminal",
+                    field="media_buy_id",
+                )
+
+            new_state = _read_target_state(patch)
+            if new_state is not None:
+                assert_media_buy_transition(buy.status, new_state, media_buy_id=media_buy_id)
+                buy.status = new_state
+
+        return {
+            "media_buy_id": media_buy_id,
+            "buyer_ref": buy.buyer_ref,
+            "status": buy.status,
+            "packages": [],
+        }
+
+    def sync_creatives(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Auto-approve. Programmatic remnant doesn't gate on creative
+        review — the SSP-side standards-and-practices is upstream."""
+        creatives = _read_creatives(req)
+        media_buy_id = _read_media_buy_id(req)
+        with self._lock:
+            buy = self._buys.get(media_buy_id) if media_buy_id else None
+            if buy is not None and creatives:
+                buy.creatives_attached += len(creatives)
+
+        return {
+            "creatives": [
+                {
+                    "creative_id": _creative_id(c, i),
+                    "approval_status": "approved",
+                }
+                for i, c in enumerate(creatives)
+            ],
+        }
+
+    def get_media_buy_delivery(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Synthesize delivery scaling with elapsed flight time and
+        budget. Variable CPM is modeled as floor × clearing-multiplier
+        — high enough to deliver under budget, low enough to spend.
+        """
+        media_buy_id = _read_media_buy_id(req)
+        with self._lock:
+            buy = self._buys.get(media_buy_id) if media_buy_id else None
+
+        if buy is None:
+            return {"media_buy_deliveries": []}
+
+        now = datetime.now(timezone.utc)
+        if buy.status not in ("active", "paused", "completed"):
+            served = 0
+            spend = 0.0
+        else:
+            elapsed = (now - buy.start_time).total_seconds()
+            window = max(1.0, (buy.end_time - buy.start_time).total_seconds())
+            ratio = max(0.0, min(1.0, elapsed / window))
+            spend = buy.total_budget_usd * ratio
+            # Average clearing CPM across the catalog floor — adopters
+            # in production read per-package clearing from their
+            # auction store.
+            avg_floor = sum(p.floor_cpm_usd for p in self._catalog.values()) / max(
+                1, len(self._catalog)
+            )
+            avg_clearing = avg_floor * self._clearing_multiplier
+            served = int((spend / max(avg_clearing, 0.01)) * 1000)
+
+        return {
+            "media_buy_deliveries": [
+                {
+                    "media_buy_id": media_buy_id,
+                    "totals": {
+                        "impressions": served,
+                        "spend": round(spend, 2),
+                    },
+                },
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Wire projection helpers (kept local — duplicated minimally for clarity)
+# ---------------------------------------------------------------------------
+
+
+def _project_product_to_wire(product: _Product) -> dict[str, Any]:
+    return {
+        "product_id": product.product_id,
+        "name": product.name,
+        "description": product.description,
+        "delivery_type": "non_guaranteed",
+        "publisher_properties": [
+            {"publisher_domain": "example.com", "selection_type": "all"},
+        ],
+        "format_ids": [
+            {
+                "agent_url": "https://creative.adcontextprotocol.org/",
+                "id": "display_300x250",
+            },
+        ],
+        "pricing_options": [
+            {
+                "pricing_option_id": "po-cpm-floor",
+                "pricing_model": "cpm",
+                "floor_price": product.floor_cpm_usd,
+                "currency": "USD",
+            },
+        ],
+        "reporting_capabilities": {
+            "available_metrics": ["impressions", "spend"],
+            "available_reporting_frequencies": ["daily"],
+            "date_range_support": "date_range",
+            "supports_webhooks": False,
+            "expected_delay_minutes": 60,
+            "timezone": "UTC",
+        },
+        "delivery_measurement": {"provider": "internal"},
+    }
+
+
+def _attr(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _read_packages(req: Any) -> list[Any]:
+    raw = _attr(req, "packages", [])
+    return list(raw) if raw else []
+
+
+def _read_buyer_ref(req: Any) -> str:
+    return str(_attr(req, "buyer_ref", "buyer_unknown"))
+
+
+def _read_window(req: Any) -> tuple[datetime, datetime]:
+    start = _attr(req, "start_time")
+    end = _attr(req, "end_time")
+    if isinstance(start, str):
+        start = _parse_iso(start)
+    if isinstance(end, str):
+        end = _parse_iso(end)
+    if not isinstance(start, datetime):
+        start = datetime.now(timezone.utc)
+    if not isinstance(end, datetime):
+        end = start
+    return start, end
+
+
+def _parse_iso(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return datetime.now(timezone.utc)
+
+
+def _read_pkg_buyer_ref(pkg: Any, idx: int) -> str:
+    return str(_attr(pkg, "buyer_ref", f"pkg-{idx}"))
+
+
+def _read_target_state(patch: Any) -> str | None:
+    if patch is None:
+        return None
+    active = _attr(patch, "active", None)
+    if active is True:
+        return "active"
+    if active is False:
+        return "paused"
+    status = _attr(patch, "status", None)
+    if isinstance(status, str):
+        return status
+    return None
+
+
+def _read_creatives(req: Any) -> list[Any]:
+    raw = _attr(req, "creatives", []) or []
+    return list(raw)
+
+
+def _read_media_buy_id(req: Any) -> str | None:
+    raw = _attr(req, "media_buy_id", None)
+    if raw is not None:
+        return str(raw)
+    ids = _attr(req, "media_buy_ids", None)
+    if isinstance(ids, list) and ids:
+        return str(ids[0])
+    return None
+
+
+def _creative_id(creative: Any, idx: int) -> str:
+    raw = _attr(creative, "creative_id", None)
+    if raw:
+        return str(raw)
+    return f"cr_{idx}"
+
+
+__all__ = ["MockNonGuaranteedPlatform"]

--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -112,6 +112,7 @@ from adcp.decisioning.platform import (
     DecisioningCapabilities,
     DecisioningPlatform,
 )
+from adcp.decisioning.platform_router import PlatformRouter
 from adcp.decisioning.registry import (
     ApiKeyCredential,
     BillingMode,
@@ -292,6 +293,7 @@ __all__ = [
     "OAuthCredential",
     "PermissionDeniedError",
     "PgTaskRegistry",
+    "PlatformRouter",
     "PostgresTaskRegistry",
     "Proposal",
     "PropertyList",

--- a/src/adcp/decisioning/platform_router.py
+++ b/src/adcp/decisioning/platform_router.py
@@ -1,0 +1,446 @@
+"""Tenant-keyed multi-platform dispatcher.
+
+:class:`PlatformRouter` lets a single ``serve()`` process host N
+``DecisioningPlatform`` instances behind one server. Each request
+resolves to a tenant via the router's :class:`AccountStore`, and the
+router dispatches every per-specialism call to the tenant's platform.
+
+This is the migration target for adopters with a salesagent-shaped
+``ADAPTER_REGISTRY: dict[str, Type[AdServerAdapter]]`` pattern: rather
+than instantiating an adapter per request from a registry, the adopter
+preloads one :class:`DecisioningPlatform` per tenant (or per backend)
+into the router and lets the framework pick the right one per request.
+
+Drop-in shape
+-------------
+
+:class:`PlatformRouter` *is* a :class:`DecisioningPlatform` —
+``isinstance(router, DecisioningPlatform)`` is true. It carries
+``capabilities``, ``accounts``, and one concrete method per
+specialism. Adopters pass it to :func:`adcp.decisioning.serve` exactly
+where they would pass a single platform.
+
+::
+
+    from adcp.decisioning import PlatformRouter, DecisioningCapabilities, serve
+
+    router = PlatformRouter(
+        accounts=tenant_routing_account_store,
+        platforms={
+            "tenant-a": MockGuaranteedPlatform(),
+            "tenant-b": MockNonGuaranteedPlatform(),
+        },
+        capabilities=DecisioningCapabilities(
+            specialisms=["sales-guaranteed", "sales-non-guaranteed"],
+            ...,
+        ),
+    )
+
+    serve(router, ...)
+
+Tenant resolution
+-----------------
+
+The router looks at ``ctx.account.metadata['tenant_id']`` to pick a
+platform. The adopter's :class:`AccountStore` is responsible for
+populating this — typically it reads the request's
+:func:`adcp.server.tenant_router.current_tenant` (set by
+:class:`SubdomainTenantMiddleware`) or maps the wire ``account_ref``
+to a tenant via its own table.
+
+If the resolved tenant has no registered platform the router raises
+``ACCOUNT_NOT_FOUND`` (terminal). The reasoning: from the buyer's
+perspective the account doesn't exist on this server — the multi-tenant
+fan-out is invisible to them, and surfacing tenant-existence as a
+distinct error code would leak deployment topology.
+
+Capabilities
+------------
+
+The router's :attr:`capabilities` is supplied by the adopter and
+should be the **union** of every child platform's specialisms. Two
+reasons for union (not intersection):
+
+1. ``tools/list`` (the ``advertised_tools_for_instance`` filter) reads
+   the router's specialisms and advertises every tool any child
+   platform serves. Buyers see the full menu and the router routes
+   per-call to the platform that supports each tool.
+2. Buyers calling a tool the resolved tenant's platform doesn't
+   implement get a structured ``UNSUPPORTED_FEATURE`` error per spec —
+   not a 404. Intersection-based capabilities would silently hide the
+   tool from sellers that DO support it on other tenants, breaking
+   the ``one URL → many tenants`` model.
+
+Protocol introspection
+----------------------
+
+At construction time the router walks the specialism Protocol classes
+(``SalesPlatform``, ``AudiencePlatform``, ``SignalsPlatform``, etc.)
+declared in :mod:`adcp.decisioning.specialisms` and synthesizes a
+delegating method for each method any child platform implements. New
+specialism Protocols added to the SDK are picked up automatically — no
+adopter code change required to extend the router's surface.
+
+Out of scope
+------------
+
+* **Cross-tenant inventory aggregation.** Each tenant is an island.
+* **Per-tenant ``upstream_url``.** The :meth:`upstream_for` helper on
+  each child platform handles that; the router doesn't proxy upstream
+  HTTP itself.
+* **Tenant fan-out (one request → many tenants).** Each request resolves
+  to exactly one tenant via the AccountStore.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from adcp.decisioning.platform import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+)
+from adcp.decisioning.specialisms import (
+    AudiencePlatform,
+    BrandRightsPlatform,
+    CampaignGovernancePlatform,
+    CollectionListsPlatform,
+    ContentStandardsPlatform,
+    CreativeAdServerPlatform,
+    CreativeBuilderPlatform,
+    PropertyListsPlatform,
+    SalesPlatform,
+    SignalsPlatform,
+)
+from adcp.decisioning.types import AdcpError
+
+if TYPE_CHECKING:
+    from adcp.decisioning.accounts import AccountStore
+    from adcp.decisioning.context import RequestContext
+
+
+# Every specialism Protocol the framework knows about. New Protocol
+# classes added to ``adcp.decisioning.specialisms`` get picked up by
+# adding them here. Walking ``__protocol_attrs__`` (set by the runtime
+# ``@runtime_checkable`` machinery) yields each method name the
+# Protocol declares. The router's synthesized delegation covers the
+# union of those names across every Protocol — adopter doesn't have
+# to enumerate them.
+_KNOWN_SPECIALISM_PROTOCOLS: tuple[type, ...] = (
+    SalesPlatform,
+    SignalsPlatform,
+    AudiencePlatform,
+    CreativeBuilderPlatform,
+    CreativeAdServerPlatform,
+    CampaignGovernancePlatform,
+    BrandRightsPlatform,
+    ContentStandardsPlatform,
+    PropertyListsPlatform,
+    CollectionListsPlatform,
+)
+
+# AccountStore methods the router forwards to its underlying store.
+# These are framework-internal — the router does NOT delegate them
+# per-tenant (the AccountStore IS the tenant resolver, so threading
+# resolution through itself would loop).
+_ACCOUNT_STORE_METHODS: frozenset[str] = frozenset({"resolve", "upsert", "list", "sync_governance"})
+
+
+def _protocol_method_names(proto: type) -> frozenset[str]:
+    """Return the public method names a runtime-checkable Protocol declares.
+
+    Walks the Protocol class body (NOT the MRO) and collects every
+    callable whose name doesn't start with ``_``. Each Protocol class
+    in :mod:`adcp.decisioning.specialisms` defines its methods directly
+    — there's no Protocol inheritance to chase, so a single ``vars()``
+    pass gets every declared method.
+
+    Annotation-only attributes (``foo: int``) are NOT picked up because
+    no Protocol in :mod:`adcp.decisioning.specialisms` declares
+    attribute-only members; if that changes, broaden the walk to
+    ``__annotations__`` too.
+    """
+    declared: set[str] = set()
+    for name, value in vars(proto).items():
+        if name.startswith("_"):
+            continue
+        if callable(value):
+            declared.add(name)
+    return frozenset(declared)
+
+
+def _all_specialism_methods() -> frozenset[str]:
+    """Union of declared method names across every known specialism Protocol."""
+    union: set[str] = set()
+    for proto in _KNOWN_SPECIALISM_PROTOCOLS:
+        union |= _protocol_method_names(proto)
+    return frozenset(union)
+
+
+def _resolve_ctx_from_args(
+    args: tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+) -> RequestContext[Any]:
+    """Pull the ``RequestContext`` out of a synthesized delegation's arguments.
+
+    The dispatcher (:func:`adcp.decisioning.dispatch._invoke_platform_method`)
+    invokes platform methods two ways:
+
+    * positional: ``method(params, ctx)`` — ctx is the second positional
+    * arg_projector: ``method(**arg_projector, ctx=ctx)`` — ctx is a kwarg
+
+    Both shapes need to surface the ``RequestContext`` so the router
+    can extract the tenant id. We probe the kwargs first (``ctx=...``)
+    and fall back to the last positional argument otherwise.
+
+    :raises AdcpError: ``INTERNAL_ERROR`` when neither shape carries a
+        ``RequestContext`` — this means the dispatcher's contract has
+        drifted and the router can't function. Adopter code never hits
+        this path.
+    """
+    # Late-import to keep the module-load circle-free.
+    from adcp.decisioning.context import RequestContext
+
+    ctx: Any = kwargs.get("ctx")
+    if ctx is None and args:
+        # Last positional is conventionally the ctx (every Protocol method
+        # signature in adcp.decisioning.specialisms ends with ``ctx``).
+        candidate = args[-1]
+        if isinstance(candidate, RequestContext):
+            ctx = candidate
+
+    if not isinstance(ctx, RequestContext):
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=(
+                "PlatformRouter delegation could not find a RequestContext "
+                "in the call arguments. The dispatcher contract requires "
+                "every platform method to receive ctx as the trailing "
+                "positional or as ``ctx=`` kwarg."
+            ),
+            recovery="terminal",
+        )
+    return ctx
+
+
+def _tenant_id_from_ctx(ctx: RequestContext[Any]) -> str:
+    """Extract the tenant id from the resolved account.
+
+    The convention: the AccountStore wired into the router populates
+    ``account.metadata['tenant_id']`` per request. This is the same
+    metadata-key precedent set by Phase 2's ``mock_upstream_url``
+    (see :mod:`adcp.decisioning.account_mode`).
+
+    :raises AdcpError: ``ACCOUNT_NOT_FOUND`` when the resolved account
+        carries no tenant id. The buyer sees the same error as a
+        nonexistent account — multi-tenant topology stays opaque to
+        the wire.
+    """
+    metadata = getattr(ctx.account, "metadata", None) or {}
+    tenant_id: Any = None
+    if isinstance(metadata, Mapping):
+        tenant_id = metadata.get("tenant_id")
+    else:
+        # Adopter passed a typed-dataclass metadata; try attribute access.
+        tenant_id = getattr(metadata, "tenant_id", None)
+
+    if not tenant_id or not isinstance(tenant_id, str):
+        raise AdcpError(
+            "ACCOUNT_NOT_FOUND",
+            message=(
+                f"PlatformRouter could not resolve a tenant for "
+                f"account_id={ctx.account.id!r}. The router's AccountStore "
+                "must populate ``metadata['tenant_id']`` on every "
+                "resolved account; got "
+                f"{tenant_id!r}."
+            ),
+            recovery="terminal",
+            field="account.metadata.tenant_id",
+        )
+    return str(tenant_id)
+
+
+class PlatformRouter(DecisioningPlatform):
+    """Drop-in :class:`DecisioningPlatform` that fans calls out across N tenants.
+
+    Each per-specialism call resolves a tenant from
+    ``ctx.account.metadata['tenant_id']`` and delegates to the
+    matching child :class:`DecisioningPlatform`. The router's class-
+    level ``capabilities`` is the union of every child's specialisms;
+    individual calls that the resolved tenant's platform doesn't
+    implement raise ``UNSUPPORTED_FEATURE``.
+
+    The set of methods the router exposes is computed at construction
+    by walking the framework's known specialism Protocols (see
+    :data:`_KNOWN_SPECIALISM_PROTOCOLS`). New Protocols added to the
+    SDK appear on the router automatically — adopters don't have to
+    update their router wiring when the specialism surface grows.
+
+    :param accounts: The adopter's :class:`AccountStore`. Resolves
+        every request to an :class:`Account` whose
+        ``metadata['tenant_id']`` keys :attr:`platforms`. This is the
+        adopter's responsibility — typically the store reads
+        :func:`adcp.server.current_tenant` (set by
+        :class:`SubdomainTenantMiddleware`) and writes the tenant id
+        onto the account metadata.
+    :param platforms: ``{tenant_id: DecisioningPlatform}`` mapping. The
+        router copies the dict shallowly at construction; later
+        mutations to the source dict are NOT reflected. Pass a fresh
+        dict per ``serve()`` call.
+    :param capabilities: The router's wire-shape capability
+        declaration. Should be the union of every child platform's
+        specialisms — the framework's ``tools/list`` filter reads this
+        to advertise the right tools, and ``validate_platform`` reads
+        the same value to verify each claimed specialism has its
+        required methods (which the router's synthesized delegation
+        provides).
+
+    :raises ValueError: when :attr:`platforms` is empty (a router with
+        no children is misconfiguration, not a valid empty state).
+    """
+
+    def __init__(
+        self,
+        *,
+        accounts: AccountStore[Any],
+        platforms: Mapping[str, DecisioningPlatform],
+        capabilities: DecisioningCapabilities,
+    ) -> None:
+        if not platforms:
+            raise ValueError(
+                "PlatformRouter requires at least one child platform; "
+                "got an empty mapping. A router with no children would "
+                "404 every request."
+            )
+
+        # Shallow copy — adopter-side dict mutations don't leak into the
+        # router's view. Children are NOT defensively copied (they're
+        # framework-instance singletons by contract).
+        self._platforms: dict[str, DecisioningPlatform] = dict(platforms)
+        self.accounts = accounts
+        self.capabilities = capabilities
+
+        # Synthesize a delegating method per specialism method name.
+        # Bound at construction so ``getattr(router, name)`` resolves
+        # to a callable that closes over ``self`` and ``method_name``.
+        # The framework's dispatcher uses ``getattr(platform, name)``
+        # to find methods; instance-level callables work for that.
+        for method_name in _all_specialism_methods():
+            if method_name in _ACCOUNT_STORE_METHODS:
+                # Defensive: AccountStore methods MUST stay on the
+                # router's accounts store, not be synthesized as
+                # tenant-keyed delegations. Skip.
+                continue
+            self.__dict__[method_name] = self._make_delegate(method_name)
+
+    # ----- per-tenant dispatch helpers --------------------------------
+
+    def _platform_for(
+        self,
+        ctx: RequestContext[Any],
+        method_name: str,
+    ) -> DecisioningPlatform:
+        """Look up the child platform for ``ctx``'s tenant.
+
+        :raises AdcpError: ``ACCOUNT_NOT_FOUND`` when the tenant id
+            resolves to no registered platform. ``UNSUPPORTED_FEATURE``
+            when the platform exists but doesn't implement
+            ``method_name``.
+        """
+        tenant_id = _tenant_id_from_ctx(ctx)
+        platform = self._platforms.get(tenant_id)
+        if platform is None:
+            raise AdcpError(
+                "ACCOUNT_NOT_FOUND",
+                message=(
+                    f"PlatformRouter has no platform for "
+                    f"tenant_id={tenant_id!r}. Register one in the "
+                    "``platforms=`` mapping passed to the router, or "
+                    "fix the AccountStore to resolve to a known tenant."
+                ),
+                recovery="terminal",
+                field="account.metadata.tenant_id",
+            )
+
+        method = getattr(platform, method_name, None)
+        if method is None or not callable(method):
+            raise AdcpError(
+                "UNSUPPORTED_FEATURE",
+                message=(
+                    f"Tenant {tenant_id!r}'s platform "
+                    f"({type(platform).__name__}) does not implement "
+                    f"{method_name!r}. The router advertises this method "
+                    "because at least one child platform supports it, "
+                    "but this tenant's platform doesn't."
+                ),
+                recovery="terminal",
+            )
+        return platform
+
+    def _make_delegate(self, method_name: str) -> Any:
+        """Create a delegating callable for ``method_name``.
+
+        The returned callable forwards every positional and keyword
+        argument verbatim to the child platform's same-named method.
+        The dispatcher invokes platform methods either as
+        ``method(params, ctx)`` (positional) or
+        ``method(**arg_projector, ctx=ctx)`` (kwargs); the synthesized
+        ``*args, **kwargs`` shape covers both.
+
+        Sync-vs-async dispatch is decided at the dispatcher
+        (:func:`adcp.decisioning.dispatch._invoke_platform_method`)
+        by checking the router's method. The delegate is always
+        ``async def`` so the dispatcher takes its async path and
+        awaits the result. Inside the delegate we re-dispatch on the
+        CHILD platform: async children are awaited directly; sync
+        children run via :func:`asyncio.to_thread` so a blocking sync
+        handler doesn't serialize the event loop.
+        """
+        router = self
+
+        async def _delegate(*args: Any, **kwargs: Any) -> Any:
+            ctx = _resolve_ctx_from_args(args, kwargs)
+            platform = router._platform_for(ctx, method_name)
+            method = getattr(platform, method_name)
+
+            if inspect.iscoroutinefunction(method):
+                return await method(*args, **kwargs)
+
+            # Sync child — push to a thread so the loop stays
+            # responsive. The framework's standard sync-platform
+            # dispatch goes through its own ThreadPoolExecutor with a
+            # contextvars snapshot; ``asyncio.to_thread`` does the same
+            # using the running loop's default executor with copied
+            # context.
+            return await asyncio.to_thread(method, *args, **kwargs)
+
+        _delegate.__name__ = method_name
+        _delegate.__qualname__ = f"PlatformRouter.{method_name}"
+        return _delegate
+
+    # ----- introspection ---------------------------------------------
+
+    @property
+    def tenants(self) -> frozenset[str]:
+        """The set of tenant ids the router knows about.
+
+        Read-only view; mutations to the source mapping after
+        construction are NOT reflected.
+        """
+        return frozenset(self._platforms)
+
+    def platform_for_tenant(self, tenant_id: str) -> DecisioningPlatform:
+        """Return the child platform registered for ``tenant_id``.
+
+        :raises KeyError: when no platform is registered for the
+            tenant. Adopter callers handle this; the router's runtime
+            dispatch path uses :meth:`_platform_for` instead, which
+            projects to ``ACCOUNT_NOT_FOUND``.
+        """
+        return self._platforms[tenant_id]
+
+
+__all__ = ["PlatformRouter"]

--- a/src/adcp/decisioning/platform_router.py
+++ b/src/adcp/decisioning/platform_router.py
@@ -328,7 +328,9 @@ class PlatformRouter(DecisioningPlatform):
         # to a callable that closes over ``self`` and ``method_name``.
         # The framework's dispatcher uses ``getattr(platform, name)``
         # to find methods; instance-level callables work for that.
-        for method_name in _all_specialism_methods():
+        # Sorted for deterministic synthesis order — easier to debug
+        # than the underlying frozenset iteration order.
+        for method_name in sorted(_all_specialism_methods()):
             if method_name in _ACCOUNT_STORE_METHODS:
                 # Defensive: AccountStore methods MUST stay on the
                 # router's accounts store, not be synthesized as

--- a/tests/test_platform_router.py
+++ b/tests/test_platform_router.py
@@ -1,0 +1,458 @@
+"""Tests for :class:`adcp.decisioning.PlatformRouter`.
+
+The router is the multi-platform-per-process primitive. These tests
+cover:
+
+* Tenant-keyed dispatch — each call routes to the right child platform.
+* Drop-in compatibility — ``isinstance(router, DecisioningPlatform)``.
+* Async + sync child methods both work via the synthesized delegation.
+* Unknown tenant + unsupported method paths raise the documented
+  structured errors (``ACCOUNT_NOT_FOUND`` and ``UNSUPPORTED_FEATURE``).
+* Capability-driven advertised tool projection — the router's union
+  ``capabilities`` flows through ``advertised_tools_for_instance``.
+* Protocol introspection — every method name declared on a known
+  specialism Protocol is reachable on the router.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    ExplicitAccounts,
+    PlatformRouter,
+    RequestContext,
+    SalesPlatform,
+)
+from adcp.decisioning.platform_router import (
+    _all_specialism_methods,
+    _protocol_method_names,
+)
+from adcp.decisioning.types import Account
+
+# ---------------------------------------------------------------------------
+# Test fixtures: minimal child platforms
+# ---------------------------------------------------------------------------
+
+
+def _capabilities(specialisms: list[str]) -> DecisioningCapabilities:
+    """Build a minimal-but-valid capabilities object for tests."""
+    from adcp.decisioning.capabilities import (
+        Adcp,
+        IdempotencySupported,
+        SupportedProtocol,
+    )
+
+    return DecisioningCapabilities(
+        specialisms=specialisms,
+        adcp=Adcp(
+            major_versions=[3],
+            idempotency=IdempotencySupported(supported=True, replay_ttl_seconds=86400),
+        ),
+        supported_protocols=[SupportedProtocol.media_buy],
+    )
+
+
+class _SyncSalesPlatform(DecisioningPlatform, SalesPlatform):
+    """Sync child platform — the minimum sales-non-guaranteed surface."""
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+        self.calls: list[tuple[str, Any]] = []
+
+    capabilities = _capabilities(["sales-non-guaranteed"])
+    accounts = ExplicitAccounts(loader=lambda _id: Account(id=_id))
+
+    def get_products(self, req: Any, ctx: RequestContext[Any]) -> dict[str, Any]:
+        self.calls.append(("get_products", ctx.account.id))
+        return {"products": [{"product_id": f"prod-{self.tag}"}]}
+
+    def create_media_buy(self, req: Any, ctx: RequestContext[Any]) -> dict[str, Any]:
+        self.calls.append(("create_media_buy", ctx.account.id))
+        return {"media_buy_id": f"mb-{self.tag}", "status": "active"}
+
+    def update_media_buy(
+        self,
+        media_buy_id: str,
+        patch: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        self.calls.append(("update_media_buy", ctx.account.id))
+        return {"media_buy_id": media_buy_id, "status": "active"}
+
+    def sync_creatives(self, req: Any, ctx: RequestContext[Any]) -> dict[str, Any]:
+        self.calls.append(("sync_creatives", ctx.account.id))
+        return {"creatives": []}
+
+    def get_media_buy_delivery(self, req: Any, ctx: RequestContext[Any]) -> dict[str, Any]:
+        self.calls.append(("get_media_buy_delivery", ctx.account.id))
+        return {"media_buy_deliveries": []}
+
+
+class _AsyncSalesPlatform(_SyncSalesPlatform):
+    """Async-method variant — every required method is ``async def``."""
+
+    async def get_products(  # type: ignore[override]
+        self, req: Any, ctx: RequestContext[Any]
+    ) -> dict[str, Any]:
+        self.calls.append(("get_products", ctx.account.id))
+        return {"products": [{"product_id": f"prod-async-{self.tag}"}]}
+
+    async def create_media_buy(  # type: ignore[override]
+        self, req: Any, ctx: RequestContext[Any]
+    ) -> dict[str, Any]:
+        self.calls.append(("create_media_buy", ctx.account.id))
+        return {"media_buy_id": f"mb-async-{self.tag}", "status": "active"}
+
+
+class _NonSalesPlatform(DecisioningPlatform):
+    """Platform that doesn't implement sales methods — used to confirm
+    UNSUPPORTED_FEATURE projection on cross-tenant capability gaps."""
+
+    def __init__(self) -> None:
+        pass
+
+    capabilities = _capabilities(["audience-sync"])
+    accounts = ExplicitAccounts(loader=lambda _id: Account(id=_id))
+
+    def sync_audiences(self, req: Any, ctx: RequestContext[Any]) -> dict[str, Any]:
+        return {"audiences": []}
+
+
+# ---------------------------------------------------------------------------
+# Account store fixture: maps wire account_ref to Account with tenant_id
+# ---------------------------------------------------------------------------
+
+
+def _make_routing_account_store(
+    account_to_tenant: dict[str, str],
+) -> ExplicitAccounts[Any]:
+    """Build an AccountStore that stamps ``metadata['tenant_id']`` per
+    the supplied mapping. Mirrors the multi-tenant adopter pattern: the
+    AccountStore is the seam that wires resolved accounts to tenants."""
+
+    def _load(account_id: str) -> Account[Any]:
+        if account_id not in account_to_tenant:
+            raise AdcpError(
+                "ACCOUNT_NOT_FOUND",
+                message=f"unknown account {account_id!r}",
+                recovery="terminal",
+            )
+        return Account(
+            id=account_id,
+            metadata={"tenant_id": account_to_tenant[account_id]},
+        )
+
+    return ExplicitAccounts(loader=_load)
+
+
+def _make_ctx(account: Account[Any]) -> RequestContext[Any]:
+    """Build a RequestContext with a resolved account, mirroring what
+    the dispatcher's ``_build_request_context`` produces."""
+    return RequestContext(account=account)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_router_is_decisioning_platform() -> None:
+    """Drop-in compat — the router IS a DecisioningPlatform, satisfying
+    ``isinstance`` checks the framework's serve() path runs."""
+    accounts = _make_routing_account_store({"acct_a": "tenant-a"})
+    router = PlatformRouter(
+        accounts=accounts,
+        platforms={"tenant-a": _SyncSalesPlatform("a")},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    assert isinstance(router, DecisioningPlatform)
+
+
+def test_router_synthesizes_every_specialism_method() -> None:
+    """Every method declared on a known specialism Protocol is reachable
+    on the router as a callable. New Protocols added to the SDK get
+    picked up automatically because the router walks the Protocol set
+    at construction.
+    """
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a"}),
+        platforms={"tenant-a": _SyncSalesPlatform("a")},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    for method_name in _all_specialism_methods():
+        assert callable(
+            getattr(router, method_name)
+        ), f"router missing synthesized delegate for {method_name!r}"
+
+
+def test_protocol_method_names_picks_up_sales_methods() -> None:
+    """Sanity check on the introspection helper itself — every method
+    on the ``SalesPlatform`` Protocol shows up. Defends against
+    accidentally regressing the introspection to skip required
+    methods.
+    """
+    names = _protocol_method_names(SalesPlatform)
+    # The required-method core per ``REQUIRED_METHODS_PER_SPECIALISM``.
+    for required in (
+        "get_products",
+        "create_media_buy",
+        "update_media_buy",
+        "sync_creatives",
+        "get_media_buy_delivery",
+    ):
+        assert required in names
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_correct_tenant() -> None:
+    """Three tenants → three platforms. Each tool call routes to the
+    tenant's platform and only that platform records the call."""
+    platform_a = _SyncSalesPlatform("a")
+    platform_b = _SyncSalesPlatform("b")
+    platform_c = _SyncSalesPlatform("c")
+
+    router = PlatformRouter(
+        accounts=_make_routing_account_store(
+            {"acct_a": "tenant-a", "acct_b": "tenant-b", "acct_c": "tenant-c"}
+        ),
+        platforms={
+            "tenant-a": platform_a,
+            "tenant-b": platform_b,
+            "tenant-c": platform_c,
+        },
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+
+    ctx_a = _make_ctx(Account(id="acct_a", metadata={"tenant_id": "tenant-a"}))
+    ctx_b = _make_ctx(Account(id="acct_b", metadata={"tenant_id": "tenant-b"}))
+    ctx_c = _make_ctx(Account(id="acct_c", metadata={"tenant_id": "tenant-c"}))
+
+    resp_a = await router.get_products({}, ctx_a)
+    resp_b = await router.get_products({}, ctx_b)
+    resp_c = await router.get_products({}, ctx_c)
+
+    assert resp_a["products"][0]["product_id"] == "prod-a"
+    assert resp_b["products"][0]["product_id"] == "prod-b"
+    assert resp_c["products"][0]["product_id"] == "prod-c"
+
+    # Cross-tenant isolation — each child saw exactly one call, only
+    # for its own account.
+    assert platform_a.calls == [("get_products", "acct_a")]
+    assert platform_b.calls == [("get_products", "acct_b")]
+    assert platform_c.calls == [("get_products", "acct_c")]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_supports_async_child_methods() -> None:
+    """Async children are awaited, sync children run in a thread — both
+    surface the same way through the router's async-def delegate."""
+    sync_platform = _SyncSalesPlatform("sync")
+    async_platform = _AsyncSalesPlatform("async")
+
+    router = PlatformRouter(
+        accounts=_make_routing_account_store(
+            {"acct_sync": "tenant-sync", "acct_async": "tenant-async"}
+        ),
+        platforms={
+            "tenant-sync": sync_platform,
+            "tenant-async": async_platform,
+        },
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+
+    ctx_sync = _make_ctx(Account(id="acct_sync", metadata={"tenant_id": "tenant-sync"}))
+    ctx_async = _make_ctx(Account(id="acct_async", metadata={"tenant_id": "tenant-async"}))
+
+    sync_resp = await router.get_products({}, ctx_sync)
+    async_resp = await router.get_products({}, ctx_async)
+
+    assert sync_resp["products"][0]["product_id"] == "prod-sync"
+    assert async_resp["products"][0]["product_id"] == "prod-async-async"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_supports_arg_projector_kwargs() -> None:
+    """The dispatcher invokes some methods with keyword args (e.g.
+    ``update_media_buy(media_buy_id=..., patch=..., ctx=...)``); the
+    router's ``*args, **kwargs`` delegate forwards them verbatim.
+    """
+    platform = _SyncSalesPlatform("a")
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a"}),
+        platforms={"tenant-a": platform},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    ctx = _make_ctx(Account(id="acct_a", metadata={"tenant_id": "tenant-a"}))
+
+    resp = await router.update_media_buy(media_buy_id="mb_123", patch={"foo": "bar"}, ctx=ctx)
+    assert resp["media_buy_id"] == "mb_123"
+    assert platform.calls == [("update_media_buy", "acct_a")]
+
+
+@pytest.mark.asyncio
+async def test_unknown_tenant_raises_account_not_found() -> None:
+    """Resolving to a tenant the router doesn't know about projects to
+    ACCOUNT_NOT_FOUND — multi-tenant topology stays opaque to the wire.
+    """
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a"}),
+        platforms={"tenant-a": _SyncSalesPlatform("a")},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    ctx_unknown = _make_ctx(Account(id="acct_x", metadata={"tenant_id": "tenant-unknown"}))
+
+    with pytest.raises(AdcpError) as excinfo:
+        await router.get_products({}, ctx_unknown)
+    assert excinfo.value.code == "ACCOUNT_NOT_FOUND"
+    assert excinfo.value.field == "account.metadata.tenant_id"
+    assert excinfo.value.recovery == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_missing_tenant_id_raises_account_not_found() -> None:
+    """Account whose metadata is missing the ``tenant_id`` key raises
+    ACCOUNT_NOT_FOUND with a diagnostic pointing at the AccountStore
+    integration as the bug source."""
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a"}),
+        platforms={"tenant-a": _SyncSalesPlatform("a")},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    ctx_no_tenant = _make_ctx(Account(id="acct_orphan", metadata={}))
+
+    with pytest.raises(AdcpError) as excinfo:
+        await router.get_products({}, ctx_no_tenant)
+    assert excinfo.value.code == "ACCOUNT_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_method_on_resolved_tenant() -> None:
+    """When the router's union capabilities advertise a method but the
+    resolved tenant's platform doesn't implement it, we project to
+    UNSUPPORTED_FEATURE per spec — not a 404, not silent failure.
+    """
+    sales_platform = _SyncSalesPlatform("sales")
+    audience_platform = _NonSalesPlatform()
+
+    router = PlatformRouter(
+        accounts=_make_routing_account_store(
+            {
+                "acct_sales": "tenant-sales",
+                "acct_audience": "tenant-audience",
+            }
+        ),
+        platforms={
+            "tenant-sales": sales_platform,
+            "tenant-audience": audience_platform,
+        },
+        # Union capabilities: the router advertises both sales and
+        # audience methods even though each tenant only does one.
+        capabilities=_capabilities(["sales-non-guaranteed", "audience-sync"]),
+    )
+
+    # Audience-tenant request to get_products → UNSUPPORTED_FEATURE.
+    ctx_audience = _make_ctx(
+        Account(
+            id="acct_audience",
+            metadata={"tenant_id": "tenant-audience"},
+        )
+    )
+    with pytest.raises(AdcpError) as excinfo:
+        await router.get_products({}, ctx_audience)
+    assert excinfo.value.code == "UNSUPPORTED_FEATURE"
+    assert excinfo.value.recovery == "terminal"
+
+
+def test_empty_platforms_mapping_rejected() -> None:
+    """An empty platforms dict is misconfiguration — fail fast at
+    construction rather than 404 every request later."""
+    with pytest.raises(ValueError, match="at least one child platform"):
+        PlatformRouter(
+            accounts=_make_routing_account_store({}),
+            platforms={},
+            capabilities=_capabilities(["sales-non-guaranteed"]),
+        )
+
+
+def test_tenants_property_lists_registered_tenants() -> None:
+    """The ``tenants`` view exposes the registered tenant ids as a
+    frozenset for adopter introspection (logging, admin endpoints,
+    health checks). Mutations to the source dict don't propagate."""
+    source = {"tenant-a": _SyncSalesPlatform("a"), "tenant-b": _SyncSalesPlatform("b")}
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a", "acct_b": "tenant-b"}),
+        platforms=source,
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+
+    assert router.tenants == frozenset({"tenant-a", "tenant-b"})
+
+    # Source mutation doesn't leak.
+    source["tenant-c"] = _SyncSalesPlatform("c")
+    assert router.tenants == frozenset({"tenant-a", "tenant-b"})
+
+
+def test_platform_for_tenant_returns_registered_child() -> None:
+    """Adopter-facing introspection — fetch the child by tenant id."""
+    platform_a = _SyncSalesPlatform("a")
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a"}),
+        platforms={"tenant-a": platform_a},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    assert router.platform_for_tenant("tenant-a") is platform_a
+    with pytest.raises(KeyError):
+        router.platform_for_tenant("tenant-missing")
+
+
+def test_router_passes_validate_platform() -> None:
+    """The router's synthesized delegates satisfy
+    ``validate_platform``'s ``_has_overridden_method`` check — the
+    same boot-time contract single-platform adopters depend on."""
+    from adcp.decisioning.dispatch import validate_platform
+
+    router = PlatformRouter(
+        accounts=_make_routing_account_store({"acct_a": "tenant-a"}),
+        platforms={"tenant-a": _SyncSalesPlatform("a")},
+        capabilities=_capabilities(["sales-non-guaranteed"]),
+    )
+    # Should not raise.
+    validate_platform(router)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ctx_from_kwargs() -> None:
+    """The context resolver picks up ``ctx=`` kwargs (the dispatcher's
+    arg_projector path uses kwargs)."""
+    from adcp.decisioning.platform_router import _resolve_ctx_from_args
+
+    ctx = _make_ctx(Account(id="acct", metadata={"tenant_id": "t"}))
+    resolved = _resolve_ctx_from_args(args=(), kwargs={"ctx": ctx})
+    assert resolved is ctx
+
+
+def test_resolve_ctx_from_positional() -> None:
+    """The context resolver picks up the trailing positional argument
+    (the dispatcher's standard path)."""
+    from adcp.decisioning.platform_router import _resolve_ctx_from_args
+
+    ctx = _make_ctx(Account(id="acct", metadata={"tenant_id": "t"}))
+    resolved = _resolve_ctx_from_args(args=({"req": "x"}, ctx), kwargs={})
+    assert resolved is ctx
+
+
+def test_resolve_ctx_missing_raises_internal_error() -> None:
+    """No ctx in args or kwargs → INTERNAL_ERROR. This path is only
+    reachable if the dispatcher's contract has drifted; adopter code
+    never hits it."""
+    from adcp.decisioning.platform_router import _resolve_ctx_from_args
+
+    with pytest.raises(AdcpError) as excinfo:
+        _resolve_ctx_from_args(args=(), kwargs={})
+    assert excinfo.value.code == "INTERNAL_ERROR"

--- a/tests/test_platform_router.py
+++ b/tests/test_platform_router.py
@@ -456,3 +456,59 @@ def test_resolve_ctx_missing_raises_internal_error() -> None:
     with pytest.raises(AdcpError) as excinfo:
         _resolve_ctx_from_args(args=(), kwargs={})
     assert excinfo.value.code == "INTERNAL_ERROR"
+
+
+def test_known_specialism_protocols_matches_specialisms_module() -> None:
+    """Guards the router's extension contract.
+
+    When a new Protocol class is added to ``adcp.decisioning.specialisms``,
+    it MUST also be added to ``_KNOWN_SPECIALISM_PROTOCOLS`` in
+    ``platform_router.py`` — otherwise the router silently fails to
+    synthesize delegates for the new specialism's methods, and the only
+    buyer-side signal is UNSUPPORTED_FEATURE on calls that should work.
+
+    This test fails the moment that drift exists.
+    """
+    from adcp.decisioning import specialisms
+    from adcp.decisioning.platform_router import _KNOWN_SPECIALISM_PROTOCOLS
+
+    known = {p.__name__ for p in _KNOWN_SPECIALISM_PROTOCOLS}
+    in_module = {name for name in specialisms.__all__ if name.endswith("Platform")}
+
+    drift = in_module ^ known
+    assert not drift, (
+        f"PlatformRouter extension contract drift. Mismatch between "
+        f"specialisms.__all__ Platform classes and _KNOWN_SPECIALISM_PROTOCOLS: "
+        f"{sorted(drift)}. Update _KNOWN_SPECIALISM_PROTOCOLS to match."
+    )
+
+
+def test_account_store_methods_denylist_matches_protocols() -> None:
+    """Guards ``_ACCOUNT_STORE_METHODS`` membership against AccountStore Protocol drift.
+
+    If ``AccountStore`` / ``AccountStoreList`` / ``AccountStoreUpsert`` /
+    ``AccountStoreSyncGovernance`` add a new method, the denylist must
+    grow with them — otherwise the router could synthesize a tenant-keyed
+    delegate over an AccountStore method by accident.
+    """
+    from adcp.decisioning.accounts import (
+        AccountStore,
+        AccountStoreList,
+        AccountStoreSyncGovernance,
+        AccountStoreUpsert,
+    )
+    from adcp.decisioning.platform_router import (
+        _ACCOUNT_STORE_METHODS,
+    )
+
+    expected = (
+        _protocol_method_names(AccountStore)
+        | _protocol_method_names(AccountStoreList)
+        | _protocol_method_names(AccountStoreUpsert)
+        | _protocol_method_names(AccountStoreSyncGovernance)
+    )
+    drift = expected ^ _ACCOUNT_STORE_METHODS
+    assert not drift, (
+        f"AccountStore Protocol method drift. Update _ACCOUNT_STORE_METHODS "
+        f"in platform_router.py: {sorted(drift)}"
+    )


### PR DESCRIPTION
## Summary

Closes #477.

- **`PlatformRouter`** — new SDK primitive in `adcp.decisioning`. Drop-in `DecisioningPlatform` subclass that fans every per-specialism call out to a child platform keyed by `ctx.account.metadata['tenant_id']`. Synthesizes its delegating methods at construction via Protocol introspection — new specialism Protocols added to the SDK appear on the router automatically.
- **`examples/multi_platform_seller/`** — two pure-Python mock platforms (`MockGuaranteedPlatform` / `MockNonGuaranteedPlatform`) behind one `serve()` boot, fronted by the existing `SubdomainTenantMiddleware`. Both subdomain (`tenant-a.localhost` / `tenant-b.localhost`) and explicit-ref (`tenant-a:account_id`) routing work against the same process.
- **CI** — new `storyboard-multi-platform-seller` job runs the `media_buy_seller` storyboard against each tenant subdomain.

This is the framework primitive that the migration doc for salesagent-shaped adopters (their `ADAPTER_REGISTRY: dict[str, Type[AdServerAdapter]]`) will reference. The doc lands in a parallel PR — `MIGRATION_FROM_ADAPTER_REGISTRY.md` is intentionally not included here.

### Migration target

The salesagent codebase at https://github.com/Prebid-Hosting/salesagent has the canonical `ADAPTER_REGISTRY` shape this primitive replaces. Adopters in that shape preload one `DecisioningPlatform` per tenant (or per backend) into `PlatformRouter` and let the framework dispatch — same mental model, framework-managed call-routing.

### Design notes

**Protocol introspection.** The router walks `_KNOWN_SPECIALISM_PROTOCOLS` (a tuple of every Protocol class exported from `adcp.decisioning.specialisms`) and reads `vars(proto)` to enumerate declared methods. Picked this approach over `__protocol_attrs__` because the latter only lands stable on Python 3.12+ and the SDK targets 3.10+. The Protocol classes don't inherit from each other, so no MRO walk is needed.

**Capabilities — union, not intersection.** The router advertises every specialism any child platform serves. `tools/list` projects this through `advertised_tools_for_instance` so buyers see the full menu; per-call dispatch raises structured `UNSUPPORTED_FEATURE` per spec when the resolved tenant doesn't implement the requested method. Intersection-based capabilities would silently hide tools that some tenants do support, breaking the "one URL → many tenants" model.

**Subdomain middleware.** Used the existing `adcp.server.SubdomainTenantMiddleware` (added in earlier work). Confirmed path: `src/adcp/server/tenant_router.py`. The example wires it via `asgi_middleware=[(SubdomainTenantMiddleware, {"router": ...})]` exactly as the docstring shows. No new primitive built.

**Async vs sync.** The router's synthesized delegate is always `async def`. Inside, it inspects the resolved child's method: async children are awaited directly; sync children run via `asyncio.to_thread` so blocking handlers don't serialize the loop. This keeps parity with the framework's standard sync/async dispatch posture without requiring two delegate variants.

### Diff size

| | Lines |
|---|---|
| `src/adcp/decisioning/platform_router.py` | 415 |
| `tests/test_platform_router.py` | 419 |
| `examples/multi_platform_seller/` | ~1100 (5 files + README) |
| `.github/workflows/ci.yml` | +101 |
| **Total** | ~2400 lines |

### Storyboard CI

The new job (`storyboard-multi-platform-seller`) is gated `continue-on-error: true` — same posture as the existing `examples/seller_agent.py` storyboard job. The mock platforms cover the five required `sales-*` methods but don't pretend to be a full storyboard pass on day one; the CI artifact captures both tenants' results so any drift surfaces.

## Test plan

- [x] `pytest tests/test_platform_router.py -v` (16/16)
- [x] `pytest tests/ -x` — full regression (3626/3626, no new skips)
- [x] `ruff check src/ tests/test_platform_router.py examples/multi_platform_seller/`
- [x] `mypy src/` (full source clean)
- [x] Smoke: `python -m examples.multi_platform_seller.src.app` boots, serves `tools/list` on both subdomains (10 tools), 404s unknown subdomains, returns the expected per-tenant catalog from `get_products`
- [x] Smoke: `PlatformHandler` end-to-end through the dispatch path — tenant-a returns guaranteed inventory, tenant-b returns programmatic remnant

## Out of scope (deferred / parallel)

- **`MIGRATION_FROM_ADAPTER_REGISTRY.md`** — separate PR, references this PR as its implementation target.
- **Refactor `examples/v3_reference_seller/` to use `PlatformRouter`** — agreed earlier this is out of scope; the reference seller stays single-platform.
- **Promoting `PlatformRouter` into `adcp.decisioning.dispatch`** — already in `adcp.decisioning` directly.
- **A third specialism mock** — two platforms is enough proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)