### PR TITLE
docs(examples): webhook wiring recipe — handler-authoring section + expanded hello_seller + new with_webhooks example

### DIFF
--- a/docs/handler-authoring.md
+++ b/docs/handler-authoring.md
@@ -1033,6 +1033,54 @@ All three Phase-2 A2A hooks (#224 TaskStore, #225 PushNotificationConfigStore,
 #226 SkillMiddleware) have landed. A2A adoption now reaches parity with
 MCP for production agents.
 
+## Webhooks
+
+When `auto_emit_completion_webhooks=True` (the default), the framework fires a
+sync-completion webhook after every successfully-dispatched tool call whose task
+type is in the spec's webhook-eligible set (`create_media_buy`, `activate_signal`,
+and their siblings). Buyers who register `push_notification_config.url` receive
+these notifications automatically.
+
+The framework requires a sender or supervisor at boot — it raises `AdcpError`
+rather than silently dropping notifications if neither is wired and auto-emit is on.
+Set `auto_emit_completion_webhooks=False` only if you emit webhooks manually inside
+your platform methods.
+
+### Sender constructors
+
+Pick one per `WebhookSender` instance. All three share the same
+`send_mcp(url, task_id, status, ...)` delivery API.
+
+| Constructor | Auth mode | When to use |
+|---|---|---|
+| `WebhookSender.from_jwk(jwk, key_id, alg)` | RFC 9421 HTTP-signature | AdCP-conformant buyers; spec baseline |
+| `WebhookSender.from_bearer_token(token)` | `Authorization: Bearer` | Simplest; no key management; requires TLS |
+| `WebhookSender.from_standard_webhooks_secret(secret)` | Standard Webhooks v1 | Svix / Resend / standardwebhooks.com receivers |
+
+### Sender vs. supervisor
+
+`WebhookSender` is the transport layer — it constructs and signs one HTTP POST.
+`InMemoryWebhookDeliverySupervisor` wraps a sender and adds retry with exponential
+backoff, per-endpoint circuit breakers, and an audit log. Pass
+`webhook_supervisor=` in production so transient receiver outages don't cause
+missed notifications.
+
+```python
+import os
+from adcp.webhook_sender import WebhookSender
+from adcp.webhook_supervisor import InMemoryWebhookDeliverySupervisor
+from adcp.decisioning import serve
+
+sender = WebhookSender.from_bearer_token(os.environ["WEBHOOK_BEARER_TOKEN"])
+supervisor = InMemoryWebhookDeliverySupervisor(sender=sender)
+serve(my_platform, webhook_supervisor=supervisor)
+```
+
+For the full constructor reference and a migration table from legacy HMAC / bare
+`requests.post` patterns, see
+[`docs/webhooks/migration-from-fragmented-senders.md`](webhooks/migration-from-fragmented-senders.md).
+See `examples/hello_seller_with_webhooks.py` for a runnable end-to-end wiring example.
+
 ## Testing
 
 The integration test pattern in `tests/test_mcp_middleware_composition.py`

--- a/docs/handler-authoring.md
+++ b/docs/handler-authoring.md
@@ -1053,9 +1053,9 @@ Pick one per `WebhookSender` instance. All three share the same
 
 | Constructor | Auth mode | When to use |
 |---|---|---|
-| `WebhookSender.from_jwk(jwk, key_id, alg)` | RFC 9421 HTTP-signature | AdCP-conformant buyers; spec baseline |
+| `WebhookSender.from_jwk(jwk)` | RFC 9421 HTTP-signature | AdCP-conformant buyers; spec baseline (`kid`/`alg`/`adcp_use` live in the JWK dict) |
 | `WebhookSender.from_bearer_token(token)` | `Authorization: Bearer` | Simplest; no key management; requires TLS |
-| `WebhookSender.from_standard_webhooks_secret(secret)` | Standard Webhooks v1 | Svix / Resend / standardwebhooks.com receivers |
+| `WebhookSender.from_standard_webhooks_secret(secret, key_id=...)` | Standard Webhooks v1 | Svix / Resend / standardwebhooks.com receivers |
 
 ### Sender vs. supervisor
 

--- a/examples/hello_seller.py
+++ b/examples/hello_seller.py
@@ -344,14 +344,17 @@ if __name__ == "__main__":
     #   from adcp.webhook_sender import WebhookSender
     #   from adcp.webhook_supervisor import InMemoryWebhookDeliverySupervisor
     #
