### PR TITLE
feat(server/a2a): structured error parity with MCP — emit field/details/retry_after, catch decisioning AdcpError

### DIFF
--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -35,8 +35,21 @@ from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.struct_pb2 import Value
 from starlette.applications import Starlette
 
-from adcp.exceptions import ADCPError, ADCPTaskError
+from adcp.exceptions import ADCPError
 from adcp.server.base import ADCPHandler, ToolContext
+
+# Decisioning-layer ``AdcpError`` (from ``adcp.decisioning.types``) is the
+# wire-shaped structured error platform methods raise. It is NOT a subclass
+# of :class:`adcp.exceptions.ADCPError`; the executor must catch both so
+# storyboards graded against decisioning adopters see the same structured
+# envelope as MCP. Lazy import — ``adcp.decisioning`` pulls in the
+# decisioning graph, which the A2A server module shouldn't load at import
+# time. When the import fails (decisioning extra not installed), only the
+# client-side ``ADCPError`` path is active.
+try:
+    from adcp.decisioning.types import AdcpError as _DecisioningAdcpError
+except Exception:  # pragma: no cover - decisioning is an optional dep surface
+    _DecisioningAdcpError = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -73,7 +86,6 @@ call the default as a fallback after your own parser returns
 """
 
 
-from adcp.server.helpers import STANDARD_ERROR_CODES  # noqa: E402
 from adcp.server.mcp_tools import create_tool_caller, get_tools_for_handler
 from adcp.server.test_controller import TestControllerStore, _handle_test_controller
 
@@ -203,15 +215,24 @@ class ADCPAgentExecutor(AgentExecutor):
             return
 
         tool_context = self._build_tool_context(skill_name, context)
+        # Catch both the client-side :class:`ADCPError` (raised by
+        # framework helpers like ``IdempotencyConflictError``) AND the
+        # decisioning-layer :class:`AdcpError` (raised by platform methods
+        # adopters write against the decisioning graph). They are
+        # disjoint hierarchies; both project onto the same structured
+        # ``adcp_error`` envelope per transport-errors.mdx §A2A Binding.
+        structured_error_types: tuple[type[BaseException], ...] = (ADCPError,)
+        if _DecisioningAdcpError is not None:
+            structured_error_types = (ADCPError, _DecisioningAdcpError)
         try:
             result = await self._dispatch_with_middleware(skill_name, params, tool_context)
             await self._send_result(event_queue, context, skill_name, result)
-        except ADCPError as exc:
-            # Application-layer AdCP error (IdempotencyConflictError etc.).
-            # Emit a failed task with the adcp_error in a DataPart per
-            # transport-errors.mdx §A2A Binding, plus a human-readable text
-            # part. The JSON-RPC channel is reserved for transport-level
-            # errors (auth rejected, rate-limited pre-dispatch).
+        except structured_error_types as exc:
+            # Application-layer AdCP error. Emit a failed task with the
+            # adcp_error in a DataPart per transport-errors.mdx §A2A
+            # Binding, plus a human-readable text part. The JSON-RPC
+            # channel is reserved for transport-level errors (auth
+            # rejected, rate-limited pre-dispatch).
             logger.info("AdCP application error for skill %s: %s", skill_name, exc)
             await self._send_adcp_error(event_queue, context, exc)
         except Exception:
@@ -406,37 +427,51 @@ class ADCPAgentExecutor(AgentExecutor):
         self,
         event_queue: EventQueue,
         context: RequestContext,
-        exc: ADCPError,
+        exc: Any,
     ) -> None:
         """Publish a failed task carrying an AdCP ``adcp_error`` payload.
 
         Follows transport-errors.mdx §A2A Binding: failed task with artifact
         containing a ``DataPart`` keyed under ``adcp_error`` plus a terse
         ``TextPart`` for human/LLM consumption.
