### PR TITLE
docs(examples): expand hello_seller.py to full 9-method sales-non-guaranteed surface

### DIFF
--- a/examples/hello_seller.py
+++ b/examples/hello_seller.py
@@ -4,15 +4,18 @@ A minimal :class:`SalesPlatform` adopter showing the full required surface:
 
 * :class:`DecisioningCapabilities` declared on the class body
 * :class:`SingletonAccounts` for the dev/single-tenant case
-* Nine required ``sales-non-guaranteed`` methods — five hard-required
+* Nine ``sales-non-guaranteed`` methods — five hard-required
   (``get_products``, ``create_media_buy``, ``update_media_buy``,
-  ``sync_creatives``, ``get_media_buy_delivery``) plus four required by the
-  SalesPlatform Protocol for any ``sales-*`` specialism in v6.0 rc.1+
+  ``sync_creatives``, ``get_media_buy_delivery``) plus four soft-required
+  by the SalesPlatform Protocol in v6.0 rc.1+
   (``get_media_buys``, ``list_creative_formats``, ``list_creatives``,
-  ``provide_performance_feedback``). The authoritative source is the
-  :data:`~adcp.decisioning.dispatch.REQUIRED_METHODS_PER_SPECIALISM` and
-  :data:`~adcp.decisioning.dispatch.RECOMMENDED_METHODS_PER_SPECIALISM`
-  maps; ``validate_platform`` checks both at server boot.
+  ``provide_performance_feedback``; in
+  :data:`~adcp.decisioning.dispatch.RECOMMENDED_METHODS_PER_SPECIALISM`).
+  The authoritative list is
+  :data:`~adcp.decisioning.dispatch.REQUIRED_METHODS_PER_SPECIALISM` +
+  :data:`~adcp.decisioning.dispatch.RECOMMENDED_METHODS_PER_SPECIALISM`;
+  ``validate_platform`` checks both at server boot — hard-fail for the
+  five, soft-warn for the four.
 
 Run::
 
@@ -21,7 +24,7 @@ Run::
 Then:
 
 * MCP discovery: connect with any AdCP MCP buyer
-* List tools: should advertise just the 3 implemented + the
+* List tools: should advertise the 9 seller methods + the
   framework's protocol tools
 * Call ``get_products``: returns one product
 * Call ``create_media_buy``: returns the success envelope
@@ -242,11 +245,11 @@ class HelloSeller(DecisioningPlatform):
             ],
         }
 
