### PR TITLE
feat(auth): per-leg header config + agent-card bearerAuth scheme

### DIFF
--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     )
     from a2a.server.tasks.task_store import TaskStore
 
+    from adcp.server.auth import BearerTokenAuth
     from adcp.server.serve import ContextFactory, SkillMiddleware
 
 from collections.abc import Callable  # noqa: E402
@@ -587,6 +588,75 @@ def _make_task(
 # ------------------------------------------------------------------
 
 
+_BEARER_HTTP_SCHEME_ID = "bearerAuth"
+_API_KEY_SCHEME_ID = "adcpAuth"
+
+
+def _build_security_for_auth(
+    auth: BearerTokenAuth | None,
+) -> tuple[dict[str, pb.SecurityScheme], list[pb.SecurityRequirement]]:
+    """Translate a :class:`BearerTokenAuth` config into A2A agent-card
+    security primitives.
+
+    a2a-sdk's client auth interceptor (``a2a.client.auth.interceptor``)
+    skips credential attachment when the agent card publishes neither
+    ``security_schemes`` nor ``security_requirements`` — buyers built on
+    a2a-sdk silently send unauthenticated requests against an
+    auth-protected seller and see a 401 they have no obvious way to fix.
+    Publishing a scheme that matches the A2A leg's actual carrier closes
+    that loop without requiring the seller to hand-roll an agent card.
+
+    Returns ``({}, [])`` when ``auth`` is ``None`` so unauthenticated
+    agents continue to publish no security envelope (preserving the
+    pre-auth public-discovery shape).
+
+    Maps the resolved A2A header / prefix config to the right OpenAPI-
+    flavored scheme. The cut is on ``bearer_prefix_required`` alone, not
+    on header name — RFC 7235 reserves ``Authorization`` for
+    ``<scheme> <credentials>`` and ``__post_init__`` already rejects the
+    misuse combo of ``Authorization`` + ``bearer_prefix_required=False``:
+
+    * Bearer prefix required → :class:`HTTPAuthSecurityScheme` with
+      ``scheme="bearer"`` (RFC 6750, scheme id ``"bearerAuth"``). This
+      is what a2a-sdk's interceptor knows how to attach credentials for
+      out of the box.
+    * No bearer prefix (raw-token custom header) →
+      :class:`APIKeySecurityScheme` (``in: header``, scheme id
+      ``"adcpAuth"``). Buyers reading the card see the right shape and
+      know to attach a raw token to the named header.
+
+    The single :class:`SecurityRequirement` references the scheme by id
+    with no scope list — bearer / api-key flows have no scope semantics
+    in OpenAPI 3.x. ``bearer_format`` is intentionally omitted: tokens
+    are validator-defined and the field is purely descriptive (a2a-sdk's
+    interceptor doesn't read it).
+    """
+    if auth is None:
+        return {}, []
+
+    header_name = auth.resolved_a2a_header_name()
+    bearer_prefix = auth.resolved_a2a_bearer_prefix_required()
+
+    if bearer_prefix:
+        scheme_id = _BEARER_HTTP_SCHEME_ID
+        scheme = pb.SecurityScheme(
+            http_auth_security_scheme=pb.HTTPAuthSecurityScheme(scheme="bearer"),
+        )
+    else:
+        scheme_id = _API_KEY_SCHEME_ID
+        scheme = pb.SecurityScheme(
+            api_key_security_scheme=pb.APIKeySecurityScheme(
+                location="header",
+                name=header_name,
+            ),
+        )
+
+    requirement = pb.SecurityRequirement(
+        schemes={scheme_id: pb.StringList(list=[])},
+    )
+    return {scheme_id: scheme}, [requirement]
+
+
 def _build_agent_card(
     handler: ADCPHandler[Any],
     *,
@@ -597,6 +667,7 @@ def _build_agent_card(
     extra_skills: list[pb.AgentSkill] | None = None,
     advertise_all: bool = False,
     push_notifications_supported: bool = False,
+    auth: BearerTokenAuth | None = None,
 ) -> pb.AgentCard:
     """Build an A2A AgentCard from an ADCPHandler's tool definitions.
 
@@ -634,10 +705,14 @@ def _build_agent_card(
 
     url = f"http://localhost:{port}/"
 
+    security_schemes, security_requirements = _build_security_for_auth(auth)
+
     return pb.AgentCard(
         name=name,
         description=description or f"ADCP agent: {name}",
         version=version,
+        security_schemes=security_schemes,
+        security_requirements=security_requirements,
         # Ordering is load-bearing: a2a-sdk's v0.3 compat converter
         # (``a2a.compat.v0_3.conversions.to_compat_agent_card``) sets
         # ``primary_interface = compat_interfaces[0]``, so the entry it
@@ -683,6 +758,7 @@ def create_a2a_server(
     advertise_all: bool = False,
     validation: ValidationHookConfig | None = SERVER_DEFAULT_VALIDATION,
     context_builder: Any | None = None,
+    auth: BearerTokenAuth | None = None,
 ) -> Any:
     """Create an A2A Starlette application from an ADCP handler.
 
@@ -768,6 +844,16 @@ def create_a2a_server(
             ``ValidationHookConfig(responses="warn")`` to log+continue
             on response drift, or ``validation=None`` to disable
             validation entirely.
+        auth: Optional :class:`~adcp.server.auth.BearerTokenAuth`
+            config. When supplied, the agent card publishes a matching
+            ``bearerAuth`` security scheme + requirement so a2a-sdk's
+            client auth interceptor attaches credentials automatically.
+            Note that ``create_a2a_server`` does **not** install the
+            request-time middleware itself — auth gating is wired by
+            :func:`adcp.server.serve` via :class:`A2ABearerAuthMiddleware`
+            at the ASGI layer. Adopters calling ``create_a2a_server``
+            directly must wrap the returned app with
+            :class:`A2ABearerAuthMiddleware` themselves.
 
     Returns:
         A Starlette app ready to be run with uvicorn.
@@ -794,6 +880,7 @@ def create_a2a_server(
         extra_skills=_test_controller_skills() if test_controller else None,
         advertise_all=advertise_all,
         push_notifications_supported=push_config_store is not None,
+        auth=auth,
     )
 
     if task_store is None:

--- a/src/adcp/server/auth.py
+++ b/src/adcp/server/auth.py
@@ -525,9 +525,8 @@ class BearerTokenAuth:
     """Cross-transport bearer-token auth config for :func:`adcp.server.serve`.
 
     Single source of truth that wires the same ``validate_token``
-    callback (and ``header_name`` / ``bearer_prefix_required`` knobs)
-    into both the MCP-side :class:`BearerTokenAuthMiddleware` and the
-    A2A-side :class:`BearerTokenContextBuilder`. Pass via
+    callback into both the MCP-side :class:`BearerTokenAuthMiddleware`
+    and the A2A-side :class:`A2ABearerAuthMiddleware`. Pass via
     ``serve(auth=BearerTokenAuth(...))`` and both legs are
     authenticated against the same token store with no per-leg
     drift::
@@ -547,25 +546,175 @@ class BearerTokenAuth:
 
     On MCP, requests without a valid token receive a JSON ``401``
     body. On A2A, requests without a valid token receive an HTTP
-    ``401`` from Starlette's :class:`HTTPException`. Discovery
-    bypasses are transport-specific:
+    ``401``. Discovery bypasses are transport-specific:
 
     * **MCP**: ``initialize`` / ``tools/list`` / ``notifications/initialized``
       / ``get_adcp_capabilities`` (JSON-RPC method-level bypass).
-    * **A2A**: ``/.well-known/agent-card.json`` (route-level — the
-      agent-card route is created separately and never invokes the
-      builder, so no path-based exemption is needed in the
-      :class:`BearerTokenContextBuilder` itself).
+    * **A2A**: ``/.well-known/agent-card.json`` (path-based — the
+      agent-card route is registered alongside the JSON-RPC routes
+      and the middleware exempts the well-known path).
 
-    Knobs mirror :class:`BearerTokenAuthMiddleware` exactly: pass
-    ``header_name="x-adcp-auth"`` and ``bearer_prefix_required=False``
-    for non-OAuth custom-header schemes.
+    **Canonical carrier: ``Authorization: Bearer <token>`` (RFC 6750).**
+    Both legs default to this. It is the only header backed by an actual
+    RFC, what every off-the-shelf MCP / A2A / HTTP client emits by
+    default, and what the AdCP spec is moving toward as canonical for
+    both transports. Reach for ``BearerTokenAuth(validate_token=...)``
+    with no other knobs and you get the protocol-canonical setup —
+    including a ``bearerAuth`` ``HTTPAuthSecurityScheme`` (``scheme="bearer"``)
+    auto-published on the agent card so a2a-sdk-based clients attach
+    credentials without seller-side intervention.
+
+    **``x-adcp-auth`` is a legacy-compat alias, not a recommended
+    default.** Some early MCP adopters baked in a custom ``x-adcp-auth``
+    header carrying a raw token (no scheme prefix) before the spec
+    settled. Sellers with deployed clients that can't be updated can
+    opt in per-leg::
+
+        BearerTokenAuth(
+            validate_token=...,
+            mcp_header_name="x-adcp-auth",          # legacy MCP clients only
+            mcp_bearer_prefix_required=False,
+            # A2A keeps the canonical RFC 6750 carrier by default
+        )
+
+    Selecting a non-``Authorization`` header on the A2A leg is
+    discouraged — buyers using non-a2a-sdk HTTP clients may not parse
+    the resulting :class:`APIKeySecurityScheme` shape, and you lose
+    interop with off-the-shelf A2A tooling. Use only when you control
+    every buyer client.
+
+    **Legacy single-knob compatibility.** ``header_name`` and
+    ``bearer_prefix_required`` are still accepted: when set, they
+    apply to *both* legs and override the per-leg defaults. Setting
+    both ``header_name`` and a per-leg ``*_header_name`` (or both
+    ``bearer_prefix_required`` and a per-leg
+    ``*_bearer_prefix_required``) raises at construction — the
+    framework can't decide which the operator intended.
     """
 
     validate_token: TokenValidator
-    header_name: str = "authorization"
-    bearer_prefix_required: bool = True
+    # Legacy single-knob — applies to BOTH legs when set. Mutually
+    # exclusive with the per-leg knobs below. Adopters who want the
+    # canonical RFC 6750 setup should leave these unset (defaults
+    # resolve to ``Authorization`` + ``Bearer`` prefix).
+    header_name: str | None = None
+    bearer_prefix_required: bool | None = None
+    # Per-leg knobs — opt-in escape hatch for adopters with legacy
+    # clients that send a raw token in a custom header (e.g.
+    # ``x-adcp-auth``). The protocol-canonical carrier is
+    # ``Authorization: Bearer <token>`` on both legs; reach for these
+    # only when you can't update the client side.
+    mcp_header_name: str | None = None
+    mcp_bearer_prefix_required: bool | None = None
+    a2a_header_name: str | None = None
+    a2a_bearer_prefix_required: bool | None = None
     unauthenticated_response: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.header_name is not None and (
+            self.mcp_header_name is not None or self.a2a_header_name is not None
+        ):
+            raise ValueError(
+                "BearerTokenAuth: set either header_name (applies to both legs) "
+                "or mcp_header_name / a2a_header_name (per-leg) — not both."
+            )
+        if self.bearer_prefix_required is not None and (
+            self.mcp_bearer_prefix_required is not None
+            or self.a2a_bearer_prefix_required is not None
+        ):
+            raise ValueError(
+                "BearerTokenAuth: set either bearer_prefix_required (applies "
+                "to both legs) or mcp_bearer_prefix_required / "
+                "a2a_bearer_prefix_required (per-leg) — not both."
+            )
+
+        # Reject empty-string headers — they would silently 401 every
+        # request because no wire header matches an empty name. A typo
+        # like ``header_name=""`` should fail loudly at construction.
+        for field_name in ("header_name", "mcp_header_name", "a2a_header_name"):
+            value = getattr(self, field_name)
+            if value is not None and not value.strip():
+                raise ValueError(f"BearerTokenAuth: {field_name} must be a non-empty string.")
+
+        # ``Authorization`` is reserved by RFC 7235 for ``<scheme>
+        # <credentials>``. Carrying a raw token in ``Authorization``
+        # breaks RFC-compliant intermediaries and a2a-sdk's auth
+        # interceptor (which treats the header as bearer-shaped). If an
+        # adopter wants a raw token, they need a custom header name.
+        for header_field, prefix_field, leg in (
+            ("header_name", "bearer_prefix_required", "both"),
+            ("mcp_header_name", "mcp_bearer_prefix_required", "MCP"),
+            ("a2a_header_name", "a2a_bearer_prefix_required", "A2A"),
+        ):
+            header = getattr(self, header_field)
+            prefix = getattr(self, prefix_field)
+            if header is not None and header.lower() == "authorization" and prefix is False:
+                raise ValueError(
+                    f"BearerTokenAuth: {header_field}='Authorization' with "
+                    f"{prefix_field}=False on the {leg} leg violates RFC 7235 "
+                    "(Authorization carries '<scheme> <credentials>'). Use a "
+                    "custom header name (e.g. 'x-adcp-auth') for raw-token "
+                    "schemes."
+                )
+
+    def resolved_mcp_header_name(self) -> str:
+        """Effective MCP header name after legacy + default fallback.
+
+        Resolution order: legacy ``header_name`` → ``mcp_header_name``
+        → ``"authorization"`` (RFC 6750, the protocol-canonical carrier
+        on MCP). Adopters with legacy clients sending ``x-adcp-auth``
+        opt in via ``mcp_header_name``; the default itself stays on
+        ``Authorization`` because that's what the spec is moving
+        toward as canonical.
+        """
+        if self.header_name is not None:
+            return self.header_name
+        if self.mcp_header_name is not None:
+            return self.mcp_header_name
+        return "authorization"
+
+    def resolved_mcp_bearer_prefix_required(self) -> bool:
+        """Effective MCP bearer-prefix flag after legacy + default fallback.
+
+        Resolution order: legacy ``bearer_prefix_required`` →
+        ``mcp_bearer_prefix_required`` → ``True`` (RFC 6750 — the
+        canonical setup is ``Authorization: Bearer <token>``).
+        """
+        if self.bearer_prefix_required is not None:
+            return self.bearer_prefix_required
+        if self.mcp_bearer_prefix_required is not None:
+            return self.mcp_bearer_prefix_required
+        return True
+
+    def resolved_a2a_header_name(self) -> str:
+        """Effective A2A header name after legacy + default fallback.
+
+        Resolution order: legacy ``header_name`` → ``a2a_header_name``
+        → ``"Authorization"`` (RFC 6750 — what a2a-sdk and every
+        off-the-shelf HTTP library send by default). Setting
+        ``a2a_header_name`` to anything else is discouraged: buyers
+        using non-a2a-sdk HTTP clients may not parse the resulting
+        :class:`APIKeySecurityScheme` shape on the agent card and
+        you lose interop with off-the-shelf A2A tooling.
+        """
+        if self.header_name is not None:
+            return self.header_name
+        if self.a2a_header_name is not None:
+            return self.a2a_header_name
+        return "Authorization"
+
+    def resolved_a2a_bearer_prefix_required(self) -> bool:
+        """Effective A2A bearer-prefix flag after legacy + default fallback.
+
+        Resolution order: legacy ``bearer_prefix_required`` →
+        ``a2a_bearer_prefix_required`` → ``True`` (RFC 6750 — the
+        canonical setup is ``Authorization: Bearer <token>``).
+        """
+        if self.bearer_prefix_required is not None:
+            return self.bearer_prefix_required
+        if self.a2a_bearer_prefix_required is not None:
+            return self.a2a_bearer_prefix_required
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -640,7 +789,8 @@ class A2ABearerAuthMiddleware:
     def __init__(self, app: Any, config: BearerTokenAuth) -> None:
         self._app = app
         self._config = config
-        self._header_name = config.header_name.lower()
+        self._header_name = config.resolved_a2a_header_name().lower()
+        self._bearer_prefix_required = config.resolved_a2a_bearer_prefix_required()
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         # Lifespan + websocket pass through unchanged. Auth applies to
@@ -725,7 +875,7 @@ class A2ABearerAuthMiddleware:
             logger.info("a2a auth rejected", extra={"reason": "header_decode"})
             return None
 
-        if self._config.bearer_prefix_required:
+        if self._bearer_prefix_required:
             bearer = _parse_bearer_header(raw_header)
         else:
             stripped = raw_header.strip()

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -147,9 +147,7 @@ class ServeConfig:
         _a2a_only = ("task_store", "push_config_store", "message_parser")
         _mcp_only = ("instructions", "streaming_responses")
         if self.transport == "a2a":
-            mcp_set = sorted(
-                f for f in _mcp_only if getattr(self, f) not in (None, False)
-            )
+            mcp_set = sorted(f for f in _mcp_only if getattr(self, f) not in (None, False))
             if mcp_set:
                 warnings.warn(
                     f"ServeConfig sets MCP-only fields {mcp_set} but "
@@ -160,9 +158,7 @@ class ServeConfig:
         elif self.transport not in ("both", "streamable-http", "sse", "stdio"):
             pass  # unknown transport — let serve() raise a clear error
         elif self.transport not in ("a2a", "both"):
-            a2a_set = sorted(
-                f for f in _a2a_only if getattr(self, f) is not None
-            )
+            a2a_set = sorted(f for f in _a2a_only if getattr(self, f) is not None)
             if a2a_set:
                 warnings.warn(
                     f"ServeConfig sets A2A-only fields {a2a_set} but "
@@ -959,8 +955,8 @@ def _wrap_mcp_with_auth(app: Any, auth: BearerTokenAuth | None) -> Any:
         BearerTokenAuthMiddleware,
         validate_token=auth.validate_token,
         unauthenticated_response=auth.unauthenticated_response,
-        header_name=auth.header_name,
-        bearer_prefix_required=auth.bearer_prefix_required,
+        header_name=auth.resolved_mcp_header_name(),
+        bearer_prefix_required=auth.resolved_mcp_bearer_prefix_required(),
     )
     return app
 
@@ -1413,6 +1409,7 @@ def _serve_a2a(
         message_parser=message_parser,
         advertise_all=advertise_all,
         validation=validation,
+        auth=auth,
     )
     # Auth wraps the A2A app innermost (closer to the inner Starlette
     # router than the discovery + size-limit + asgi_middleware
@@ -1559,6 +1556,7 @@ def _build_mcp_and_a2a_app(
         message_parser=message_parser,
         advertise_all=advertise_all,
         validation=validation,
+        auth=auth,
     )
     # Auth wraps both legs *before* ``_dispatch`` captures references —
     # otherwise the closure points at unwrapped apps and auth is

--- a/tests/test_auth_per_leg_headers.py
+++ b/tests/test_auth_per_leg_headers.py
@@ -1,0 +1,410 @@
+"""Per-leg header config + agent-card security envelope (issue #57).
+
+Two upstream items from salesagent#57 land here:
+
+1. ``BearerTokenAuth`` exposes per-leg ``mcp_*`` / ``a2a_*`` knobs so
+   one config drives both legs without a translation shim. Defaults
+   preserve the pre-#57 single-knob behavior — both legs default to
+   ``Authorization`` + ``Bearer`` prefix. Adopters who want the
+   AdCP-convention ``x-adcp-auth`` on MCP opt in via ``mcp_header_name``.
+2. ``_build_agent_card`` publishes a matching security scheme +
+   requirement when ``BearerTokenAuth`` is configured, so a2a-sdk's
+   client auth interceptor attaches credentials instead of
+   short-circuiting against an empty envelope. The scheme variant is
+   chosen on ``bearer_prefix_required``: prefix-required publishes
+   :class:`HTTPAuthSecurityScheme` (``scheme="bearer"``, id ``bearerAuth``);
+   raw-token custom-header configs publish
+   :class:`APIKeySecurityScheme` (id ``adcpAuth``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from asgi_lifespan import LifespanManager
+
+from adcp.server import ADCPHandler
+from adcp.server.auth import (
+    A2ABearerAuthMiddleware,
+    BearerTokenAuth,
+    Principal,
+    validator_from_token_map,
+)
+
+
+class _Handler(ADCPHandler):
+    async def get_adcp_capabilities(self, params: Any, context: Any = None) -> dict[str, Any]:
+        return {"adcp": {"major_versions": [3]}, "supported_protocols": ["media_buy"]}
+
+
+def _validator() -> Any:
+    return validator_from_token_map({"good-token": Principal(caller_identity="p", tenant_id="t")})
+
+
+# ===========================================================================
+# Resolved values
+# ===========================================================================
+
+
+class TestResolvedDefaults:
+    """Back-compat: defaults match the pre-#57 single-knob behavior on
+    both legs (``Authorization`` + ``Bearer`` prefix). Adopters who want
+    a different carrier on one leg opt in via the per-leg knobs;
+    adopters who want the same non-default carrier on both legs use the
+    legacy single knob."""
+
+    def test_mcp_default_is_authorization_with_prefix(self):
+        """Back-compat: existing ``BearerTokenAuth(validate_token=...)``
+        on MCP keeps reading ``Authorization: Bearer ...`` exactly as it
+        did pre-#57."""
+        cfg = BearerTokenAuth(validate_token=_validator())
+        assert cfg.resolved_mcp_header_name() == "authorization"
+        assert cfg.resolved_mcp_bearer_prefix_required() is True
+
+    def test_a2a_default_is_authorization_with_prefix(self):
+        cfg = BearerTokenAuth(validate_token=_validator())
+        assert cfg.resolved_a2a_header_name() == "Authorization"
+        assert cfg.resolved_a2a_bearer_prefix_required() is True
+
+    def test_legacy_header_name_applies_to_both_legs(self):
+        """Back-compat: pre-#57 adopters set ``header_name`` once and
+        the same carrier wires both legs."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            header_name="x-adcp-auth",
+            bearer_prefix_required=False,
+        )
+        assert cfg.resolved_mcp_header_name() == "x-adcp-auth"
+        assert cfg.resolved_a2a_header_name() == "x-adcp-auth"
+        assert cfg.resolved_mcp_bearer_prefix_required() is False
+        assert cfg.resolved_a2a_bearer_prefix_required() is False
+
+    def test_per_leg_overrides_take_effect(self):
+        """Opt-in per-leg config: AdCP-convention ``x-adcp-auth`` on
+        MCP, RFC 6750 ``Authorization: Bearer ...`` on A2A."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            mcp_header_name="x-adcp-auth",
+            mcp_bearer_prefix_required=False,
+            a2a_header_name="Authorization",
+            a2a_bearer_prefix_required=True,
+        )
+        assert cfg.resolved_mcp_header_name() == "x-adcp-auth"
+        assert cfg.resolved_a2a_header_name() == "Authorization"
+        assert cfg.resolved_mcp_bearer_prefix_required() is False
+        assert cfg.resolved_a2a_bearer_prefix_required() is True
+
+
+class TestConflictingKnobsRejected:
+    """Setting both legacy and per-leg knobs for the same axis is
+    ambiguous — fail closed at construction so misconfigurations don't
+    ship to production silently."""
+
+    def test_legacy_and_mcp_header_conflict(self):
+        with pytest.raises(ValueError, match="header_name"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                header_name="authorization",
+                mcp_header_name="x-adcp-auth",
+            )
+
+    def test_legacy_and_a2a_header_conflict(self):
+        with pytest.raises(ValueError, match="header_name"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                header_name="authorization",
+                a2a_header_name="x-other",
+            )
+
+    def test_legacy_and_per_leg_prefix_conflict(self):
+        with pytest.raises(ValueError, match="bearer_prefix_required"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                bearer_prefix_required=True,
+                a2a_bearer_prefix_required=False,
+            )
+
+
+class TestConstructionGuards:
+    """``__post_init__`` rejects misconfigurations that would otherwise
+    silently 401 every request or violate RFC 7235."""
+
+    def test_empty_legacy_header_rejected(self):
+        with pytest.raises(ValueError, match="header_name.*non-empty"):
+            BearerTokenAuth(validate_token=_validator(), header_name="")
+
+    def test_empty_mcp_header_rejected(self):
+        with pytest.raises(ValueError, match="mcp_header_name.*non-empty"):
+            BearerTokenAuth(validate_token=_validator(), mcp_header_name="   ")
+
+    def test_authorization_without_bearer_prefix_rejected_legacy(self):
+        """RFC 7235: ``Authorization`` carries ``<scheme> <credentials>``.
+        Carrying a raw token in ``Authorization`` breaks RFC-compliant
+        intermediaries and a2a-sdk's auth interceptor."""
+        with pytest.raises(ValueError, match="RFC 7235"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                header_name="Authorization",
+                bearer_prefix_required=False,
+            )
+
+    def test_authorization_without_bearer_prefix_rejected_a2a(self):
+        with pytest.raises(ValueError, match="RFC 7235"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                a2a_header_name="authorization",
+                a2a_bearer_prefix_required=False,
+            )
+
+    def test_authorization_with_bearer_prefix_accepted(self):
+        """The legitimate combo (default) still constructs cleanly."""
+        BearerTokenAuth(
+            validate_token=_validator(),
+            a2a_header_name="Authorization",
+            a2a_bearer_prefix_required=True,
+        )
+
+    def test_custom_header_without_bearer_prefix_accepted(self):
+        """The legitimate raw-token combo still constructs cleanly."""
+        BearerTokenAuth(
+            validate_token=_validator(),
+            mcp_header_name="x-adcp-auth",
+            mcp_bearer_prefix_required=False,
+        )
+
+
+# ===========================================================================
+# A2A leg honors per-leg config at request time
+# ===========================================================================
+
+
+def _scope(path: str = "/", headers: list[tuple[bytes, bytes]] | None = None) -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": list(headers or []),
+    }
+
+
+class TestA2AMiddlewareHonorsPerLegConfig:
+    @pytest.mark.asyncio
+    async def test_a2a_uses_a2a_header_name_when_set(self):
+        """Per-leg ``a2a_header_name`` carries the credential on A2A
+        even when the MCP leg keeps the AdCP-convention header."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            a2a_header_name="x-fleet-auth",
+            a2a_bearer_prefix_required=False,
+        )
+        inner_calls: list[dict] = []
+
+        async def inner(scope: Any, _receive: Any, _send: Any) -> None:
+            inner_calls.append(scope)
+
+        mw = A2ABearerAuthMiddleware(inner, cfg)
+        await mw(
+            _scope(headers=[(b"x-fleet-auth", b"good-token")]),
+            lambda: None,
+            lambda _: None,
+        )
+        assert len(inner_calls) == 1
+        assert inner_calls[0]["user"].display_name == "p"
+
+    @pytest.mark.asyncio
+    async def test_a2a_default_requires_bearer_prefix(self):
+        """Default A2A behavior: raw token without ``Bearer `` prefix
+        is rejected (RFC 6750)."""
+        sent: list[dict] = []
+
+        async def send(message: dict) -> None:
+            sent.append(message)
+
+        async def _unused_inner(*_args: Any) -> None:  # never reached on 401
+            pass
+
+        cfg = BearerTokenAuth(validate_token=_validator())
+        mw = A2ABearerAuthMiddleware(_unused_inner, cfg)
+        await mw(
+            _scope(headers=[(b"authorization", b"good-token")]),  # no Bearer prefix
+            lambda: None,
+            send,
+        )
+        assert sent[0]["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_a2a_header_name_case_insensitive_match(self):
+        """Adopters who set ``a2a_header_name="X-Adcp-Auth"`` (mixed
+        case) still match wire headers in the lowercased form ASGI
+        normalizes to. The middleware lowercases the configured name at
+        construction so the case used in config is irrelevant."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            a2a_header_name="X-Custom-Auth",
+            a2a_bearer_prefix_required=False,
+        )
+        inner_calls: list[dict] = []
+
+        async def inner(scope: Any, _receive: Any, _send: Any) -> None:
+            inner_calls.append(scope)
+
+        mw = A2ABearerAuthMiddleware(inner, cfg)
+        await mw(
+            _scope(headers=[(b"x-custom-auth", b"good-token")]),
+            lambda: None,
+            lambda _: None,
+        )
+        assert len(inner_calls) == 1
+
+
+# ===========================================================================
+# MCP leg honors per-leg config end-to-end
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_mcp_per_leg_header_routes_through_middleware() -> None:
+    """End-to-end: ``mcp_header_name="x-adcp-auth"`` +
+    ``mcp_bearer_prefix_required=False`` thread the resolved values
+    into the MCP-side ``BearerTokenAuthMiddleware``. A request carrying
+    the raw token in ``x-adcp-auth`` passes; a request carrying it in
+    ``Authorization`` (the legacy default carrier) is rejected.
+    """
+    from adcp.server import create_mcp_server
+    from adcp.server.serve import _wrap_mcp_with_auth
+
+    cfg = BearerTokenAuth(
+        validate_token=_validator(),
+        mcp_header_name="x-adcp-auth",
+        mcp_bearer_prefix_required=False,
+    )
+    mcp = create_mcp_server(_Handler(), name="t", validation=None)
+    mcp_app = mcp.streamable_http_app()
+    app = _wrap_mcp_with_auth(mcp_app, cfg)
+    body = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "tools/call",
+        "params": {"name": "get_products", "arguments": {}},
+    }
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=True,
+        ) as client:
+            resp_x_adcp = await client.post(
+                "/mcp",
+                json=body,
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                    "x-adcp-auth": "good-token",
+                },
+            )
+            resp_authz = await client.post(
+                "/mcp",
+                json=body,
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer good-token",
+                },
+            )
+    # x-adcp-auth carrier accepted — anything except 401 means auth
+    # passed through to the inner handler.
+    assert resp_x_adcp.status_code != 401, resp_x_adcp.text
+    # Authorization carrier rejected — the per-leg config moved the
+    # carrier off the legacy default.
+    assert resp_authz.status_code == 401
+
+
+# ===========================================================================
+# Agent card auto-publishes bearerAuth scheme
+# ===========================================================================
+
+
+class TestAgentCardSecurityEnvelope:
+    """Issue #57 #1 — when auth is configured, the agent card must
+    publish a matching ``bearerAuth`` security scheme + requirement
+    so a2a-sdk's client auth interceptor attaches credentials."""
+
+    def test_no_auth_card_has_empty_security_envelope(self):
+        from adcp.server.a2a_server import _build_agent_card
+
+        card = _build_agent_card(_Handler(), name="test", port=3001, advertise_all=True)
+        assert dict(card.security_schemes) == {}
+        assert list(card.security_requirements) == []
+
+    def test_default_auth_publishes_bearer_http_scheme(self):
+        """Default A2A leg (Authorization + bearer prefix) publishes
+        an HTTPAuthSecurityScheme with ``scheme="bearer"``."""
+        from adcp.server.a2a_server import _build_agent_card
+
+        cfg = BearerTokenAuth(validate_token=_validator())
+        card = _build_agent_card(_Handler(), name="test", port=3001, advertise_all=True, auth=cfg)
+        assert "bearerAuth" in card.security_schemes
+        scheme = card.security_schemes["bearerAuth"]
+        assert scheme.http_auth_security_scheme.scheme == "bearer"
+        assert len(card.security_requirements) == 1
+        assert "bearerAuth" in card.security_requirements[0].schemes
+
+    def test_custom_header_publishes_api_key_scheme(self):
+        """Custom A2A header without bearer prefix publishes an
+        APIKeySecurityScheme under id ``adcpAuth`` — that's the
+        OpenAPI/A2A way to describe a custom-header credential. The
+        scheme id is distinct from ``bearerAuth`` so buyers reading the
+        card can tell HTTP-bearer from raw-token at a glance."""
+        from adcp.server.a2a_server import _build_agent_card
+
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            a2a_header_name="x-adcp-auth",
+            a2a_bearer_prefix_required=False,
+        )
+        card = _build_agent_card(_Handler(), name="test", port=3001, advertise_all=True, auth=cfg)
+        assert "adcpAuth" in card.security_schemes
+        assert "bearerAuth" not in card.security_schemes
+        scheme = card.security_schemes["adcpAuth"]
+        assert scheme.api_key_security_scheme.location == "header"
+        assert scheme.api_key_security_scheme.name == "x-adcp-auth"
+        assert "adcpAuth" in card.security_requirements[0].schemes
+
+    def test_legacy_header_name_authorization_publishes_bearer_scheme(self):
+        """Adopters using the legacy single-knob with the standard
+        ``Authorization`` header still get the bearer HTTP scheme on
+        their card."""
+        from adcp.server.a2a_server import _build_agent_card
+
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            header_name="Authorization",
+            bearer_prefix_required=True,
+        )
+        card = _build_agent_card(_Handler(), name="test", port=3001, advertise_all=True, auth=cfg)
+        scheme = card.security_schemes["bearerAuth"]
+        assert scheme.http_auth_security_scheme.scheme == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_agent_card_route_returns_security_envelope() -> None:
+    """End-to-end: the published ``/.well-known/agent-card.json`` MUST
+    serialize the ``bearerAuth`` scheme so a2a-sdk-based clients can
+    parse it from the wire."""
+    from adcp.server.a2a_server import create_a2a_server
+
+    cfg = BearerTokenAuth(validate_token=_validator())
+    inner = create_a2a_server(_Handler(), name="t", validation=None, auth=cfg)
+    async with LifespanManager(inner):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=inner), base_url="http://test"
+        ) as client:
+            response = await client.get("/.well-known/agent-card.json")
+    assert response.status_code == 200
+    body = response.json()
+    schemes = body.get("securitySchemes") or body.get("security_schemes")
+    assert schemes is not None and "bearerAuth" in schemes
+    requirements = body.get("security") or body.get("security_requirements") or []
+    assert requirements, "security_requirements missing from card"


