### PR TITLE
feat(decisioning): built-in fields projection on get_products responses

### DIFF
--- a/src/adcp/decisioning/_get_products_helpers.py
+++ b/src/adcp/decisioning/_get_products_helpers.py
@@ -1,0 +1,100 @@
+"""Fields-projection helper for ``MediaBuyHandler.get_products``.
+
+When a buyer supplies ``GetProductsRequest.fields`` (a 30-value enum,
+``min_length=1``), the framework drops unrequested product fields before
+returning the response.  This module owns that post-processing.
+
+Three categories of ``Product`` fields are **always** passed through
+regardless of the buyer's selection:
+
+1. **Required-by-schema fields** — ``Product.model_fields`` entries where
+   ``field_info.is_required()`` is True.  These eight fields cannot be
+   ``None`` and the model cannot be constructed without them:
+   ``product_id``, ``name``, ``description``, ``publisher_properties``,
+   ``format_ids``, ``delivery_type``, ``pricing_options``,
+   ``reporting_capabilities``.
+
+2. **Non-enum declared fields** — optional ``Product.model_fields`` entries
+   that have no corresponding ``GetProductsField`` enum value
+   (``cancellation_policy``, ``ext``, ``is_custom``, ``material_submission``,
+   ``measurement_readiness``, ``measurement_terms``, ``performance_standards``,
+   ``property_targeting_allowed``, ``signal_targeting_allowed``).  The enum
+   does not name them so a buyer has no mechanism to opt in or out; the
+   framework leaves them unchanged.
+
+3. **Extension fields** — keys present in ``Product.__pydantic_extra__``
+   (the model carries ``extra='allow'``).  These are seller-defined
+   extension fields not named by the spec; the framework passes them through
+   unconditionally.
+
+When ``params.fields`` is ``None`` or empty the handler guard
+(``if params.fields:``) prevents this function from being called at all;
+no copy is made.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from adcp.types import GetProductsField, GetProductsResponse, Product
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants derived from the live model so they stay in sync
+# with schema regenerations.
+# ---------------------------------------------------------------------------
+
+#: All schema-required Product fields.  The projection must keep these
+#: regardless of what the buyer requested — they cannot be None and the
+#: model cannot be constructed without them.
+_REQUIRED_PRODUCT_FIELDS: frozenset[str] = frozenset(
+    k for k, v in Product.model_fields.items() if v.is_required()
+)
+
+#: Every string value in the GetProductsField enum (the buyer selection
+#: surface, 30 values).
+_GET_PRODUCTS_FIELD_VALUES: frozenset[str] = frozenset(f.value for f in GetProductsField)
+
+#: Optional Product.model_fields keys that have no GetProductsField enum
+#: entry.  A buyer cannot request or exclude these; the framework always
+#: passes them through.
+_NON_ENUM_PRODUCT_FIELDS: frozenset[str] = (
+    frozenset(Product.model_fields.keys()) - _GET_PRODUCTS_FIELD_VALUES
+)
+
+
+def _project_product_fields(
+    response: GetProductsResponse,
+    fields: list[GetProductsField],
+) -> GetProductsResponse:
+    """Drop unrequested product fields from *response*.
+
+    Keeps: all required-by-schema fields, all non-enum declared fields,
+    all extension (``extra='allow'``) fields, and any explicitly requested
+    fields.  Drops only: optional enum-declared fields the buyer did not
+    request.
+
+    The caller must ensure *fields* is non-empty (the handler guard
+    ``if params.fields:`` enforces this).
+    """
+    requested = frozenset(f.value for f in fields)
+    keep_declared = _REQUIRED_PRODUCT_FIELDS | requested | _NON_ENUM_PRODUCT_FIELDS
+
+    projected: list[Product] = []
+    for p in response.products:
+        raw = p.model_dump(mode="json")
+        # Extra keys: present in the serialised dict but not declared in
+        # model_fields.  model_dump() with extra='allow' emits them at the
+        # top level alongside declared fields.
+        extra_keys = frozenset(raw.keys()) - frozenset(Product.model_fields.keys())
+        all_keep = keep_declared | extra_keys
+        filtered = {k: v for k, v in raw.items() if k in all_keep}
+        projected.append(Product.model_validate(filtered))
+
+    logger.debug(
+        "[adcp.decisioning] fields projection applied to %d product(s)", len(projected)
+    )
+    return response.model_copy(update={"products": projected})
+
+

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
+from adcp.decisioning._get_products_helpers import _project_product_fields
 from adcp.decisioning.context import AuthInfo
 from adcp.decisioning.dispatch import (
     _build_request_context,
@@ -1017,10 +1018,17 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         params: GetProductsRequest,
         context: ToolContext | None = None,
     ) -> GetProductsResponse:
+        """Invoke the platform's ``get_products`` method and apply fields projection.
+
+        When ``params.fields`` is set the framework drops unrequested product
+        fields after the platform method returns, always retaining the eight
+        schema-required fields.  When ``params.fields`` is ``None`` the
+        response passes through unchanged.
+        """
         tool_ctx = context or ToolContext()
         account = await self._resolve_account(params.account, tool_ctx)
         ctx = self._build_ctx(tool_ctx, account)
-        return cast(
+        response = cast(
             "GetProductsResponse",
             await _invoke_platform_method(
                 self._platform,
@@ -1031,6 +1039,9 @@ class PlatformHandler(ADCPHandler[ToolContext]):
                 registry=self._registry,
             ),
         )
+        if params.fields:
+            response = _project_product_fields(response, params.fields)
+        return response
 
     async def create_media_buy(  # type: ignore[override]
         self,

--- a/tests/test_get_products_projection.py
+++ b/tests/test_get_products_projection.py
@@ -1,0 +1,317 @@
+"""Tests for the built-in fields projection on get_products responses.
+
+Covers _project_product_fields from adcp.decisioning._get_products_helpers
+and the end-to-end handler shim integration.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    InMemoryTaskRegistry,
+    SingletonAccounts,
+)
+from adcp.decisioning._get_products_helpers import (
+    _NON_ENUM_PRODUCT_FIELDS,
+    _REQUIRED_PRODUCT_FIELDS,
+    _project_product_fields,
+)
+from adcp.decisioning.handler import PlatformHandler
+from adcp.server.base import ToolContext
+from adcp.types import GetProductsField, GetProductsRequest, GetProductsResponse, Product
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL_PRODUCT_DICT: dict[str, Any] = {
+    "product_id": "p1",
+    "name": "Product 1",
+    "description": "A test product",
+    "publisher_properties": [
+        {"selection_type": "all", "publisher_domain": "pub.example.com"}
+    ],
+    "format_ids": [],
+    "delivery_type": "non_guaranteed",
+    "pricing_options": [
+        {"pricing_model": "cpm", "pricing_option_id": "po1", "currency": "USD"}
+    ],
+    "reporting_capabilities": {
+        "available_reporting_frequencies": ["daily"],
+        "expected_delay_minutes": 60,
+        "timezone": "UTC",
+        "supports_webhooks": False,
+        "available_metrics": ["impressions"],
+        "date_range_support": "date_range",
+    },
+}
+
+
+def _make_product(**overrides: Any) -> Product:
+    return Product.model_validate({**_MINIMAL_PRODUCT_DICT, **overrides})
+
+
+def _make_response(*products: Product) -> GetProductsResponse:
+    return GetProductsResponse(products=list(products))
+
+
+# ---------------------------------------------------------------------------
+# Constant integrity tests — must match the live model
+# ---------------------------------------------------------------------------
+
+
+def test_required_product_fields_matches_model() -> None:
+    """_REQUIRED_PRODUCT_FIELDS must equal the set of is_required() fields
+    in Product.model_fields.  If the schema is regenerated and a required
+    field changes, this test surfaces the drift immediately."""
+    live = frozenset(k for k, v in Product.model_fields.items() if v.is_required())
+    assert _REQUIRED_PRODUCT_FIELDS == live
+
+
+def test_required_product_fields_includes_expected_names() -> None:
+    """Smoke-check the eight names the DX/code-review experts called out."""
+    expected = {
+        "product_id", "name", "description", "publisher_properties",
+        "format_ids", "delivery_type", "pricing_options", "reporting_capabilities",
+    }
+    assert expected <= _REQUIRED_PRODUCT_FIELDS
+
+
+def test_non_enum_product_fields_does_not_overlap_field1() -> None:
+    """Non-enum fields must be disjoint from the GetProductsField enum values."""
+    field1_vals = frozenset(f.value for f in GetProductsField)
+    assert not (_NON_ENUM_PRODUCT_FIELDS & field1_vals)
+
+
+def test_non_enum_product_fields_includes_pass_through_fields() -> None:
+    """The nine non-selectable optional fields should all be in the set."""
+    expected = {
+        "cancellation_policy", "ext", "is_custom", "material_submission",
+        "measurement_readiness", "measurement_terms", "performance_standards",
+        "property_targeting_allowed", "signal_targeting_allowed",
+    }
+    assert expected <= _NON_ENUM_PRODUCT_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Core projection behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_projection_with_all_fields_preserves_everything() -> None:
+    """Round-trip with all enum values — output Product has same field set."""
+    product = _make_product(channels=["display"])
+    response = _make_response(product)
+    projected = _project_product_fields(response, list(GetProductsField))
+    result = projected.products[0]
+    # All declared fields present (same as original)
+    assert result.model_dump() == product.model_dump()
+
+
+def test_projection_drops_unrequested_optional_enum_field() -> None:
+    """Requesting only product_id drops channels even when it was set."""
+    product = _make_product(channels=["display"])
+    response = _make_response(product)
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    result = projected.products[0]
+    assert result.channels is None
+
+
+def test_projection_keeps_all_required_fields_even_when_not_requested() -> None:
+    """All eight required fields survive even when the buyer only asks for
+    product_id — they cannot be absent from a valid Product."""
+    product = _make_product()
+    response = _make_response(product)
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    result = projected.products[0]
+    dumped = result.model_dump()
+    for field in _REQUIRED_PRODUCT_FIELDS:
+        assert dumped[field] is not None, f"Required field {field!r} was dropped"
+
+
+def test_projection_keeps_product_id_and_name_when_not_in_fields() -> None:
+    """product_id and name are always retained per the wire-schema spec."""
+    product = _make_product()
+    response = _make_response(product)
+    # Explicitly do NOT include product_id or name in the requested fields
+    fields = [f for f in GetProductsField
+              if f not in (GetProductsField.product_id, GetProductsField.name)]
+    projected = _project_product_fields(response, fields)
+    result = projected.products[0]
+    assert result.product_id == "p1"
+    assert result.name == "Product 1"
+
+
+def test_projection_preserves_extra_allow_fields() -> None:
+    """Extension fields (extra='allow') must survive the projection."""
+    product = _make_product(**{"my_ext_field": "ext_value", "seller_data": {"x": 1}})
+    assert product.model_extra == {"my_ext_field": "ext_value", "seller_data": {"x": 1}}
+    response = _make_response(product)
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    result = projected.products[0]
+    dumped = result.model_dump()
+    assert dumped.get("my_ext_field") == "ext_value"
+    assert dumped.get("seller_data") == {"x": 1}
+
+
+def test_projection_preserves_non_enum_declared_fields() -> None:
+    """Non-enum optional fields like property_targeting_allowed pass through."""
+    product = _make_product(property_targeting_allowed=True, signal_targeting_allowed=True)
+    response = _make_response(product)
+    # Only request product_id — non-enum fields should NOT be dropped
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    result = projected.products[0]
+    assert result.property_targeting_allowed is True
+    assert result.signal_targeting_allowed is True
+
+
+def test_projection_does_not_corrupt_default_false_bool_fields() -> None:
+    """property_targeting_allowed / signal_targeting_allowed have default=False.
+    Projection must not change them to None."""
+    product = _make_product()
+    # Both fields default to False (not None).
+    assert product.property_targeting_allowed is False
+    assert product.signal_targeting_allowed is False
+    response = _make_response(product)
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    result = projected.products[0]
+    assert result.property_targeting_allowed is False
+    assert result.signal_targeting_allowed is False
+
+
+def test_projection_applies_to_all_products_in_response() -> None:
+    """Multiple products in the response are each projected."""
+    p1 = _make_product(product_id="p1", channels=["display"])
+    p2 = _make_product(product_id="p2", channels=["ctv"])
+    response = _make_response(p1, p2)
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    assert projected.products[0].channels is None
+    assert projected.products[1].channels is None
+    assert projected.products[0].product_id == "p1"
+    assert projected.products[1].product_id == "p2"
+
+
+def test_projection_preserves_other_response_fields() -> None:
+    """proposals, errors, property_list_applied and other response fields
+    are untouched by product projection."""
+    product = _make_product()
+    response = GetProductsResponse(
+        products=[product],
+        property_list_applied=True,
+        errors=None,
+    )
+    projected = _project_product_fields(response, [GetProductsField.product_id])
+    assert projected.property_list_applied is True
+    assert projected.errors is None
+
+
+# ---------------------------------------------------------------------------
+# Handler integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def executor() -> ThreadPoolExecutor:
+    pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-proj-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+def _make_handler(platform: DecisioningPlatform, executor: ThreadPoolExecutor) -> PlatformHandler:
+    return PlatformHandler(platform, executor=executor, registry=InMemoryTaskRegistry())
+
+
+@pytest.mark.asyncio
+async def test_handler_no_fields_returns_response_unchanged(executor) -> None:
+    """When params.fields is None the projection is skipped entirely."""
+    product = _make_product(channels=["display"])
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct")
+
+        async def get_products(self, req, ctx):
+            return GetProductsResponse(products=[product])
+
+    handler = _make_handler(_Platform(), executor)
+    req = GetProductsRequest(buying_mode="brief", brief="any")
+    assert req.fields is None
+    resp = await handler.get_products(req, ToolContext())
+    # channels preserved because no projection ran
+    assert resp.products[0].channels is not None
+
+
+@pytest.mark.asyncio
+async def test_handler_with_fields_drops_unrequested_optional(executor) -> None:
+    """When params.fields is set, the handler applies projection."""
+    product = _make_product(channels=["display"])
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct")
+
+        async def get_products(self, req, ctx):
+            return GetProductsResponse(products=[product])
+
+    handler = _make_handler(_Platform(), executor)
+    req = GetProductsRequest(
+        buying_mode="brief",
+        brief="any",
+        fields=[GetProductsField.product_id],
+    )
+    resp = await handler.get_products(req, ToolContext())
+    assert resp.products[0].channels is None
+    assert resp.products[0].product_id == "p1"
+
+
+@pytest.mark.asyncio
+async def test_handler_fields_preserves_required_fields(executor) -> None:
+    """Handler projection never drops required fields."""
+    product = _make_product()
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct")
+
+        async def get_products(self, req, ctx):
+            return GetProductsResponse(products=[product])
+
+    handler = _make_handler(_Platform(), executor)
+    req = GetProductsRequest(
+        buying_mode="brief",
+        brief="any",
+        fields=[GetProductsField.product_id],
+    )
+    resp = await handler.get_products(req, ToolContext())
+    result = resp.products[0]
+    dumped = result.model_dump()
+    for field in _REQUIRED_PRODUCT_FIELDS:
+        assert dumped[field] is not None, f"Handler dropped required field {field!r}"
+
+
+@pytest.mark.asyncio
+async def test_handler_fields_empty_list_is_noop(executor) -> None:
+    """Empty fields list (cannot arrive from wire, min_length=1, but defensive)
+    must not alter the response."""
+    product = _make_product(channels=["display"])
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acct")
+
+        async def get_products(self, req, ctx):
+            return GetProductsResponse(products=[product])
+
+    handler = _make_handler(_Platform(), executor)
+    # Manually construct request with empty fields list to test the guard
+    req = GetProductsRequest(buying_mode="brief", brief="any")
+    object.__setattr__(req, "fields", [])  # bypass Pydantic min_length=1
+    resp = await handler.get_products(req, ToolContext())
+    # Guard: `if params.fields:` is False for empty list — no projection
+    assert resp.products[0].channels is not None


