### PR TITLE
docs(contributing): document PR title format to prevent silent CHANGELOG drops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
         types: [python]
         pass_filenames: false
         args: [src/adcp]
+      - id: check-commit-msg
+        name: release-please commit subject check
+        entry: scripts/check-commit-msg.sh
+        language: script
+        stages: [commit-msg]
+        always_run: true
 
   # Security scanning with bandit
   - repo: https://github.com/PyCQA/bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
         entry: scripts/check-commit-msg.sh
         language: script
         stages: [commit-msg]
-        always_run: true
 
   # Security scanning with bandit
   - repo: https://github.com/PyCQA/bandit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ git clone https://github.com/adcontextprotocol/adcp-client-python.git
 cd adcp-client-python
 ```
 
-2. Install dependencies:
+2. Install dependencies and pre-commit hooks:
 ```bash
 pip install -e ".[dev]"
+pre-commit install
+pre-commit install --hook-type commit-msg
 ```
 
 3. Run tests:
@@ -87,10 +89,11 @@ src/adcp/
 This repository uses squash merges. The PR title becomes the commit subject that
 release-please reads to build the CHANGELOG and determine version bumps.
 
-**The description portion of the commit subject — everything after `type(scope):` —
+**The description portion of the commit subject — the text after `type(scope):` —
 must not contain `(`, `)`, or `"` characters.** The release-please parser treats
-these as grammar tokens and silently drops the commit from the CHANGELOG with no
-error signal.
+those characters as grammar tokens when they appear in the description and silently
+drops the commit from the CHANGELOG with no error signal. (The `type(scope)` prefix
+itself is fine; only the description portion is constrained.)
 
 **Wrong — parser drops these commits silently:**
 
@@ -107,13 +110,13 @@ feat(auth): add A2A sibling and cross-transport shortcut for bearer auth
 ```
 
 Place code snippets, type names with parens, and parenthetical clarifications in the PR
-description body, not the title. release-please reads body footers (`BREAKING CHANGE:`,
-`Fixes #N`) but otherwise ignores the body for CHANGELOG purposes.
+body (release-please reads body footers like `BREAKING CHANGE:` and `Fixes #N` but
+otherwise ignores the body for CHANGELOG purposes).
 
 A `commit-msg` pre-commit hook (`scripts/check-commit-msg.sh`) catches violations on
 direct commits. It does **not** catch squash-merge subjects (those are set by GitHub on
 merge from the PR title), so keeping the PR title clean is the primary responsibility.
-To enable the hook: `pre-commit install --hook-type commit-msg`.
+Hook setup is included in step 2 of Development Setup above.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,39 @@ src/adcp/
 4. Update documentation
 5. Submit PR with clear description
 
+### PR Title Format
+
+This repository uses squash merges. The PR title becomes the commit subject that
+release-please reads to build the CHANGELOG and determine version bumps.
+
+**The description portion of the commit subject — everything after `type(scope):` —
+must not contain `(`, `)`, or `"` characters.** The release-please parser treats
+these as grammar tokens and silently drops the commit from the CHANGELOG with no
+error signal.
+
+**Wrong — parser drops these commits silently:**
+
+```
+fix(auth): synthesize AuthInfo(kind="bearer") in _build_request_context
+feat(auth): serve(auth=BearerTokenAuth(...)) — A2A sibling shortcut
+```
+
+**Right — move code examples and parenthetical details to the PR body:**
+
+```
+fix(auth): synthesize bearer AuthInfo in _build_request_context
+feat(auth): add A2A sibling and cross-transport shortcut for bearer auth
+```
+
+Place code snippets, type names with parens, and parenthetical clarifications in the PR
+description body, not the title. release-please reads body footers (`BREAKING CHANGE:`,
+`Fixes #N`) but otherwise ignores the body for CHANGELOG purposes.
+
+A `commit-msg` pre-commit hook (`scripts/check-commit-msg.sh`) catches violations on
+direct commits. It does **not** catch squash-merge subjects (those are set by GitHub on
+merge from the PR title), so keeping the PR title clean is the primary responsibility.
+To enable the hook: `pre-commit install --hook-type commit-msg`.
+
 ## Questions?
 
 Open an issue or email maintainers@adcontextprotocol.org