-    #   # RFC 9421 JWK signing — AdCP spec baseline (recommended):
-    #   sender = WebhookSender.from_jwk(signing_jwk, key_id="kid_1", alg="ES256")
+    #   # RFC 9421 JWK signing — AdCP spec baseline (recommended).
+    #   # signing_jwk must be a dict with kid, alg, and adcp_use="webhook-signing":
+    #   sender = WebhookSender.from_jwk(signing_jwk)
     #
     #   # Shared bearer token — no key management, requires TLS:
     #   sender = WebhookSender.from_bearer_token(os.environ["WEBHOOK_BEARER_TOKEN"])
     #
     #   # Standard Webhooks v1 — Svix / Resend / standardwebhooks.com interop:
-    #   sender = WebhookSender.from_standard_webhooks_secret(os.environ["WHSEC"])
+    #   sender = WebhookSender.from_standard_webhooks_secret(
+    #       os.environ["WHSEC"], key_id="whsec_v1",
+    #   )
     #
     #   supervisor = InMemoryWebhookDeliverySupervisor(sender=sender)
     #   serve(HelloSeller(), name="hello-seller", webhook_supervisor=supervisor)

--- a/examples/hello_seller.py
+++ b/examples/hello_seller.py
@@ -334,9 +334,27 @@ if __name__ == "__main__":
     # server. Default port 3001 over streamable-http; override via
     # ``serve(seller, port=...)``.
     #
-    # ``auto_emit_completion_webhooks=False`` opts out of the F12
-    # sync-completion webhook auto-emit so the example boots without
-    # a ``webhook_sender``. Wire ``webhook_sender=`` in production so
-    # buyers who register ``push_notification_config.url`` get
-    # notifications.
+    # ``auto_emit_completion_webhooks=False`` opts out here because this
+    # example has no signing key.  Production sellers want webhooks on so
+    # buyers who register ``push_notification_config.url`` get sync-
+    # completion notifications.  Pick a constructor and pass
+    # ``webhook_supervisor=`` (retry + circuit breaker, recommended) or
+    # ``webhook_sender=`` (transport only):
+    #
+    #   from adcp.webhook_sender import WebhookSender
+    #   from adcp.webhook_supervisor import InMemoryWebhookDeliverySupervisor
+    #
+    #   # RFC 9421 JWK signing — AdCP spec baseline (recommended):
+    #   sender = WebhookSender.from_jwk(signing_jwk, key_id="kid_1", alg="ES256")
+    #
+    #   # Shared bearer token — no key management, requires TLS:
+    #   sender = WebhookSender.from_bearer_token(os.environ["WEBHOOK_BEARER_TOKEN"])
+    #
+    #   # Standard Webhooks v1 — Svix / Resend / standardwebhooks.com interop:
+    #   sender = WebhookSender.from_standard_webhooks_secret(os.environ["WHSEC"])
+    #
+    #   supervisor = InMemoryWebhookDeliverySupervisor(sender=sender)
+    #   serve(HelloSeller(), name="hello-seller", webhook_supervisor=supervisor)
+    #
+    # See docs/handler-authoring.md#webhooks for the full wiring recipe.
     serve(HelloSeller(), name="hello-seller", auto_emit_completion_webhooks=False)

--- a/examples/hello_seller_with_webhooks.py
+++ b/examples/hello_seller_with_webhooks.py
@@ -7,7 +7,7 @@ as the auth mode — no key management, simplest first step.
 
 Run::
 
-    WEBHOOK_BEARER_TOKEN=dev-fixture-token uv run python examples/hello_seller_with_webhooks.py
+    WEBHOOK_BEARER_TOKEN=<your-token> uv run python examples/hello_seller_with_webhooks.py
 
 The server boots on http://localhost:3001/mcp.  Any buyer that registers
 ``push_notification_config.url`` on a ``create_media_buy`` request receives a
@@ -35,7 +35,17 @@ from adcp.webhook_sender import WebhookSender
 from adcp.webhook_supervisor import InMemoryWebhookDeliverySupervisor
 
 if __name__ == "__main__":
-    token = os.environ.get("WEBHOOK_BEARER_TOKEN", "dev-fixture-token")
+    token = os.environ.get("WEBHOOK_BEARER_TOKEN", "")
+    if not token:
+        import warnings
+
+        warnings.warn(
+            "WEBHOOK_BEARER_TOKEN is not set; using 'dev-fixture-token'. "
+            "Set WEBHOOK_BEARER_TOKEN=<real-token> before connecting real buyers.",
+            category=UserWarning,
+            stacklevel=1,
+        )
+        token = "dev-fixture-token"
     sender = WebhookSender.from_bearer_token(token)
     # InMemoryWebhookDeliverySupervisor wraps the sender with retry
     # (exponential backoff, 3 attempts) and per-endpoint circuit breakers.

