### PR TITLE
fix(decisioning): wire sync_accounts/list_accounts dispatch to AccountStore Protocols

### DIFF
--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -81,6 +81,7 @@ logger = logging.getLogger(__name__)
 # exception, and the dispatcher falls back to the dict path — which
 # crashes inside the shim with ``'dict' object has no attribute
 # 'account'`` (Emma sales-direct backend test, verdict 2/10).
+from adcp.decisioning.accounts import ResolveContext, _call_with_optional_ctx
 from adcp.types import (
     AccountReference,
     AcquireRightsRequest,
@@ -131,6 +132,8 @@ from adcp.types import (
     GetRightsSuccessResponse,
     GetSignalsRequest,
     GetSignalsResponse,
+    ListAccountsRequest,
+    ListAccountsResponse,
     ListCollectionListsRequest,
     ListCollectionListsResponse,
     ListContentStandardsRequest,
@@ -147,6 +150,8 @@ from adcp.types import (
     ProvidePerformanceFeedbackResponse,
     ReportPlanOutcomeRequest,
     ReportPlanOutcomeResponse,
+    SyncAccountsRequest,
+    SyncAccountsResponse,
     SyncAudiencesRequest,
     SyncAudiencesSuccessResponse,
     SyncCreativesRequest,
@@ -203,6 +208,20 @@ _SALES_ADVERTISED_TOOLS: frozenset[str] = frozenset(
         "provide_performance_feedback",
         "list_creative_formats",
         "list_creatives",
+    }
+)
+#: Account-management tools — buyers reach the seller's account
+#: roster via these. Per spec, every seller MUST expose at least one
+#: of ``sync_accounts`` (declarative push) or ``list_accounts`` (read-
+#: only enumerate). Wired through the platform's :class:`AccountStore`
+#: surface (:class:`AccountStoreUpsert` / :class:`AccountStoreList`),
+#: not via the per-specialism Protocol method dispatch — see
+#: :data:`adcp.decisioning.platform_router._ACCOUNT_STORE_METHODS`
+#: for the corresponding router-side carve-out.
+_ACCOUNT_ADVERTISED_TOOLS: frozenset[str] = frozenset(
+    {
+        "list_accounts",
+        "sync_accounts",
     }
 )
 _CREATIVE_ADVERTISED_TOOLS: frozenset[str] = frozenset(
@@ -309,12 +328,18 @@ _OPTIONAL_PLATFORM_METHODS: frozenset[str] = frozenset(
 #: another specialism that does.
 SPECIALISM_TO_ADVERTISED_TOOLS: dict[str, frozenset[str]] = {
     # Sales-* archetypes — all use the unified SalesPlatform surface.
-    "sales-non-guaranteed": _SALES_ADVERTISED_TOOLS,
-    "sales-guaranteed": _SALES_ADVERTISED_TOOLS,
-    "sales-broadcast-tv": _SALES_ADVERTISED_TOOLS,
-    "sales-social": _SALES_ADVERTISED_TOOLS,
-    "sales-catalog-driven": _SALES_ADVERTISED_TOOLS,
-    "sales-proposal-mode": _SALES_ADVERTISED_TOOLS,
+    # Sales adopters expose account discovery via ``sync_accounts`` /
+    # ``list_accounts`` — adding the union here so the per-instance
+    # advertisement filter doesn't strip them. The override filter still
+    # drops them when the platform's :class:`AccountStore` doesn't
+    # implement the optional :class:`AccountStoreUpsert` /
+    # :class:`AccountStoreList` Protocols.
+    "sales-non-guaranteed": _SALES_ADVERTISED_TOOLS | _ACCOUNT_ADVERTISED_TOOLS,
+    "sales-guaranteed": _SALES_ADVERTISED_TOOLS | _ACCOUNT_ADVERTISED_TOOLS,
+    "sales-broadcast-tv": _SALES_ADVERTISED_TOOLS | _ACCOUNT_ADVERTISED_TOOLS,
+    "sales-social": _SALES_ADVERTISED_TOOLS | _ACCOUNT_ADVERTISED_TOOLS,
+    "sales-catalog-driven": _SALES_ADVERTISED_TOOLS | _ACCOUNT_ADVERTISED_TOOLS,
+    "sales-proposal-mode": _SALES_ADVERTISED_TOOLS | _ACCOUNT_ADVERTISED_TOOLS,
     # Creative — Builder + AdServer. Builder claims expose
     # build_creative + optional preview_creative; AdServer adds
     # get_creative_delivery (per CreativeAdServerPlatform Protocol).
@@ -677,6 +702,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
     #: would advertise all 40+ shims (Emma cross-cutting P1).
     advertised_tools: ClassVar[set[str]] = (
         set(_SALES_ADVERTISED_TOOLS)
+        | set(_ACCOUNT_ADVERTISED_TOOLS)
         | set(_CREATIVE_ADVERTISED_TOOLS)
         | set(_SIGNALS_ADVERTISED_TOOLS)
         | set(_AUDIENCE_ADVERTISED_TOOLS)
@@ -876,6 +902,29 @@ class PlatformHandler(ADCPHandler[ToolContext]):
 
         record_resolved_account_mode(resolved)
         return resolved
+
+    def _make_resolve_context(
+        self,
+        tool_ctx: ToolContext,
+        tool_name: str,
+    ) -> ResolveContext:
+        """Build a :class:`ResolveContext` for AccountStore-routed tools.
+
+        Mirrors :meth:`_resolve_account`'s auth/agent-registry wiring
+        without going through ``AccountStore.resolve`` itself — the
+        ``upsert`` / ``list`` / ``sync_governance`` Protocols receive
+        their own ``ResolveContext`` rather than a
+        :class:`RequestContext`, since the resolved account isn't yet
+        available (sync_accounts) or operates on multiple accounts at
+        once (list_accounts).
+        """
+        auth_info = self._extract_auth_info(tool_ctx)
+        buyer_agent = tool_ctx.metadata.get("adcp.buyer_agent") if tool_ctx.metadata else None
+        return ResolveContext(
+            auth_info=auth_info,
+            tool_name=tool_name,
+            agent=buyer_agent,
+        )
 
     @staticmethod
     def _extract_auth_info(ctx: ToolContext) -> AuthInfo | None:
@@ -1581,6 +1630,72 @@ class PlatformHandler(ADCPHandler[ToolContext]):
                 registry=self._registry,
             ),
         )
+
+    # ----- AccountStore-routed dispatchers ----------------------------
+    #
+    # ``sync_accounts`` and ``list_accounts`` flow through the platform's
+    # :class:`AccountStore` Protocol surface (specifically
+    # :class:`AccountStoreUpsert` / :class:`AccountStoreList`), not the
+    # per-specialism platform-method dispatch — see
+    # :data:`adcp.decisioning.platform_router._ACCOUNT_STORE_METHODS`
+    # for the corresponding router-side carve-out. Both Protocols are
+    # OPTIONAL on the AccountStore: surface ``UNSUPPORTED_FEATURE``
+    # rather than ``AttributeError`` when the adopter's store doesn't
+    # implement them.
+
+    async def sync_accounts(  # type: ignore[override]
+        self,
+        params: SyncAccountsRequest,
+        context: ToolContext | None = None,
+    ) -> SyncAccountsResponse:
+        """Forward ``sync_accounts`` to ``platform.accounts.upsert``.
+
+        Wire request has no ``account`` field — the ``accounts`` array
+        IS the discovery payload. Resolve via auth only; the
+        :class:`ResolveContext` carries the caller's
+        :class:`AuthInfo` / agent so adopter impls can apply
+        principal-keyed gates (e.g. spec
+        ``BILLING_NOT_PERMITTED_FOR_AGENT``).
+        """
+        upsert = getattr(self._platform.accounts, "upsert", None)
+        if upsert is None:
+            return cast("SyncAccountsResponse", self._not_supported("sync_accounts"))
+        tool_ctx = context or ToolContext()
+        account = await self._resolve_account(None, tool_ctx)
+        ctx = self._build_ctx(tool_ctx, account)
+        resolve_ctx = self._make_resolve_context(tool_ctx, "sync_accounts")
+        result = _call_with_optional_ctx(upsert, params, ctx=resolve_ctx)
+        if inspect.isawaitable(result):
+            result = await result
+        # Adopters MAY return either the wire-shaped ``SyncAccountsResponse``
+        # (typical when forwarding to a buyer-shaped impl) or a
+        # ``list[SyncAccountsResultRow]`` per the Protocol's narrower
+        # contract. Pass through unchanged — the typed dispatcher serializer
+        # downstream handles both shapes.
+        del ctx, account
+        return cast("SyncAccountsResponse", result)
+
+    async def list_accounts(  # type: ignore[override]
+        self,
+        params: ListAccountsRequest,
+        context: ToolContext | None = None,
+    ) -> ListAccountsResponse:
+        """Forward ``list_accounts`` to ``platform.accounts.list``.
+
+        Wire request has no ``account`` field. Resolve via auth only.
+        """
+        list_fn = getattr(self._platform.accounts, "list", None)
+        if list_fn is None:
+            return cast("ListAccountsResponse", self._not_supported("list_accounts"))
+        tool_ctx = context or ToolContext()
+        account = await self._resolve_account(None, tool_ctx)
+        ctx = self._build_ctx(tool_ctx, account)
+        resolve_ctx = self._make_resolve_context(tool_ctx, "list_accounts")
+        result = _call_with_optional_ctx(list_fn, params, ctx=resolve_ctx)
+        if inspect.isawaitable(result):
+            result = await result
+        del ctx, account
+        return cast("ListAccountsResponse", result)
 
     # ----- Optional-method gate -----
 

--- a/tests/test_decisioning_handler_shims.py
+++ b/tests/test_decisioning_handler_shims.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -71,6 +72,9 @@ def test_advertised_tools_covers_every_specialism_wire_tool() -> None:
         "provide_performance_feedback",
         "list_creative_formats",
         "list_creatives",
+        # Account management — routed through AccountStore Protocols
+        "sync_accounts",
+        "list_accounts",
         # Creative (Builder + AdServer)
         "build_creative",
         "preview_creative",
@@ -374,6 +378,176 @@ async def test_create_property_list_shim_routes_to_platform(executor) -> None:
         CreatePropertyListRequest.model_construct(), ToolContext()
     )
     assert result == {"list_id": "pl_1", "fetch_token": "tok_x"}
+
+
+# ---- AccountStore-routed dispatchers (sync_accounts / list_accounts) ----
+
+
+@pytest.mark.asyncio
+async def test_sync_accounts_shim_routes_to_account_store_upsert(executor) -> None:
+    """``sync_accounts`` flows through ``platform.accounts.upsert`` (the
+    framework's AccountStoreUpsert Protocol), NOT ``platform.sync_accounts``
+    — accounts surface lives on the AccountStore per the
+    ``LazyPlatformRouter._ACCOUNT_STORE_METHODS`` carve-out."""
+
+    upsert_calls: list[tuple[Any, Any]] = []
+
+    class _StoreWithUpsert(SingletonAccounts):
+        def upsert(self, params, ctx=None):
+            upsert_calls.append((params, ctx))
+            return {"accounts": [{"account_id": "acc_42", "action": "created"}]}
+
+    class _SalesAgentWithUpsert(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        accounts = _StoreWithUpsert(account_id="hello")
+
+        def get_products(self, req, ctx):
+            return {"products": []}
+
+        def create_media_buy(self, req, ctx):
+            raise NotImplementedError
+
+        def update_media_buy(self, *, media_buy_id, patch, ctx):
+            raise NotImplementedError
+
+        def sync_creatives(self, req, ctx):
+            raise NotImplementedError
+
+    handler = PlatformHandler(
+        _SalesAgentWithUpsert(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    from adcp.types import SyncAccountsRequest
+
+    request = SyncAccountsRequest.model_construct(
+        accounts=[],
+        idempotency_key="idem-acc-1234567890abcdef",
+    )
+    result = await handler.sync_accounts(request, ToolContext())
+
+    assert len(upsert_calls) == 1
+    assert upsert_calls[0][0] is request
+    # ResolveContext was threaded through with the tool name set
+    resolve_ctx = upsert_calls[0][1]
+    assert resolve_ctx.tool_name == "sync_accounts"
+    assert result == {"accounts": [{"account_id": "acc_42", "action": "created"}]}
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_shim_routes_to_account_store_list(executor) -> None:
+    """``list_accounts`` flows through ``platform.accounts.list``."""
+
+    list_calls: list[tuple[Any, Any]] = []
+
+    class _StoreWithList(SingletonAccounts):
+        def list(self, params, ctx=None):
+            list_calls.append((params, ctx))
+            return {"accounts": [{"account_id": "acc_42"}]}
+
+    class _SalesAgentWithList(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        accounts = _StoreWithList(account_id="hello")
+
+        def get_products(self, req, ctx):
+            return {"products": []}
+
+        def create_media_buy(self, req, ctx):
+            raise NotImplementedError
+
+        def update_media_buy(self, *, media_buy_id, patch, ctx):
+            raise NotImplementedError
+
+        def sync_creatives(self, req, ctx):
+            raise NotImplementedError
+
+    handler = PlatformHandler(
+        _SalesAgentWithList(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    from adcp.types import ListAccountsRequest
+
+    request = ListAccountsRequest.model_construct()
+    result = await handler.list_accounts(request, ToolContext())
+
+    assert len(list_calls) == 1
+    assert list_calls[0][0] is request
+    resolve_ctx = list_calls[0][1]
+    assert resolve_ctx.tool_name == "list_accounts"
+    assert result == {"accounts": [{"account_id": "acc_42"}]}
+
+
+@pytest.mark.asyncio
+async def test_sync_accounts_unsupported_when_store_lacks_upsert(executor) -> None:
+    """When the platform's AccountStore doesn't implement
+    :class:`AccountStoreUpsert`, ``sync_accounts`` surfaces
+    ``OPERATION_NOT_SUPPORTED`` rather than ``AttributeError``."""
+
+    class _SalesAgentNoUpsert(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        accounts = SingletonAccounts(account_id="hello")  # no upsert method
+
+        def get_products(self, req, ctx):
+            return {"products": []}
+
+        def create_media_buy(self, req, ctx):
+            raise NotImplementedError
+
+        def update_media_buy(self, *, media_buy_id, patch, ctx):
+            raise NotImplementedError
+
+        def sync_creatives(self, req, ctx):
+            raise NotImplementedError
+
+    handler = PlatformHandler(
+        _SalesAgentNoUpsert(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    from adcp.types import SyncAccountsRequest
+
+    result = await handler.sync_accounts(
+        SyncAccountsRequest.model_construct(
+            accounts=[],
+            idempotency_key="idem-acc-1234567890abcdef",
+        ),
+        ToolContext(),
+    )
+    # ``_not_supported`` returns a NotImplementedResponse object whose
+    # ``status`` carries the canonical "not supported" envelope.
+    assert getattr(result, "supported", None) is False
+    assert getattr(getattr(result, "error", None), "code", None) == "NOT_SUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_unsupported_when_store_lacks_list(executor) -> None:
+    class _SalesAgentNoList(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        accounts = SingletonAccounts(account_id="hello")  # no list method
+
+        def get_products(self, req, ctx):
+            return {"products": []}
+
+        def create_media_buy(self, req, ctx):
+            raise NotImplementedError
+
+        def update_media_buy(self, *, media_buy_id, patch, ctx):
+            raise NotImplementedError
+
+        def sync_creatives(self, req, ctx):
+            raise NotImplementedError
+
+    handler = PlatformHandler(
+        _SalesAgentNoList(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    from adcp.types import ListAccountsRequest
+
+    result = await handler.list_accounts(ListAccountsRequest.model_construct(), ToolContext())
+    assert getattr(result, "supported", None) is False
+    assert getattr(getattr(result, "error", None), "code", None) == "NOT_SUPPORTED"
 
 
 # ---- Optional-method UNSUPPORTED_FEATURE gate ----


### PR DESCRIPTION
## Problem

`PlatformHandler.sync_accounts` and `PlatformHandler.list_accounts` are inherited as `_not_supported` stubs from `ADCPHandler`. Every adopter that implements `AccountStoreUpsert` / `AccountStoreList` on their platform's `accounts` store is invisible on the wire — both tools return `OPERATION_NOT_SUPPORTED` regardless of what the store declares.

Compared to e.g. `provide_performance_feedback` in the same handler, which properly threads through `_invoke_platform_method` to `platform.provide_performance_feedback(params, ctx)`. The account dispatchers were never given the equivalent treatment.

Tracked at [adcontextprotocol/adcp-client#1631](https://github.com/adcontextprotocol/adcp-client/issues/1631).

## Fix

Wire real shims that route through the documented design — `AccountStore.upsert` / `.list`, NOT `platform.<method>`, since `LazyPlatformRouter._ACCOUNT_STORE_METHODS` already excludes account ops from per-tenant delegation:

```python
async def sync_accounts(self, params, context=None):
    upsert = getattr(self._platform.accounts, "upsert", None)
    if upsert is None:
        return self._not_supported("sync_accounts")
    tool_ctx = context or ToolContext()
    account = await self._resolve_account(None, tool_ctx)
    ctx = self._build_ctx(tool_ctx, account)
    resolve_ctx = self._make_resolve_context(tool_ctx, "sync_accounts")
    result = _call_with_optional_ctx(upsert, params, ctx=resolve_ctx)
    if inspect.isawaitable(result):
        result = await result
    return cast("SyncAccountsResponse", result)
```

The `ResolveContext` carries the caller's `AuthInfo` and resolved `BuyerAgent` — same threading `AccountStore.resolve` already uses, so adopter impls implementing principal-keyed gates (e.g. spec `BILLING_NOT_PERMITTED_FOR_AGENT`) read the principal off the canonical context.

Both `upsert` and `list` are OPTIONAL on the AccountStore. The shims surface `OPERATION_NOT_SUPPORTED` (via `_not_supported`) when the store doesn't expose them — distinct from `AttributeError`, which is what an unguarded `getattr().()` would produce.

## Wire advertisement

Adds `_ACCOUNT_ADVERTISED_TOOLS = {"sync_accounts", "list_accounts"}` and unions it into every `sales-*` entry of `SPECIALISM_TO_ADVERTISED_TOOLS` (every sales-* claim implies an account roster — per spec, buyers must be able to reach it). The override-detection filter still drops the tools when the platform's store doesn't expose the corresponding Protocol method, so adopters who don't yet implement them aren't suddenly over-advertising.

## Tests

- `test_advertised_tools_covers_every_specialism_wire_tool` — extended with the two new tools.
- New positive: `sync_accounts` / `list_accounts` route through to `platform.accounts.upsert` / `.list` with `ResolveContext.tool_name` set correctly.
- New negative: stores that don't implement the optional Protocols surface `OPERATION_NOT_SUPPORTED` via `NotImplementedResponse` — distinct from `AttributeError` from an unguarded `getattr` chain.

877 tests pass locally (`pytest tests/ -k "decisioning or account or handler or platform"`).

## Storyboard impact

Downstream sellers running the AdCP storyboard `media_buy_seller/refine_products/setup` against an agent that implements the optional store Protocols will see the scenario graduate from `skipped (missing_tool)` to graded the moment they pull this in. Verified end-to-end against [bokelley/salesagent@4e62024c](https://github.com/bokelley/salesagent/commit/4e62024c) — `MCP 31→32 passed, 28→27 skipped`.

## Side note

Tracked salesagent monkey-patch that this PR replaces: https://github.com/bokelley/salesagent/blob/main/core/platforms/account_polyfill.py — happy to drop the polyfill once this lands.