### PR TITLE
feat(decisioning): surface advertise_all=False on create_adcp_server_from_platform

### DIFF
--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -87,6 +87,7 @@ def create_adcp_server_from_platform(
     buyer_agent_registry: BuyerAgentRegistry | None = None,
     config_store: ProductConfigStore | None = None,
     property_list_fetcher: PropertyListFetcher | None = None,
+    advertise_all: bool = False,
 ) -> tuple[PlatformHandler, ThreadPoolExecutor, TaskRegistry]:
     """Build the :class:`PlatformHandler` + supporting wiring from a
     :class:`DecisioningPlatform`.
@@ -176,6 +177,14 @@ def create_adcp_server_from_platform(
         (avoid duplicate delivery; idempotency-key dedup at the
         receiver would handle it but explicit suppression matches the
         v5 manual-emit posture for adopters mid-migration).
+    :param advertise_all: When ``False`` (default), ``handler.advertised_tools``
+        is filtered to the tools covered by the platform's claimed
+        specialisms — matching :func:`serve`'s default. When ``True``,
+        the full spec surface is retained on ``handler.advertised_tools``
+        (useful for spec-compliance storyboards). Either way, the
+        per-instance specialism filter and the override-detection filter
+        still apply inside :func:`~adcp.server.mcp_tools.get_tools_for_handler`
+        when the handler is wired into an MCP/A2A server.
 
     To wire a :class:`ProposalManager` (v1 two-platform composition),
     pass it on a :class:`PlatformRouter` via
@@ -331,6 +340,20 @@ def create_adcp_server_from_platform(
 
     validate_capabilities_response_shape(handler)
 
+    # Filter handler.advertised_tools to the platform's claimed specialisms
+    # when advertise_all=False (the default). The ClassVar holds the full
+    # union of all shim-covered tools (~40+); adopters using the standalone
+    # build-the-handler path saw all of them when accessing
+    # handler.advertised_tools directly, instead of the per-specialism
+    # subset that serve() already projects through
+    # get_tools_for_handler → advertised_tools_for_instance(). Override at
+    # the instance level so the ClassVar (and the _HANDLER_TOOLS registry
+    # populated at class-definition time) are unaffected.
+    if not advertise_all:
+        per_instance = set(handler.advertised_tools_for_instance())
+        if per_instance:
+            handler.advertised_tools = per_instance  # type: ignore[misc]
+
     return handler, executor, registry
 
 
@@ -428,6 +451,7 @@ def serve(
         buyer_agent_registry=buyer_agent_registry,
         config_store=config_store,
         property_list_fetcher=property_list_fetcher,
+        advertise_all=advertise_all,
     )
 
     # Phase 1 sandbox-authority — wire the comply controller's account

--- a/tests/test_decisioning_serve.py
+++ b/tests/test_decisioning_serve.py
@@ -504,3 +504,52 @@ def test_serve_does_not_fire_gate_for_platform_without_webhook_eligible_tools() 
     handler, executor, _ = create_adcp_server_from_platform(platform)
     assert handler._webhook_sender is None
     executor.shutdown(wait=True)
+
+
+# ---- Issue #519: advertise_all=False filters handler.advertised_tools ----
+
+
+def test_create_default_filters_advertised_tools_to_specialism() -> None:
+    """handler.advertised_tools with default advertise_all=False returns
+    only the tools for the platform's claimed specialisms, not the full
+    ~40-tool union across all PlatformHandler shims."""
+    from adcp.decisioning.handler import _SALES_ADVERTISED_TOOLS
+
+    platform = _SalesPlatformWithRequiredMethods()
+    # Disable auto-emit so the webhook-sender gate doesn't fire — this
+    # test focuses on advertised_tools filtering, not F12 validation.
+    handler, executor, _ = create_adcp_server_from_platform(
+        platform, auto_emit_completion_webhooks=False
+    )
+    executor.shutdown(wait=True)
+    assert handler.advertised_tools == set(_SALES_ADVERTISED_TOOLS)
+    assert "build_creative" not in handler.advertised_tools
+    assert "activate_signal" not in handler.advertised_tools
+    assert "sync_audiences" not in handler.advertised_tools
+
+
+def test_create_advertise_all_true_retains_full_tool_surface() -> None:
+    """advertise_all=True keeps handler.advertised_tools as the full
+    class-level union — spec-compliance storyboards use this escape hatch."""
+    from adcp.decisioning.handler import PlatformHandler
+
+    platform = _SalesPlatformWithRequiredMethods()
+    handler, executor, _ = create_adcp_server_from_platform(
+        platform, advertise_all=True, auto_emit_completion_webhooks=False
+    )
+    executor.shutdown(wait=True)
+    assert handler.advertised_tools == PlatformHandler.advertised_tools
+    assert "build_creative" in handler.advertised_tools
+    assert "activate_signal" in handler.advertised_tools
+
+
+def test_create_bare_platform_no_specialism_leaves_classlevel_intact() -> None:
+    """When advertised_tools_for_instance() returns empty (no recognized
+    specialism), the fallback leaves the ClassVar intact so the handler
+    is not accidentally muted."""
+    from adcp.decisioning.handler import PlatformHandler
+
+    platform = _BarePlatform()
+    handler, executor, _ = create_adcp_server_from_platform(platform)
+    executor.shutdown(wait=True)
+    assert handler.advertised_tools == PlatformHandler.advertised_tools


### PR DESCRIPTION
Closes #519

## Summary

Adopters using the standalone "build the handler" path saw ~40+ entries in `handler.advertised_tools` after `create_adcp_server_from_platform()` because the `ClassVar` holds the full union across all `PlatformHandler` shims. `serve()` already defaulted `advertise_all=False` and passed it through `get_tools_for_handler → advertised_tools_for_instance()` to filter `tools/list`, but that filter was invisible to anyone inspecting `handler.advertised_tools` directly.

This PR adds `advertise_all: bool = False` to `create_adcp_server_from_platform()` and, when `False`, overrides `handler.advertised_tools` at the instance level with `set(handler.advertised_tools_for_instance())`. The ClassVar (and the `_HANDLER_TOOLS` registry populated at class-definition time) are unaffected. `serve()` now forwards `advertise_all` into `create_adcp_server_from_platform()` for consistency.

**Before:**
```python
handler, _, _ = create_adcp_server_from_platform(platform=MySalesPlatform())
len(handler.advertised_tools)  # ~42 (full union)
```
**After:**
```python
handler, _, _ = create_adcp_server_from_platform(platform=MySalesPlatform())
len(handler.advertised_tools)  # 9 (sales specialism set only)
```

## What was tested

- `pytest tests/test_decisioning_serve.py` — 34/34 pass (3 new tests covering default filter, `advertise_all=True` escape hatch, and empty-specialism fallback)
- `mypy src/adcp/decisioning/serve.py` — clean
- `ruff check src/adcp/decisioning/serve.py` — clean
- `pytest tests/test_decisioning_advertised_per_specialism.py tests/test_decisioning_handler.py tests/test_advertised_tools_gate.py tests/test_register_handler_tools.py` — 50/50 pass

## Pre-PR review

- **code-reviewer:** approved — no blockers; noted that `get_tools_for_handler` reads `_HANDLER_TOOLS[cls.__name__]` (ClassVar, class-definition time) and calls `advertised_tools_for_instance()` independently, so the instance attribute shadow and the MCP tools/list filter are separate paths.
- **dx-expert:** approved — `advertise_all=False` is the right default and name (consistent with `serve()`); noted behavior change for existing callers who may have relied on the full ~40-tool ClassVar (changelog note warranted).

**Nits (not fixed — addressed here):**
- Test imports `_SALES_ADVERTISED_TOOLS` (a private symbol). Acceptable: the test is specifically verifying the specialism-to-tool mapping; using the private frozenset is the most precise assertion available.
- `# type: ignore[misc]` on the ClassVar instance write: mypy classifies this as `[misc]`, not `[assignment]`; `[misc]` is the narrowest suppressor available for this specific diagnostic.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01VYgrLhaR7HWfBf3VxbMn5K

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYgrLhaR7HWfBf3VxbMn5K)_