### PR TITLE
feat(server/idempotency): complete PgBackend for multi-worker durable replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           pytest tests/conformance/signing/test_pg_replay_store.py \
                  tests/conformance/signing/test_pg_replay_store_e2e.py \
                  tests/conformance/decisioning/test_pg_buyer_agent_registry.py \
+                 tests/conformance/decisioning/test_pg_idempotency_backend.py \
                  -v
 
   conventional-commits:

--- a/src/adcp/server/idempotency/__init__.py
+++ b/src/adcp/server/idempotency/__init__.py
@@ -47,9 +47,11 @@ Backends:
 
 - :class:`MemoryBackend` — in-process dict with TTL; use for tests and
   single-process reference implementations.
-- :class:`PgBackend` — scaffold for a SQLAlchemy/asyncpg-backed store that can
-  commit cache writes atomically with business writes. Implementation arrives
-  in a follow-up PR.
+- :class:`PgBackend` — Postgres-backed store for multi-worker durable
+  replay. Requires the ``adcp[pg]`` extra. ``await
+  backend.create_schema()`` once at boot; commits go through a fresh
+  pool connection (separate from the handler's transaction in v1 —
+  co-tx wiring is a v1.1 affordance).
 """
 
 from adcp.server.idempotency.backends import (

--- a/src/adcp/server/idempotency/backends.py
+++ b/src/adcp/server/idempotency/backends.py
@@ -5,9 +5,11 @@ A backend owns two responsibilities:
 1. Retrieve a cached response by ``(principal_id, idempotency_key)``, honoring
    the seller's replay TTL.
 2. Atomically commit ``(payload_hash, response)`` on a fresh key. Atomicity
-   with the handler's business writes is the backend's choice — :class:`MemoryBackend`
-   makes no such guarantee; :class:`PgBackend` (follow-up) will when the handler
-   uses the same engine.
+   with the handler's business writes is the backend's choice —
+   :class:`MemoryBackend` makes no such guarantee; :class:`PgBackend` shares
+   a connection pool so adopters with the same Postgres can compose their
+   handler's transaction with the cache write (v1 commits in a separate
+   pool connection — co-tx wiring is a v1.1 affordance).
 
 Backends expose async methods. The in-process :class:`MemoryBackend` is
 synchronous under the hood but wrapped in ``async`` signatures so the store
@@ -17,11 +19,43 @@ can remain backend-agnostic.
 from __future__ import annotations
 
 import asyncio
+import json
+import re
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
+
+try:
+    import psycopg  # noqa: F401
+    import psycopg_pool  # noqa: F401
+
+    _PG_AVAILABLE = True
+except ImportError:
+    _PG_AVAILABLE = False
+
+_PG_INSTALL_HINT = (
+    "PgBackend requires psycopg3 and psycopg-pool. "
+    "Install the 'pg' extra: `pip install 'adcp[pg]'`."
+)
+
+# Byte-level ASCII identifier guard — same rationale as PgReplayStore /
+# PgWebhookDeliverySupervisor. ``str.islower()`` accepts non-ASCII Unicode
+# letters which would format verbatim into SQL as a different table than
+# configured.
+_SAFE_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+DEFAULT_IDEMPOTENCY_TABLE = "adcp_idempotency"
+
+
+def _safe_identifier(name: str) -> str:
+    if not _SAFE_IDENTIFIER_RE.fullmatch(name):
+        raise ValueError(
+            f"Table name must match [a-z_][a-z0-9_]{{0,62}} (ASCII only), got {name!r}"
+        )
+    return name
 
 
 @dataclass(frozen=True)
@@ -150,72 +184,227 @@ class MemoryBackend(IdempotencyBackend):
 
 
 class PgBackend(IdempotencyBackend):
-    """PostgreSQL-backed store — **scaffold, not yet implemented**.
+    """PostgreSQL-backed :class:`IdempotencyBackend`.
 
-    .. warning::
-       Calling ``PgBackend(...)`` raises ``NotImplementedError`` today. Use
-       :class:`MemoryBackend` for tests, or implement your own
-       :class:`IdempotencyBackend` subclass against the database of your
-       choice until this implementation lands. Tracked at
-       https://github.com/adcontextprotocol/adcp-client-python/issues/182.
+    Multi-worker durable replay cache. Adopters running ≥2 processes wire
+    this in place of :class:`MemoryBackend` so a retry that lands on a
+    different worker still replays the cached response.
 
-    **Design intent.** Share a transaction with the handler's business
-    writes so the cache entry commits atomically with side effects. Without
-    that, a crash between ``handler success`` and ``cache commit`` causes
-    the retry to re-execute the handler, duplicating side effects.
+    Example::
 
-    **Schema sketch for the implementer.**
+        from psycopg_pool import AsyncConnectionPool
+        from adcp.server.idempotency import IdempotencyStore, PgBackend
+
+        pool = AsyncConnectionPool("postgresql://...", min_size=2, max_size=10)
+        backend = PgBackend(pool=pool)
+        await backend.create_schema()  # idempotent; safe to call on every boot
+
+        store = IdempotencyStore(backend=backend, ttl_seconds=86400)
+
+    **Atomicity caveat (v1).** ``put`` commits on a fresh pool connection —
+    the cache write is NOT in the same transaction as the handler's
+    business writes. A crash between handler success and cache commit
+    leaves the slot empty; the next retry re-executes the handler.
+    Idempotent handlers absorb this without harm. **Handlers with
+    non-idempotent side effects** (e.g., ``INSERT INTO media_buys``
+    without a unique constraint on the buyer's idempotency_key) need
+    either: (a) handler-level dedupe via a database unique constraint
+    that maps to the same key the SDK uses, or (b) the co-tx variant
+    once it ships. Co-tx — handler passes its own connection so the
+    cache write commits atomically with side effects — is planned as a
+    follow-on enhancement.
+
+    **Schema bootstrap caveat.** :meth:`create_schema` uses
+    ``CREATE TABLE IF NOT EXISTS`` — if a table with the same name but
+    a different shape already exists (Alembic migration drift, manual
+    DDL with ``response JSON`` instead of ``JSONB``, missing
+    ``COLLATE "C"``), this method is a no-op and the backend will run
+    against the wrong column types. If you manage the schema with
+    Alembic / dbmate, copy the DDL inside :meth:`create_schema`
+    verbatim into a migration revision — keep ``COLLATE "C"`` and
+    ``JSONB`` identical — and skip calling :meth:`create_schema` at
+    boot.
+
+    **Response payload contract.** :attr:`CachedResponse.response` is
+    serialized via ``json.dumps`` for the JSONB column. Values must be
+    JSON-safe — no ``datetime``, ``Decimal``, ``set``, or ``bytes``.
+    Coerce in your handler before returning.
+
+    **Cardinality / DoS.** This backend has no row cap; only TTL
+    bounds the table size. Per AdCP spec, per-principal rate limiting
+    at the auth tier is required — the backend trusts that. Schedule
+    :meth:`delete_expired` as a cron / pg_cron / app-loop sweep
+    (``get`` self-filters expired rows, but they accumulate on disk
+    until something deletes them).
+
+    **Schema.** Created idempotently by :meth:`create_schema`:
 
     .. code-block:: sql
 
-        CREATE TABLE adcp_idempotency (
-            scope_key    TEXT       COLLATE "C" NOT NULL,
-            key          TEXT       COLLATE "C" NOT NULL,
-            payload_hash TEXT       NOT NULL,
-            response     JSONB      NOT NULL,
+        CREATE TABLE IF NOT EXISTS adcp_idempotency (
+            scope_key    TEXT        COLLATE "C" NOT NULL,
+            key          TEXT        COLLATE "C" NOT NULL,
+            payload_hash TEXT        NOT NULL,
+            response     JSONB       NOT NULL,
             expires_at   TIMESTAMPTZ NOT NULL,
             PRIMARY KEY (scope_key, key)
         );
+        CREATE INDEX IF NOT EXISTS adcp_idempotency_expires_idx
+            ON adcp_idempotency (expires_at);
 
-    Notes:
+    ``COLLATE "C"`` on identifier columns avoids locale-driven equivalence
+    (``Principal-A`` ≡ ``principal-a`` under Turkish/locale-aware
+    collations) collapsing distinct tenants into the same cache slot.
 
-    * ``COLLATE "C"`` (or ``CITEXT`` with a deliberate case policy) — avoid
-      the default locale collation on the identifier columns. On some
-      locales ``Principal-A`` and ``principal-a`` compare equal, which
-      would collapse distinct tenants into the same cache slot.
-    * ``scope_key`` is already composed from ``(tenant_id, caller_identity)``
-      by the store — Postgres sees it as an opaque string. Queries MUST
-      still filter on ``scope_key`` in the ``WHERE`` clause even with the
-      composite PK — row-level security (RLS) enforced via a policy like
-      ``USING (scope_key = current_setting('adcp.scope_key')::text)`` gives
-      belt-and-suspenders protection against accidental cross-tenant reads
-      in future handlers.
-    * ``get`` uses ``SELECT ... WHERE expires_at > now()``.
-    * ``put`` uses ``INSERT ... ON CONFLICT (scope_key, key) DO UPDATE``.
-    * Accept a SQLAlchemy/asyncpg session factory so the caller can thread
-      the handler's transaction through for atomic commit — the atomicity
-      guarantee is the whole reason to use a SQL backend.
+    :param pool: ``psycopg_pool.AsyncConnectionPool`` owned by the caller.
+        Each operation acquires a short-lived connection. We don't open,
+        own, or close the pool.
+    :param table_name: Override the default table name. Useful for
+        multi-tenant schema scoping. Default ``adcp_idempotency``.
+
+    :raises ImportError: when psycopg/psycopg-pool are not installed.
+        Install via the ``pg`` extra: ``pip install 'adcp[pg]'``.
+    :raises ValueError: when ``table_name`` is not a safe ASCII
+        identifier (``[a-z_][a-z0-9_]{0,62}``).
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError(
-            "PgBackend is scaffolded but not yet implemented. Use MemoryBackend "
-            "for tests, or implement your own IdempotencyBackend subclass "
-            "against your database of choice until the PgBackend implementation "
-            "lands. Tracking: "
-            "https://github.com/adcontextprotocol/adcp-client-python/issues/182."
-        )
+    def __init__(
+        self,
+        *,
+        pool: Any,  # psycopg_pool.AsyncConnectionPool — Any avoids runtime psycopg import
+        table_name: str = DEFAULT_IDEMPOTENCY_TABLE,
+    ) -> None:
+        if not _PG_AVAILABLE:
+            raise ImportError(_PG_INSTALL_HINT)
+        self._pool = pool
+        self._table = _safe_identifier(table_name)
 
-    async def get(self, scope_key: str, key: str) -> CachedResponse | None:  # pragma: no cover
-        raise NotImplementedError
+        # Pre-format SQL once. Validated identifier so f-string interpolation
+        # is byte-safe; values always go through %s parameterization. Same
+        # convention as PgWebhookDeliverySupervisor / PgReplayStore.
+        t = self._table
+        self._sql_get = (
+            f"SELECT payload_hash, response, expires_at "  # noqa: S608
+            f"FROM {t} WHERE scope_key = %s AND key = %s AND expires_at > now()"
+        )
+        # First-writer-wins under concurrent put. The store's pre-check
+        # ("slot is empty or expired") is NOT a lock — two workers can
+        # both see an empty slot and race into put. With a naive
+        # last-writer-wins ON CONFLICT, the second put would overwrite
+        # the first's payload_hash, violating the cache invariant
+        # "same (scope, key) → same hash". The WHERE on the UPDATE
+        # arm restricts the overwrite to actually-expired rows: a
+        # concurrent fresh write becomes a no-op, both callers
+        # observe an equivalent cached entry from the first writer.
+        self._sql_put = (
+            f"INSERT INTO {t} "  # noqa: S608
+            f"(scope_key, key, payload_hash, response, expires_at) "
+            f"VALUES (%s, %s, %s, %s::jsonb, %s) "
+            f"ON CONFLICT (scope_key, key) DO UPDATE SET "
+            f"  payload_hash = EXCLUDED.payload_hash, "
+            f"  response     = EXCLUDED.response, "
+            f"  expires_at   = EXCLUDED.expires_at "
+            f"WHERE {t}.expires_at <= now()"
+        )
+        self._sql_delete_expired = f"DELETE FROM {t} WHERE expires_at <= %s"  # noqa: S608
+
+    async def create_schema(self) -> None:
+        """Bootstrap the table + index. Idempotent.
+
+        Safe to call on every app boot. Each DDL statement is executed
+        separately — psycopg does not split on ``;``.
+        """
+        t = self._table
+        statements = [
+            f"""CREATE TABLE IF NOT EXISTS {t} (
+                scope_key    TEXT        COLLATE "C" NOT NULL,
+                key          TEXT        COLLATE "C" NOT NULL,
+                payload_hash TEXT        NOT NULL,
+                response     JSONB       NOT NULL,
+                expires_at   TIMESTAMPTZ NOT NULL,
+                PRIMARY KEY (scope_key, key)
+            )""",
+            # Partial-free expiry index — cheap eviction sweep.
+            f"""CREATE INDEX IF NOT EXISTS {t}_expires_idx
+                ON {t} (expires_at)""",
+        ]
+        async with self._pool.connection() as conn:
+            for stmt in statements:
+                await conn.execute(stmt)
+
+    async def get(self, scope_key: str, key: str) -> CachedResponse | None:
+        """Read the cached entry, filtering expired rows in the WHERE clause.
+
+        Lazy expiry — expired rows stay on disk until ``delete_expired``
+        sweeps them. ``get`` self-filters via ``expires_at > now()`` so a
+        stale row never replays.
+        """
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(self._sql_get, (scope_key, key))
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            payload_hash, response, expires_at = row
+            return CachedResponse(
+                payload_hash=payload_hash,
+                response=response if isinstance(response, dict) else json.loads(response),
+                expires_at_epoch=_to_epoch(expires_at),
+            )
 
     async def put(
         self,
         scope_key: str,
         key: str,
         entry: CachedResponse,
-    ) -> None:  # pragma: no cover
-        raise NotImplementedError
+    ) -> None:
+        """Atomic upsert under ``(scope_key, key)``.
 
