### PR TITLE
docs(migration): note 161 figure is v4.0 worst case

### DIFF
--- a/MIGRATION_v3_to_v4.md
+++ b/MIGRATION_v3_to_v4.md
@@ -56,6 +56,15 @@ the whole codebase. salesagent re-exported through `src/core/schemas/_base.py`
 during pytest collect-only**, and stubbing it revealed the next ~140-test
 cascade from `BrandManifest`, then the next from the `generated_poc` reach-ins.
 
+> **The 161 figure is the worst case at v4.0 release.** A salesagent
+> re-run against v4.3+ (after expanded type aliases, `pending_activation`
+> codemod flagger, and the smaller-blast-radius
+> `_base.py`-cascade-warning landed) hit 141 codemod findings and ~36
+> collection errors — markedly less than the worst-case framing above.
+> Expect the lower number on v4.3+ checkouts; the worst-case story is
+> preserved here so adopters who copy salesagent's pre-v4.3 pattern know
+> what to triage first.
+
 The codemod's static finding count understates this by 100x+. To minimize the
 felt blast radius, work in this order:
 


### PR DESCRIPTION
Closes #520.

## Summary

Adds a callout block right after the "270 files scanned, 161 test-collection failures" line in `MIGRATION_v3_to_v4.md` noting that:

- 161 is the worst case at v4.0 release.
- A re-run on v4.3+ (after expanded type aliases, `pending_activation` codemod flagger, and the `_base.py`-cascade warning landed) hit 141 codemod findings and ~36 collection errors.

Preserves the original worst-case framing (it's still what adopters who copy salesagent's pre-v4.3 pattern will see) but tells v4.3+ adopters what to actually expect.

## Why

Salesagent migration feedback #15: the figures "made me expect worse pain than I actually hit." The 4.x improvements between the prior attempt and now are working, and the guide should reflect that.

## Test plan

- [x] Pre-commit hooks pass (markdown isn't linted but EOF/whitespace checks did)
- [ ] Reviewer eye on accuracy of the 141 / ~36 numbers (lifted directly from `core/SDK_FEEDBACK.md` adopter context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)