--- a/examples/hello_seller_with_webhooks.py
+++ b/examples/hello_seller_with_webhooks.py
@@ -1,0 +1,48 @@
+"""Hello-seller-with-webhooks — canonical ``WebhookSender`` + supervisor wiring.
+
+Extends ``hello_seller.py`` with a wired :class:`InMemoryWebhookDeliverySupervisor`
+so sync-completion webhooks are delivered to buyers who register
+``push_notification_config.url``.  Uses :meth:`WebhookSender.from_bearer_token`
+as the auth mode — no key management, simplest first step.
+
+Run::
+
+    WEBHOOK_BEARER_TOKEN=dev-fixture-token uv run python examples/hello_seller_with_webhooks.py
+
+The server boots on http://localhost:3001/mcp.  Any buyer that registers
+``push_notification_config.url`` on a ``create_media_buy`` request receives a
+completion notification POSTed with ``Authorization: Bearer <token>``.
+
+To use RFC 9421 JWK signing instead (AdCP spec baseline, required for buyers
+that verify body signatures), swap :meth:`~WebhookSender.from_bearer_token`
+for :meth:`~WebhookSender.from_jwk`.  See ``docs/handler-authoring.md#webhooks``
+for the full constructor comparison.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Allow importing hello_seller as a sibling module when run as a script.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from hello_seller import HelloSeller  # type: ignore[import]  # noqa: E402
+
+from adcp.decisioning import serve
+from adcp.webhook_sender import WebhookSender
+from adcp.webhook_supervisor import InMemoryWebhookDeliverySupervisor
+
+if __name__ == "__main__":
+    token = os.environ.get("WEBHOOK_BEARER_TOKEN", "dev-fixture-token")
+    sender = WebhookSender.from_bearer_token(token)
+    # InMemoryWebhookDeliverySupervisor wraps the sender with retry
+    # (exponential backoff, 3 attempts) and per-endpoint circuit breakers.
+    # Pass webhook_supervisor= rather than webhook_sender= in production.
+    supervisor = InMemoryWebhookDeliverySupervisor(sender=sender)
+    serve(
+        HelloSeller(),
+        name="hello-seller-with-webhooks",
+        webhook_supervisor=supervisor,
+    )


### PR DESCRIPTION
Closes #546

## Summary

Three non-breaking documentation and examples changes that together close the silent-no-op trap for first-time `DecisioningPlatform` adopters:

- **`docs/handler-authoring.md`**: adds a new `## Webhooks` section covering the three sender constructors (comparison table), the sender-vs-supervisor distinction, a wiring snippet, and cross-links to the migration guide and the new example. The section makes `docs/handler-authoring.md#webhooks` a live anchor (previously the issue proposed linking there but the section didn't exist).
- **`examples/hello_seller.py`**: expands the three-line "wire webhook_sender= in production" note into a full three-constructor menu with import lines, a JWK field reminder, and a link to `docs/handler-authoring.md#webhooks`.
- **`examples/hello_seller_with_webhooks.py`** (new): ~57-LOC runnable wiring example using `WebhookSender.from_bearer_token` + `InMemoryWebhookDeliverySupervisor`, the first copy-paste-ready path from bare handler to production-grade webhooks.

Note: the boot-time fail-fast (`validate_webhook_sender_for_platform`) was already shipping as a hard `AdcpError` raise — this PR closes the documentation gap that let adopters reach that error without knowing how to resolve it.

## What was tested

- `pytest` (3866 passed, 32 skipped, 1 pre-existing network test failure on `signing/test_ip_pinned_transport.py::test_real_tls_handshake_still_validates_hostname` — unrelated to this PR, pre-exists on `main`)
- `mypy src/adcp/` — 878 errors, identical to `main` (no source files changed)
- `ruff check src/` — all checks passed

## Pre-PR review

Two expert passes were run (blockers fixed before final sign-off):

- **code-reviewer**: approved — prior blocker (silent `dev-fixture-token` fallback) resolved with `warnings.warn`; 1 nit noted in PR body
- **dx-expert**: approved — prior blocker (`from_jwk` kwargs mismatch) resolved; `kid`/`alg`/`adcp_use` now correctly documented as JWK dict fields

**Nits surfaced (not fixed):**
- `examples/README.md` does not list `hello_seller_with_webhooks.py` — consistent with how other `hello_seller_*.py` variants are handled (none appear to be individually listed); can be addressed in a follow-on README update pass.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Ay2SJvRpBg8EP9nG9DgQMy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2SJvRpBg8EP9nG9DgQMy)_