-    async def delete_expired(self, now_epoch: float | None = None) -> int:  # pragma: no cover
-        raise NotImplementedError
+        ``ON CONFLICT DO UPDATE`` because the store only calls ``put``
+        after verifying the slot is empty or expired — an overwrite in
+        that window is a legitimate retry of the write itself.
+        """
+        expires_at_dt = datetime.fromtimestamp(entry.expires_at_epoch, tz=timezone.utc)
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                self._sql_put,
+                (
+                    scope_key,
+                    key,
+                    entry.payload_hash,
+                    json.dumps(entry.response),
+                    expires_at_dt,
+                ),
+            )
+
+    async def delete_expired(self, now_epoch: float | None = None) -> int:
+        """Best-effort sweep of expired entries. Returns rows removed."""
+        cutoff = now_epoch if now_epoch is not None else time.time()
+        cutoff_dt = datetime.fromtimestamp(cutoff, tz=timezone.utc)
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(self._sql_delete_expired, (cutoff_dt,))
+            return cur.rowcount or 0
+
+
+def _to_epoch(dt: Any) -> float:
+    """Convert a psycopg-returned ``TIMESTAMPTZ`` to epoch seconds.
+
+    psycopg returns ``datetime`` for ``TIMESTAMPTZ`` columns. A
+    tz-naive datetime here means schema drift — adopters managing the
+    schema with Alembic / dbmate may have created the column as
+    ``TIMESTAMP WITHOUT TIME ZONE`` instead of ``TIMESTAMPTZ``. Per
+    project fail-fast policy, raise rather than silently coerce —
+    silent UTC defaults will produce wrong replay windows when the
+    server's local time is not UTC.
+    """
+    if not isinstance(dt, datetime):
+        return float(dt)
+    if dt.tzinfo is None:
+        raise ValueError(
+            "PgBackend received a naive datetime from expires_at. "
+            "This usually means the column was created as "
+            "TIMESTAMP WITHOUT TIME ZONE instead of TIMESTAMPTZ — "
+            "adopter Alembic migration drift from the SDK schema. "
+            "Recreate the column as TIMESTAMPTZ (see "
+            "PgBackend.create_schema for the canonical DDL)."
+        )
+    return float(dt.timestamp())

--- a/src/adcp/server/idempotency/store.py
+++ b/src/adcp/server/idempotency/store.py
@@ -29,6 +29,7 @@ fail-closed rather than collapse every buyer into a shared namespace.
 from __future__ import annotations
 
 import copy
+import hashlib
 import logging
 import time
 import warnings
@@ -164,7 +165,7 @@ class IdempotencyStore:
                 if cached.payload_hash == payload_hash:
                     logger.debug(
                         "idempotency replay: scope=%s key_prefix=%s",
-                        scope_key,
+                        _scope_log_id(scope_key),
                         idempotency_key[:8],
                     )
                     return _clone_response(cached.response)
@@ -211,7 +212,7 @@ class IdempotencyStore:
                     "handler completed but a subsequent retry with this key will "
                     "re-execute rather than replay. This indicates an operational "
                     "issue with the idempotency backend.",
-                    scope_key,
+                    _scope_log_id(scope_key),
                     idempotency_key[:8],
                     exc_info=True,
                 )
@@ -284,6 +285,19 @@ class IdempotencyStore:
             UserWarning,
             stacklevel=3,
         )
+
+
+def _scope_log_id(scope_key: str) -> str:
+    """Return a non-reversible short identifier for ``scope_key`` log lines.
+
+    ``scope_key`` carries the buyer's authenticated principal id (and
+    possibly tenant id) — that's PII / commercially-sensitive identity
+    data that should not land in centralized log sinks verbatim. We hash
+    + truncate so operators can correlate log entries without the raw
+    identity ever leaving the process.
+    """
+    digest = hashlib.sha256(scope_key.encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:12]}"
 
 
 def _to_dict(value: Any) -> dict[str, Any]:
@@ -364,7 +378,31 @@ def _extract_scope_key(context: Any) -> str | None:
     if principal_id is None:
         return None
     if tenant_id is None:
+        # Single-tenant deployments: principal_id alone is the scope.
+        # Validate the principal doesn't contain the separator either —
+        # if a downstream caller upgrades to multi-tenant, the same
+        # scope key string would now collide with a multi-tenant
+        # composition.
+        if _SCOPE_SEP in principal_id:
+            raise ValueError(
+                "caller_identity / principal_id contains the reserved "
+                "scope separator U+001E; refusing to compose a scope "
+                "key that could collide with a tenant-prefixed scope. "
+                "Sanitize principal ids before they reach ToolContext."
+            )
         return principal_id
+    # Multi-tenant: validate neither half carries the separator,
+    # otherwise tenant=A + sep + B with principal=X collides with
+    # tenant=A and principal=B + sep + X. Fail-closed — the SDK
+    # never auto-strips, since either input being injected is a
+    # configuration bug an operator needs to fix.
+    if _SCOPE_SEP in tenant_id or _SCOPE_SEP in principal_id:
+        raise ValueError(
+            "tenant_id or caller_identity contains the reserved scope "
+            "separator U+001E; refusing to compose a scope key that "
+            "could collide with a different (tenant, principal) pair. "
+            "Sanitize these values upstream of ToolContext."
+        )
     return f"{tenant_id}{_SCOPE_SEP}{principal_id}"
 
 

--- a/tests/conformance/decisioning/test_pg_idempotency_backend.py
+++ b/tests/conformance/decisioning/test_pg_idempotency_backend.py
@@ -88,8 +88,10 @@ async def test_put_then_get_round_trips(isolated_backend: PgBackend) -> None:
 
 
 @pytest.mark.asyncio
-async def test_put_overwrites_via_on_conflict(isolated_backend: PgBackend) -> None:
-    """``put`` is upsert — replaces the prior entry's hash + response."""
+async def test_put_against_fresh_slot_is_noop(isolated_backend: PgBackend) -> None:
+    """First-writer-wins: a sequential put against a non-expired slot
+    is a no-op. The cache invariant ('same key → same hash') depends
+    on the first writer's row staying put."""
     first = CachedResponse(
         payload_hash="hash-1", response={"a": 1}, expires_at_epoch=time.time() + 3600
     )