-    # ---- v6.0 rc.1 required methods ----------------------------------------
-    # These four methods are required by the SalesPlatform Protocol for any
-    # sales-* specialism in v6.0 rc.1+. The stubs below return the minimal
-    # valid wire shape (empty collections / acknowledged). Wire them to your
-    # inventory system / analytics pipeline in production.
+    # ---- v6.0 rc.1 recommended methods (RECOMMENDED_METHODS_PER_SPECIALISM) --
+    # Staged for promotion to hard-required at v6.0 rc.1 GA. Stubs return the
+    # minimal valid wire shape. Wire each to your production systems before
+    # declaring rc.1 compliance (set ADCP_DECISIONING_STRICT_VALIDATE_PLATFORM=1
+    # in CI to confirm the full surface is present).
 
     def get_media_buys(
         self,

--- a/examples/hello_seller.py
+++ b/examples/hello_seller.py
@@ -85,7 +85,7 @@ from adcp.decisioning import (
 class HelloSeller(DecisioningPlatform):
     """The canonical v6.0 sales-non-guaranteed adopter.
 
-    Implements all nine required methods of ``sales-non-guaranteed``: the
+    Implements all nine methods of the ``sales-non-guaranteed`` surface: the
     five hard-required (``get_products``, ``create_media_buy``,
     ``update_media_buy``, ``sync_creatives``, ``get_media_buy_delivery``)
     and the four soft-required by the SalesPlatform Protocol in v6.0 rc.1+
@@ -288,8 +288,17 @@ class HelloSeller(DecisioningPlatform):
         Return all creatives the buyer has synced. Wire to your creative
         asset store in production; buyers use this to check approval
         statuses and discover available creatives.
+
+        ``query_summary`` and ``pagination`` are required by the spec
+        envelope — fill ``total_matching``/``returned`` from the
+        post-filter result count and ``has_more`` from the cursor state
+        once you have a real store.
         """
-        return {"creatives": []}
+        return {
+            "query_summary": {"total_matching": 0, "returned": 0},
+            "pagination": {"has_more": False},
+            "creatives": [],
+        }
 
     def provide_performance_feedback(
         self,

--- a/examples/hello_seller.py
+++ b/examples/hello_seller.py
@@ -1,15 +1,18 @@
-"""Hello-seller — the smallest possible v6.0 DecisioningPlatform.
+"""Hello-seller — the canonical v6.0 DecisioningPlatform starting point.
 
-A minimal :class:`SalesPlatform` adopter showing the canonical surface:
+A minimal :class:`SalesPlatform` adopter showing the full required surface:
 
 * :class:`DecisioningCapabilities` declared on the class body
 * :class:`SingletonAccounts` for the dev/single-tenant case
-* Five required ``sales-non-guaranteed`` methods (``get_products``,
-  ``create_media_buy``, ``update_media_buy``, ``sync_creatives``,
-  ``get_media_buy_delivery``) — all sync, sync return path. The full
-  required set is enforced at server boot by ``validate_platform``
-  via :data:`REQUIRED_METHODS_PER_SPECIALISM` — omitting any of the
-  five fails fast with INVALID_REQUEST.
+* Nine required ``sales-non-guaranteed`` methods — five hard-required
+  (``get_products``, ``create_media_buy``, ``update_media_buy``,
+  ``sync_creatives``, ``get_media_buy_delivery``) plus four required by the
+  SalesPlatform Protocol for any ``sales-*`` specialism in v6.0 rc.1+
+  (``get_media_buys``, ``list_creative_formats``, ``list_creatives``,
+  ``provide_performance_feedback``). The authoritative source is the
+  :data:`~adcp.decisioning.dispatch.REQUIRED_METHODS_PER_SPECIALISM` and
+  :data:`~adcp.decisioning.dispatch.RECOMMENDED_METHODS_PER_SPECIALISM`
+  maps; ``validate_platform`` checks both at server boot.
 
 Run::
 
@@ -77,13 +80,18 @@ from adcp.decisioning import (
 
 
 class HelloSeller(DecisioningPlatform):
-    """The canonical minimal v6.0 sales-non-guaranteed adopter.
+    """The canonical v6.0 sales-non-guaranteed adopter.
 
-    Implements all five required methods of ``sales-non-guaranteed``
-    (the full contract per :data:`REQUIRED_METHODS_PER_SPECIALISM`):
-    ``get_products``, ``create_media_buy``, ``update_media_buy``,
-    ``sync_creatives``, ``get_media_buy_delivery``. ``validate_platform``
-    runs at boot and fails fast on any missing method.
+    Implements all nine required methods of ``sales-non-guaranteed``: the
+    five hard-required (``get_products``, ``create_media_buy``,
+    ``update_media_buy``, ``sync_creatives``, ``get_media_buy_delivery``)
+    and the four required by the SalesPlatform Protocol in v6.0 rc.1+
+    (``get_media_buys``, ``list_creative_formats``, ``list_creatives``,
+    ``provide_performance_feedback``).
+
+    ``validate_platform`` runs at boot and fails fast on any missing
+    hard-required method; it soft-warns (or hard-fails in strict mode) for
+    the four rc.1+ methods. This example passes all checks cleanly.
     """
 
     capabilities = DecisioningCapabilities(
@@ -233,6 +241,66 @@ class HelloSeller(DecisioningPlatform):
                 },
             ],
         }
+
+    # ---- v6.0 rc.1 required methods ----------------------------------------
+    # These four methods are required by the SalesPlatform Protocol for any
+    # sales-* specialism in v6.0 rc.1+. The stubs below return the minimal
+    # valid wire shape (empty collections / acknowledged). Wire them to your
+    # inventory system / analytics pipeline in production.
+
+    def get_media_buys(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """List media buys for the resolved account.
+
+        Return all active media buys here. Wire to your order-management
+        system in production; buyers use this for status polling and
+        reconciliation.
+        """
+        return {"media_buys": []}
+
+    def list_creative_formats(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Catalog of accepted creative formats.
+
+        Return the full list of format definitions this seller accepts.
+        Wire to your creative-spec registry in production; buyers use this
+        to validate creatives before submission.
+        """
+        return {"formats": []}
+
+    def list_creatives(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """List the seller's view of buyer-uploaded creatives.
+
+        Return all creatives the buyer has synced. Wire to your creative
+        asset store in production; buyers use this to check approval
+        statuses and discover available creatives.
+        """
+        return {"creatives": []}
+
+    def provide_performance_feedback(
+        self,
+        req: Any,
+        ctx: RequestContext[Any],
+    ) -> dict[str, Any]:
+        """Buyer-supplied performance signal back to the seller.
+
+        Acknowledge receipt and log to your analytics pipeline in
+        production. Buyers send conversion events (clicks, installs,
+        purchases) here so the seller can optimize pacing and targeting.
+        """
+        return {"success": True}
+
+    # -------------------------------------------------------------------------
 
     @staticmethod
     def _get_packages(req: Any) -> list[dict[str, Any]]:

--- a/examples/hello_seller.py
+++ b/examples/hello_seller.py
@@ -88,9 +88,10 @@ class HelloSeller(DecisioningPlatform):
     Implements all nine required methods of ``sales-non-guaranteed``: the
     five hard-required (``get_products``, ``create_media_buy``,
     ``update_media_buy``, ``sync_creatives``, ``get_media_buy_delivery``)
-    and the four required by the SalesPlatform Protocol in v6.0 rc.1+
+    and the four soft-required by the SalesPlatform Protocol in v6.0 rc.1+
     (``get_media_buys``, ``list_creative_formats``, ``list_creatives``,
-    ``provide_performance_feedback``).
+    ``provide_performance_feedback``;
+    see :data:`~adcp.decisioning.dispatch.RECOMMENDED_METHODS_PER_SPECIALISM`).
 
     ``validate_platform`` runs at boot and fails fast on any missing
     hard-required method; it soft-warns (or hard-fails in strict mode) for

--- a/tests/test_hello_seller_integration.py
+++ b/tests/test_hello_seller_integration.py
@@ -259,35 +259,42 @@ async def test_advertised_tools_class_attribute_set(
 
 
 @pytest.mark.asyncio
-async def test_get_media_buys_returns_empty_list(handler: PlatformHandler) -> None:
-    """Smoke: stub returns valid wire shape for get_media_buys."""
-    from adcp.types import GetMediaBuysRequest
+async def test_get_media_buys_returns_spec_valid_envelope(handler: PlatformHandler) -> None:
+    """Stub returns a wire shape that satisfies ``GetMediaBuysResponse``."""
+    from adcp.types import GetMediaBuysRequest, GetMediaBuysResponse
 
     req = GetMediaBuysRequest(account={"account_id": "buyer-1"})
     resp = await handler.get_media_buys(req, ToolContext())
-    assert isinstance(resp, dict)
+    # Validate against the canonical Pydantic model — catches drift
+    # between stub and spec, not just dict-key presence.
+    GetMediaBuysResponse.model_validate(resp)
     assert resp["media_buys"] == []
 
 
 @pytest.mark.asyncio
-async def test_list_creative_formats_returns_empty_list(handler: PlatformHandler) -> None:
-    """Smoke: stub returns valid wire shape for list_creative_formats."""
-    from adcp.types import ListCreativeFormatsRequest
+async def test_list_creative_formats_returns_spec_valid_envelope(
+    handler: PlatformHandler,
+) -> None:
+    """Stub returns a wire shape that satisfies ``ListCreativeFormatsResponse``."""
+    from adcp.types import ListCreativeFormatsRequest, ListCreativeFormatsResponse
 
     req = ListCreativeFormatsRequest()
     resp = await handler.list_creative_formats(req, ToolContext())
-    assert isinstance(resp, dict)
+    ListCreativeFormatsResponse.model_validate(resp)
     assert resp["formats"] == []
 
 
 @pytest.mark.asyncio
-async def test_list_creatives_returns_empty_list(handler: PlatformHandler) -> None:
-    """Smoke: stub returns valid wire shape for list_creatives."""
-    from adcp.types import ListCreativesRequest
+async def test_list_creatives_returns_spec_valid_envelope(handler: PlatformHandler) -> None:
+    """Stub returns a wire shape that satisfies ``ListCreativesResponse``,
+    including the spec-required ``query_summary`` and ``pagination``
+    envelopes (a buyer hitting the example otherwise gets a non-conformant
+    response)."""
+    from adcp.types import ListCreativesRequest, ListCreativesResponse
 
     req = ListCreativesRequest(account={"account_id": "buyer-1"})
     resp = await handler.list_creatives(req, ToolContext())
-    assert isinstance(resp, dict)
+    ListCreativesResponse.model_validate(resp)
     assert resp["creatives"] == []
 
 

--- a/tests/test_hello_seller_integration.py
+++ b/tests/test_hello_seller_integration.py
@@ -256,3 +256,81 @@ async def test_advertised_tools_class_attribute_set(
     assert "update_media_buy" in PlatformHandler.advertised_tools
     assert "sync_creatives" in PlatformHandler.advertised_tools
     assert "get_media_buy_delivery" in PlatformHandler.advertised_tools
+
+
+@pytest.mark.asyncio
+async def test_get_media_buys_returns_empty_list(handler: PlatformHandler) -> None:
+    """Smoke: stub returns valid wire shape for get_media_buys."""
+    from adcp.types import GetMediaBuysRequest
+
+    req = GetMediaBuysRequest(account={"account_id": "buyer-1"})
+    resp = await handler.get_media_buys(req, ToolContext())
+    assert isinstance(resp, dict)
+    assert resp["media_buys"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_creative_formats_returns_empty_list(handler: PlatformHandler) -> None:
+    """Smoke: stub returns valid wire shape for list_creative_formats."""
+    from adcp.types import ListCreativeFormatsRequest
+
+    req = ListCreativeFormatsRequest()
+    resp = await handler.list_creative_formats(req, ToolContext())
+    assert isinstance(resp, dict)
+    assert resp["formats"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_creatives_returns_empty_list(handler: PlatformHandler) -> None:
+    """Smoke: stub returns valid wire shape for list_creatives."""
+    from adcp.types import ListCreativesRequest
+
+    req = ListCreativesRequest(account={"account_id": "buyer-1"})
+    resp = await handler.list_creatives(req, ToolContext())
+    assert isinstance(resp, dict)
+    assert resp["creatives"] == []
+
+
+@pytest.mark.asyncio
+async def test_provide_performance_feedback_acknowledges(handler: PlatformHandler) -> None:
+    """Smoke: stub returns success acknowledgment for provide_performance_feedback."""
+    from adcp.types import ProvidePerformanceFeedbackRequest
+
+    req = ProvidePerformanceFeedbackRequest(
+        account={"account_id": "buyer-1"},
+        media_buy_id="mb_test",
+        idempotency_key="perf-feedback-test-key-001",
+        measurement_period={"start": "2026-05-01T00:00:00Z", "end": "2026-05-31T23:59:59Z"},
+        performance_index=1.0,
+        feedback=[],
+    )
+    resp = await handler.provide_performance_feedback(req, ToolContext())
+    assert isinstance(resp, dict)
+    assert resp["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_validate_platform_no_soft_warns_on_hello_seller() -> None:
+    """HelloSeller passes validate_platform without any soft-warn for the
+    four RECOMMENDED_METHODS_PER_SPECIALISM methods."""
+    import warnings
+
+    from adcp.decisioning.dispatch import validate_platform
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        validate_platform(_hello.HelloSeller())
+    soft_warns = [
+        x
+        for x in w
+        if any(
+            m in str(x.message)
+            for m in [
+                "get_media_buys",
+                "list_creative_formats",
+                "list_creatives",
+                "provide_performance_feedback",
+            ]
+        )
+    ]
+    assert soft_warns == [], f"Unexpected soft-warns: {[str(x.message) for x in soft_warns]}"


### PR DESCRIPTION
Closes #515

## Summary

`hello_seller.py` implemented only the five hard-required `sales-non-guaranteed` methods, causing `validate_platform` to soft-warn about four additional SalesPlatform Protocol methods staged for hard-required status at v6.0 rc.1 GA (`get_media_buys`, `list_creative_formats`, `list_creatives`, `provide_performance_feedback`). A canonical example that emits warnings at boot teaches adopters to ignore validator signal — the opposite of the fail-fast contract.

**Decision:** Expand the example (option 1 from the issue). The four methods are in `RECOMMENDED_METHODS_PER_SPECIALISM` on an explicit promotion path to `REQUIRED_METHODS_PER_SPECIALISM`; the example should reflect the full required shape that adopters will need.

Changes:
- Add stub implementations for all four soft-required methods, each returning the minimal valid wire shape with clear docstrings directing adopters to wire production systems
- Update module and class docstrings: correct "five required" → "nine required", add hard/soft distinction ("soft-required", pointer to `RECOMMENDED_METHODS_PER_SPECIALISM`), fix stale "3 implemented" → "9 seller methods" in list-tools walkthrough
- Add dispatch-path smoke tests for all four new stubs + a `validate_platform` assertion confirming HelloSeller passes with zero soft-warns

## What tested

- `pytest tests/test_hello_seller_integration.py` — 12 passed (7 pre-existing + 5 new)
- Full suite: `pytest tests/ -m "not integration"` — 3759 passed, 0 regressions (1 pre-existing TLS environment failure unrelated to this change: `test_real_tls_handshake_still_validates_hostname`)
- `validate_platform(HelloSeller())` — zero soft-warns for the four recommended methods
- `python -c "import ast; ast.parse(open('examples/hello_seller.py').read())"` — syntax OK

## Pre-PR review

- **code-reviewer:** approved — no blockers after second pass. Found and fixed: stale "3 implemented" count, D1 projection signatures verified correct (all four use standard `(req, ctx)`), test coverage gap → addressed with 5 new tests.
- **dx-expert:** approved direction — stubs clearly annotated as wiring targets, section comment uses "recommended (rc.1+ staging)" language consistent with `RECOMMENDED_METHODS_PER_SPECIALISM` naming.
- **docs-expert:** approved — module docstring correctly distinguishes hard/soft with "hard-fail for the five, soft-warn for the four"; section comment updated to "recommended" to match map name; `ADCP_DECISIONING_STRICT_VALIDATE_PLATFORM=1` CI guidance added.

**Nits surfaced (not fixed — PR scope):**
- `sales.py` per-method docstrings for the four methods still say "Required … validate_platform fails server boot" (hard-required language). These live in the Protocol file, not the example. Separate cleanup issue warranted.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01SQEG3PCARK4eKHBbqu4fTS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQEG3PCARK4eKHBbqu4fTS)_