### PR TITLE
feat(decisioning): cursor-based pagination helper for list responses

### DIFF
--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -44,6 +44,7 @@ from adcp.decisioning.dispatch import (
     _invoke_platform_method,
 )
 from adcp.decisioning.implementation_config import ProductConfigStore
+from adcp.decisioning.pagination import _query_hash, apply_framework_pagination
 from adcp.decisioning.webhook_emit import maybe_emit_sync_completion
 from adcp.server.base import ADCPHandler, ToolContext
 
@@ -1075,6 +1076,15 @@ class PlatformHandler(ADCPHandler[ToolContext]):
                 registry=self._registry,
             ),
         )
+        if self._platform.capabilities.auto_paginate and params.pagination is not None:
+            response = cast(
+                "GetProductsResponse",
+                apply_framework_pagination(
+                    response,
+                    params.pagination,
+                    _query_hash(params),
+                ),
+            )
         if params.fields:
             response = _project_product_fields(response, params.fields)
         return response

--- a/src/adcp/decisioning/pagination.py
+++ b/src/adcp/decisioning/pagination.py
@@ -1,0 +1,208 @@
+"""Framework-managed cursor pagination for list responses.
+
+When an adopter sets ``auto_paginate=True`` on :class:`DecisioningCapabilities`,
+the handler intercepts ``get_products``, calls the adopter's implementation to
+retrieve the full product set, and slices the result to the requested page.
+
+.. warning:: **Adoption ceiling.**  ``auto_paginate=True`` requires the adopter's
+   ``get_products`` to return the *complete* unfiltered product set on every call —
+   the framework slices it. This pattern works well for in-memory and small-catalog
+   sellers (≲10 k products). Adopters with DB-backed catalogs at production scale
+   MUST handle cursor logic natively and leave ``auto_paginate=False`` (the default).
+   Returning a 100 k-product list only to have the framework discard 99 950 rows is
+   a silent production latency and memory spike that only manifests at scale.
+
+The cursor is an **HMAC-SHA-256-signed** JSON envelope::
+
+    base64url( JSON({ "p": JSON({"v":1,"o":<offset>,"qh":<filter-hash>}), "s":<hex-sig> }) )
+
+The ``qh`` field is a SHA-256 fingerprint of the request parameters (excluding
+``pagination`` itself), so if a buyer changes filters between pages the framework
+returns ``INVALID_REQUEST`` with ``field="pagination.cursor"`` rather than silently
+serving the wrong page slice.
+
+**Secret management.** The HMAC key defaults to a per-process random secret (stable
+within the process, different across restarts). Stale cursors from a prior process
+return ``INVALID_REQUEST`` — this is the correct behaviour for stateless sellers.
+Horizontally-scaled or stateless sellers that need cursors to survive process restarts
+MUST set ``ADCP_PAGINATION_SECRET`` in the environment.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Any
+
+from adcp.decisioning.types import AdcpError
+
+logger = logging.getLogger(__name__)
+
+_CURSOR_VERSION = 1
+
+# Per-process fallback secret. Generated once at import time; stable within a
+# process, different across restarts. Stale cursors from prior processes fail
+# the HMAC check and return INVALID_REQUEST — correct for stateless sellers.
+_PROCESS_SECRET: bytes = os.urandom(32)
+
+
+def _secret() -> bytes:
+    """Return the active HMAC secret."""
+    env = os.environ.get("ADCP_PAGINATION_SECRET")
+    return env.encode() if env else _PROCESS_SECRET
+
+
+def _sign(payload: bytes, secret: bytes) -> str:
+    return hmac.new(secret, payload, digestmod="sha256").hexdigest()
+
+
+def _encode_cursor(offset: int, query_hash: str, secret: bytes | None = None) -> str:
+    """Return an opaque, HMAC-signed cursor string for the given page offset."""
+    payload = json.dumps(
+        {"v": _CURSOR_VERSION, "o": offset, "qh": query_hash}, separators=(",", ":")
+    ).encode()
+    sig = _sign(payload, secret if secret is not None else _secret())
+    envelope = json.dumps(
+        {"p": payload.decode(), "s": sig}, separators=(",", ":")
+    ).encode()
+    return base64.urlsafe_b64encode(envelope).rstrip(b"=").decode()
+
+
+def _decode_cursor(cursor: str, expected_query_hash: str, secret: bytes | None = None) -> int:
+    """Decode *cursor* and return the page offset.
+
+    :raises AdcpError: ``INVALID_REQUEST`` (``field="pagination.cursor"``,
+        ``recovery="correctable"``) when the cursor is malformed, has an invalid
+        HMAC signature, or embeds a query-hash that doesn't match
+        *expected_query_hash* (filters changed between pages).
+    """
+    _bad = AdcpError(
+        "INVALID_REQUEST",
+        message=(
+            "pagination.cursor is malformed or expired. Omit the cursor to restart from page 1."
+        ),
+        field="pagination.cursor",
+        recovery="correctable",
+        suggestion="Omit the cursor to start from the first page.",
+    )
+    try:
+        # Restore stripped padding before decoding.
+        padded = cursor + "=" * ((4 - len(cursor) % 4) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode())
+        envelope = json.loads(raw)
+        payload_str: str = envelope["p"]
+        sig: str = envelope["s"]
+    except Exception:
+        raise _bad
+
+    payload_bytes = payload_str.encode()
+    expected_sig = _sign(payload_bytes, secret if secret is not None else _secret())
+    if not hmac.compare_digest(sig, expected_sig):
+        raise _bad
+
+    try:
+        inner = json.loads(payload_bytes)
+        offset: int = int(inner["o"])
+        qh: str = inner["qh"]
+    except Exception:
+        raise _bad
+
+    if not hmac.compare_digest(qh, expected_query_hash):
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message=(
+                "pagination.cursor is stale: request filters changed since this cursor was "
+                "issued. Omit the cursor to restart pagination with the new filter values."
+            ),
+            field="pagination.cursor",
+            recovery="correctable",
+            suggestion="Omit the cursor to start from the first page with the updated filters.",
+        )
+
+    return offset
+
+
+def _query_hash(params: Any) -> str:
+    """Compute a stable fingerprint of request params, excluding ``pagination``.
+
+    Detects filter drift between pages. ``pagination`` is excluded so
+    successive page requests with different cursors still match the same hash.
+    """
+    try:
+        if hasattr(params, "model_dump"):
+            d: Any = params.model_dump(mode="json", exclude={"pagination"})
+        else:
+            d = {k: v for k, v in dict(params).items() if k != "pagination"}
+        canonical = json.dumps(d, sort_keys=True, separators=(",", ":"), default=str)
+    except Exception:
+        canonical = repr(params)
+    return hashlib.sha256(canonical.encode()).hexdigest()[:32]
+
+
+def apply_framework_pagination(
+    response: Any,
+    pagination: Any,
+    query_hash: str,
+    secret: bytes | None = None,
+) -> Any:
+    """Slice a full-list ``GetProductsResponse`` to the requested page.
+
+    Called by the handler post-adapter when ``auto_paginate=True`` on
+    :class:`~adcp.decisioning.platform.DecisioningCapabilities`.
+
+    Short-circuits (returns *response* unchanged) when:
+
+    * ``response.pagination`` is already populated — the adopter handled
+      pagination natively; the framework must not overwrite it.
+    * ``response.products`` is absent — unexpected shape; pass through and
+      let wire validation surface the issue.
+
+    Clamps ``max_results`` to ``[1, 100]`` before slicing.
+
+    :param response: The adopter's full-list ``GetProductsResponse``.
+    :param pagination: The wire ``Pagination`` request object
+        (``max_results``, ``cursor``).
+    :param query_hash: Filter fingerprint from :func:`_query_hash` on the
+        original request. Used to anchor the cursor.
+    :param secret: HMAC key override. ``None`` uses the active process secret.
+    :returns: A new ``GetProductsResponse`` with ``products`` sliced to the
+        page and ``pagination`` populated, or the original *response* if the
+        short-circuit fired.
+    """
+    # Short-circuit: adopter already populated pagination.
+    if getattr(response, "pagination", None) is not None:
+        return response
+
+    products = getattr(response, "products", None)
+    if products is None:
+        return response
+
+    # Decode cursor or start at offset 0.
+    cursor_str = getattr(pagination, "cursor", None)
+    if cursor_str:
+        offset = _decode_cursor(cursor_str, query_hash, secret)
+    else:
+        offset = 0
+
+    # Clamp max_results to wire schema bounds [1, 100].
+    raw_max = getattr(pagination, "max_results", None)
+    max_results = max(1, min(100, raw_max if raw_max is not None else 50))
+
+    full_list = list(products)
+    page = full_list[offset : offset + max_results]
+    has_more = (offset + max_results) < len(full_list)
+    next_cursor = (
+        _encode_cursor(offset + max_results, query_hash, secret) if has_more else None
+    )
+
+    from adcp.types import PaginationResponse
+
+    new_pagination = PaginationResponse(has_more=has_more, cursor=next_cursor)
+    return response.model_copy(update={"products": page, "pagination": new_pagination})
+
+
+__all__ = ["apply_framework_pagination"]

--- a/src/adcp/decisioning/pagination.py
+++ b/src/adcp/decisioning/pagination.py
@@ -87,7 +87,6 @@ def _decode_cursor(cursor: str, expected_query_hash: str, secret: bytes | None =
         ),
         field="pagination.cursor",
         recovery="correctable",
-        suggestion="Omit the cursor to start from the first page.",
     )
     try:
         # Restore stripped padding before decoding.
@@ -97,19 +96,19 @@ def _decode_cursor(cursor: str, expected_query_hash: str, secret: bytes | None =
         payload_str: str = envelope["p"]
         sig: str = envelope["s"]
     except Exception:
-        raise _bad
+        raise _bad from None  # suppress decode-error chain; internal detail
 
     payload_bytes = payload_str.encode()
     expected_sig = _sign(payload_bytes, secret if secret is not None else _secret())
     if not hmac.compare_digest(sig, expected_sig):
-        raise _bad
+        raise _bad from None
 
     try:
         inner = json.loads(payload_bytes)
         offset: int = int(inner["o"])
         qh: str = inner["qh"]
     except Exception:
-        raise _bad
+        raise _bad from None
 
     if not hmac.compare_digest(qh, expected_query_hash):
         raise AdcpError(
@@ -168,12 +167,18 @@ def apply_framework_pagination(
         (``max_results``, ``cursor``).
     :param query_hash: Filter fingerprint from :func:`_query_hash` on the
         original request. Used to anchor the cursor.
-    :param secret: HMAC key override. ``None`` uses the active process secret.
+    :param secret: HMAC key override for testing and direct use. ``None`` uses
+        :func:`_secret` (reads ``ADCP_PAGINATION_SECRET`` env var, falls back
+        to the per-process random secret). The handler always passes ``None``
+        — configure production secrets via the env var.
     :returns: A new ``GetProductsResponse`` with ``products`` sliced to the
         page and ``pagination`` populated, or the original *response* if the
         short-circuit fired.
     """