+
+        The structured envelope carries the full spec shape — ``code``,
+        ``message``, ``recovery``, ``field``, ``suggestion``,
+        ``retry_after``, ``details`` — populated when the raised
+        exception supplies them, omitted when ``None``. Field extraction
+        is shared with the MCP path via
+        :func:`adcp.server.translate._extract_structured_fields`, so
+        both transports project off the same source-of-truth shape.
         """
-        # Derive the spec error code. ADCPTaskError carries a list of codes
-        # (e.g. IdempotencyConflictError → IDEMPOTENCY_CONFLICT); fall back
-        # to a generic INTERNAL_ERROR when the exception doesn't supply one.
-        code = "INTERNAL_ERROR"
-        if isinstance(exc, ADCPTaskError) and exc.error_codes:
-            code = str(exc.error_codes[0])
+        # Lazy import — ``translate.py`` pulls in heavier server deps
+        # (mcp.types) which the A2A module doesn't otherwise need.
+        from adcp.server.translate import _extract_structured_fields
+
+        code, message, recovery, field, suggestion, details, _errors = _extract_structured_fields(
+            exc
+        )
 
         adcp_error: dict[str, Any] = {
             "code": code,
-            "message": exc.message,
+            "message": message,
+            "recovery": recovery,
         }
-        recovery = STANDARD_ERROR_CODES.get(code, {}).get("recovery")
-        if recovery:
-            adcp_error["recovery"] = recovery
-        suggestion = getattr(exc, "suggestion", None)
-        if suggestion:
+        if field is not None:
+            adcp_error["field"] = field
+        if suggestion is not None:
             adcp_error["suggestion"] = suggestion
+        # ``retry_after`` lives on decisioning AdcpError; project when present.
+        retry_after = getattr(exc, "retry_after", None)
+        if retry_after is not None:
+            adcp_error["retry_after"] = retry_after
+        if details:
+            adcp_error["details"] = dict(details)
 
         task = _make_task(
             context,
             state=pb.TaskState.TASK_STATE_FAILED,
             data={"adcp_error": adcp_error},
-            message=exc.message,
+            message=message,
         )
         await event_queue.enqueue_event(task)
 

--- a/tests/test_a2a_structured_error.py
+++ b/tests/test_a2a_structured_error.py
@@ -1,0 +1,332 @@
+"""Tests for A2A structured error projection (issue #530).
+
+Mirrors :mod:`tests.test_mcp_structured_error` for the A2A surface. Verifies
+that AdcpError raised from a platform method projects onto the wire as a
+failed-task DataPart keyed under ``adcp_error`` with the full spec shape
+— matching transport-errors.mdx §A2A Binding and PR #525's MCP fix.
+
+Two parity gaps closed:
+
+1. The executor catches both :class:`adcp.exceptions.ADCPError` (client-
+   side) AND :class:`adcp.decisioning.types.AdcpError` (server-side
+   structured error). Previously decisioning errors fell into the
+   generic ``except Exception`` and rendered as plain "Skill execution
+   failed" text.
+2. The DataPart envelope carries ``code``, ``message``, ``recovery``,
+   ``field``, ``suggestion``, ``retry_after``, ``details`` — populated
+   when present, omitted when absent. Previously only ``code`` /
+   ``message`` / ``recovery`` / ``suggestion`` were emitted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from a2a import types as pb
+from a2a.server.agent_execution.context import RequestContext as _RealRequestContext
+from a2a.server.events.event_queue import EventQueueLegacy as EventQueue
+from google.protobuf.json_format import MessageToDict as _MessageToDict
+from google.protobuf.json_format import ParseDict
+from google.protobuf.struct_pb2 import Value
+
+from adcp.decisioning.types import AdcpError as DecisioningAdcpError
+from adcp.exceptions import ADCPTaskError
+from adcp.server import ADCPHandler
+from adcp.server.a2a_server import ADCPAgentExecutor as _ADCPAgentExecutor
+from adcp.types import Error
+
+
+@pytest.fixture(autouse=True)
+def _admit_sandbox_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A2A executor tests run outside the sandbox-authority gate."""
+    monkeypatch.setenv("ADCP_SANDBOX", "1")
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures (mirrors test_a2a_server.py shims)
+# ---------------------------------------------------------------------------
+
+
+def _data_part(data: dict[str, Any]) -> pb.Part:
+    value = Value()
+    ParseDict(data, value)
+    return pb.Part(data=value)
+
+
+def _make_datapart_msg(skill: str, parameters: dict[str, Any] | None = None) -> pb.Message:
+    return pb.Message(
+        message_id="msg-1",
+        role=pb.Role.ROLE_USER,
+        parts=[_data_part({"skill": skill, "parameters": parameters or {}})],
+    )
+
+
+def _empty_call_context() -> Any:
+    from a2a.auth.user import UnauthenticatedUser
+    from a2a.server.context import ServerCallContext
+
+    return ServerCallContext(user=UnauthenticatedUser())
+
+
+def _request_context(skill: str) -> _RealRequestContext:
+    return _RealRequestContext(
+        call_context=_empty_call_context(),
+        request=pb.SendMessageRequest(message=_make_datapart_msg(skill)),
+    )
+
+
+def _executor(handler: ADCPHandler) -> _ADCPAgentExecutor:
+    """Build an executor with validation disabled — these tests focus on
+    the error-projection contract, not wire-conformance for success
+    payloads."""
+    return _ADCPAgentExecutor(handler, validation=None)
+
+
+def _adcp_error_data_part(task: pb.Task) -> dict[str, Any]:
+    """Pull the ``adcp_error`` payload out of a failed task's DataPart."""
+    assert task.artifacts, "expected at least one artifact on failed task"
+    for part in task.artifacts[0].parts:
+        if part.WhichOneof("content") != "data":
+            continue
+        payload = _MessageToDict(part.data)
+        if isinstance(payload, dict) and "adcp_error" in payload:
+            return payload["adcp_error"]
+    raise AssertionError("no adcp_error DataPart found on task artifacts")
+
+
+# ---------------------------------------------------------------------------
+# Handlers that raise specific structured errors
+# ---------------------------------------------------------------------------
+
+
+class _AdcpCapsBase(ADCPHandler):
+    """Stub ADCP capabilities — required for ADCPHandler conformance."""
+
+    async def get_adcp_capabilities(self, params: Any, context: Any = None) -> dict[str, Any]:
+        return {"adcp": {"major_versions": [3]}, "supported_protocols": ["media_buy"]}
+
+
+class _DecisioningRaiser(_AdcpCapsBase):
+    """Raises a configurable decisioning ``AdcpError`` from get_products."""
+
+    def __init__(self, exc_factory: Any) -> None:
+        self._exc_factory = exc_factory
+
+    async def get_products(self, params: Any, context: Any = None) -> Any:
+        raise self._exc_factory()
+
+
+class _TaskErrorRaiser(_AdcpCapsBase):
+    """Raises an ADCPTaskError from get_products."""
+
+    def __init__(self, errors: list[Error]) -> None:
+        self._errors = errors
+
+    async def get_products(self, params: Any, context: Any = None) -> Any:
+        raise ADCPTaskError("get_products", self._errors)
+
+
+# ============================================================================
+# Decisioning AdcpError projection — the main parity gap
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_decisioning_adcp_error_caught_not_dropped_to_generic_exception() -> None:
+    """Pre-fix this raised through ``except Exception`` and rendered as
+    "Skill execution failed: get_products" — losing the structured shape."""
+    handler = _DecisioningRaiser(
+        lambda: DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
+    )
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, pb.Task)
+    assert event.status.state == pb.TaskState.TASK_STATE_FAILED
+    payload = _adcp_error_data_part(event)
+    assert payload["code"] == "MEDIA_BUY_NOT_FOUND"
+    assert payload["message"] == "no such buy"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "code,recovery",
+    [
+        ("MEDIA_BUY_NOT_FOUND", "terminal"),
+        ("PACKAGE_NOT_FOUND", "terminal"),
+        ("TERMS_REJECTED", "terminal"),
+        ("BUDGET_TOO_LOW", "correctable"),
+    ],
+)
+async def test_specific_codes_round_trip(code: str, recovery: str) -> None:
+    """Each spec code reaches the wire with its code intact — storyboard
+    runner's ``/adcp_error/code`` JSON-pointer assertion resolves to the
+    actual code, not a generic fallback. Mirrors the MCP-side parametrized
+    test in ``test_mcp_structured_error.py``.
+    """
+    handler = _DecisioningRaiser(
+        lambda: DecisioningAdcpError(code, message="test", recovery=recovery)  # type: ignore[arg-type]
+    )
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, pb.Task)
+    assert event.status.state == pb.TaskState.TASK_STATE_FAILED
+    payload = _adcp_error_data_part(event)
+    assert payload["code"] == code
+    assert payload["recovery"] == recovery
+
+
+# ============================================================================
+# Optional-field gating: populate when present, omit when absent
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_envelope_populated_when_all_fields_present() -> None:
+    """Spec wire shape: ``{code, message, recovery, field, suggestion,
+    retry_after, details}`` populated when the raised error supplies them."""
+    handler = _DecisioningRaiser(
+        lambda: DecisioningAdcpError(
+            "BUDGET_TOO_LOW",
+            message="below floor",
+            recovery="correctable",
+            field="total_budget",
+            suggestion="Increase to at least $0.50",
+            retry_after=30,
+            details={"floor_cpm": "0.50", "impressions": 1000},
+        )
+    )
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    payload = _adcp_error_data_part(event)
+    assert payload["code"] == "BUDGET_TOO_LOW"
+    assert payload["message"] == "below floor"
+    assert payload["recovery"] == "correctable"
+    assert payload["field"] == "total_budget"
+    assert payload["suggestion"] == "Increase to at least $0.50"
+    assert payload["retry_after"] == 30
+    assert payload["details"] == {"floor_cpm": "0.50", "impressions": 1000}
+
+
+@pytest.mark.asyncio
+async def test_optional_fields_omitted_when_absent() -> None:
+    """When the raised error doesn't populate ``field`` / ``suggestion`` /
+    ``retry_after`` / ``details``, those keys MUST NOT appear on the wire —
+    omitted, not set to None. Buyers checking ``"field" in payload`` rely
+    on this gating to distinguish "not provided" from "explicitly null"."""
+    handler = _DecisioningRaiser(lambda: DecisioningAdcpError("INTERNAL_ERROR", message="oops"))
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    payload = _adcp_error_data_part(event)
+    assert "field" not in payload
+    assert "suggestion" not in payload
+    assert "retry_after" not in payload
+    assert "details" not in payload
+    # Required fields still present.
+    assert payload["code"] == "INTERNAL_ERROR"
+    assert payload["message"] == "oops"
+    assert "recovery" in payload
+
+
+@pytest.mark.asyncio
+async def test_field_populated_without_suggestion() -> None:
+    """Independent gating — ``field`` populates without forcing
+    ``suggestion`` to appear."""
+    handler = _DecisioningRaiser(
+        lambda: DecisioningAdcpError("INVALID_REQUEST", message="bad budget", field="total_budget")
+    )
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    payload = _adcp_error_data_part(event)
+    assert payload["field"] == "total_budget"
+    assert "suggestion" not in payload
+
+
+@pytest.mark.asyncio
+async def test_retry_after_populated_for_transient() -> None:
+    """``retry_after`` projects when present (mainly for ``transient``
+    recovery codes like ``RATE_LIMITED``)."""
+    handler = _DecisioningRaiser(
+        lambda: DecisioningAdcpError(
+            "RATE_LIMITED",
+            message="slow down",
+            recovery="transient",
+            retry_after=60,
+        )
+    )
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    payload = _adcp_error_data_part(event)
+    assert payload["retry_after"] == 60
+    assert payload["recovery"] == "transient"
+
+
+# ============================================================================
+# Client-side ADCPError (e.g. ADCPTaskError) — already-supported path stays green
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_adcp_task_error_still_caught_after_refactor() -> None:
+    """Regression: ``ADCPTaskError`` (carrying spec codes via ``error_codes``)
+    continues to project as a structured envelope after the dual-catch
+    refactor. This was the only path that worked pre-fix."""
+    handler = _TaskErrorRaiser([Error(code="IDEMPOTENCY_CONFLICT", message="payload differs")])
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, pb.Task)
+    assert event.status.state == pb.TaskState.TASK_STATE_FAILED
+    payload = _adcp_error_data_part(event)
+    assert payload["code"] == "IDEMPOTENCY_CONFLICT"
+
+
+@pytest.mark.asyncio
+async def test_adcp_task_error_with_field_projects_field() -> None:
+    """``ADCPTaskError`` carrying an :class:`Error` with ``field`` populates
+    ``field`` on the wire (parity with MCP's ``Error`` model handling)."""
+    handler = _TaskErrorRaiser(
+        [
+            Error(
+                code="VALIDATION_ERROR",
+                message="missing field",
+                field="packages[0].budget",
+            )
+        ]
+    )
+    executor = _executor(handler)
+    queue = EventQueue()
+
+    await executor.execute(_request_context("get_products"), queue)
+
+    event = await queue.dequeue_event()
+    payload = _adcp_error_data_part(event)
+    assert payload["code"] == "VALIDATION_ERROR"
+    assert payload["field"] == "packages[0].budget"


