### PR TITLE
docs(migration): anchor v3→v4 adopter numbers to v4.0 release, point to live codemod

### DIFF
--- a/MIGRATION_v3_to_v4.md
+++ b/MIGRATION_v3_to_v4.md
@@ -50,7 +50,7 @@ dependencies = [
 
 Real-adopter feedback (salesagent v3→v4 experiment at v4.0 release): 270 files
 scanned, 161 test-collection failures. These figures reflect tooling at initial
-release, before alias coverage and codemod improvements; run the codemod against
+release, before subsequent alias coverage and codemod improvements; run the codemod against
 your own tree to see your actual count. Consumers tend to centralize SDK imports
 in one schema module, so a single broken import there crashes test collection
 across the whole codebase. salesagent re-exported through

--- a/MIGRATION_v3_to_v4.md
+++ b/MIGRATION_v3_to_v4.md
@@ -48,10 +48,13 @@ dependencies = [
 
 ## Fix removed-type imports first — they cascade
 
-Real-adopter feedback (salesagent v3→v4 experiment, 270 files scanned, 161
-test-collection failures): consumers tend to centralize SDK imports in one
-schema module, so a single broken import there crashes test collection across
-the whole codebase. salesagent re-exported through `src/core/schemas/_base.py`
+Real-adopter feedback (salesagent v3→v4 experiment at v4.0 release, 270 files
+scanned, 161 test-collection failures — these figures reflect tooling at
+initial release, before alias coverage and codemod improvements; run the
+codemod against your own tree to see your actual count): consumers tend to
+centralize SDK imports in one schema module, so a single broken import there
+crashes test collection across the whole codebase. salesagent re-exported
+through `src/core/schemas/_base.py`
 — **one missing `FormatCategory` import there cascaded into ~140 test failures
 during pytest collect-only**, and stubbing it revealed the next ~140-test
 cascade from `BrandManifest`, then the next from the `generated_poc` reach-ins.

--- a/MIGRATION_v3_to_v4.md
+++ b/MIGRATION_v3_to_v4.md
@@ -48,16 +48,16 @@ dependencies = [
 
 ## Fix removed-type imports first — they cascade
 
-Real-adopter feedback (salesagent v3→v4 experiment at v4.0 release, 270 files
-scanned, 161 test-collection failures — these figures reflect tooling at
-initial release, before alias coverage and codemod improvements; run the
-codemod against your own tree to see your actual count): consumers tend to
-centralize SDK imports in one schema module, so a single broken import there
-crashes test collection across the whole codebase. salesagent re-exported
-through `src/core/schemas/_base.py`
-— **one missing `FormatCategory` import there cascaded into ~140 test failures
-during pytest collect-only**, and stubbing it revealed the next ~140-test
-cascade from `BrandManifest`, then the next from the `generated_poc` reach-ins.
+Real-adopter feedback (salesagent v3→v4 experiment at v4.0 release): 270 files
+scanned, 161 test-collection failures. These figures reflect tooling at initial
+release, before alias coverage and codemod improvements; run the codemod against
+your own tree to see your actual count. Consumers tend to centralize SDK imports
+in one schema module, so a single broken import there crashes test collection
+across the whole codebase. salesagent re-exported through
+`src/core/schemas/_base.py` — **one missing `FormatCategory` import there
+cascaded into ~140 test failures during pytest collect-only**, and stubbing it
+revealed the next ~140-test cascade from `BrandManifest`, then the next from
+the `generated_poc` reach-ins.
 
 The codemod's static finding count understates this by 100x+. To minimize the
 felt blast radius, work in this order:


### PR DESCRIPTION
Closes #520

The `MIGRATION_v3_to_v4.md` guide cited "270 files scanned, 161 test-collection failures" as if these were current migration difficulty benchmarks. They are real adopter data, but from the v4.0 release period — before subsequent alias coverage and codemod improvements that materially reduced finding counts at v4.3+. The misleading framing caused an adopter to expect worse migration pain than they actually hit.

This PR anchors the data point temporally ("at v4.0 release"), adds a standalone disclaimer sentence clarifying the figures reflect initial-release tooling, and redirects adopters to run the codemod against their own tree for a current count — so the note ages gracefully without becoming another stale number.

The cascade mechanics explanation (import re-export amplification, ordering steps) is unchanged; those are version-independent.

## What was tested

- Verified markdown renders correctly (prose-only change, no code touched)
- `ruff check .` — not applicable (no Python files changed)
- `mypy src/` — not applicable (no Python files changed)

## Pre-PR review

- **code-reviewer:** approved — no blockers; nit on sentence seam (noted below), changeset correctly omitted for release-please repo
- **docs-expert:** approved — blocker from round 1 (nested em-dash + semicolon in parenthetical) resolved by restructure; one nit applied ("before subsequent alias coverage…")

Noted nits not fixed (pre-existing): the `salesagent re-exported through…` line is technically a sentence fragment; the two-idea paragraph could use a blank-line break between the data point and the cascade narrative. Neither was introduced by this PR.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0138z8359JAkARZJWfmBLprE

---
_Generated by [Claude Code](https://claude.ai/code/session_0138z8359JAkARZJWfmBLprE)_