### PR TITLE
feat(server): MCP error responses populate structuredContent.adcp_error (closes #509)

### DIFF
--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -1684,16 +1684,15 @@ def _register_tool(
     """
     from mcp.server.fastmcp.tools import Tool
     from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
+    from mcp.types import CallToolResult
     from pydantic import ConfigDict
 
     from adcp.exceptions import ADCPError
-    from adcp.server.translate import translate_error
+    from adcp.server.translate import build_mcp_error_result
 
     # Lazy import — decisioning is optional for non-platform handlers,
     # but when present its ``AdcpError`` carries structured ``details``
-    # (caused_by, validation_errors) that ``translate_error`` now
-    # understands. AudioStack Emma P0: pre-fix this exception class
-    # propagated to FastMCP's default handler and ``details`` was lost.
+    # (caused_by, validation_errors) that need to reach the wire.
     try:
         from adcp.decisioning.types import AdcpError as DecisioningAdcpError  # noqa: N813
     except Exception:
@@ -1738,26 +1737,30 @@ def _register_tool(
             else:
                 result = await _call_handler()
         except ADCPError as exc:
-            # Translate AdCP-typed exceptions (IdempotencyConflictError,
-            # ADCPTaskError with a spec code, etc.) into a ToolError so FastMCP
-            # surfaces ``is_error=true`` with the spec error code in the
-            # message text. Clients per AdCP §transport-errors will extract
-            # the code via either structuredContent.adcp_error (if populated)
-            # or the text-fallback path.
-            raise translate_error(exc, protocol="mcp") from exc
+            # AdCP-typed exceptions (IdempotencyConflictError, ADCPTaskError
+            # with a spec code, etc.) project to a CallToolResult with
+            # ``isError=True`` AND ``structuredContent.adcp_error`` populated
+            # — matching transport-errors.mdx §MCP Binding. Returning the
+            # result directly bypasses FastMCP's ``_make_error_result`` path
+            # which strips ``structuredContent`` from error envelopes. The
+            # ``-> dict[str, Any]`` annotation drives FastMCP's output_schema
+            # derivation; the actual return type is broader (CallToolResult
+            # is a valid return per the lowlevel handler's contract).
+            return build_mcp_error_result(exc)  # type: ignore[return-value]
         except Exception as exc:
             # Decisioning ``AdcpError`` is NOT a subclass of
             # ``adcp.exceptions.ADCPError`` (different class hierarchy
-            # — ``adcp.decisioning.types.AdcpError``). Without this
-            # branch it propagated to FastMCP's default exception
-            # handler and ``details`` was lost on the wire. AudioStack
-            # Emma P0 confirmed pre-fix.
+            # — ``adcp.decisioning.types.AdcpError``). Catch it explicitly
+            # and project the same structured envelope.
             if DecisioningAdcpError is not None and isinstance(exc, DecisioningAdcpError):
-                # ``# type: ignore[arg-type]`` because mypy can't see
-                # that ``translate_error`` accepts decisioning AdcpError
-                # via the lazy-import branch.
-                raise translate_error(exc, protocol="mcp") from exc  # type: ignore[arg-type]
+                return build_mcp_error_result(exc)  # type: ignore[return-value]
             raise
+        # Pre-built CallToolResult (error envelope from build_mcp_error_result)
+        # passes through FastMCP's convert_result and the lowlevel handler
+        # without re-validation against the success-path output_model — the
+        # custom FuncMetadata subclass below handles the bypass.
+        if isinstance(result, CallToolResult):
+            return result  # type: ignore[return-value]
         if hasattr(result, "model_dump"):
             return result.model_dump(mode="json", exclude_none=True)  # type: ignore[no-any-return]
         if isinstance(result, dict):
@@ -1784,6 +1787,23 @@ def _register_tool(
                 result.update(self.model_extra)
             return result
 
+    class _AdcpFuncMetadata(FuncMetadata):
+        """FuncMetadata that skips success-path output validation for error
+        ``CallToolResult`` returns.
+
+        FastMCP's stock ``convert_result`` validates ``result.structuredContent``
+        against the success-path ``output_model`` whenever the tool returns a
+        ``CallToolResult`` — but when the framework projects an ``AdcpError``
+        as ``{"adcp_error": {...}}``, that payload doesn't conform to the
+        success schema. Skip validation for ``isError=True`` envelopes; success
+        envelopes still validate normally.
+        """
+
+        def convert_result(self, result: Any) -> Any:
+            if isinstance(result, CallToolResult) and result.isError:
+                return result
+            return super().convert_result(result)
+
     # Advertise the spec response schema on ``tools/list`` when one is
     # available. FastMCP serializes ``Tool.output_schema`` (which reads
     # ``fn_metadata.output_schema``) into the ``outputSchema`` field of
@@ -1793,7 +1813,7 @@ def _register_tool(
     effective_output_schema = (
         output_schema if output_schema is not None else tool.fn_metadata.output_schema
     )
-    tool.fn_metadata = FuncMetadata(
+    tool.fn_metadata = _AdcpFuncMetadata(
         arg_model=_AdcpArgs,
         output_schema=effective_output_schema,
         output_model=tool.fn_metadata.output_model,

--- a/src/adcp/server/translate.py
+++ b/src/adcp/server/translate.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 
 from a2a.utils.errors import A2AError, InternalError, InvalidParamsError
 from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import CallToolResult, TextContent
 
 from adcp.exceptions import (
     ADCPAuthenticationError,
@@ -100,6 +101,120 @@ def _build_error_data(
     return data
 
 
+def _extract_structured_fields(
+    exc: ADCPError | Error | Any,
+) -> tuple[str, str, str, str | None, str | None, dict[str, Any] | None, list[Any] | None]:
+    """Extract (code, message, recovery, field, suggestion, details, errors).
+
+    Handles three input shapes:
+    - ``adcp.types.Error`` (Pydantic model)
+    - ``adcp.decisioning.types.AdcpError`` (decisioning-layer exception)
+    - ``adcp.exceptions.ADCPError`` (client-side exception, including ADCPTaskError)
+
+    Used by both ``translate_error`` and ``build_mcp_error_result`` so the
+    field-extraction logic stays in one place.
+    """
+    # Lazy import — ``adcp.decisioning.types`` pulls in the decisioning
+    # graph, which translate.py shouldn't load at module-import time.
+    try:
+        from adcp.decisioning.types import AdcpError as DecisioningAdcpError  # noqa: N813
+    except Exception:
+        DecisioningAdcpError = None  # type: ignore[assignment,misc]  # noqa: N806
+
+    field: str | None = None
+    if isinstance(exc, Error):
+        code = exc.code
+        message = exc.message
+        suggestion = exc.suggestion
+        details = exc.details
+        # Error.recovery is an Optional Recovery enum; unwrap to a string
+        # for downstream wire projection. Falls back to the recovery
+        # classification looked up from the code when unset.
+        recovery_val = exc.recovery
+        if recovery_val is None:
+            recovery = _recovery_for_code(code)
+        elif hasattr(recovery_val, "value"):
+            recovery = recovery_val.value
+        else:
+            recovery = str(recovery_val)
+        errors = None
+        field = exc.field
+    elif DecisioningAdcpError is not None and isinstance(exc, DecisioningAdcpError):
+        code = exc.code
+        message = exc.args[0] if exc.args else ""
+        suggestion = exc.suggestion
+        recovery = exc.recovery
+        details = exc.details or None
+        errors = None
+        field = exc.field
+    elif isinstance(exc, ADCPError):
+        code = _error_code_for_exception(exc)
+        message = exc.message
+        suggestion = exc.suggestion
+        recovery = _recovery_for_code(code)
+        details = None
+        errors = getattr(exc, "errors", None)
+        if errors:
+            first = errors[0]
+            field = getattr(first, "field", None)
+            details = getattr(first, "details", None)
+    else:
+        raise TypeError(f"Expected ADCPError or Error, got {type(exc).__name__}")
+
+    return code, message, recovery, field, suggestion, details, errors
+
+
+def build_mcp_error_result(exc: ADCPError | Error | Any) -> CallToolResult:
+    """Build an MCP ``CallToolResult`` carrying the structured ``adcp_error`` envelope.
+
+    The framework dispatcher returns this when a platform method raises a
+    structured AdCP error. The result has ``isError=True`` AND
+    ``structuredContent={"adcp_error": {...}}`` on the same envelope —
+    matching the spec's transport-errors.mdx §MCP Binding shape that the
+    storyboard runner's ``/adcp_error/code`` JSON-pointer assertion
+    expects.
+
+    The text fallback in ``content[]`` preserves human-readable display
+    for clients that do not consume ``structuredContent`` (LLM tool-use
+    surfaces, log viewers).
+
+    Buyer agents read the structured envelope first; the text fallback
+    is only consulted when ``structuredContent`` is absent, per the
+    spec's structured-error precedence rules.
+    """
+    code, message, recovery, field, suggestion, details, _errors = _extract_structured_fields(exc)
+
+    adcp_error: dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "recovery": recovery,
+    }
+    if field is not None:
+        adcp_error["field"] = field
+    if suggestion is not None:
+        adcp_error["suggestion"] = suggestion
+    # ``retry_after`` lives on decisioning AdcpError; project it when present.
+    retry_after = getattr(exc, "retry_after", None)
+    if retry_after is not None:
+        adcp_error["retry_after"] = retry_after
+    if details:
+        adcp_error["details"] = dict(details)
+
+    # Text fallback for clients that don't read structuredContent.
+    if field:
+        text = f"{code}[{field}]: {message}"
+    else:
+        text = f"{code}: {message}"
+    if suggestion:
+        text += f"\nSuggestion: {suggestion}"
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        structuredContent={"adcp_error": adcp_error},
+        isError=True,
+    )
+
+
 def translate_error(
     exc: ADCPError | Error,
     protocol: Literal["mcp", "a2a"] | Protocol,
@@ -144,62 +259,7 @@ def translate_error(
     if proto not in ("mcp", "a2a"):
         raise ValueError(f"protocol must be 'mcp' or 'a2a', got {protocol!r}")
 
-    # Lazy import — ``adcp.decisioning.types`` pulls in the decisioning
-    # graph, which translate.py shouldn't load at module-import time.
-    # Match against ``BaseException`` here and let the elif body do the
-    # actual isinstance check via the imported name.
-    try:
-        from adcp.decisioning.types import AdcpError as DecisioningAdcpError  # noqa: N813
-    except Exception:
-        DecisioningAdcpError = None  # type: ignore[assignment,misc]  # noqa: N806
-
-    # Extract structured fields from the input
-    field: str | None = None
-    if isinstance(exc, Error):
-        code = exc.code
-        message = exc.message
-        suggestion = exc.suggestion
-        details = exc.details
-        recovery = _recovery_for_code(code)
-        errors = None
-        field = exc.field
-    elif DecisioningAdcpError is not None and isinstance(exc, DecisioningAdcpError):
-        # Decisioning-layer ``AdcpError`` (distinct from
-        # ``adcp.exceptions.ADCPError``) carries its own structured
-        # ``details`` (e.g. ``caused_by`` from the INTERNAL_ERROR wrap,
-        # ``validation_errors`` from #341's narrowing). AudioStack Emma
-        # P0: pre-fix this branch was missing entirely, so AdcpError
-        # propagated to FastMCP's default exception path and ``details``
-        # never reached the wire.
-        code = exc.code
-        message = exc.args[0] if exc.args else ""
-        suggestion = exc.suggestion
-        recovery = exc.recovery
-        details = exc.details or None
-        errors = None
-        field = exc.field
-    elif isinstance(exc, ADCPError):
-        code = _error_code_for_exception(exc)
-        message = exc.message
-        suggestion = exc.suggestion
-        recovery = _recovery_for_code(code)
-        details = None
-        errors = getattr(exc, "errors", None)
-        # ADCPTaskError carries a list of Error objects — lift the first
-        # error's ``field`` so MCP clients see the field path too (A2A
-        # already surfaces it inside ``data.errors[i].field`` via the
-        # structured error passthrough).
-        if errors:
-            first = errors[0]
-            field = getattr(first, "field", None)
-            # ADCPTaskError errors[0].details (e.g. validation_errors
-            # from create_tool_caller's INVALID_REQUEST projection)
-            # should also reach MCP — A2A already passes them via the
-            # ``errors`` array, but MCP only sees the first error's
-            # field/message. Embed details too.
-            details = getattr(first, "details", None)
-    else:
-        raise TypeError(f"Expected ADCPError or Error, got {type(exc).__name__}")
+    code, message, recovery, field, suggestion, details, errors = _extract_structured_fields(exc)
 
     if proto == "mcp":
         return _to_mcp(code, message, suggestion=suggestion, field=field, details=details)
@@ -242,15 +302,15 @@ def _to_mcp(
     reached MCP buyers — only A2A. Now both transports surface the
     structured breadcrumb.
 
-    **Bridge, not endpoint.** The protocol-correct shape is MCP's
-    ``CallToolResult.structuredContent`` (carries ``isError=True``
-    AND a structured ``adcp_error`` object on the same envelope —
-    see ``mcp.types.CallToolResult``). FastMCP's
-    ``_make_error_result`` (``mcp/server/lowlevel/server.py:467``)
-    drops ``structuredContent`` for error results, so we can't reach
-    that channel via FastMCP's ``ToolError`` raise path. Migrating
-    to lowlevel ``Server.call_tool`` registration would unlock it;
-    until then this text-suffix is the working bridge.
+    **For proxy / custom-transport callers only.** The standard
+    framework path (``serve()`` / ``ADCPAgentExecutor``) projects the
+    structured envelope via :func:`build_mcp_error_result` directly,
+    bypassing FastMCP's ``_make_error_result`` (which drops
+    ``structuredContent`` for error results). This text-payload
+    ``ToolError`` shape exists for adopters running custom MCP servers
+    that catch ``ADCPError`` and need a single value to ``raise`` —
+    the field-bracket prefix gives clients a programmatic handle even
+    on the text-only channel.
     """
     if field:
         text = f"{code}[{field}]: {message}"

--- a/tests/test_mcp_structured_error.py
+++ b/tests/test_mcp_structured_error.py
@@ -1,0 +1,303 @@
+"""Tests for MCP structured error projection (issue #509).
+
+Verifies that AdcpError raised from a platform method projects onto the
+wire as a ``CallToolResult`` with ``isError=True`` AND
+``structuredContent.adcp_error`` populated — matching transport-errors.mdx
+§MCP Binding and the storyboard runner's ``/adcp_error/code`` JSON-pointer
+assertion.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from adcp.decisioning.types import AdcpError as DecisioningAdcpError
+from adcp.exceptions import ADCPError, ADCPTaskError
+from adcp.server.translate import build_mcp_error_result
+from adcp.types import Error
+
+# ============================================================================
+# Unit tests: build_mcp_error_result shape
+# ============================================================================
+
+
+class TestBuildMcpErrorResultShape:
+    """The structured envelope shape matches the spec."""
+
+    def test_returns_call_tool_result_with_is_error_true(self):
+        exc = DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
+        result = build_mcp_error_result(exc)
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+
+    def test_structured_content_keyed_under_adcp_error(self):
+        exc = DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent is not None
+        assert "adcp_error" in result.structuredContent
+
+    def test_structured_content_carries_code(self):
+        exc = DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
+
+    def test_structured_content_carries_message(self):
+        exc = DecisioningAdcpError("PACKAGE_NOT_FOUND", message="package gone")
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["message"] == "package gone"
+
+    def test_structured_content_carries_recovery(self):
+        exc = DecisioningAdcpError("BUDGET_TOO_LOW", message="under floor", recovery="correctable")
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["recovery"] == "correctable"
+
+    def test_text_fallback_present_in_content(self):
+        exc = DecisioningAdcpError(
+            "MEDIA_BUY_NOT_FOUND", message="no such buy", field="media_buy_id"
+        )
+        result = build_mcp_error_result(exc)
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+        assert "MEDIA_BUY_NOT_FOUND" in result.content[0].text
+        assert "no such buy" in result.content[0].text
+
+
+class TestBuildMcpErrorResultOptionalFields:
+    """Optional fields populate when present, omit when absent."""
+
+    def test_field_populated_when_present(self):
+        exc = DecisioningAdcpError("INVALID_REQUEST", message="bad budget", field="total_budget")
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["field"] == "total_budget"
+
+    def test_field_omitted_when_absent(self):
+        exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
+        result = build_mcp_error_result(exc)
+        assert "field" not in result.structuredContent["adcp_error"]
+
+    def test_suggestion_populated_when_present(self):
+        exc = DecisioningAdcpError(
+            "BUDGET_TOO_LOW",
+            message="too low",
+            suggestion="Increase to at least $0.50",
+        )
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["suggestion"] == "Increase to at least $0.50"
+
+    def test_suggestion_omitted_when_absent(self):
+        exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
+        result = build_mcp_error_result(exc)
+        assert "suggestion" not in result.structuredContent["adcp_error"]
+
+    def test_details_populated_when_present(self):
+        details: dict[str, Any] = {"validation_errors": [{"path": "x", "msg": "bad"}]}
+        exc = DecisioningAdcpError("VALIDATION_ERROR", message="bad fields", details=details)
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["details"] == details
+
+    def test_details_omitted_when_absent(self):
+        exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
+        result = build_mcp_error_result(exc)
+        assert "details" not in result.structuredContent["adcp_error"]
+
+    def test_retry_after_populated_when_present(self):
+        exc = DecisioningAdcpError(
+            "RATE_LIMITED",
+            message="slow down",
+            recovery="transient",
+            retry_after=30,
+        )
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["retry_after"] == 30
+
+
+class TestBuildMcpErrorResultExceptionTypes:
+    """Handles all three input shapes: ADCPError, decisioning AdcpError, Error model."""
+
+    def test_handles_adcp_task_error(self):
+        err = Error(code="TERMS_REJECTED", message="terms unacceptable")
+        exc = ADCPTaskError("create_media_buy", [err])
+        result = build_mcp_error_result(exc)
+        assert result.isError is True
+        assert result.structuredContent["adcp_error"]["code"] == "TERMS_REJECTED"
+        # ADCPTaskError prefixes the operation; the original Error.message
+        # text is preserved in the projected message.
+        assert "terms unacceptable" in result.structuredContent["adcp_error"]["message"]
+
+    def test_handles_error_model(self):
+        err = Error(
+            code="VALIDATION_ERROR",
+            message="missing field",
+            field="packages[0].budget",
+        )
+        result = build_mcp_error_result(err)
+        assert result.structuredContent["adcp_error"]["code"] == "VALIDATION_ERROR"
+        assert result.structuredContent["adcp_error"]["field"] == "packages[0].budget"
+
+    def test_handles_plain_adcp_error_falls_back_to_internal(self):
+        exc = ADCPError("unexpected")
+        result = build_mcp_error_result(exc)
+        assert result.structuredContent["adcp_error"]["code"] == "INTERNAL_ERROR"
+
+    def test_rejects_unknown_type(self):
+        with pytest.raises(TypeError):
+            build_mcp_error_result(ValueError("not an adcp error"))
+
+
+# ============================================================================
+# Integration: through the FastMCP tool registration path
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_adcp_error_from_handler_projects_to_structured_content():
+    """End-to-end: AdcpError raised from a handler reaches the wire as
+    ``CallToolResult(isError=True, structuredContent={"adcp_error": {...}})``.
+
+    Exercises the full FastMCP path: tool dispatch, fn_metadata.convert_result,
+    lowlevel handler short-circuit on CallToolResult instances.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    from adcp.server.serve import _register_tool
+
+    async def caller(_kwargs: dict[str, Any], *, context: Any = None) -> Any:
+        raise DecisioningAdcpError(
+            "MEDIA_BUY_NOT_FOUND",
+            message="No media buy with id mb-404",
+            recovery="terminal",
+            field="media_buy_id",
+            details={"media_buy_id": "mb-404"},
+        )
+
+    mcp = FastMCP("test-structured-error")
+    _register_tool(
+        mcp,
+        "get_media_buy_delivery",
+        "test description",
+        {"type": "object", "properties": {"media_buy_id": {"type": "string"}}},
+        caller,
+    )
+
+    result = await mcp.call_tool("get_media_buy_delivery", {"media_buy_id": "mb-404"})
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent is not None
+    assert result.structuredContent["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
+    assert result.structuredContent["adcp_error"]["message"] == "No media buy with id mb-404"
+    assert result.structuredContent["adcp_error"]["recovery"] == "terminal"
+    assert result.structuredContent["adcp_error"]["field"] == "media_buy_id"
+    assert result.structuredContent["adcp_error"]["details"] == {"media_buy_id": "mb-404"}
+    # Text fallback preserved.
+    assert any(
+        "MEDIA_BUY_NOT_FOUND" in c.text for c in result.content if isinstance(c, TextContent)
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "code,recovery",
+    [
+        ("MEDIA_BUY_NOT_FOUND", "terminal"),
+        ("PACKAGE_NOT_FOUND", "terminal"),
+        ("TERMS_REJECTED", "terminal"),
+        ("BUDGET_TOO_LOW", "correctable"),
+    ],
+)
+async def test_specific_codes_round_trip(code: str, recovery: str):
+    """Each spec code reaches the wire with its code intact —
+    storyboard runner's ``/adcp_error/code`` JSON-pointer assertion
+    resolves to the actual code, not ``mcp_error``.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    from adcp.server.serve import _register_tool
+
+    async def caller(_kwargs: dict[str, Any], *, context: Any = None) -> Any:
+        raise DecisioningAdcpError(code, message="test", recovery=recovery)
+
+    mcp = FastMCP("test-codes")
+    _register_tool(
+        mcp,
+        "test_tool",
+        "test",
+        {"type": "object"},
+        caller,
+    )
+
+    result = await mcp.call_tool("test_tool", {})
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["adcp_error"]["code"] == code
+    assert result.structuredContent["adcp_error"]["recovery"] == recovery
+
+
+@pytest.mark.asyncio
+async def test_adcp_task_error_round_trips_through_register_tool():
+    """ADCPError subclasses (ADCPTaskError, IdempotencyConflictError, etc.)
+    also reach the wire as structured envelopes, not ToolError text.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    from adcp.server.serve import _register_tool
+
+    async def caller(_kwargs: dict[str, Any], *, context: Any = None) -> Any:
+        err = Error(code="IDEMPOTENCY_CONFLICT", message="payload differs")
+        raise ADCPTaskError("create_media_buy", [err])
+
+    mcp = FastMCP("test-task-error")
+    _register_tool(
+        mcp,
+        "create_media_buy",
+        "test",
+        {"type": "object"},
+        caller,
+    )
+
+    result = await mcp.call_tool("create_media_buy", {})
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["adcp_error"]["code"] == "IDEMPOTENCY_CONFLICT"
+
+
+@pytest.mark.asyncio
+async def test_success_path_unchanged():
+    """Regression: success-path responses still validate against the
+    output schema. The structuredContent error bypass MUST NOT leak
+    into the success path.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    from adcp.server.serve import _register_tool
+
+    async def caller(_kwargs: dict[str, Any], *, context: Any = None) -> Any:
+        return {"status": "ok", "value": 42}
+
+    mcp = FastMCP("test-success")
+    _register_tool(
+        mcp,
+        "ok_tool",
+        "test",
+        {"type": "object"},
+        caller,
+    )
+
+    result = await mcp.call_tool("ok_tool", {})
+    # FastMCP returns (unstructured, structured) tuple for dict returns
+    # without a CallToolResult wrap; lowlevel handler then builds
+    # CallToolResult(isError=False, ...).
+    # mcp.call_tool here returns the convert_result output, which is a
+    # tuple of (content_list, structured_dict).
+    if isinstance(result, tuple):
+        _content, structured = result
+        assert structured == {"status": "ok", "value": 42}
+    else:
+        # Single-channel return: still must contain the data.
+        assert result == {"status": "ok", "value": 42} or (
+            hasattr(result, "structuredContent")
+            and result.structuredContent == {"status": "ok", "value": 42}
+        )


### PR DESCRIPTION
## Summary

- AdcpError raised from a platform method now reaches the MCP wire as `CallToolResult(isError=True, structuredContent={"adcp_error": {code, message, recovery, field?, suggestion?, retry_after?, details?}})` — matching transport-errors.mdx §MCP Binding.
- The text fallback in `content[]` is preserved (`MEDIA_BUY_NOT_FOUND[id]: …`) for clients that don't read `structuredContent`.
- The storyboard runner's `/adcp_error/code` JSON-pointer assertions now resolve to the actual code (`MEDIA_BUY_NOT_FOUND`, `PACKAGE_NOT_FOUND`, `TERMS_REJECTED`, …) instead of the previous `mcp_error` fallback.

Closes #509. Surfacing context: PR #508 (multi_platform_seller storyboard fix-pack).

## Approach

Went with **option (b) — bypass FastMCP's error-result construction**, not patch.

- `translate.py` exposes a new `build_mcp_error_result(exc)` helper that constructs a `CallToolResult` with `isError=True` AND `structuredContent.adcp_error` populated.
- `serve.py:_register_tool` catches `ADCPError` / decisioning `AdcpError` inside the tool function and **returns** the pre-built `CallToolResult` instead of raising `ToolError`.
- A small `FuncMetadata` subclass (`_AdcpFuncMetadata`) skips success-path output validation when `result.isError` is `True`, so the error envelope reaches the lowlevel handler's `CallToolResult` short-circuit (`mcp/server/lowlevel/server.py:540`) without being re-validated against the success schema.

The previous limitation comment at `translate.py:246-250` (about `_make_error_result` stripping `structuredContent`) is now resolved for the standard `serve()` path. The text-projection `_to_mcp` / `translate_error` codepath remains for proxy / custom-transport adopters who need a `ToolError` to raise.

## A2A parity

`adcp.server.a2a_server._send_adcp_error` already projects an `adcp_error` envelope as a `DataPart` on a failed task event, so the A2A surface is structurally correct today. Two gaps that justify a separate follow-up issue (out of scope here):

- It catches `adcp.exceptions.ADCPError` only — decisioning-layer `AdcpError` propagates to the generic `except Exception` path.
- It surfaces `code`/`message`/`recovery`/`suggestion` but not `field`, `details`, or `retry_after`.

## Test plan

- [x] Unit tests on `build_mcp_error_result` (shape, optional field gating, all three exception types: ADCPError, decisioning AdcpError, Error model)
- [x] End-to-end test through `mcp.call_tool` exercising FastMCP → lowlevel handler with the structured envelope intact
- [x] Parametrized round-trip for `MEDIA_BUY_NOT_FOUND`, `PACKAGE_NOT_FOUND`, `TERMS_REJECTED`, `BUDGET_TOO_LOW`
- [x] Success-path regression (output schema validation still enforced for `isError=False`)
- [x] Existing `tests/test_translate.py` suite stays green (43 tests)
- [x] Full repo regression: 3784 passed
- [x] `ruff check` + `mypy src/adcp/server/` clean
- [x] Manual JSON-pointer assertion sim: `/adcp_error/code` resolves to `MEDIA_BUY_NOT_FOUND` for an `AdcpError("MEDIA_BUY_NOT_FOUND", ...)` raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)