--- a/scripts/check-commit-msg.sh
+++ b/scripts/check-commit-msg.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Validates commit subjects against release-please parser constraints.
+# Embedded ( ) or " in the description silently drop commits from the CHANGELOG.
+# NOTE: this hook runs on direct commits only — squash-merge subjects (set by
+# GitHub from the PR title) bypass it. Keep the PR title clean as the primary fix.
+#
+# Enable: pre-commit install --hook-type commit-msg
+
+set -euo pipefail
+
+msg_file="$1"
+subject=$(head -1 "$msg_file")
+
+# Only validate conventional commit messages: type(scope): desc or type: desc
+cc_pattern='^[a-z]+(\([^)]*\))?(!)?: '
+if echo "$subject" | grep -qE "$cc_pattern"; then
+    description="${subject#*: }"
+    if echo "$description" | grep -qE '[()"]'; then
+        echo ""
+        echo "commit-msg: release-please will silently drop this commit from the CHANGELOG."
+        echo ""
+        echo "  Subject: $subject"
+        echo ""
+        echo '  The description (text after "type(scope):") contains ( ) or " characters,'
+        echo "  which break release-please's conventional commit parser."
+        echo ""
+        echo "  Fix: reword to avoid parentheses and quotes in the description."
+        echo "  Move code snippets and type names with parens to the PR body instead."
+        echo ""
+        echo "  Example:"
+        echo '    Wrong: fix(auth): synthesize AuthInfo(kind="bearer") in _build_request_context'
+        echo "    Right: fix(auth): synthesize bearer AuthInfo in _build_request_context"
+        echo ""
+        exit 1
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
Closes #578

release-please silently drops conventional commits from the CHANGELOG when their subjects contain `(`, `)`, or `"` in the description portion (verified in run 25326163877: three commits missing from v4.4.0). Since this repo uses squash merges, the PR title becomes the commit subject — keeping the title free of those characters is the primary fix. This PR documents that convention in CONTRIBUTING.md with before/after examples from the three affected commits, and adds `scripts/check-commit-msg.sh` as a commit-msg pre-commit hook to catch violations on direct commits.

## What changed

- **`CONTRIBUTING.md`** — new "PR Title Format" subsection under Pull Request Process: causal chain (squash-merge → commit subject → release-please parser), bolded constraint, before/after examples, note on where to put moved details. Dev Setup step 2 now includes `pre-commit install --hook-type commit-msg` so new contributors get the hook without having to find the section.
- **`scripts/check-commit-msg.sh`** — executable bash script; validates that conventional-commit descriptions contain no `(`, `)`, or `"`. Prints an actionable error with the offending subject and a corrected example. No-ops on non-conventional-commit messages.
- **`.pre-commit-config.yaml`** — adds `check-commit-msg` as a `commit-msg`-stage local hook. Squash-merge subjects (set by GitHub on merge) bypass it, so the doc convention is the primary safeguard.

## What tested

- `bash -n scripts/check-commit-msg.sh` — shell syntax clean
- Manual script test against all three real failing commit subjects from #578: correctly rejected
- Clean commit subjects: correctly allowed  
- `python -c "import yaml; yaml.safe_load(...)"` on updated `.pre-commit-config.yaml`: valid YAML

**Pre-PR review:**
- code-reviewer: approved — no blockers; removed `always_run: true` (redundant on commit-msg hooks) and added Dev Setup hook install steps per reviewer notes
- docs-expert: approved after fix — prose ambiguity in constraint sentence resolved (clarified "description portion only, not `type(scope)` prefix")

**Known limitation (nit, not fixed):** The description extraction in `check-commit-msg.sh` uses `${subject#*: }` which could false-positive on a scope containing colon-space (e.g., `fix(api: v2): add foo`). Standard scope names don't contain spaces, so this is a low-risk edge case. A follow-up can tighten the extraction with `sed -E` if it triggers in practice.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RZJ2jX6omDh5V9ua1UKkzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZJ2jX6omDh5V9ua1UKkzy)_