### PR TITLE
feat(decisioning): ProductConfigStore lookup helper for create_media_buy

### DIFF
--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -96,6 +96,7 @@ from adcp.decisioning.errors import (
     ValidationError,
 )
 from adcp.decisioning.helpers import ref_account_id
+from adcp.decisioning.implementation_config import ProductConfigStore
 from adcp.decisioning.media_buy_store import (
     MediaBuyStore,
     create_media_buy_store,
@@ -296,6 +297,7 @@ __all__ = [
     "Proposal",
     "PropertyList",
     "PropertyListReference",
+    "ProductConfigStore",
     "PropertyListsPlatform",
     "RateLimitedBuyerAgentRegistry",
     "RateLimitedError",

--- a/src/adcp/decisioning/dispatch.py
+++ b/src/adcp/decisioning/dispatch.py
@@ -1107,8 +1107,7 @@ async def _invoke_platform_method(
         # outer middleware projects to the wire envelope.
         raise
     except TypeError as exc:
-        # Most likely an arg_projector signature-drift bug — adopter
-        # renamed update_media_buy's `patch` kwarg → `update`, etc.
+        # Most likely an arg_projector or extra_kwargs signature-drift bug.
         # Bare INTERNAL_ERROR would hide the cause; project to
         # INVALID_REQUEST with a hint pointing at the adopter's
         # method signature so they fix it without a server-log dive.
@@ -1130,6 +1129,23 @@ async def _invoke_platform_method(
                     "the adopter method rejected them. Check the "
                     "method's Python signature against the per-specialism "
                     "Protocol class (typically a renamed parameter)."
+                ),
+                recovery="terminal",
+            ) from exc
+        if extra_kwargs is not None:
+            logger.exception(
+                "TypeError invoking platform.%s — likely extra_kwargs "
+                "signature drift (injected kwargs %s vs adopter signature)",
+                method_name,
+                sorted(extra_kwargs.keys()),
+            )
+            raise AdcpError(
+                "INVALID_REQUEST",
+                message=(
+                    f"Platform method {method_name!r} rejected framework-injected "
+                    f"kwargs {sorted(extra_kwargs.keys())!r}. Declare the matching "
+                    "parameter(s) in your platform method signature, or remove them "
+                    "if you don't need them."
                 ),
                 recovery="terminal",
             ) from exc

--- a/src/adcp/decisioning/dispatch.py
+++ b/src/adcp/decisioning/dispatch.py
@@ -1040,6 +1040,7 @@ async def _invoke_platform_method(
     executor: ThreadPoolExecutor,
     registry: TaskRegistry,
     arg_projector: dict[str, Any] | None = None,
+    extra_kwargs: dict[str, Any] | None = None,
 ) -> Any:
     """Invoke a platform method, projecting hybrid returns.
 
@@ -1064,8 +1065,13 @@ async def _invoke_platform_method(
     :param arg_projector: Optional kwargs dict for tools whose Python
         method signature differs from the wire shape (D1
         arg-projection, e.g. ``update_media_buy(media_buy_id, patch,
-        ctx)``). Codegen-emitted shims pass this for those tools;
-        most tools call with ``None``.
+        ctx)``). Replaces the default positional ``(params, ctx)``
+        call entirely. Codegen-emitted shims pass this for those
+        tools; most tools call with ``None``.
+    :param extra_kwargs: Optional additional kwargs appended to the
+        normal ``(params, ctx)`` call, used when the framework injects
+        framework-computed values (e.g. ``configs=`` from
+        ``ProductConfigStore``). Ignored when ``arg_projector`` is set.
     """
     method = getattr(platform, method_name)
 
@@ -1073,6 +1079,8 @@ async def _invoke_platform_method(
         if asyncio.iscoroutinefunction(method):
             if arg_projector is not None:
                 result = await method(**arg_projector, ctx=ctx)
+            elif extra_kwargs:
+                result = await method(params, ctx, **extra_kwargs)
             else:
                 result = await method(params, ctx)
         else:
@@ -1083,6 +1091,11 @@ async def _invoke_platform_method(
                 result = await loop.run_in_executor(
                     executor,
                     functools.partial(ctx_snapshot.run, method, **projected_kwargs),
+                )
+            elif extra_kwargs:
+                result = await loop.run_in_executor(
+                    executor,
+                    functools.partial(ctx_snapshot.run, method, params, ctx, **extra_kwargs),
                 )
             else:
                 result = await loop.run_in_executor(

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -1083,7 +1083,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         if self._config_store is not None:
             # proposal_id flows have packages=None — skip lookup, inject {}
             if params.packages:
-                product_ids = list({p.product_id for p in params.packages})
+                product_ids = list(dict.fromkeys(p.product_id for p in params.packages))
                 try:
                     configs = await self._config_store.lookup_implementation_configs(
                         product_ids, ctx

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -32,6 +32,9 @@ get a focused ``tools/list`` filter without manual registration.
 from __future__ import annotations
 
 import asyncio
+import inspect
+import logging
+import warnings
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from adcp.decisioning.context import AuthInfo
@@ -39,8 +42,11 @@ from adcp.decisioning.dispatch import (
     _build_request_context,
     _invoke_platform_method,
 )
+from adcp.decisioning.implementation_config import ProductConfigStore
 from adcp.decisioning.webhook_emit import maybe_emit_sync_completion
 from adcp.server.base import ADCPHandler, ToolContext
+
+logger = logging.getLogger(__name__)
 
 # Pydantic Request/Response types are imported at module scope (NOT
 # under TYPE_CHECKING) so that ``typing.get_type_hints(method)`` can
@@ -574,6 +580,18 @@ def _project_sync_audiences(result: Any) -> Any:
     return result
 
 
+def _method_accepts_configs(platform: Any, method_name: str) -> bool:
+    """Return True when the platform's ``method_name`` declares a ``configs`` parameter."""
+    method = getattr(platform, method_name, None)
+    if method is None:
+        return False
+    try:
+        sig = inspect.signature(method)
+        return "configs" in sig.parameters
+    except (ValueError, TypeError):
+        return False
+
+
 class PlatformHandler(ADCPHandler[ToolContext]):
     """ADCPHandler subclass that routes wire requests to a
     :class:`DecisioningPlatform` via :func:`_invoke_platform_method`.
@@ -675,6 +693,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         webhook_supervisor: WebhookDeliverySupervisor | None = None,
         auto_emit_completion_webhooks: bool = True,
         buyer_agent_registry: BuyerAgentRegistry | None = None,
+        config_store: ProductConfigStore | None = None,
     ) -> None:
         super().__init__()
         self._platform = platform
@@ -686,6 +705,23 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         self._webhook_supervisor = webhook_supervisor
         self._auto_emit_completion_webhooks = auto_emit_completion_webhooks
         self._buyer_agent_registry = buyer_agent_registry
+        self._config_store = config_store
+
+        # Cache whether the platform's create_media_buy accepts 'configs'
+        # so we only pay the inspect.signature cost at construction time.
+        self._create_media_buy_accepts_configs = _method_accepts_configs(
+            platform, "create_media_buy"
+        )
+        if config_store is None and self._create_media_buy_accepts_configs:
+            warnings.warn(
+                "create_media_buy declares a 'configs' parameter but no "
+                "ProductConfigStore was wired — the framework will inject "
+                "configs={} (empty dict) on every call. Wire a store via "
+                "config_store= in create_adcp_server_from_platform to enable "
+                "automatic implementation_config lookup.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     # ----- account resolution helper -----
 
@@ -1037,9 +1073,42 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         params: CreateMediaBuyRequest,
         context: ToolContext | None = None,
     ) -> CreateMediaBuySuccessResponse:
+        from adcp.decisioning.types import AdcpError
+
         tool_ctx = context or ToolContext()
         account = await self._resolve_account(params.account, tool_ctx)
         ctx = self._build_ctx(tool_ctx, account)
+
+        configs: dict[str, Any] = {}
+        if self._config_store is not None:
+            # proposal_id flows have packages=None — skip lookup, inject {}
+            if params.packages:
+                product_ids = list({p.product_id for p in params.packages})
+                try:
+                    configs = await self._config_store.lookup_implementation_configs(
+                        product_ids, ctx
+                    )
+                except AdcpError:
+                    raise
+                except Exception as exc:
+                    logger.exception(
+                        "[adcp.decisioning] ProductConfigStore.lookup_implementation_configs "
+                        "raised for create_media_buy — translating to SERVICE_UNAVAILABLE"
+                    )
+                    raise AdcpError(
+                        "SERVICE_UNAVAILABLE",
+                        message=(
+                            "implementation_config lookup failed for "
+                            f"{len(product_ids)} product(s). Retry the request; "
+                            "if the problem persists contact the seller."
+                        ),
+                        recovery="transient",
+                        details={"caused_by": {"type": type(exc).__name__}},
+                    ) from exc
+
+        extra: dict[str, Any] | None = (
+            {"configs": configs} if self._create_media_buy_accepts_configs else None
+        )
         result = await _invoke_platform_method(
             self._platform,
             "create_media_buy",
@@ -1047,6 +1116,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             ctx,
             executor=self._executor,
             registry=self._registry,
+            extra_kwargs=extra,
         )
         self._maybe_auto_emit_sync_completion("create_media_buy", params, result)
         return cast("CreateMediaBuySuccessResponse", result)

--- a/src/adcp/decisioning/implementation_config.py
+++ b/src/adcp/decisioning/implementation_config.py
@@ -1,0 +1,68 @@
+"""ProductConfigStore — pluggable implementation_config lookup for create_media_buy.
+
+Seller adapters (GAM, Kevel, Xandr, Prebid Server, …) attach seller-side
+configuration to each ``Product`` under ``Product.ext.implementation_config``
+by convention.  Every adopter that implements ``create_media_buy`` writes the
+same boilerplate: pull the packages off the request, collect the product_ids,
+look up the per-product config from a store, hand it to the adapter alongside
+the wire request.
+
+This module lifts that loop into the framework.  The adopter wires a
+``ProductConfigStore`` once at server construction; the framework calls
+``lookup_implementation_configs`` before invoking the platform method and
+injects the result as ``configs=`` kwarg.  Adopters who declare ``configs`` in
+their ``create_media_buy`` signature receive the resolved dict automatically.
+Adopters who don't wire a store receive ``configs={}`` (current behaviour,
+fully backward-compatible).
+
+Reference pattern: ``adcp.decisioning.webhook_emit`` — same "framework
+intercepts at the handler seam before the platform method fires" design.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from adcp.decisioning.context import RequestContext
+
+
+@runtime_checkable
+class ProductConfigStore(Protocol):
+    """Adopter-supplied lookup for seller-side product configuration.
+
+    The framework calls ``lookup_implementation_configs`` once per
+    ``create_media_buy`` request, before invoking the platform method.
+    Adopters return a dict keyed by ``product_id``; the framework injects
+    it as ``configs=`` on the platform method call.
+
+    If the store returns a partial dict (some product_ids missing), the
+    adopter handles it — the framework does not fabricate entries for missing
+    ids.  If the store raises, the framework surfaces
+    ``SERVICE_UNAVAILABLE`` with ``recovery='transient'`` to the buyer.
+
+    The ``ctx`` parameter carries the resolved ``RequestContext``, including
+    ``ctx.account`` for multi-tenant stores that need tenant isolation.
+    """
+
+    async def lookup_implementation_configs(
+        self,
+        product_ids: list[str],
+        ctx: RequestContext[Any],
+    ) -> dict[str, dict[str, Any]]:
+        """Return seller-side config keyed by product_id.
+
+        :param product_ids: Deduplicated list of product ids from
+            ``CreateMediaBuyRequest.packages[*].product_id``.  Empty when
+            the request uses ``proposal_id`` without an explicit
+            ``packages`` array.
+        :param ctx: Resolved request context — use ``ctx.account`` for
+            tenant scoping.
+        :returns: Dict mapping each product_id to its config dict.  Missing
+            keys mean "no config for this product"; the framework passes the
+            partial dict to the adopter unchanged.
+        """
+        ...
+
+
+__all__ = ["ProductConfigStore"]

--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -40,6 +40,7 @@ from adcp.decisioning.task_registry import InMemoryTaskRegistry
 from adcp.decisioning.types import AdcpError
 
 if TYPE_CHECKING:
+    from adcp.decisioning.implementation_config import ProductConfigStore
     from adcp.decisioning.platform import DecisioningPlatform
     from adcp.decisioning.registry import BuyerAgentRegistry
     from adcp.decisioning.resolve import ResourceResolver
@@ -83,6 +84,7 @@ def create_adcp_server_from_platform(
     webhook_supervisor: WebhookDeliverySupervisor | None = None,
     auto_emit_completion_webhooks: bool = True,
     buyer_agent_registry: BuyerAgentRegistry | None = None,
+    config_store: ProductConfigStore | None = None,
 ) -> tuple[PlatformHandler, ThreadPoolExecutor, TaskRegistry]:
     """Build the :class:`PlatformHandler` + supporting wiring from a
     :class:`DecisioningPlatform`.
@@ -272,6 +274,7 @@ def create_adcp_server_from_platform(
         webhook_supervisor=webhook_supervisor,
         auto_emit_completion_webhooks=auto_emit_completion_webhooks,
         buyer_agent_registry=buyer_agent_registry,
+        config_store=config_store,
     )
 
     # F12 boot-time fail-fast (Emma sales-direct P0 root cause): if
@@ -322,6 +325,7 @@ def serve(
     webhook_supervisor: WebhookDeliverySupervisor | None = None,
     auto_emit_completion_webhooks: bool = True,
     buyer_agent_registry: BuyerAgentRegistry | None = None,
+    config_store: ProductConfigStore | None = None,
     advertise_all: bool = False,
     mock_ad_server: Any | None = None,
     enable_debug_endpoints: bool = False,
@@ -399,6 +403,7 @@ def serve(
         webhook_supervisor=webhook_supervisor,
         auto_emit_completion_webhooks=auto_emit_completion_webhooks,
         buyer_agent_registry=buyer_agent_registry,
+        config_store=config_store,
     )
 
     # Phase 1 sandbox-authority — wire the comply controller's account

--- a/src/adcp/decisioning/specialisms/sales.py
+++ b/src/adcp/decisioning/specialisms/sales.py
@@ -136,6 +136,21 @@ class SalesPlatform(Protocol, Generic[TMeta]):
         * ``media_buy_id`` field present → sync success
         * ``task_id`` + ``status='submitted'`` → poll ``tasks_get`` or
           receive webhook
+
+        **Framework injection:** when a :class:`~adcp.decisioning.ProductConfigStore`
+        is wired via ``config_store=`` in
+        :func:`adcp.decisioning.serve.create_adcp_server_from_platform`,
+        the framework calls the store before invoking this method and
+        injects the result as ``configs: dict[str, dict[str, Any]]``.
+        Declare ``configs`` in your method signature to receive it::
+
+            def create_media_buy(self, req, ctx, configs=None):
+                configs = configs or {}
+                line_item_id = configs.get(pkg.product_id, {}).get("line_item_id")
+
+        When the store is not wired, or when ``req.packages`` is
+        ``None`` (proposal-id flow), ``configs`` arrives as an empty
+        dict ``{}``.
         """
         ...
 

--- a/tests/test_implementation_config.py
+++ b/tests/test_implementation_config.py
@@ -1,0 +1,313 @@
+"""Tests for adcp.decisioning.implementation_config + PlatformHandler wiring.
+
+Covers:
+- Full 3-product-id lookup: adopter sees complete configs dict.
+- Partial return (2-of-3): adopter sees partial dict, no framework error.
+- Store raises: translates to SERVICE_UNAVAILABLE.
+- packages=None (proposal_id flow): no lookup, adopter sees configs={}.
+- No store wired: adopter sees configs={} without store being called.
+- Adopter without 'configs' kwarg: lookup skipped even when store wired.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adcp.decisioning import (
+    AdcpError,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    InMemoryTaskRegistry,
+    ProductConfigStore,
+    SingletonAccounts,
+)
+from adcp.decisioning.handler import PlatformHandler
+from adcp.decisioning.implementation_config import ProductConfigStore as _ProductConfigStoreProto
+from adcp.server.base import ToolContext
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def executor():
+    pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-config-store-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+def _make_request(product_ids: list[str] | None):
+    """Build a minimal CreateMediaBuyRequest with the given product ids.
+
+    Passing None simulates a proposal_id-driven request (no packages).
+    """
+    from adcp.types import CreateMediaBuyRequest
+
+    packages = None
+    if product_ids is not None:
+        packages = [
+            {"product_id": pid, "budget": 1000.0, "pricing_option_id": "cpm_flat"}
+            for pid in product_ids
+        ]
+
+    return CreateMediaBuyRequest(
+        idempotency_key="test-key-12345678",
+        account={"account_id": "acct_test"},
+        brand={"domain": "example.com"},
+        start_time="2026-06-01T00:00:00Z",
+        end_time="2026-07-01T00:00:00Z",
+        packages=packages,
+        proposal_id=None if product_ids is not None else "prop-123",
+    )
+
+
+def _make_handler(
+    platform: DecisioningPlatform,
+    executor: ThreadPoolExecutor,
+    config_store: Any = None,
+) -> PlatformHandler:
+    return PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        config_store=config_store,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_lookup_all_three_products(executor) -> None:
+    """Store returns configs for all 3 product_ids; adopter sees full dict."""
+    received_configs: list[dict] = []
+
+    class _Store:
+        async def lookup_implementation_configs(self, product_ids, ctx):
+            return {pid: {"line_item_id": f"li_{pid}"} for pid in product_ids}
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            received_configs.append(configs or {})
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_001", packages=[])
+
+    handler = _make_handler(_Platform(), executor, config_store=_Store())
+    req = _make_request(["pid1", "pid2", "pid3"])
+    await handler.create_media_buy(req, ToolContext())
+
+    assert len(received_configs) == 1
+    assert set(received_configs[0].keys()) == {"pid1", "pid2", "pid3"}
+    assert received_configs[0]["pid1"] == {"line_item_id": "li_pid1"}
+
+
+@pytest.mark.asyncio
+async def test_partial_return_adopter_sees_subset(executor) -> None:
+    """Store returns only 2 of 3 configs; framework does not fail."""
+    received_configs: list[dict] = []
+
+    class _Store:
+        async def lookup_implementation_configs(self, product_ids, ctx):
+            # Intentionally omit pid3
+            return {
+                "pid1": {"kind": "display"},
+                "pid2": {"kind": "video"},
+            }
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            received_configs.append(configs or {})
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_002", packages=[])
+
+    handler = _make_handler(_Platform(), executor, config_store=_Store())
+    req = _make_request(["pid1", "pid2", "pid3"])
+    await handler.create_media_buy(req, ToolContext())
+
+    assert received_configs[0] == {"pid1": {"kind": "display"}, "pid2": {"kind": "video"}}
+
+
+@pytest.mark.asyncio
+async def test_store_raises_translates_to_service_unavailable(executor) -> None:
+    """Store raises a generic exception; framework surfaces SERVICE_UNAVAILABLE."""
+
+    class _Store:
+        async def lookup_implementation_configs(self, product_ids, ctx):
+            raise ConnectionError("db gone")
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_003", packages=[])
+
+    handler = _make_handler(_Platform(), executor, config_store=_Store())
+    req = _make_request(["pid1"])
+    with pytest.raises(AdcpError) as exc_info:
+        await handler.create_media_buy(req, ToolContext())
+
+    err = exc_info.value
+    assert err.code == "SERVICE_UNAVAILABLE"
+    assert err.recovery == "transient"
+
+
+@pytest.mark.asyncio
+async def test_store_adcp_error_propagates_verbatim(executor) -> None:
+    """An AdcpError raised by the store is not wrapped — it propagates as-is."""
+
+    class _Store:
+        async def lookup_implementation_configs(self, product_ids, ctx):
+            raise AdcpError("RATE_LIMITED", message="slow down", recovery="transient")
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_004", packages=[])
+
+    handler = _make_handler(_Platform(), executor, config_store=_Store())
+    req = _make_request(["pid1"])
+    with pytest.raises(AdcpError) as exc_info:
+        await handler.create_media_buy(req, ToolContext())
+
+    assert exc_info.value.code == "RATE_LIMITED"
+
+
+@pytest.mark.asyncio
+async def test_proposal_id_flow_no_lookup(executor) -> None:
+    """packages=None (proposal_id path) → store not called, adopter gets configs={}."""
+    store_calls: list[list] = []
+
+    class _Store:
+        async def lookup_implementation_configs(self, product_ids, ctx):
+            store_calls.append(product_ids)
+            return {}
+
+    received_configs: list[dict] = []
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            received_configs.append(configs or {})
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_005", packages=[])
+
+    handler = _make_handler(_Platform(), executor, config_store=_Store())
+    req = _make_request(None)  # proposal_id flow, packages=None
+    await handler.create_media_buy(req, ToolContext())
+
+    assert store_calls == []  # store never called
+    assert received_configs == [{}]
+
+
+@pytest.mark.asyncio
+async def test_no_store_wired_adopter_gets_empty_configs(executor) -> None:
+    """When config_store=None, adopter receives configs={} without any lookup."""
+    received_configs: list[dict] = []
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            received_configs.append(configs or {})
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_006", packages=[])
+
+    # No config_store passed
+    handler = _make_handler(_Platform(), executor, config_store=None)
+    req = _make_request(["pid1", "pid2"])
+    # Warning expected because method accepts configs but no store wired
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        await handler.create_media_buy(req, ToolContext())
+
+    assert received_configs == [{}]
+
+
+@pytest.mark.asyncio
+async def test_adopter_without_configs_kwarg_store_skips_injection(executor) -> None:
+    """Adopter not declaring 'configs' still works; store is called but not injected."""
+    store_calls: list[list] = []
+
+    class _Store:
+        async def lookup_implementation_configs(self, product_ids, ctx):
+            store_calls.append(list(product_ids))
+            return {"pid1": {"x": 1}}
+
+    received_req_ids: list[str] = []
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx):  # no configs kwarg
+            received_req_ids.append(req.idempotency_key)
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_007", packages=[])
+
+    handler = _make_handler(_Platform(), executor, config_store=_Store())
+    req = _make_request(["pid1"])
+    await handler.create_media_buy(req, ToolContext())
+
+    # Store was called (lookup happened)
+    assert len(store_calls) == 1
+    # Method still received the request correctly (no injection)
+    assert received_req_ids == ["test-key-12345678"]
+
+
+def test_product_config_store_protocol_exported() -> None:
+    """ProductConfigStore is importable from adcp.decisioning."""
+    from adcp.decisioning import ProductConfigStore as PCS
+
+    assert PCS is _ProductConfigStoreProto
+
+
+def test_no_store_with_configs_kwarg_emits_warning(executor) -> None:
+    """UserWarning fires when method accepts 'configs' but no store is wired."""
+    import warnings
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="seller")
+
+        async def create_media_buy(self, req, ctx, configs=None):
+            from adcp.types import CreateMediaBuySuccessResponse
+
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_008", packages=[])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _make_handler(_Platform(), executor, config_store=None)
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert any("ProductConfigStore" in str(w.message) for w in user_warnings)

--- a/tests/test_implementation_config.py
+++ b/tests/test_implementation_config.py
@@ -240,15 +240,15 @@ async def test_no_store_wired_adopter_gets_empty_configs(executor) -> None:
 
             return CreateMediaBuySuccessResponse(media_buy_id="mb_006", packages=[])
 
-    # No config_store passed
-    handler = _make_handler(_Platform(), executor, config_store=None)
-    req = _make_request(["pid1", "pid2"])
-    # Warning expected because method accepts configs but no store wired
     import warnings
 
+    # Warning fires at construction time (not at call time), so suppress there.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        await handler.create_media_buy(req, ToolContext())
+        handler = _make_handler(_Platform(), executor, config_store=None)
+
+    req = _make_request(["pid1", "pid2"])
+    await handler.create_media_buy(req, ToolContext())
 
     assert received_configs == [{}]
 


### PR DESCRIPTION
Closes #497

Adds a pluggable `ProductConfigStore` Protocol that the framework calls before invoking `SalesPlatform.create_media_buy`, injecting seller-side per-product implementation configs as a `configs=` kwarg. Adopters who declare `configs` in their method signature receive the resolved dict; adopters who don't declare it (or who don't wire a store) see no change — fully backward-compatible. Follows the same "framework intercepts at the handler seam" pattern as the F12 webhook auto-emit (`webhook_emit.py`).

**What changed:**
- `src/adcp/decisioning/implementation_config.py` (new) — `ProductConfigStore` Protocol with `async def lookup_implementation_configs(product_ids, ctx)`
- `dispatch.py` — `extra_kwargs` param on `_invoke_platform_method`; matching `TypeError` diagnostic branch for injection failures
- `handler.py` — `config_store=` on `PlatformHandler.__init__`; `create_media_buy` shim calls the store (guards `packages=None` for proposal-id flows), injects via `extra_kwargs`; `UserWarning` at boot when method accepts `configs` but no store is wired
- `serve.py` — `config_store=` threaded through `create_adcp_server_from_platform` and `serve`
- `specialisms/sales.py` — docstring on `create_media_buy` documenting the framework injection
- `__init__.py` — `ProductConfigStore` exported from `adcp.decisioning`

**What was tested:**
- `pytest tests/test_implementation_config.py` — 9 new tests: full 3-product lookup, partial return (2-of-3), store raises → `SERVICE_UNAVAILABLE`, `AdcpError` propagates verbatim, `packages=None` skips lookup, no store wired → `configs={}`, adopter without `configs` kwarg → lookup runs but not injected, Protocol exported, boot warning fires
- `pytest tests/test_decisioning_handler.py` — 12 existing tests, all pass
- `ruff check src/adcp/decisioning/` — no issues
- `mypy src/adcp/decisioning/handler.py` — no new errors in changed files

**Nits (not fixed, surface for reviewer):**
- `implementation_config.py:26-27` — `RequestContext` only imported under `TYPE_CHECKING`; works correctly because of `from __future__ import annotations` deferral, but worth noting for readers
- The `serve()` docstring doesn't yet mention `config_store=`; `create_adcp_server_from_platform` has the canonical param doc

**Pre-PR review:**
- code-reviewer: approved — TypeError branch for extra_kwargs fixed, dict.fromkeys dedup preserves insertion order, test warning placement corrected; no blockers remaining
- dx-expert: approved — wiring is one parameter at server construction, warning fires early with actionable fix text, Protocol docstring now documents the injection contract

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WS8EChCkSo6diBNgbXBMM1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS8EChCkSo6diBNgbXBMM1)_