@@ -102,8 +104,10 @@ async def test_put_overwrites_via_on_conflict(isolated_backend: PgBackend) -> No
 
     cached = await isolated_backend.get("scope", "key")
     assert cached is not None
-    assert cached.payload_hash == "hash-2"
-    assert cached.response == {"a": 2}
+    # First writer wins — second put's UPDATE arm was filtered out by
+    # the WHERE expires_at <= now() guard.
+    assert cached.payload_hash == "hash-1"
+    assert cached.response == {"a": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/conformance/decisioning/test_pg_idempotency_backend.py
+++ b/tests/conformance/decisioning/test_pg_idempotency_backend.py
@@ -1,0 +1,231 @@
+"""Conformance tests for :class:`adcp.server.idempotency.PgBackend`.
+
+Requires a real PostgreSQL instance. To run locally::
+
+    docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=pg postgres:16
+    export ADCP_PG_TEST_URL=postgresql://postgres:pg@localhost:5432/postgres
+    pytest tests/conformance/decisioning/test_pg_idempotency_backend.py -v
+
+The entire module skips when ``ADCP_PG_TEST_URL`` is unset, so the
+default test matrix stays green without a database dependency. CI runs
+this in the same Postgres-16 job as the PgReplayStore tests.
+
+Each test runs in an isolated table (``test_adcp_idem_<random>``) so
+parallel runs and rerun-after-crash don't collide.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+psycopg = pytest.importorskip("psycopg")
+psycopg_pool = pytest.importorskip("psycopg_pool")
+
+TEST_URL = os.environ.get("ADCP_PG_TEST_URL")
+if not TEST_URL:
+    pytest.skip(
+        "ADCP_PG_TEST_URL not set — skipping PgBackend conformance tests",
+        allow_module_level=True,
+    )
+
+from adcp.server.idempotency import IdempotencyStore  # noqa: E402
+from adcp.server.idempotency.backends import CachedResponse, PgBackend  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def isolated_backend() -> AsyncIterator[PgBackend]:
+    """Fresh async pool + isolated table per test. Drops on teardown."""
+    table = f"test_adcp_idem_{secrets.token_hex(6)}"
+    async with psycopg_pool.AsyncConnectionPool(TEST_URL, min_size=2, max_size=8) as pool:
+        backend = PgBackend(pool=pool, table_name=table)
+        await backend.create_schema()
+        try:
+            yield backend
+        finally:
+            async with pool.connection() as conn:
+                await conn.execute(f"DROP TABLE IF EXISTS {table}")
+
+
+# ----- create_schema bootstrap ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_schema_is_idempotent(isolated_backend: PgBackend) -> None:
+    """Safe to call multiple times — ``CREATE TABLE IF NOT EXISTS``."""
+    await isolated_backend.create_schema()
+    await isolated_backend.create_schema()
+
+
+# ----- get / put round-trip ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_for_unknown_key(isolated_backend: PgBackend) -> None:
+    assert await isolated_backend.get("scope-x", "key-1") is None
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_round_trips(isolated_backend: PgBackend) -> None:
+    entry = CachedResponse(
+        payload_hash="hash-abc",
+        response={"status": "ok", "task_id": "task-1"},
+        expires_at_epoch=time.time() + 3600,
+    )
+    await isolated_backend.put("scope-a", "key-1", entry)
+
+    cached = await isolated_backend.get("scope-a", "key-1")
+    assert cached is not None
+    assert cached.payload_hash == "hash-abc"
+    assert cached.response == {"status": "ok", "task_id": "task-1"}
+    # Allow ~1s of round-trip / clock-skew slack.
+    assert abs(cached.expires_at_epoch - entry.expires_at_epoch) < 2.0
+
+
+@pytest.mark.asyncio
+async def test_put_overwrites_via_on_conflict(isolated_backend: PgBackend) -> None:
+    """``put`` is upsert — replaces the prior entry's hash + response."""
+    first = CachedResponse(
+        payload_hash="hash-1", response={"a": 1}, expires_at_epoch=time.time() + 3600
+    )
+    await isolated_backend.put("scope", "key", first)
+
+    second = CachedResponse(
+        payload_hash="hash-2", response={"a": 2}, expires_at_epoch=time.time() + 7200
+    )
+    await isolated_backend.put("scope", "key", second)
+
+    cached = await isolated_backend.get("scope", "key")
+    assert cached is not None
+    assert cached.payload_hash == "hash-2"
+    assert cached.response == {"a": 2}
+
+
+@pytest.mark.asyncio
+async def test_scope_key_isolation(isolated_backend: PgBackend) -> None:
+    """Same key under different scopes must not collide."""
+    e1 = CachedResponse(
+        payload_hash="h1", response={"who": "a"}, expires_at_epoch=time.time() + 3600
+    )
+    e2 = CachedResponse(
+        payload_hash="h2", response={"who": "b"}, expires_at_epoch=time.time() + 3600
+    )
+    await isolated_backend.put("scope-a", "shared-key", e1)
+    await isolated_backend.put("scope-b", "shared-key", e2)
+
+    assert (await isolated_backend.get("scope-a", "shared-key")).response == {"who": "a"}
+    assert (await isolated_backend.get("scope-b", "shared-key")).response == {"who": "b"}
+
+
+# ----- expiry -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_filters_expired_entries(isolated_backend: PgBackend) -> None:
+    """``expires_at <= now()`` rows must NOT be returned by ``get``."""
+    expired = CachedResponse(payload_hash="h", response={"v": 1}, expires_at_epoch=time.time() - 1)
+    await isolated_backend.put("scope", "key", expired)
+    assert await isolated_backend.get("scope", "key") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_removes_only_expired(isolated_backend: PgBackend) -> None:
+    fresh = CachedResponse(payload_hash="h-fresh", response={}, expires_at_epoch=time.time() + 3600)
+    stale = CachedResponse(payload_hash="h-stale", response={}, expires_at_epoch=time.time() - 60)
+    await isolated_backend.put("scope", "fresh", fresh)
+    await isolated_backend.put("scope", "stale", stale)
+
+    deleted = await isolated_backend.delete_expired()
+    assert deleted == 1
+    # Fresh remains queryable after the sweep.
+    assert (await isolated_backend.get("scope", "fresh")).payload_hash == "h-fresh"
+
+
+# ----- concurrent put under ON CONFLICT ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_put_first_writer_wins(isolated_backend: PgBackend) -> None:
+    """``ON CONFLICT (scope_key, key) DO UPDATE … WHERE expires_at <= now()``
+    means a second concurrent put against a fresh slot is a no-op —
+    the first writer's payload_hash + response remain. Without the
+    WHERE guard this would be last-writer-wins and violate the
+    cache invariant 'same key → same hash'."""
+    import asyncio
+
+    e1 = CachedResponse(
+        payload_hash="hash-A", response={"v": "A"}, expires_at_epoch=time.time() + 3600
+    )
+    e2 = CachedResponse(
+        payload_hash="hash-B", response={"v": "B"}, expires_at_epoch=time.time() + 3600
+    )
+
+    # Two concurrent writers racing the same (scope, key). The first to
+    # commit wins; the second's INSERT hits ON CONFLICT, the UPDATE
+    # arm's WHERE rejects the overwrite (existing row not yet expired).
+    await asyncio.gather(
+        isolated_backend.put("scope", "key", e1),
+        isolated_backend.put("scope", "key", e2),
+    )
+
+    cached = await isolated_backend.get("scope", "key")
+    assert cached is not None
+    # We don't assert WHICH writer won — only that the result is a
+    # consistent first-writer-wins, not a torn read or last-writer.
+    assert cached.payload_hash in {"hash-A", "hash-B"}
+    assert cached.response in ({"v": "A"}, {"v": "B"})
+
+
+@pytest.mark.asyncio
+async def test_concurrent_put_overwrites_expired_row(isolated_backend: PgBackend) -> None:
+    """A put against an expired slot DOES overwrite — the WHERE clause
+    only blocks overwriting *fresh* rows."""
+    expired = CachedResponse(
+        payload_hash="h-expired",
+        response={"v": "expired"},
+        expires_at_epoch=time.time() - 60,
+    )
+    await isolated_backend.put("scope", "key", expired)
+
+    fresh = CachedResponse(
+        payload_hash="h-fresh",
+        response={"v": "fresh"},
+        expires_at_epoch=time.time() + 3600,
+    )
+    await isolated_backend.put("scope", "key", fresh)
+
+    cached = await isolated_backend.get("scope", "key")
+    assert cached is not None
+    assert cached.payload_hash == "h-fresh"
+
+
+# ----- IdempotencyStore composition -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotency_store_replays_via_pg_backend(isolated_backend: PgBackend) -> None:
+    """End-to-end: a wrapped handler returns from cache on a second call
+    with the same scope + key + payload."""
+    store = IdempotencyStore(backend=isolated_backend, ttl_seconds=3600)
+    call_count = {"n": 0}
+
+    @store.wrap
+    async def handler(self, params, context=None):
+        call_count["n"] += 1
+        return {"task_id": f"task-{call_count['n']}", "status": "ok"}
+
+    class Ctx:
+        caller_identity = "buyer-acme"
+        tenant_id = "tenant-1"
+
+    params = {"idempotency_key": "key-1", "x": 42}
+    r1 = await handler(None, params, Ctx())
+    r2 = await handler(None, params, Ctx())
+
+    assert call_count["n"] == 1  # second call replayed
+    assert r1 == r2

--- a/tests/test_pg_idempotency_backend.py
+++ b/tests/test_pg_idempotency_backend.py
@@ -1,0 +1,281 @@
+"""Unit tests for :class:`adcp.server.idempotency.PgBackend` — mocked pool.
+
+psycopg3 is an optional dependency (``adcp[pg]``); these tests mock the
+pool and connection entirely so they pass without a real Postgres
+instance. Conformance tests against a real database live at
+``tests/conformance/decisioning/test_pg_idempotency_backend.py``.
+
+Behaviour under test:
+
+* Construction validation — invalid identifier rejected; missing pg deps
+  raise ImportError.
+* ``create_schema`` issues exactly one ``execute()`` per DDL statement
+  (psycopg does not split on semicolons).
+* ``get`` reads the row, parses JSONB, normalizes timestamp to epoch
+  seconds, returns ``None`` on miss (filtered server-side by
+  ``expires_at > now()``).
+* ``put`` upserts with ``ON CONFLICT DO UPDATE``; serializes response
+  via json.dumps; converts epoch to tz-aware datetime.
+* ``delete_expired`` returns the rowcount.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adcp.server.idempotency import IdempotencyBackend
+from adcp.server.idempotency.backends import (
+    DEFAULT_IDEMPOTENCY_TABLE,
+    CachedResponse,
+    PgBackend,
+)
+
+
+@pytest.fixture(autouse=True)
+def _patch_pg_available():
+    """psycopg3 is an optional dep; patch the availability gate so the
+    mock-pool tests run on CI nodes that don't install ``adcp[pg]``."""
+    with patch("adcp.server.idempotency.backends._PG_AVAILABLE", True):
+        yield
+
+
+def _cursor(fetchone_value: Any = None, rowcount: int = 0) -> AsyncMock:
+    cur = AsyncMock()
+    cur.fetchone = AsyncMock(return_value=fetchone_value)
+    cur.rowcount = rowcount
+    return cur
+
+
+def _make_conn(*cursors: AsyncMock) -> AsyncMock:
+    """Async context-manager mock yielding sequential cursors per execute()."""
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.execute = AsyncMock(side_effect=list(cursors))
+    return conn
+
+
+def _make_pool(conn: AsyncMock) -> MagicMock:
+    pool = MagicMock()
+
+    @asynccontextmanager
+    async def _connection():
+        yield conn
+
+    pool.connection = _connection
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_default_table_name(self) -> None:
+        pool = MagicMock()
+        backend = PgBackend(pool=pool)
+        assert backend._table == DEFAULT_IDEMPOTENCY_TABLE
+
+    def test_custom_table_name_accepted(self) -> None:
+        pool = MagicMock()
+        backend = PgBackend(pool=pool, table_name="my_idem_cache")
+        assert backend._table == "my_idem_cache"
+
+    def test_invalid_identifier_rejected(self) -> None:
+        pool = MagicMock()
+        with pytest.raises(ValueError, match="Table name must match"):
+            PgBackend(pool=pool, table_name="bad-name")
+
+    def test_uppercase_identifier_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Table name must match"):
+            PgBackend(pool=MagicMock(), table_name="MyTable")
+
+    def test_satisfies_idempotency_backend_protocol(self) -> None:
+        backend = PgBackend(pool=MagicMock())
+        assert isinstance(backend, IdempotencyBackend)
+
+
+# ---------------------------------------------------------------------------
+# create_schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_schema_executes_create_table_and_index() -> None:
+    """Two DDL statements: CREATE TABLE + CREATE INDEX. Each must be a
+    separate ``execute()`` call (psycopg does not split on ``;``)."""
+    conn = _make_conn(_cursor(), _cursor())
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool, table_name="adcp_idempotency")
+
+    await backend.create_schema()
+
+    assert conn.execute.call_count == 2
+    table_stmt = conn.execute.call_args_list[0].args[0]
+    index_stmt = conn.execute.call_args_list[1].args[0]
+    assert "CREATE TABLE IF NOT EXISTS adcp_idempotency" in table_stmt
+    assert 'COLLATE "C"' in table_stmt
+    assert "PRIMARY KEY (scope_key, key)" in table_stmt
+    assert "CREATE INDEX IF NOT EXISTS adcp_idempotency_expires_idx" in index_stmt
+
+
+@pytest.mark.asyncio
+async def test_create_schema_uses_custom_table_name() -> None:
+    conn = _make_conn(_cursor(), _cursor())
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool, table_name="alt_idem")
+
+    await backend.create_schema()
+    assert "CREATE TABLE IF NOT EXISTS alt_idem" in conn.execute.call_args_list[0].args[0]
+    assert (
+        "CREATE INDEX IF NOT EXISTS alt_idem_expires_idx" in conn.execute.call_args_list[1].args[0]
+    )
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_on_miss() -> None:
+    conn = _make_conn(_cursor(fetchone_value=None))
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    assert await backend.get("scope-x", "key-y") is None
+    sql = conn.execute.call_args.args[0]
+    assert "expires_at > now()" in sql
+
+
+@pytest.mark.asyncio
+async def test_get_parses_dict_response() -> None:
+    """psycopg returns dict for JSONB columns by default — pass through."""
+    expires = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    conn = _make_conn(_cursor(fetchone_value=("hash-1", {"k": "v"}, expires)))
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    cached = await backend.get("scope-a", "key-1")
+    assert cached is not None
+    assert cached.payload_hash == "hash-1"
+    assert cached.response == {"k": "v"}
+    assert cached.expires_at_epoch == expires.timestamp()
+
+
+@pytest.mark.asyncio
+async def test_get_parses_json_string_response() -> None:
+    """If the driver/casts return JSON as a string, parse it."""
+    expires = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    conn = _make_conn(_cursor(fetchone_value=("hash-1", '{"k":"v"}', expires)))
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    cached = await backend.get("scope-a", "key-1")
+    assert cached is not None
+    assert cached.response == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_get_raises_on_naive_timestamp() -> None:
+    """Naive datetime indicates schema drift (TIMESTAMP vs TIMESTAMPTZ).
+    Fail-fast over silent UTC coercion — silent coercion would produce
+    wrong replay windows when the server's local time is not UTC."""
+    naive = datetime(2030, 1, 1)
+    conn = _make_conn(_cursor(fetchone_value=("hash", {}, naive)))
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    with pytest.raises(ValueError, match="naive datetime"):
+        await backend.get("scope", "key")
+
+
+# ---------------------------------------------------------------------------
+# put
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_upserts_with_on_conflict() -> None:
+    conn = _make_conn(_cursor())
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    entry = CachedResponse(
+        payload_hash="hash-1",
+        response={"k": "v"},
+        expires_at_epoch=time.time() + 3600,
+    )
+    await backend.put("scope-a", "key-1", entry)
+
+    sql, params = conn.execute.call_args.args
+    assert "INSERT INTO adcp_idempotency" in sql
+    assert "ON CONFLICT (scope_key, key) DO UPDATE" in sql
+    # First-writer-wins: the UPDATE only applies to actually-expired
+    # rows. Concurrent put against a fresh slot is a no-op.
+    assert "WHERE adcp_idempotency.expires_at <= now()" in sql
+    assert "::jsonb" in sql
+    scope_key, key, payload_hash, response_json, expires_at = params
+    assert scope_key == "scope-a"
+    assert key == "key-1"
+    assert payload_hash == "hash-1"
+    assert response_json == '{"k": "v"}'
+    assert isinstance(expires_at, datetime)
+    assert expires_at.tzinfo is not None  # tz-aware
+
+
+# ---------------------------------------------------------------------------
+# delete_expired
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_uses_supplied_cutoff() -> None:
+    conn = _make_conn(_cursor(rowcount=7))
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    cutoff_epoch = 1_000_000_000.0
+    deleted = await backend.delete_expired(cutoff_epoch)
+    assert deleted == 7
+
+    sql, params = conn.execute.call_args.args
+    assert "DELETE FROM adcp_idempotency" in sql
+    assert "expires_at <= %s" in sql
+    (cutoff_dt,) = params
+    assert isinstance(cutoff_dt, datetime)
+    assert cutoff_dt.timestamp() == cutoff_epoch
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_defaults_to_wall_clock() -> None:
+    conn = _make_conn(_cursor(rowcount=0))
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    before = time.time()
+    deleted = await backend.delete_expired()
+    after = time.time()
+
+    assert deleted == 0
+    (cutoff_dt,) = conn.execute.call_args.args[1]
+    # Cutoff should be roughly "now" — within the test execution window.
+    assert before <= cutoff_dt.timestamp() <= after
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_returns_zero_on_no_rowcount() -> None:
+    """``rowcount`` may be ``-1`` or ``None`` on some psycopg paths;
+    backend coerces to 0."""
+    conn = _make_conn(_cursor(rowcount=None))  # type: ignore[arg-type]
+    pool = _make_pool(conn)
+    backend = PgBackend(pool=pool)
+
+    assert await backend.delete_expired() == 0