### PR DESCRIPTION
## Summary

Closes upstream items 1 and 2 from [salesagent#57](https://github.com/bokelley/salesagent/issues/57). With these in place, the `BearerToAdcpAuthMiddleware` shim in salesagent PR #60 becomes deletable.

- **Per-leg header knobs on `BearerTokenAuth`** — `mcp_header_name` / `a2a_header_name` / `mcp_bearer_prefix_required` / `a2a_bearer_prefix_required`. One config drives both legs without a translation middleware. Setting both legacy `header_name` and a per-leg knob raises `ValueError` at construction.
- **Agent card auto-publishes a security envelope** — when `BearerTokenAuth` is configured, `_build_agent_card` emits a matching `securitySchemes` + `securityRequirements` so a2a-sdk's client auth interceptor attaches credentials instead of short-circuiting against an empty envelope. Bearer-prefix configs publish `HTTPAuthSecurityScheme(scheme="bearer")` under id `bearerAuth`; raw-token custom-header configs publish `APIKeySecurityScheme` under id `adcpAuth`.

## Defaults & back-compat

`Authorization: Bearer <token>` (RFC 6750) is the protocol-canonical carrier on **both** legs. It's the only header backed by an actual RFC, what every off-the-shelf MCP / A2A / HTTP client emits by default, and what the AdCP spec is moving toward as canonical for both transports.

`x-adcp-auth` is an **opt-in legacy-compat alias**, not a default — for adopters with deployed MCP clients that send a raw token in a custom header and can't be updated. Reach for it via:

```python
BearerTokenAuth(
    validate_token=...,
    mcp_header_name="x-adcp-auth",
    mcp_bearer_prefix_required=False,
)
```

Defaults preserve pre-#57 single-knob behavior — existing `BearerTokenAuth(validate_token=...)` adopters keep working unchanged.

## Construction guards (`__post_init__`)

- Mutually exclusive: legacy single-knob vs per-leg knobs for the same axis.
- Empty / whitespace-only header names rejected (would silently 401 every request).
- `Authorization` + `bearer_prefix_required=False` rejected — RFC 7235 reserves `Authorization` for `<scheme> <credentials>`. Raw-token schemes need a custom header name.

## Out of scope

- Item 3 from salesagent#57 (spec text declaring `Authorization: Bearer` canonical with `x-adcp-auth` as a documented compat alias) is a separate spec-repo PR.

## Test plan

- [x] `ruff check src/` clean
- [x] `mypy src/adcp/` clean (783 source files)
- [x] `pytest tests/ -v` — 4165 passed (+8 new tests vs prior run)
- [x] New file `tests/test_auth_per_leg_headers.py` — 22 tests covering: resolved-default precedence, legacy single-knob back-compat, per-leg overrides, conflict guards, empty-header rejection, RFC 7235 misuse rejection, A2A middleware honors per-leg config, A2A header-name case-insensitive match, agent-card scheme variants (`bearerAuth` HTTP / `adcpAuth` API-key), end-to-end MCP per-leg routing through `BearerTokenAuthMiddleware`, end-to-end agent-card route serialization
- [x] Reviewed by ad-tech-protocol-expert, security-reviewer, code-reviewer, adtech-product-expert; punch-list addressed (RFC 7235 misuse guard, scheme-variant id branching, dropped non-standard `bearer_format`, empty-header rejection, missing E2E + case-sensitivity tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)