### PR TITLE
feat(decisioning): TaskHandoff create_media_buy on_complete + on_failure hooks

### DIFF
--- a/src/adcp/decisioning/dispatch.py
+++ b/src/adcp/decisioning/dispatch.py
@@ -1043,6 +1043,8 @@ async def _invoke_platform_method(
     registry: TaskRegistry,
     arg_projector: dict[str, Any] | None = None,
     extra_kwargs: dict[str, Any] | None = None,
+    on_complete: Callable[[Any], Awaitable[None]] | None = None,
+    on_failure: Callable[[BaseException], Awaitable[None]] | None = None,
 ) -> Any:
     """Invoke a platform method, projecting hybrid returns.
 
@@ -1074,6 +1076,21 @@ async def _invoke_platform_method(
         normal ``(params, ctx)`` call, used when the framework injects
         framework-computed values (e.g. ``configs=`` from
         ``ProductConfigStore``). Ignored when ``arg_projector`` is set.
+
+    :param on_complete: Optional framework hook invoked with the
+        adapter's typed return value before the dispatch returns to
+        the caller. Fired exactly once per call — inline on the sync
+        return path, or (forwarded to :func:`_project_handoff`) after
+        the bg task lands on the handoff path. Used by v1.5
+        create_media_buy to finalize the consumption reservation when
+        the typed result is available.
+
+    :param on_failure: Optional framework hook invoked with the
+        terminal exception when the adapter raises (sync path) or
+        when the handoff fn / on_complete raises (handoff path).
+        Symmetric with ``on_complete``. Used by v1.5 create_media_buy
+        to release the consumption reservation so the buyer can retry.
+        Hook errors are logged but never block exception propagation.
     """
     method = getattr(platform, method_name)
 
@@ -1104,9 +1121,13 @@ async def _invoke_platform_method(
                     executor,
                     functools.partial(ctx_snapshot.run, method, params, ctx),
                 )
-    except AdcpError:
+    except AdcpError as exc:
         # Adopter raised structured error — propagate verbatim. The
-        # outer middleware projects to the wire envelope.
+        # outer middleware projects to the wire envelope. Fire
+        # on_failure first so the framework can release any reservation
+        # taken before dispatch (v1.5 create_media_buy lifecycle).
+        if on_failure is not None:
+            await _safe_on_failure_call(on_failure, exc, method_name)
         raise
     except TypeError as exc:
         # Most likely an arg_projector or extra_kwargs signature-drift bug.
@@ -1122,7 +1143,7 @@ async def _invoke_platform_method(
                 method_name,
                 sorted(arg_projector.keys()),
             )