--- a/tests/test_server_idempotency.py
+++ b/tests/test_server_idempotency.py
@@ -178,11 +178,68 @@ class TestMemoryBackend:
         assert all(h.response["i"] == i for i, h in enumerate(hits))  # type: ignore[union-attr]
 
 
-class TestPgBackendScaffold:
-    def test_construction_raises(self) -> None:
-        # Scaffold shouldn't be usable yet; surface the follow-up issue clearly.
-        with pytest.raises(NotImplementedError, match="PgBackend"):
-            PgBackend()
+class TestPgBackendImportGuard:
+    def test_construction_without_pg_extra_raises_import_error(self) -> None:
+        """PgBackend requires the ``adcp[pg]`` extra. Without psycopg
+        installed, the constructor raises ImportError with an install
+        hint — full unit coverage of the working backend is in
+        tests/test_pg_idempotency_backend.py (mocked psycopg pool)
+        and tests/conformance/decisioning/test_pg_idempotency_backend.py
+        (real Postgres)."""
+        from unittest.mock import MagicMock, patch
+
+        with patch("adcp.server.idempotency.backends._PG_AVAILABLE", False):
+            with pytest.raises(ImportError, match="adcp\\[pg\\]"):
+                PgBackend(pool=MagicMock())
+
+
+class TestScopeKeySeparatorValidation:
+    """The scope key composes ``tenant_id`` + ``\\x1e`` + ``principal_id``.
+    A tenant_id or principal_id containing ``\\x1e`` would let one
+    (tenant, principal) pair forge a scope key identical to a different
+    pair, defeating multi-tenant isolation. The store must fail-closed."""
+
+    def test_principal_id_with_separator_rejected_single_tenant(self) -> None:
+        """Single-tenant deployments use principal_id alone as the
+        scope. A principal containing the separator would collide if
+        the deployment later upgrades to multi-tenant — reject early."""
+        from adcp.server.idempotency.store import _extract_scope_key
+
+        class Ctx:
+            caller_identity = "buyer\x1eattacker-suffix"
+
+        with pytest.raises(ValueError, match="U\\+001E"):
+            _extract_scope_key(Ctx())
+
+    def test_tenant_id_with_separator_rejected(self) -> None:
+        from adcp.server.idempotency.store import _extract_scope_key
+
+        class Ctx:
+            tenant_id = "tenant\x1eA"
+            caller_identity = "buyer-1"
+
+        with pytest.raises(ValueError, match="U\\+001E"):
+            _extract_scope_key(Ctx())
+
+    def test_principal_id_with_separator_rejected_multi_tenant(self) -> None:
+        from adcp.server.idempotency.store import _extract_scope_key
+
+        class Ctx:
+            tenant_id = "tenant-A"
+            caller_identity = "buyer\x1eX"
+
+        with pytest.raises(ValueError, match="U\\+001E"):
+            _extract_scope_key(Ctx())
+
+    def test_clean_inputs_pass(self) -> None:
+        from adcp.server.idempotency.store import _extract_scope_key
+
+        class Ctx:
+            tenant_id = "tenant-A"
+            caller_identity = "buyer-1"
+
+        scope = _extract_scope_key(Ctx())
+        assert scope == "tenant-A\x1ebuyer-1"
 
 
 class _FakeHandler:


