### PR TITLE
fix(examples/multi_platform_seller): list_creatives populates query_summary

### DIFF
--- a/examples/multi_platform_seller/src/mock_guaranteed.py
+++ b/examples/multi_platform_seller/src/mock_guaranteed.py
@@ -155,6 +155,10 @@ class MockGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
             p.product_id: p.capacity_impressions for p in self._catalog.values()
         }
         self._buys: dict[str, _MediaBuy] = {}
+        # Creative library — populated by sync_creatives, read by
+        # list_creatives. Wire-shape dicts keyed by creative_id so
+        # list_creatives can return them without re-projecting.
+        self._creatives: dict[str, dict[str, Any]] = {}
 
     # The router's AccountStore is what runtime dispatch threads
     # ctx.account through; this attribute exists only to satisfy
@@ -380,6 +384,9 @@ class MockGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
                     )
                     buy.status = "pending_start"
                     buy.creatives_attached += len(creatives)
+            for i, c in enumerate(creatives):
+                stored = _project_creative_to_wire(c, i)
+                self._creatives[stored["creative_id"]] = stored
 
         return {
             "creatives": [
@@ -390,6 +397,27 @@ class MockGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
                 }
                 for i, c in enumerate(creatives)
             ],
+        }
+
+    def list_creatives(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Return the seller's view of buyer-uploaded creatives.
+
+        Returns the full library; pagination is not modeled (the mock
+        runs against a small fixed-size storyboard catalog). The
+        ``query_summary`` block is required by
+        ``schemas/3.0.6/creative/list-creatives-response.json``.
+        """
+        with self._lock:
+            creatives = list(self._creatives.values())
+        total = len(creatives)
+        return {
+            "query_summary": {"total_matching": total, "returned": total},
+            "pagination": {"has_more": False, "total_count": total},
+            "creatives": creatives,
         }
 
     def get_media_buys(
@@ -624,6 +652,37 @@ def _check_measurement_terms(terms: Any) -> None:
             recovery="correctable",
             field="measurement_terms",
         )
+
+
+def _project_creative_to_wire(creative: Any, idx: int) -> dict[str, Any]:
+    """Project a sync_creatives input item to the
+    ``schemas/3.0.6/creative/list-creatives-response.json`` Creative
+    shape. Auto-approval mirrors the sync_creatives policy: every
+    submitted creative comes back as ``approved``."""
+    creative_id = _creative_id(creative, idx)
+    name = _attr(creative, "name", None) or creative_id
+    raw_format = _attr(creative, "format_id", None)
+    if isinstance(raw_format, dict):
+        format_id = raw_format
+    elif raw_format is not None:
+        format_id = {
+            "agent_url": "https://creative.adcontextprotocol.org/",
+            "id": str(raw_format),
+        }
+    else:
+        format_id = {
+            "agent_url": "https://creative.adcontextprotocol.org/",
+            "id": "display_300x250",
+        }
+    now_iso = datetime.now(timezone.utc).isoformat()
+    return {
+        "creative_id": creative_id,
+        "name": str(name),
+        "format_id": format_id,
+        "status": "approved",
+        "created_date": now_iso,
+        "updated_date": now_iso,
+    }
 
 
 def _project_media_buy_to_wire(buy: _MediaBuy) -> dict[str, Any]:

--- a/examples/multi_platform_seller/src/mock_non_guaranteed.py
+++ b/examples/multi_platform_seller/src/mock_non_guaranteed.py
@@ -141,6 +141,10 @@ class MockNonGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
         # storyboard's delivery assertions stay deterministic.
         self._clearing_multiplier = clearing_multiplier
         self._buys: dict[str, _MediaBuy] = {}
+        # Creative library — populated by sync_creatives, read by
+        # list_creatives. Wire-shape dicts keyed by creative_id so
+        # list_creatives can return them without re-projecting.
+        self._creatives: dict[str, dict[str, Any]] = {}
 
     accounts: Any = None  # type: ignore[assignment]
 
@@ -349,6 +353,9 @@ class MockNonGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
                     assert_media_buy_transition(buy.status, "active", media_buy_id=buy.media_buy_id)
                     buy.status = "active"
                     buy.creatives_attached += len(creatives)
+            for i, c in enumerate(creatives):
+                stored = _project_creative_to_wire(c, i)
+                self._creatives[stored["creative_id"]] = stored
 
         return {
             "creatives": [
@@ -359,6 +366,27 @@ class MockNonGuaranteedPlatform(DecisioningPlatform, SalesPlatform):
                 }
                 for i, c in enumerate(creatives)
             ],
+        }
+
+    def list_creatives(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Return the seller's view of buyer-uploaded creatives.
+
+        Returns the full library; pagination is not modeled (the mock
+        runs against a small fixed-size storyboard catalog). The
+        ``query_summary`` block is required by
+        ``schemas/3.0.6/creative/list-creatives-response.json``.
+        """
+        with self._lock:
+            creatives = list(self._creatives.values())
+        total = len(creatives)
+        return {
+            "query_summary": {"total_matching": total, "returned": total},
+            "pagination": {"has_more": False, "total_count": total},
+            "creatives": creatives,
         }
 
     def get_media_buys(
@@ -595,6 +623,37 @@ def _check_measurement_terms(terms: Any) -> None:
             recovery="correctable",
             field="measurement_terms",
         )
+
+
+def _project_creative_to_wire(creative: Any, idx: int) -> dict[str, Any]:
+    """Project a sync_creatives input item to the
+    ``schemas/3.0.6/creative/list-creatives-response.json`` Creative
+    shape. Auto-approval mirrors the sync_creatives policy: every
+    submitted creative comes back as ``approved``."""
+    creative_id = _creative_id(creative, idx)
+    name = _attr(creative, "name", None) or creative_id
+    raw_format = _attr(creative, "format_id", None)
+    if isinstance(raw_format, dict):
+        format_id = raw_format
+    elif raw_format is not None:
+        format_id = {
+            "agent_url": "https://creative.adcontextprotocol.org/",
+            "id": str(raw_format),
+        }
+    else:
+        format_id = {
+            "agent_url": "https://creative.adcontextprotocol.org/",
+            "id": "display_300x250",
+        }
+    now_iso = datetime.now(timezone.utc).isoformat()
+    return {
+        "creative_id": creative_id,
+        "name": str(name),
+        "format_id": format_id,
+        "status": "approved",
+        "created_date": now_iso,
+        "updated_date": now_iso,
+    }
 
 
 def _project_media_buy_to_wire(buy: _MediaBuy) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Closes #510. Surfaced by PR #508's storyboard artifact: post-#508, both tenants still fail one storyboard step — `creative_fate_after_cancellation/list_creatives_before_cancel` — because the mocks didn't implement `list_creatives` at all, and the wire contract requires `query_summary` on every response.

This PR adds `list_creatives` to both `MockGuaranteedPlatform` and `MockNonGuaranteedPlatform`. Each mock now:

- Persists creatives at `sync_creatives` time into an in-memory library (`_creatives: dict[str, dict]` keyed by `creative_id`)
- Returns the full library on `list_creatives` with the required `query_summary` block (`total_matching`, `returned`) and `pagination` block (`has_more=False`, `total_count`)
- Projects each item to the `schemas/3.0.6/creative/list-creatives-response.json` Creative shape: `{creative_id, name, format_id, status: "approved", created_date, updated_date}`

Auto-approval (`status: "approved"`) mirrors the existing `sync_creatives` policy on both mocks. Pagination is intentionally trivial — the storyboard catalog is small and modeling cursor-based paging would add noise without illustrating a new platform-shape concern.

## Expected delta

Per-tenant pass count should go up by 1 (one storyboard step now passes per tenant). The remaining 3 failures per tenant are blocked on #509 (MCP error projection), per the issue.

## Test plan

- [x] `ruff check examples/multi_platform_seller/` — clean
- [x] `mypy src/adcp/` — clean (777 source files)
- [x] `pytest tests/ -x -q` — 3760 passed, 32 skipped, 1 xfailed
- [x] Functional sanity: `ListCreativesResponse.model_validate(...)` accepts the output on both mocks across empty-library and populated-library cases
- [ ] CI storyboard run on tenant-a + tenant-b — verifies `list_creatives_before_cancel` now passes

## Refs

- Closes #510
- Surfacing context: PR #508 storyboard artifact, post-fix
- Sibling open issue: #509 (MCP error projection — out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)