-            raise AdcpError(
+            wrapped = AdcpError(
                 "INVALID_REQUEST",
                 message=(
                     f"Platform method {method_name!r} signature mismatch — "
@@ -1133,7 +1154,10 @@ async def _invoke_platform_method(
                     "Protocol class (typically a renamed parameter)."
                 ),
                 recovery="terminal",
-            ) from exc
+            )
+            if on_failure is not None:
+                await _safe_on_failure_call(on_failure, wrapped, method_name)
+            raise wrapped from exc
         if extra_kwargs is not None:
             logger.exception(
                 "TypeError invoking platform.%s — likely extra_kwargs "
@@ -1141,7 +1165,7 @@ async def _invoke_platform_method(
                 method_name,
                 sorted(extra_kwargs.keys()),
             )
-            raise AdcpError(
+            wrapped = AdcpError(
                 "INVALID_REQUEST",
                 message=(
                     f"Platform method {method_name!r} rejected framework-injected "
@@ -1150,18 +1174,24 @@ async def _invoke_platform_method(
                     "if you don't need them."
                 ),
                 recovery="terminal",
-            ) from exc
+            )
+            if on_failure is not None:
+                await _safe_on_failure_call(on_failure, wrapped, method_name)
+            raise wrapped from exc
         # Non-projected TypeError — fall through to generic wrap.
         logger.exception(
             "Unhandled exception in platform.%s — wrapping to INTERNAL_ERROR",
             method_name,
         )
-        raise AdcpError(
+        wrapped = AdcpError(
             "INTERNAL_ERROR",
             message=_internal_error_message(method_name, exc),
             recovery="terminal",
             details=_internal_error_details(exc),
-        ) from exc
+        )
+        if on_failure is not None:
+            await _safe_on_failure_call(on_failure, wrapped, method_name)
+        raise wrapped from exc
     except Exception as exc:
         # Wrap unexpected exceptions so the wire never sees a stack
         # trace. Adopter logs the original via observability hooks;
@@ -1178,12 +1208,15 @@ async def _invoke_platform_method(
             "Unhandled exception in platform.%s — wrapping to INTERNAL_ERROR",
             method_name,
         )
-        raise AdcpError(
+        wrapped = AdcpError(
             "INTERNAL_ERROR",
             message=_internal_error_message(method_name, exc),
             recovery="terminal",
             details=_internal_error_details(exc),
-        ) from exc
+        )
+        if on_failure is not None:
+            await _safe_on_failure_call(on_failure, wrapped, method_name)
+        raise wrapped from exc
 
     if is_task_handoff(result):
         return await _project_handoff(
@@ -1192,6 +1225,8 @@ async def _invoke_platform_method(
             method_name=method_name,
             registry=registry,
             executor=executor,
+            on_complete=on_complete,
+            on_failure=on_failure,
         )
     if is_workflow_handoff(result):
         return await _project_workflow_handoff(
@@ -1202,6 +1237,19 @@ async def _invoke_platform_method(
             executor=executor,
         )
 
+    # Sync return path. Fire on_complete with the typed result before
+    # the credential strip + return. If the hook raises, fire on_failure
+    # and propagate — same single-hook-per-call semantic as the handoff
+    # path. v1.5 create_media_buy uses on_complete to finalize the
+    # consumption reservation when the adapter returned inline.
+    if on_complete is not None:
+        try:
+            await on_complete(result)
+        except BaseException as exc:
+            if on_failure is not None:
+                await _safe_on_failure_call(on_failure, exc, method_name)
+            raise
+
     # Defense-in-depth credential strip on every sync return. The typed
     # projections (:func:`to_wire_account` etc.) handle the case where
     # the adopter returns the framework's typed dataclasses; this
@@ -1209,6 +1257,29 @@ async def _invoke_platform_method(
     # ``extra='allow'``. Method-gated to avoid walking large product
     # / signal catalogs that can't carry credentials.
     return strip_credentials_from_wire_result(method_name, result)
+
+
+async def _safe_on_failure_call(
+    on_failure: Callable[[BaseException], Awaitable[None]],
+    exc: BaseException,
+    method_name: str,
+) -> None:
+    """Fire the framework on_failure hook; log and swallow hook errors.
+
+    Hook errors must NEVER block exception propagation — the buyer
+    needs to see the original adapter failure. Used by both the sync
+    path in :func:`_invoke_platform_method` and (via the inner
+    ``_fail`` closure) the handoff path in :func:`_project_handoff`.
+    """
+    try:
+        await on_failure(exc)
+    except Exception:
+        logger.exception(
+            "on_failure hook raised while handling %s for %s — original "
+            "exception still propagates",
+            type(exc).__name__,
+            method_name,
+        )
 
 
 async def _project_handoff(
@@ -1219,6 +1290,7 @@ async def _project_handoff(
     registry: TaskRegistry,
     executor: ThreadPoolExecutor,
     on_complete: Callable[[Any], Awaitable[None]] | None = None,
+    on_failure: Callable[[BaseException], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Promote a TaskHandoff to a background task.
 
@@ -1254,11 +1326,22 @@ async def _project_handoff(
         the proposal-finalize lifecycle to commit the proposal to
         :class:`ProposalStore` exactly once when the HITL approval
         lands. If the hook raises, the framework treats it like a
-        handoff fn failure: ``registry.fail`` is called with the wrapped
-        error and ``registry.complete`` is NOT called. This is what
-        gives the v1.5 single-ledger guarantee its teeth — a commit
-        failure cannot leave the task in 'submitted' forever or land
-        the proposal in a half-committed state.
+        handoff fn failure: ``on_failure`` runs (if set), then
+        ``registry.fail`` is called with the wrapped error, and
+        ``registry.complete`` is NOT called. This is what gives the
+        v1.5 single-ledger guarantee its teeth — a commit failure
+        cannot leave the task in 'submitted' forever or land the
+        proposal in a half-committed state.
+
+    :param on_failure: Optional framework hook invoked with the
+        terminal exception when the handoff fn raises OR when
+        ``on_complete`` raises. Used by the v1.5 create_media_buy HITL
+        path to release the consumption reservation
+        (``CONSUMING → COMMITTED``) so the buyer can retry without
+        ``PROPOSAL_NOT_COMMITTED`` blocking them. Hook errors are
+        logged but never block the ``registry.fail`` call — the buyer
+        needs the failure visible via ``tasks/get`` regardless of
+        hook outcomes.
 
     The handoff fn is extracted via the type-identity dispatch in
     :func:`adcp.decisioning.types.is_task_handoff`. Subclassed
@@ -1277,6 +1360,22 @@ async def _project_handoff(
     # terminal artifact via the registry.
     handoff_ctx = TaskHandoffContext(id=task_id, _registry=registry)
 
+    async def _fail(exc: AdcpError) -> None:
+        """Run the framework's on_failure hook (if set) then
+        ``registry.fail``. Hook errors are logged but never block the
+        registry.fail — the buyer needs the failure visible via
+        tasks/get regardless of hook outcomes."""
+        if on_failure is not None:
+            try:
+                await on_failure(exc)
+            except Exception:
+                logger.exception(
+                    "on_failure hook raised for task %s — failure is "
+                    "still recorded in the registry",
+                    task_id,
+                )
+        await registry.fail(task_id, exc.to_wire())
+
     async def _run() -> None:
         try:
             if asyncio.iscoroutinefunction(fn):
@@ -1289,7 +1388,7 @@ async def _project_handoff(
                     functools.partial(ctx_snapshot.run, fn, handoff_ctx),
                 )
         except AdcpError as exc:
-            await registry.fail(task_id, exc.to_wire())
+            await _fail(exc)
             return
         except Exception as exc:
             logger.exception(
@@ -1305,23 +1404,22 @@ async def _project_handoff(
                 recovery="terminal",
                 details=_internal_error_details(exc),
             )
-            await registry.fail(task_id, wrapped.to_wire())
+            await _fail(wrapped)
             return
 
         # Framework completion hook (e.g., proposal_store.commit for
-        # finalize). Runs with the TYPED result before model_dump so
-        # the closure can pull typed fields (.expires_at, .proposal)
+        # finalize, mark_proposal_consumed for create_media_buy). Runs
+        # with the TYPED result before model_dump so the closure can
+        # pull typed fields (.expires_at, .proposal, .media_buy_id)
         # off it directly. Failures here are treated identically to a
-        # handoff fn failure: registry.fail, no registry.complete. This
-        # is the load-bearing seam for the v1.5 single-ledger D3
-        # guarantee — if the proposal_store.commit raises, the proposal
-        # stays DRAFT and the task lands in 'failed', so the buyer's
-        # tasks/get returns the failure rather than a phantom success.
+        # handoff fn failure: on_failure runs, registry.fail is called,
+        # registry.complete is NOT called. This is the load-bearing seam
+        # for the v1.5 single-ledger D3 guarantee.
         if on_complete is not None:
             try:
                 await on_complete(result)
             except AdcpError as exc:
-                await registry.fail(task_id, exc.to_wire())
+                await _fail(exc)
                 return
             except Exception as exc:
                 logger.exception(
@@ -1337,7 +1435,7 @@ async def _project_handoff(
                     recovery="terminal",
                     details=_internal_error_details(exc),
                 )
-                await registry.fail(task_id, wrapped.to_wire())
+                await _fail(wrapped)
                 return
 
         # Persist terminal artifact. Pydantic responses get

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -35,6 +35,7 @@ import asyncio
 import inspect
 import logging
 import warnings
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from adcp.decisioning._get_products_helpers import _project_product_fields
@@ -1352,46 +1353,56 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         extra: dict[str, Any] | None = (
             {"configs": configs} if self._create_media_buy_accepts_configs else None
         )
-        try:
-            result = await _invoke_platform_method(
-                self._platform,
-                "create_media_buy",
-                params,
-                ctx,
-                executor=self._executor,
-                registry=self._registry,
-                extra_kwargs=extra,
-            )
-        except BaseException:
-            # Adapter raised — roll back the consumption reservation so
-            # the buyer can retry. If we leave it in CONSUMING, the next
-            # create_media_buy(proposal_id=X) call would see
-            # PROPOSAL_NOT_COMMITTED until the eviction window passes.
-            # BaseException catches AdcpError + asyncio.CancelledError +
-            # generic exceptions; the reservation gets released no matter
-            # how the adapter exits.
-            if proposal_record is not None:
-                await release_proposal_reservation(self._platform, proposal_record, ctx)
-            raise
-        # Finalize the consumption once create_media_buy returns
-        # successfully. Idempotent on re-call with the same media_buy_id
-        # (idempotency_key replays land here too).
+
+        # Build the consumption-lifecycle hooks. Used inline on the
+        # sync return path AND forwarded into _project_handoff on the
+        # TaskHandoff path — same closure, two firing points. Single
+        # source of truth for "what to do when create_media_buy lands"
+        # regardless of whether it lands now or after HITL approval.
+        on_complete: Callable[[Any], Awaitable[None]] | None = None
+        on_failure: Callable[[BaseException], Awaitable[None]] | None = None
         if proposal_record is not None:
-            media_buy_id = _extract_media_buy_id(result)
-            if media_buy_id is not None:
-                await mark_proposal_consumed(
-                    self._platform,
-                    proposal_record,
-                    media_buy_id=media_buy_id,
-                    ctx=ctx,
-                )
-            # else: TaskHandoff path returned a Submitted envelope; the
-            # proposal stays CONSUMING until the handoff resolves. The
-            # framework's _project_handoff on_complete hook (wired below
-            # for v1.5+) finalizes consumption when the bg task lands.
-            # Until that hook is wired for create_media_buy specifically,
-            # the proposal will sit in CONSUMING until eviction — flagged
-            # as a v1.5.1 follow-up.
+            captured_record = proposal_record
+            captured_ctx = ctx
+            captured_platform = self._platform
+
+            async def _finalize_consumption_hook(create_result: Any) -> None:
+                # Idempotent on re-call with the same media_buy_id
+                # (idempotency_key replays land here too). For the
+                # handoff path the create_result is the typed
+                # CreateMediaBuySuccess from the bg task, NOT the
+                # Submitted envelope — _extract_media_buy_id reads .id
+                # off either shape.
+                media_buy_id = _extract_media_buy_id(create_result)
+                if media_buy_id is not None:
+                    await mark_proposal_consumed(
+                        captured_platform,
+                        captured_record,
+                        media_buy_id=media_buy_id,
+                        ctx=captured_ctx,
+                    )
+
+            async def _release_reservation_hook(_exc: BaseException) -> None:
+                # Adapter raised (sync) OR handoff fn raised (HITL) OR
+                # finalize_consumption raised: release the reservation
+                # so the buyer can retry without PROPOSAL_NOT_COMMITTED
+                # blocking them.
+                await release_proposal_reservation(captured_platform, captured_record, captured_ctx)
+
+            on_complete = _finalize_consumption_hook
+            on_failure = _release_reservation_hook
+
+        result = await _invoke_platform_method(
+            self._platform,
+            "create_media_buy",
+            params,
+            ctx,
+            executor=self._executor,
+            registry=self._registry,
+            extra_kwargs=extra,
+            on_complete=on_complete,
+            on_failure=on_failure,
+        )
         self._maybe_auto_emit_sync_completion("create_media_buy", params, result)
         return cast("CreateMediaBuySuccessResponse", result)
 

--- a/tests/test_proposal_lifecycle_e2e.py
+++ b/tests/test_proposal_lifecycle_e2e.py
@@ -1208,3 +1208,231 @@ async def test_create_media_buy_adapter_failure_rolls_back_reservation(
         )
     finally:
         target_platform.create_media_buy = original  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# Phase 13: TaskHandoff create_media_buy — HITL accept-proposal path
+#
+# v1.5.1 follow-up to PR #550. Adopter returns ctx.handoff_to_task(...)
+# from create_media_buy(proposal_id=...); the framework projects Submitted
+# immediately, runs the handoff fn in the background, and finalizes the
+# consumption (CONSUMING → CONSUMED) via the on_complete hook when the
+# bg task lands. Failures release the reservation so the buyer can retry.
+# ---------------------------------------------------------------------------
+
+
+def _build_handoff_create_media_buy_router(handoff_fn: Any) -> Any:
+    """Build a router whose create_media_buy returns a TaskHandoff
+    wrapping the supplied fn. Reuses the example's manager / store /
+    capabilities; only the platform's create_media_buy differs."""
+    from adcp.decisioning.types import TaskHandoff
+    from examples.sales_proposal_mode_seller.src.platform import (
+        ProposalModeDecisioningPlatform,
+    )
+
+    router = build_router()
+
+    class _HandoffPlatform(ProposalModeDecisioningPlatform):
+        async def create_media_buy(self, req: Any, ctx: Any) -> Any:  # type: ignore[override]
+            del req, ctx
+            return TaskHandoff(handoff_fn)
+
+    router._platforms = {"default": _HandoffPlatform()}  # noqa: SLF001
+    return router
+
+
+def _build_create_media_buy_request(suffix: str) -> Any:
+    from adcp.types import CreateMediaBuyRequest
+
+    return CreateMediaBuyRequest.model_validate(
+        {
+            "proposal_id": PROPOSAL_ID,
+            "total_budget": {"amount": 50000, "currency": "USD"},
+            "start_time": "2026-04-01T00:00:00Z",
+            "end_time": "2026-06-30T23:59:59Z",
+            "buyer_ref": f"buyer-handoff-cmb-{suffix}",
+            "idempotency_key": _CMB_IDEM + f"hcmb{suffix}",
+            "brand": _BRAND,
+            "account": _ACCOUNT,
+        }
+    )
+
+
+async def _seed_committed_proposal(handler: PlatformHandler) -> None:
+    """brief → finalize → committed proposal ready for create_media_buy."""
+    from adcp.types import GetProductsRequest
+
+    await handler.get_products(
+        GetProductsRequest(buying_mode="brief", brief="initial"),
+        ToolContext(),
+    )
+    await handler.get_products(
+        GetProductsRequest.model_validate(
+            {
+                "buying_mode": "refine",
+                "refine": [
+                    {
+                        "scope": "proposal",
+                        "proposal_id": PROPOSAL_ID,
+                        "action": "finalize",
+                    }
+                ],
+            }
+        ),
+        ToolContext(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_handoff_finalizes_consumption_on_completion(
+    executor: ThreadPoolExecutor,
+    registry: InMemoryTaskRegistry,
+) -> None:
+    """Happy path. Adopter returns TaskHandoff; buyer gets Submitted;
+    proposal stays CONSUMING; bg task lands with a typed
+    CreateMediaBuySuccess; on_complete fires; proposal → CONSUMED with
+    the media_buy_id back-reference."""
+    finish = asyncio.Event()
+
+    async def _handoff_body(task_ctx: Any) -> Any:
+        del task_ctx
+        await finish.wait()
+        # Match the typed CreateMediaBuySuccess shape via dict — the
+        # framework's _extract_media_buy_id reads media_buy_id off
+        # either dicts or Pydantic instances.
+        return {"media_buy_id": "mb_handoff_001", "status": "active"}
+
+    router = _build_handoff_create_media_buy_router(_handoff_body)
+    store = router.proposal_store_for_tenant("default")
+    handler = _build_handler(router, executor, registry)
+
+    await _seed_committed_proposal(handler)
+    response = await handler.create_media_buy(
+        _build_create_media_buy_request("happy"), ToolContext()
+    )
+    response_dict = response if isinstance(response, dict) else response.model_dump(mode="json")
+
+    # Wire Submitted envelope returned synchronously to the buyer.
+    assert response_dict["status"] == "submitted"
+    task_id = response_dict["task_id"]
+
+    # Reservation held — proposal in CONSUMING, not yet CONSUMED.
+    record = await store.get(PROPOSAL_ID, expected_account_id="acct_demo")
+    assert record is not None
+    assert record.state == ProposalState.CONSUMING
+
+    # Let the bg task land. on_complete fires inside the bg task's
+    # asyncio coroutine, not on the main thread.
+    finish.set()
+    await asyncio.wait_for(_drain_background_tasks(), timeout=2.0)
+
+    # Promotion to CONSUMED with the media_buy_id back-reference. The
+    # reverse-index lookup hydrates correctly for subsequent
+    # update_media_buy / get_delivery dispatch.
+    record = await store.get(PROPOSAL_ID, expected_account_id="acct_demo")
+    assert record is not None
+    assert record.state == ProposalState.CONSUMED
+    assert record.media_buy_id == "mb_handoff_001"
+
+    by_buy = await store.get_by_media_buy_id("mb_handoff_001", expected_account_id="acct_demo")
+    assert by_buy is not None
+    assert by_buy.proposal_id == PROPOSAL_ID
+
+    # Registry row reached completed state.
+    task_record = await registry.get(task_id, expected_account_id="acct_demo")
+    assert task_record is not None
+    assert task_record["state"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_handoff_fn_raises_releases_reservation(
+    executor: ThreadPoolExecutor,
+    registry: InMemoryTaskRegistry,
+) -> None:
+    """Bg task raises AdcpError → on_failure fires → proposal rolls
+    back from CONSUMING to COMMITTED. Buyer can retry without
+    PROPOSAL_NOT_COMMITTED blocking them — the closing of the v1.5.1
+    gap that previously left HITL-rejected proposals stuck in
+    CONSUMING until eviction."""
+
+    async def _handoff_body(task_ctx: Any) -> Any:
+        del task_ctx
+        raise AdcpError(
+            "GOVERNANCE_DENIED",
+            message="Trafficker rejected the inventory hold.",
+            recovery="terminal",
+        )
+
+    router = _build_handoff_create_media_buy_router(_handoff_body)
+    store = router.proposal_store_for_tenant("default")
+    handler = _build_handler(router, executor, registry)
+
+    await _seed_committed_proposal(handler)
+    response = await handler.create_media_buy(
+        _build_create_media_buy_request("denied"), ToolContext()
+    )
+    response_dict = response if isinstance(response, dict) else response.model_dump(mode="json")
+    task_id = response_dict["task_id"]
+
+    await asyncio.wait_for(_drain_background_tasks(), timeout=2.0)
+
+    # Reservation released — proposal back in COMMITTED. Buyer can
+    # call create_media_buy(proposal_id=...) again with a different
+    # buyer_ref / idempotency_key and the framework reserves cleanly.
+    record = await store.get(PROPOSAL_ID, expected_account_id="acct_demo")
+    assert record is not None
+    assert record.state == ProposalState.COMMITTED
+
+    # Registry shows the original failure for the buyer's tasks/get
+    # poll — the reservation release is invisible at the wire layer.
+    task_record = await registry.get(task_id, expected_account_id="acct_demo")
+    assert task_record is not None
+    assert task_record["state"] == "failed"
+    assert task_record["error"]["code"] == "GOVERNANCE_DENIED"
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_handoff_buyer_can_retry_after_release(
+    executor: ThreadPoolExecutor,
+    registry: InMemoryTaskRegistry,
+) -> None:
+    """End-to-end retry semantic. First attempt's handoff fails; buyer
+    retries with a different idempotency_key and the second attempt
+    completes. Proves the reservation-release path actually unblocks
+    retries — the whole point of the on_failure hook."""
+
+    fail_first = {"count": 0}
+
+    async def _flaky_handoff(task_ctx: Any) -> Any:
+        del task_ctx
+        fail_first["count"] += 1
+        if fail_first["count"] == 1:
+            raise AdcpError(
+                "AGENT_TIMEOUT",
+                message="upstream slow on first attempt",
+                recovery="transient",
+            )
+        return {"media_buy_id": "mb_retry_002", "status": "active"}
+
+    router = _build_handoff_create_media_buy_router(_flaky_handoff)
+    store = router.proposal_store_for_tenant("default")
+    handler = _build_handler(router, executor, registry)
+
+    await _seed_committed_proposal(handler)
+
+    # First attempt — Submitted envelope; bg task fails; release fires.
+    await handler.create_media_buy(_build_create_media_buy_request("first"), ToolContext())
+    await asyncio.wait_for(_drain_background_tasks(), timeout=2.0)
+    record = await store.get(PROPOSAL_ID, expected_account_id="acct_demo")
+    assert record is not None
+    assert record.state == ProposalState.COMMITTED
+
+    # Second attempt — succeeds. Without the on_failure release path,
+    # this would raise PROPOSAL_NOT_COMMITTED before reaching the
+    # adapter.
+    await handler.create_media_buy(_build_create_media_buy_request("second"), ToolContext())
+    await asyncio.wait_for(_drain_background_tasks(), timeout=2.0)
+    record = await store.get(PROPOSAL_ID, expected_account_id="acct_demo")
+    assert record is not None
+    assert record.state == ProposalState.CONSUMED
+    assert record.media_buy_id == "mb_retry_002"


### PR DESCRIPTION
## Summary

Closes the v1.5.1 follow-up flagged in PR #550. Adopters returning \`ctx.handoff_to_task(...)\` from \`create_media_buy(proposal_id=...)\` now get the same single-ledger D3 guarantee as the inline path: the proposal transitions \`CONSUMING → CONSUMED\` via the framework's \`on_complete\` hook when the bg task lands; failures release the reservation so the buyer can retry.

The previous gap: HITL accept-proposal flows left the proposal in \`CONSUMING\` until the eviction window passed. No data leak, but the reverse-index lookup couldn't hydrate, and a second \`create_media_buy(proposal_id=X)\` after a HITL rejection would hit \`PROPOSAL_NOT_COMMITTED\` until eviction.

## Mechanism

- \`_project_handoff\`: new \`on_failure\` kwarg paired with \`on_complete\`. Inner \`_fail()\` helper centralizes "invoke on_failure (best effort) → registry.fail" so all four failure branches share one path.
- \`_invoke_platform_method\`: forwards both kwargs into \`_project_handoff\` on the handoff path; fires \`on_complete\` inline before sync return; fires \`on_failure\` on every adapter exception path. One API surface for inline + HITL.
- \`handler.py:create_media_buy\`: replaces local try/except + post-call \`mark_consumed\` branches with two closures (finalize + release) passed to \`_invoke_platform_method\`. Single source of truth.

## Test plan
- [x] \`test_create_media_buy_handoff_finalizes_consumption_on_completion\` — happy path: Submitted envelope → CONSUMING → bg drain → CONSUMED + reverse-index lookup hydrates
- [x] \`test_create_media_buy_handoff_fn_raises_releases_reservation\` — GOVERNANCE_DENIED → reservation released → COMMITTED → registry shows the buyer-facing failure
- [x] \`test_create_media_buy_handoff_buyer_can_retry_after_release\` — end-to-end: first attempt fails, second attempt succeeds (proves on_failure release actually unblocks retries)
- [x] All 5 existing finalize-handoff tests still pass
- [x] 4014 passed, 33 skipped, 0 regressions
- [x] ruff + mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)