### PR DESCRIPTION
## Summary

Closes #548. Replaces the `NotImplementedError` scaffold with a real psycopg3-async-pool-backed `PgBackend`. Multi-worker AdCP sellers can now declare `IdempotencySupported(supported=True)` and actually dedupe across workers.

- `PgBackend(pool=...)` — async pool, per-call connection acquisition (matches `PgWebhookDeliverySupervisor` / `PgReplayStore`)
- `await create_schema()` — idempotent CREATE TABLE IF NOT EXISTS + INDEX. JSONB response, `COLLATE "C"` on PK text columns
- **First-writer-wins** under concurrent put: `ON CONFLICT … DO UPDATE … WHERE existing.expires_at <= now()` — concurrent writers racing the same fresh slot can't violate the cache invariant "same (scope, key) → same payload_hash"
- Naive datetime → `ValueError` with schema-drift hint (fail-fast over silent UTC coercion)
- ASCII identifier regex on `table_name`; `adcp[pg]` extra; `ImportError` when missing

## Security hardening alongside the backend

- `IdempotencyStore._extract_scope_key` rejects `tenant_id` / `caller_identity` containing the U+001E scope separator. Without this, `tenant="A\x1eB"` + `principal="X"` collides with `tenant="A"` + `principal="B\x1eX"` — multi-tenant isolation defeated
- Log lines use `_scope_log_id(scope_key)` — sha256-truncated identifier instead of the raw principal id. PII no longer lands in centralized log sinks