-    # Short-circuit: adopter already populated pagination.
+    # Short-circuit: adopter already populated pagination. Also short-circuits
+    # when _invoke_platform_method returned a TaskHandoff projection dict
+    # ({"task_id": ..., "status": "submitted"}) — dicts have no .products
+    # attribute so the products-None branch below fires and passes through.
     if getattr(response, "pagination", None) is not None:
         return response
 
@@ -199,6 +204,7 @@ def apply_framework_pagination(
         _encode_cursor(offset + max_results, query_hash, secret) if has_more else None
     )
 
+    # Deferred: adcp.types imports adcp.decisioning.types; top-level import is circular.
     from adcp.types import PaginationResponse
 
     new_pagination = PaginationResponse(has_more=has_more, cursor=next_cursor)

--- a/src/adcp/decisioning/platform.py
+++ b/src/adcp/decisioning/platform.py
@@ -169,6 +169,13 @@ class DecisioningCapabilities:
     creative_agents: list[Any] = field(default_factory=list)
     config: dict[str, Any] = field(default_factory=dict)
     governance_aware: bool = False
+    # When True, the framework calls get_products and slices the full result
+    # set to the requested page. Only suitable for in-memory / small-catalog
+    # adopters whose get_products returns the complete unfiltered product set.
+    # Adopters with DB-backed catalogs at production scale MUST leave this
+    # False and handle cursor logic natively — returning 100k products only
+    # to discard 99 950 is a silent production latency and memory spike.
+    auto_paginate: bool = False
 
     # Wire capability blocks (mirror ``GetAdcpCapabilitiesResponse``)
     adcp: Adcp | None = None