### PR DESCRIPTION
## Summary

Closes #530. Mirrors the MCP-side fix from #525 onto the A2A surface so storyboards graded against A2A-served sellers see the same structured `adcp_error` envelope as MCP buyers. Without this, A2A surfaces would surface a wire-conformance gap once the storyboard runner's structured-error checks run against A2A (or via the upstream storyboard runner UX work in adcp-client#1527).

## Two parity gaps closed

**1. Catch both exception hierarchies.** `ADCPAgentExecutor.execute()` now catches both `adcp.exceptions.ADCPError` (client-side framework error) AND `adcp.decisioning.types.AdcpError` (server-side structured error platform methods raise). They are disjoint hierarchies — pre-fix the decisioning case fell into `except Exception` and rendered as plain "Skill execution failed" text, losing the structured shape entirely for adopters using `DecisioningPlatform`.

**2. Emit the full envelope.** `_send_adcp_error` now projects `code`, `message`, `recovery`, `field`, `suggestion`, `retry_after`, `details` — populated when the raised exception supplies them, omitted when `None`. Pre-fix only `code` / `message` / `recovery` / `suggestion` reached the wire.

## Reuse, not duplication

Field extraction is shared with the MCP path via `adcp.server.translate._extract_structured_fields` (the helper #525 factored out for exactly this purpose). Both transports project off the same source-of-truth shape — no drift between MCP and A2A error envelopes.

`_extract_structured_fields` was reusable as-is — no factoring needed.

## Test plan

- [x] Unit tests parametrized over the same code set as #525's MCP test (`MEDIA_BUY_NOT_FOUND`, `PACKAGE_NOT_FOUND`, `TERMS_REJECTED`, `BUDGET_TOO_LOW`)
- [x] Decisioning `AdcpError` reaches A2A `DataPart` as structured envelope (the main parity gap — was dropped pre-fix)
- [x] All optional fields (`field`, `details`, `retry_after`, `suggestion`) populate when present, omit when absent
- [x] `ADCPTaskError` (the only path that worked pre-fix) regression: still caught, still projects structured envelope, `field` populates when carried on `Error.field`
- [x] Existing `tests/test_a2a_server.py` suite stays green (40 tests)
- [x] Full repo regression: 3795 passed
- [x] `ruff check` + `mypy src/adcp/server/` clean

## Refs

- #530 — this issue
- #525 — sibling MCP-side fix (closed #509). Reused `_extract_structured_fields` directly
- adcp-client#1527 — upstream storyboard runner UX. When the runner adds structured-error checks to A2A storyboards, this gap would have become a wire-conformance failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)