## Docstring caveats

- **Atomicity (v1)**: cache write commits on a fresh pool connection (not handler's tx). Non-idempotent handler side effects need handler-level dedup on a unique constraint, or the co-tx follow-on
- **Schema bootstrap**: `CREATE TABLE IF NOT EXISTS` no-ops on a pre-existing wrong-shape table — Alembic-first deployments must copy the DDL verbatim
- **JSON-safe contract**: response dict must serialize via `json.dumps`; no datetime/Decimal/set/bytes
- **DoS**: no row cap, only TTL. Per-principal rate limiting at the auth tier is the AdCP spec's expectation; schedule `delete_expired()` as a sweep

## Test plan

- [x] 15 unit tests with mocked psycopg pool — `tests/test_pg_idempotency_backend.py`
- [x] 9 conformance tests against real Postgres (skipped without `ADCP_PG_TEST_URL`): first-writer-wins concurrent put, expired-row overwrite, scope isolation, end-to-end `IdempotencyStore` replay through `PgBackend`
- [x] 4 scope-separator-rejection unit tests in `tests/test_server_idempotency.py`
- [x] CI workflow extended to run the new conformance suite in the Postgres-16 job
- [x] Adjacent + full unit suite green (3511 passed, 0 failures)
- [x] `ruff check` + `mypy` clean

## Reviewed by

Pre-PR review by `code-reviewer`, `security-reviewer`, `python-expert`. Material concerns addressed:
- **`ON CONFLICT DO UPDATE` race** (python-expert) — added `WHERE expires_at <= now()` for first-writer-wins (was last-writer-wins)
- **`\x1e` separator confusion** (security-expert) — added validator in `_extract_scope_key`, fail-closed on either tenant or principal containing the separator
- **PII in logs** (security-expert) — sha256-truncated `_scope_log_id` replaces raw `scope_key` in WARNING/DEBUG lines
- **Naive datetime** (python-expert) — fail-fast with schema-drift hint instead of silent UTC coercion
- Docstring expansions for atomicity caveat, Alembic-first drift, JSON-safe contract, DoS expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)