### PR DESCRIPTION
Closes #492

Adds framework-level projection of `GetProductsRequest.fields` to `MediaBuyHandler.get_products`. After the adopter's platform method returns, if `params.fields` is set the framework strips unrequested product fields before the response reaches the buyer — honoring the lightweight-discovery contract without requiring every adopter to reimplement the same post-filter.

**Three field categories always pass through regardless of the buyer's selection:**
1. All eight schema-required `Product` fields (derived dynamically from `Product.model_fields.is_required()` so schema regenerations stay in sync): `product_id`, `name`, `description`, `publisher_properties`, `format_ids`, `delivery_type`, `pricing_options`, `reporting_capabilities`
2. Nine optional declared fields with no `GetProductsField` enum entry (buyer has no mechanism to select/deselect them): `cancellation_policy`, `ext`, `is_custom`, `material_submission`, `measurement_readiness`, `measurement_terms`, `performance_standards`, `property_targeting_allowed`, `signal_targeting_allowed`
3. All `extra='allow'` extension fields

When `params.fields` is `None` the response is returned unchanged with no allocation.

**New files:**
- `src/adcp/decisioning/_get_products_helpers.py` — `_project_product_fields` helper + three module-level constants; mirrors the `webhook_emit.py` intercept-at-the-seam pattern
- `tests/test_get_products_projection.py` — 17 tests covering constant integrity, projection correctness, extra-field preservation, default-false boolean preservation, handler integration

**What was tested:**
- `pytest tests/test_get_products_projection.py tests/test_decisioning_handler.py` → 29/29 passed
- `mypy src/adcp/decisioning/_get_products_helpers.py src/adcp/decisioning/handler.py` → no issues
- `ruff check` → clean

**Pre-PR review:**
- code-reviewer: approved — no blockers; nits applied (renamed `_FIELD1_VALUES` → `_GET_PRODUCTS_FIELD_VALUES`, removed redundant `__all__`, renamed test for enum-count accuracy, applied `mode="json"` consistency nit)
- ad-tech-protocol-expert: approved — non-breaking per spec; confirmed unconditional projection is correct AdCP behavior (no `fields_projection_supported` capability gate in spec); confirmed `proposals[]` exclusion is correct

**Nits surfaced (not blocking):**
- DX expert noted an opt-out flag (`apply_fields_projection: bool = True`) would benefit adopters who project at the DB query level. The issue author explicitly ruled out a capability gate; this can be added as a non-breaking follow-up if needed.
- "Linked from migration guide" acceptance criterion (#489) requires human action — cannot be automated.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/cse_01H7Q7ZKYj9Atw5KCBBo5ndC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7Q7ZKYj9Atw5KCBBo5ndC)_