--- a/tests/test_decisioning_pagination.py
+++ b/tests/test_decisioning_pagination.py
@@ -1,0 +1,297 @@
+"""Tests for adcp.decisioning.pagination: cursor codec + page-slice helper.
+
+Covers all acceptance criteria from issue #493:
+- encode/decode round-trip
+- INVALID_REQUEST on hash mismatch and malformed cursor
+- auto_paginate=False (default) leaves existing adopters untouched
+- auto_paginate=True slices response and sets has_more correctly
+- max_results clamped to [1, 100]
+- 250-product / 5-page test
+- cursor rejection when filters change between calls
+- short-circuit when adopter already set response.pagination
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    SingletonAccounts,
+)
+from adcp.decisioning.handler import PlatformHandler
+from adcp.decisioning.pagination import (
+    _decode_cursor,
+    _encode_cursor,
+    _query_hash,
+    apply_framework_pagination,
+)
+from adcp.decisioning.task_registry import InMemoryTaskRegistry
+from adcp.decisioning.types import AdcpError
+from adcp.server.base import ToolContext
+from adcp.types import (
+    GetProductsRequest,
+    GetProductsResponse,
+    PaginationRequest,
+    PaginationResponse,
+    Product,
+)
+
+
+@pytest.fixture
+def executor():
+    pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-pag-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+def _make_handler(platform: DecisioningPlatform, executor: ThreadPoolExecutor) -> PlatformHandler:
+    return PlatformHandler(platform, executor=executor, registry=InMemoryTaskRegistry())
+
+_SECRET = b"test-secret-key"
+
+
+# ---------------------------------------------------------------------------
+# Cursor codec
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_roundtrip() -> None:
+    cursor = _encode_cursor(50, "abc123", _SECRET)
+    offset = _decode_cursor(cursor, "abc123", _SECRET)
+    assert offset == 50
+
+
+def test_encode_decode_offset_zero() -> None:
+    cursor = _encode_cursor(0, "qh1", _SECRET)
+    assert _decode_cursor(cursor, "qh1", _SECRET) == 0
+
+
+def test_decode_raises_on_hash_mismatch() -> None:
+    cursor = _encode_cursor(50, "hash-A", _SECRET)
+    with pytest.raises(AdcpError) as exc_info:
+        _decode_cursor(cursor, "hash-B", _SECRET)
+    err = exc_info.value
+    assert err.code == "INVALID_REQUEST"
+    assert "stale" in (err.args[0] if err.args else "").lower()
+    assert err.field == "pagination.cursor"
+    assert err.recovery == "correctable"
+
+
+def test_decode_raises_on_malformed_cursor() -> None:
+    with pytest.raises(AdcpError) as exc_info:
+        _decode_cursor("not-valid-base64!!!", "qh", _SECRET)
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.field == "pagination.cursor"
+
+
+def test_decode_raises_on_tampered_signature() -> None:
+    cursor = _encode_cursor(0, "qh", _SECRET)
+    # Flip the last character of the cursor.
+    tampered = cursor[:-1] + ("A" if cursor[-1] != "A" else "B")
+    with pytest.raises(AdcpError) as exc_info:
+        _decode_cursor(tampered, "qh", _SECRET)
+    assert exc_info.value.code == "INVALID_REQUEST"
+
+
+def test_decode_raises_wrong_process_secret() -> None:
+    cursor = _encode_cursor(0, "qh", b"secret-A")
+    with pytest.raises(AdcpError):
+        _decode_cursor(cursor, "qh", b"secret-B")
+
+
+# ---------------------------------------------------------------------------
+# apply_framework_pagination
+# ---------------------------------------------------------------------------
+
+
+def _make_response(n: int) -> GetProductsResponse:
+    """Return a GetProductsResponse with n stub products (bypasses validation)."""
+    products = [Product.model_construct(product_id=f"p{i}") for i in range(n)]
+    return GetProductsResponse.model_construct(products=products)
+
+
+def _make_pagination_request(max_results: int = 50, cursor: str | None = None) -> PaginationRequest:
+    return PaginationRequest(max_results=max_results, cursor=cursor)
+
+
+def test_first_page_has_more_true() -> None:
+    resp = _make_response(100)
+    pag = _make_pagination_request(max_results=50)
+    result = apply_framework_pagination(resp, pag, "qh", _SECRET)
+    assert len(result.products) == 50
+    assert result.pagination is not None
+    assert result.pagination.has_more is True
+    assert result.pagination.cursor is not None
+
+
+def test_last_page_has_more_false() -> None:
+    resp = _make_response(30)
+    pag = _make_pagination_request(max_results=50)
+    result = apply_framework_pagination(resp, pag, "qh", _SECRET)
+    assert len(result.products) == 30
+    assert result.pagination is not None
+    assert result.pagination.has_more is False
+    assert result.pagination.cursor is None
+
+
+def test_250_products_5_pages() -> None:
+    """250 products, max_results=50 → exactly 5 pages, last has has_more=False."""
+    qh = "fixed-qh"
+    page_sizes: list[int] = []
+    cursor: str | None = None
+
+    for _ in range(10):  # cap iterations to prevent infinite loop in test
+        resp = _make_response(250)
+        pag = _make_pagination_request(max_results=50, cursor=cursor)
+        result = apply_framework_pagination(resp, pag, qh, _SECRET)
+        page_sizes.append(len(result.products))
+        assert result.pagination is not None
+        if not result.pagination.has_more:
+            break
+        cursor = result.pagination.cursor
+
+    assert len(page_sizes) == 5
+    assert all(s == 50 for s in page_sizes)
+    assert result.pagination.has_more is False  # type: ignore[union-attr]
+
+
+def test_max_results_clamped_above_100() -> None:
+    resp = _make_response(200)
+    # Bypass wire validation to test the framework clamp.
+    pag = PaginationRequest.model_construct(max_results=9999, cursor=None)
+    result = apply_framework_pagination(resp, pag, "qh", _SECRET)
+    # Clamped to 100.
+    assert len(result.products) == 100
+    assert result.pagination is not None
+    assert result.pagination.has_more is True
+
+
+def test_max_results_clamped_below_1() -> None:
+    resp = _make_response(10)
+    # Bypass wire validation to test the framework clamp.
+    pag = PaginationRequest.model_construct(max_results=0, cursor=None)
+    result = apply_framework_pagination(resp, pag, "qh", _SECRET)
+    # Clamped to 1.
+    assert len(result.products) == 1
+
+
+def test_short_circuit_when_pagination_already_set() -> None:
+    resp = _make_response(10)
+    existing = PaginationResponse(has_more=False, cursor=None)
+    resp = resp.model_copy(update={"pagination": existing})
+    pag = _make_pagination_request(max_results=5)
+    result = apply_framework_pagination(resp, pag, "qh", _SECRET)
+    # Must not overwrite the adopter's pagination.
+    assert result is resp
+    assert result.pagination is existing
+
+
+def test_cursor_rejects_when_filters_change() -> None:
+    """Cursor from request with qh='hash-A' must reject when qh='hash-B'."""
+    resp = _make_response(100)
+    pag_page1 = _make_pagination_request(max_results=50)
+    result = apply_framework_pagination(resp, pag_page1, "hash-A", _SECRET)
+    next_cursor = result.pagination.cursor  # type: ignore[union-attr]
+    assert next_cursor is not None
+
+    # Simulate filter change: different query hash.
+    pag_page2 = _make_pagination_request(max_results=50, cursor=next_cursor)
+    with pytest.raises(AdcpError) as exc_info:
+        apply_framework_pagination(resp, pag_page2, "hash-B", _SECRET)
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert "stale" in (exc_info.value.args[0] if exc_info.value.args else "").lower()
+
+
+# ---------------------------------------------------------------------------
+# query_hash stability
+# ---------------------------------------------------------------------------
+
+
+def test_query_hash_excludes_pagination() -> None:
+    req_no_pag = GetProductsRequest(buying_mode="brief", brief="test")
+    req_with_pag = GetProductsRequest(
+        buying_mode="brief",
+        brief="test",
+        pagination=PaginationRequest(max_results=50, cursor="xyz"),
+    )
+    assert _query_hash(req_no_pag) == _query_hash(req_with_pag)
+
+
+def test_query_hash_changes_when_filters_change() -> None:
+    req_a = GetProductsRequest(buying_mode="brief", brief="shoes")
+    req_b = GetProductsRequest(buying_mode="brief", brief="bags")
+    assert _query_hash(req_a) != _query_hash(req_b)
+
+
+# ---------------------------------------------------------------------------
+# Integration: auto_paginate flag through PlatformHandler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_paginate_false_default_passthrough(executor: ThreadPoolExecutor) -> None:
+    """auto_paginate=False (default) — handler returns full list unchanged."""
+
+    class TestPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acme")
+
+        def get_products(self, req: GetProductsRequest, ctx: object) -> GetProductsResponse:
+            return _make_response(10)
+
+    handler = _make_handler(TestPlatform(), executor)
+    req = GetProductsRequest(
+        buying_mode="brief",
+        brief="test",
+        pagination=PaginationRequest(max_results=5),
+    )
+    result = await handler.get_products(req, ToolContext())
+    # No slicing: all 10 products returned, no pagination set by framework.
+    assert len(result.products) == 10
+    assert result.pagination is None
+
+
+@pytest.mark.asyncio
+async def test_auto_paginate_true_slices_response(executor: ThreadPoolExecutor) -> None:
+    """auto_paginate=True — handler slices and sets pagination."""
+
+    class TestPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(auto_paginate=True)
+        accounts = SingletonAccounts(account_id="acme")
+
+        def get_products(self, req: GetProductsRequest, ctx: object) -> GetProductsResponse:
+            return _make_response(10)
+
+    handler = _make_handler(TestPlatform(), executor)
+    req = GetProductsRequest(
+        buying_mode="brief",
+        brief="test",
+        pagination=PaginationRequest(max_results=5),
+    )
+    result = await handler.get_products(req, ToolContext())
+    assert len(result.products) == 5
+    assert result.pagination is not None
+    assert result.pagination.has_more is True
+
+
+@pytest.mark.asyncio
+async def test_auto_paginate_no_pagination_in_request_passthrough(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """auto_paginate=True but no pagination in request — full list returned."""
+
+    class TestPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(auto_paginate=True)
+        accounts = SingletonAccounts(account_id="acme")
+
+        def get_products(self, req: GetProductsRequest, ctx: object) -> GetProductsResponse:
+            return _make_response(10)
+
+    handler = _make_handler(TestPlatform(), executor)
+    req = GetProductsRequest(buying_mode="brief", brief="test")
+    result = await handler.get_products(req, ToolContext())
+    assert len(result.products) == 10


### PR DESCRIPTION
Closes #493

Adds framework-managed cursor pagination for `get_products` behind a new `auto_paginate=False` capability flag. Existing adopters are unaffected — the flag defaults `False` and the entire code path is gated on it. When opted in, the handler calls the adopter's `get_products`, slices the full result to the requested page, encodes an HMAC-SHA-256-signed cursor, and detects filter drift between pages, returning `INVALID_REQUEST(field="pagination.cursor")` on mismatch.

**Adoption ceiling (documented in module docstring and field comment):** `auto_paginate=True` requires `get_products` to return the complete unfiltered product set. Suitable for in-memory and small-catalog sellers (≲10k products). Adopters with DB-backed catalogs at scale must handle cursor logic natively and leave this `False`.

**Error code note:** `INVALID_CURSOR` is absent from the spec error catalog (`schemas/cache/enums/error-code.json`). `INVALID_REQUEST(field="pagination.cursor")` is used until the spec adds the dedicated code; this is tracked in the issue.

## What changed

- **`src/adcp/decisioning/pagination.py`** (new): `_encode_cursor` / `_decode_cursor` (HMAC-SHA-256-signed, constant-time compare, `raise ... from None` to suppress internal decode chains) and `apply_framework_pagination` post-adapter.
- **`src/adcp/decisioning/platform.py`**: `auto_paginate: bool = False` in the SDK-internal dispatch section alongside `governance_aware`.
- **`src/adcp/decisioning/handler.py`**: `get_products` calls the post-adapter when `auto_paginate=True` and `params.pagination is not None`.
- **`tests/test_decisioning_pagination.py`**: 18 tests covering the 250-product/5-page criterion, cursor rejection on filter change, `max_results` clamping, short-circuit when adopter pre-populates `pagination`, handler passthrough when `auto_paginate=False`.

## What was tested

- `pytest tests/test_decisioning_pagination.py` — 18/18 passed
- `pytest tests/` (full fast suite, excluding integration/slow) — 3208 passed, 0 failures
- `ruff check src/adcp/decisioning/pagination.py src/adcp/decisioning/handler.py src/adcp/decisioning/platform.py tests/test_decisioning_pagination.py` — clean
- `mypy src/adcp/decisioning/pagination.py src/adcp/decisioning/handler.py` — no new errors

## Pre-PR review

- **code-reviewer:** approved — no CI blockers; pre-existing ruff B904 suppression means `raise ... from None` (fixed before PR) is the correct form; TaskHandoff short-circuit documented in function comment; `digestmod=hashlib.sha256` preferred over string form (nit, both equivalent on 3.10+)
- **dx-expert:** approved — `auto_paginate` name is correct (parallels `governance_aware`); deferred import annotated; `secret=None` in handler clarified to mean env-var path; nit: `_query_hash` fallback could log a warning (follow-up)

## Nits (not fixed, lower priority)

- `digestmod="sha256"` string vs `digestmod=hashlib.sha256` constructor — equivalent on all 3.10+ targets
- `_query_hash` repr-fallback could log a `WARNING` when triggered — deferred
- Weak `ADCP_PAGINATION_SECRET` (< 16 bytes) could log a WARNING — deferred

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018LPzKLNDoC8F537kDKWNYj

---
_Generated by [Claude Code](https://claude.ai/code/session_018LPzKLNDoC8F537kDKWNYj)_