### PR TITLE
feat(webhooks)!: create_mcp_webhook_payload returns McpWebhookPayload

### DIFF
--- a/src/adcp/webhook_sender.py
+++ b/src/adcp/webhook_sender.py
@@ -50,7 +50,7 @@ from adcp.signing.ip_pinned_transport import (
     build_async_ip_pinned_transport,
 )
 from adcp.signing.standard_webhooks import decode_secret as _decode_sw_secret
-from adcp.types import GeneratedTaskStatus
+from adcp.types import GeneratedTaskStatus, TaskType
 from adcp.types.generated_poc.core.async_response_data import AdcpAsyncResponseData
 from adcp.webhook_auth import (
     AdcpLegacyHmacStrategy,
@@ -68,6 +68,7 @@ from adcp.webhook_transport_hooks import (
 from adcp.webhooks import (
     create_mcp_webhook_payload,
     generate_webhook_idempotency_key,
+    to_wire_dict,
 )
 
 # The signer emits a signature valid for 300 seconds; anything beyond that
@@ -521,7 +522,7 @@ class WebhookSender:
         url: str,
         task_id: str,
         status: GeneratedTaskStatus | str,
-        task_type: str | None = None,
+        task_type: TaskType | str,
         result: AdcpAsyncResponseData | dict[str, Any] | None = None,
         timestamp: datetime | None = None,
         operation_id: str | None = None,
@@ -562,8 +563,8 @@ class WebhookSender:
         )
         return await self.send_raw(
             url=url,
-            idempotency_key=str(payload["idempotency_key"]),
-            payload=payload,
+            idempotency_key=payload.idempotency_key,
+            payload=to_wire_dict(payload),
             extra_headers=extra_headers,
         )
 

--- a/src/adcp/webhook_supervisor.py
+++ b/src/adcp/webhook_supervisor.py
@@ -56,6 +56,10 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 # isort rule.
 UTC = timezone.utc
 
+# Runtime import — used to coerce TaskType enum to its on-wire string at
+# the audit-log boundary. Must not be inside TYPE_CHECKING.
+from adcp.types import TaskType  # noqa: E402
+
 if TYPE_CHECKING:
     from adcp.types import GeneratedTaskStatus
     from adcp.webhook_sender import WebhookDeliveryResult, WebhookSender
@@ -210,7 +214,7 @@ class WebhookDeliverySupervisor(Protocol):
         url: str,
         task_id: str,
         status: GeneratedTaskStatus | str,
-        task_type: str | None = None,
+        task_type: TaskType | str,
         result: Any = None,
         token: str | None = None,
         sequence_key: str | None = None,
@@ -397,7 +401,7 @@ class InMemoryWebhookDeliverySupervisor:
         url: str,
         task_id: str,
         status: GeneratedTaskStatus | str,
-        task_type: str | None = None,
+        task_type: TaskType | str,
         result: Any = None,
         token: str | None = None,
         sequence_key: str | None = None,
@@ -443,6 +447,9 @@ class InMemoryWebhookDeliverySupervisor:
         """
         breaker = self._breaker_for(breaker_key or url)
         sequence_number: int | None = None  # allocated AFTER breaker check
+        # Audit log + DeliveryAttempt store the on-wire string; TaskType
+        # enum is normalized once here so every record sees the same value.
+        task_type_str: str = task_type.value if isinstance(task_type, TaskType) else task_type
 
         if not breaker.can_attempt():
             await self._record(
@@ -459,7 +466,7 @@ class InMemoryWebhookDeliverySupervisor:
                     occurred_at=datetime.now(UTC),
                     will_retry=False,
                     next_retry_at=None,
-                    task_type=task_type,
+                    task_type=task_type_str,
                     task_id=task_id,
                     payload_size_bytes=None,
                     notification_type=notification_type,
@@ -521,7 +528,7 @@ class InMemoryWebhookDeliverySupervisor:
                             occurred_at=attempt_started,
                             will_retry=False,
                             next_retry_at=None,
-                            task_type=task_type,
+                            task_type=task_type_str,
                             task_id=task_id,
                             payload_size_bytes=len(last_result.sent_body),
                             notification_type=notification_type,
@@ -556,7 +563,7 @@ class InMemoryWebhookDeliverySupervisor:
                         occurred_at=attempt_started,
                         will_retry=will_retry,
                         next_retry_at=next_retry_at,
-                        task_type=task_type,
+                        task_type=task_type_str,
                         task_id=task_id,
                         payload_size_bytes=len(last_result.sent_body),
                         notification_type=notification_type,
@@ -588,7 +595,7 @@ class InMemoryWebhookDeliverySupervisor:
                         occurred_at=attempt_started,
                         will_retry=will_retry,
                         next_retry_at=next_retry_at,
-                        task_type=task_type,
+                        task_type=task_type_str,
                         task_id=task_id,
                         payload_size_bytes=None,
                         notification_type=notification_type,

--- a/src/adcp/webhook_supervisor_pg.py
+++ b/src/adcp/webhook_supervisor_pg.py
@@ -140,6 +140,7 @@ try:
 except ImportError:
     PG_AVAILABLE = False
 
+from adcp.types import TaskType
 from adcp.webhook_supervisor import (
     CircuitBreakerPolicy,
     DeliveryAttempt,
@@ -412,7 +413,7 @@ class PgWebhookDeliverySupervisor:
         url: str,
         task_id: str,
         status: GeneratedTaskStatus | str,
-        task_type: str | None = None,
+        task_type: TaskType | str,
         result: Any = None,
         token: str | None = None,
         sequence_key: str | None = None,
@@ -444,6 +445,12 @@ class PgWebhookDeliverySupervisor:
                 "is running. Call asyncio.create_task(supervisor.run_worker()) at startup."
             )
 
+        # The queue column is TEXT; psycopg would otherwise bind a TaskType
+        # enum via repr (`"TaskType.create_media_buy"`), corrupting the wire
+        # value. Normalize once here so every persistence + log site sees
+        # the on-wire string.
+        task_type_str: str = task_type.value if isinstance(task_type, TaskType) else task_type
+
         bkey = breaker_key or url
 
         # Check circuit state; reject immediately if OPEN within the timeout window.
@@ -473,7 +480,7 @@ class PgWebhookDeliverySupervisor:
                         occurred_at=occurred_at,
                         will_retry=False,
                         next_retry_at=None,
-                        task_type=task_type,
+                        task_type=task_type_str,
                         task_id=task_id,
                         payload_size_bytes=None,
                         notification_type=notification_type,
@@ -483,7 +490,7 @@ class PgWebhookDeliverySupervisor:
                     logger.warning(
                         "[adcp.webhook_supervisor_pg] circuit OPEN for %s — skipped %s",
                         bkey,
-                        task_type or "webhook",
+                        task_type_str,
                     )
                     return None
                 # Open timeout elapsed; transition to half_open so next worker probes.
@@ -500,7 +507,7 @@ class PgWebhookDeliverySupervisor:
                     bkey,
                     url,
                     task_id,
-                    task_type,
+                    task_type_str,
                     status_str,
                     result_json,
                     token,

--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -56,7 +56,7 @@ from adcp.signing.webhook_verifier import (
     WebhookVerifyOptions,
     verify_webhook_signature,
 )
-from adcp.types import GeneratedTaskStatus
+from adcp.types import GeneratedTaskStatus, McpWebhookPayload, TaskType
 from adcp.types.base import AdCPBaseModel
 from adcp.webhook_receiver import (
     LegacyHmacFallback,
@@ -86,63 +86,78 @@ def generate_webhook_idempotency_key() -> str:
 def create_mcp_webhook_payload(
     task_id: str,
     status: GeneratedTaskStatus | str,
+    task_type: TaskType | str,
+    *,
     result: PydanticBaseModel | dict[str, Any] | None = None,
     timestamp: datetime | None = None,
-    task_type: str | None = None,
     operation_id: str | None = None,
     message: str | None = None,
     context_id: str | None = None,
     domain: str | None = None,
     idempotency_key: str | None = None,
     token: str | None = None,
-) -> dict[str, Any]:
+) -> McpWebhookPayload:
     """
-    Create MCP webhook payload dictionary.
+    Build an :class:`McpWebhookPayload` for a tracked async task.
 
-    This function helps agent implementations construct properly formatted
-    webhook payloads for sending to clients.
+    Pair with :func:`to_wire_dict` for HTTP transport — Pydantic-typed at
+    construction so the publisher catches schema drift before it leaves
+    the process.
+
+    ``task_type`` is restricted to the closed :class:`TaskType` enum (the
+    spec's complete set of async/tracked operations). Synchronous-only
+    operations (e.g. ``get_products``, ``list_creatives``) are not in the
+    enum because they don't go through the task management system —
+    passing them would have produced a webhook payload the receiver would
+    reject as schema-invalid.
 
     Args:
-        task_id: Unique identifier for the task
-        status: Current task status
-        task_type: Optionally type of AdCP operation (e.g., "get_products", "create_media_buy")
-        timestamp: When the webhook was generated (defaults to current UTC time)
-        result: Task-specific payload — any Pydantic model or plain dict
-        operation_id: Client-generated identifier the buyer embedded in the
-            webhook URL when registering push-notification config. Publishers
-            MUST echo this back in the payload so buyers correlate notifications
-            without parsing URL paths (per ``mcp-webhook-payload.json``).
-            Senders extracting the value from the URL path on emission populate
-            this field; callers constructing payloads directly pass it through.
-        message: Human-readable summary of task state
-        context_id: Session/conversation identifier
-        domain: AdCP domain this task belongs to
-        idempotency_key: Sender-generated key stable across retries of the same
-            event. Defaults to a freshly-generated UUID v4 — callers retrying
-            delivery of the same event MUST pass the key from their first
-            attempt; passing None twice mints two keys and defeats dedup.
+        task_id: Unique identifier for the task.
+        status: Current task status.
+        task_type: Type of AdCP async operation (see :class:`TaskType`).
+        result: Task-specific payload — any Pydantic model or plain dict.
+            Plain dicts are validated against
+            :class:`AdcpAsyncResponseData`'s discriminated union.
+        timestamp: When the webhook was generated. Defaults to current UTC.
+        operation_id: Client-generated identifier the buyer embedded in
+            the webhook URL when registering push-notification config.
+            Publishers MUST echo this back so buyers correlate
+            notifications without parsing URL paths.
+        message: Human-readable summary of task state.
+        context_id: Session/conversation identifier.
+        domain: AdCP domain this task belongs to.
+        idempotency_key: Sender-generated key stable across retries of the
+            same event. Defaults to a freshly-generated UUID v4 — callers
+            retrying delivery of the same event MUST pass the key from
+            their first attempt; passing None twice mints two keys and
+            defeats dedup.
+        token: Buyer-supplied token from ``push_notification_config.token``,
+            echoed back per spec for authenticity validation.
 
     Returns:
-        Dictionary matching McpWebhookPayload schema, ready to be sent as JSON
+        :class:`McpWebhookPayload` instance. Use :func:`to_wire_dict` (or
+        ``payload.model_dump(mode="json", exclude_none=True)``) to get the
+        JSON-ready dict for HTTP transport.
 
     Examples:
         Create a completed webhook with results:
-        >>> from adcp.webhooks import create_mcp_webhook_payload
+        >>> from adcp.webhooks import create_mcp_webhook_payload, to_wire_dict
         >>> from adcp.types import GeneratedTaskStatus
         >>>
         >>> payload = create_mcp_webhook_payload(
         ...     task_id="task_123",
-        ...     task_type="get_products",
         ...     status=GeneratedTaskStatus.completed,
-        ...     result={"products": [...]},
-        ...     message="Found 5 products"
+        ...     task_type="create_media_buy",
+        ...     result={"media_buy_id": "mb_1", "buyer_ref": "ref_1"},
+        ...     message="Created campaign"
         ... )
+        >>> wire = to_wire_dict(payload)
 
         Create a failed webhook with error:
         >>> payload = create_mcp_webhook_payload(
         ...     task_id="task_456",
-        ...     task_type="create_media_buy",
         ...     status=GeneratedTaskStatus.failed,
+        ...     task_type="create_media_buy",
         ...     result={"errors": [{"code": "INVALID_INPUT", "message": "..."}]},
         ...     message="Validation failed"
         ... )
@@ -150,8 +165,8 @@ def create_mcp_webhook_payload(
         Create a working status update:
         >>> payload = create_mcp_webhook_payload(
         ...     task_id="task_789",
-        ...     task_type="sync_creatives",
         ...     status=GeneratedTaskStatus.working,
+        ...     task_type="sync_creatives",
         ...     message="Processing 3 of 10 creatives"
         ... )
     """
@@ -160,48 +175,42 @@ def create_mcp_webhook_payload(
     if idempotency_key is None:
         idempotency_key = generate_webhook_idempotency_key()
 
-    # Convert status enum to string value
     status_value = status.value if hasattr(status, "value") else str(status)
 
-    # Build payload matching McpWebhookPayload schema
-    payload: dict[str, Any] = {
-        "idempotency_key": idempotency_key,
-        "task_id": task_id,
-        "task_type": task_type,
-        "status": status_value,
-        "timestamp": timestamp.isoformat() if isinstance(timestamp, datetime) else timestamp,
-    }
+    # Foreign BaseModel subclasses (anything outside AdcpAsyncResponseData)
+    # don't match the discriminated-union variants by identity — dump to a
+    # dict so the union picks by shape, matching the dict path.
+    result_value: PydanticBaseModel | dict[str, Any] | None
+    if isinstance(result, PydanticBaseModel):
+        result_value = result.model_dump(mode="json")
+    else:
+        result_value = result
 
-    # Add optional fields only if provided
-    if result is not None:
-        # Convert Pydantic model to dict if needed for JSON serialization
-        if hasattr(result, "model_dump"):
-            payload["result"] = result.model_dump(mode="json")
-        else:
-            payload["result"] = result
-
-    if operation_id is not None:
-        payload["operation_id"] = operation_id
-
-    if message is not None:
-        payload["message"] = message
-
-    if context_id is not None:
-        payload["context_id"] = context_id
-
+    # `domain` and `token` aren't in the schema but are accepted via
+    # `extra='allow'`; they round-trip through `model_dump`.
+    extras: dict[str, Any] = {}
     if domain is not None:
-        payload["domain"] = domain
-
+        extras["domain"] = domain
     if token is not None:
         # Buyer-supplied token from push_notification_config.token,
         # echoed back per push-notification-config.json spec text:
         # "Echoed back in webhook payload to validate request authenticity."
-        # Cross-language wire-parity with the JS implementation
-        # (``buildTaskWebhookPayload`` in ``from-platform.ts``) — buyers
-        # validating against the spec read body.token, not headers.
-        payload["token"] = token
+        extras["token"] = token
 
-    return payload
+    return McpWebhookPayload.model_validate(
+        {
+            "idempotency_key": idempotency_key,
+            "task_id": task_id,
+            "task_type": task_type,
+            "status": status_value,
+            "timestamp": timestamp,
+            "operation_id": operation_id,
+            "message": message,
+            "context_id": context_id,
+            "result": result_value,
+            **extras,
+        }
+    )
 
 
 def get_adcp_signed_headers_for_webhook(
@@ -245,9 +254,9 @@ def get_adcp_signed_headers_for_webhook(
         >>>
         >>> payload = create_mcp_webhook_payload(
         ...     task_id="task_123",
-        ...     task_type="get_products",
         ...     status="completed",
-        ...     result={"products": [...]}
+        ...     task_type="create_media_buy",
+        ...     result={"media_buy_id": "mb_1"},
         ... )
         >>> headers = {"Content-Type": "application/json"}
         >>> signed_headers = get_adcp_signed_headers_for_webhook(

--- a/tests/conformance/signing/test_webhook_e2e_fastapi.py
+++ b/tests/conformance/signing/test_webhook_e2e_fastapi.py
@@ -32,6 +32,7 @@ from adcp.webhooks import (
     create_mcp_webhook_payload,
     sign_legacy_webhook,
     sign_webhook,
+    to_wire_dict,
 )
 
 VECTORS_DIR = Path(__file__).parent.parent / "vectors" / "request-signing"
@@ -115,7 +116,7 @@ async def test_signed_webhook_verifies_end_to_end() -> None:
         idempotency_key="whk_e2e_firstaaaaaaaaaaaaaa",
         result={"media_buy_id": "mb_1"},
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload)).encode("utf-8")
     headers = _sign_and_send_body(body)
 
     transport = httpx.ASGITransport(app=app)
@@ -142,7 +143,7 @@ async def test_duplicate_retry_dedupes_over_real_http() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_e2e_dupeaaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload)).encode("utf-8")
     headers = _sign_and_send_body(body)
 
     transport = httpx.ASGITransport(app=app)
@@ -195,7 +196,7 @@ async def test_tampered_body_rejected_over_http() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_e2e_tamperaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload)).encode("utf-8")
     headers = _sign_and_send_body(body)
     tampered = body.replace(b"completed", b"failedAAA")
 
@@ -231,7 +232,7 @@ async def test_httpx_json_kwarg_breaks_signature_by_reserialization() -> None:
         "timestamp": "2026-04-19T00:00:00Z",
     }
     # Sign against our serialization
-    body = json.dumps(payload).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload)).encode("utf-8")
     headers = _sign_and_send_body(body)
 
     transport = httpx.ASGITransport(app=app)

--- a/tests/conformance/signing/test_webhook_receiver.py
+++ b/tests/conformance/signing/test_webhook_receiver.py
@@ -26,6 +26,7 @@ from adcp.webhooks import (
     create_mcp_webhook_payload,
     get_adcp_signed_headers_for_webhook,
     sign_webhook,
+    to_wire_dict,
 )
 
 VECTORS_DIR = Path(__file__).parent.parent / "vectors" / "request-signing"
@@ -79,7 +80,7 @@ async def test_happy_path_9421() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_aaaaaaaaaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver()
@@ -101,7 +102,7 @@ async def test_duplicate_detected() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_dupeaaaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -145,7 +146,7 @@ async def test_tampered_body_rejected() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_tamperaaaaaaaaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -183,7 +184,7 @@ async def test_legacy_hmac_fallback_when_9421_absent() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_hmaclegacyaaaaaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -215,7 +216,7 @@ async def test_from_shared_secret_shortcut() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_sharedshortcutaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -306,7 +307,7 @@ async def test_accepts_content_type_with_charset() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_charsetaaaaaaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     # Sign with plain content-type (what sign_webhook emits) then mutate the
     # header on the wire to include a charset parameter. The 9421 signature
     # covers content-type; this test asserts the receiver's content-type
@@ -339,7 +340,7 @@ async def test_rejects_malformed_idempotency_key() -> None:
         "status": "completed",
         "timestamp": "2026-04-19T00:00:00Z",
     }
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
     receiver = _build_receiver()
 
@@ -362,7 +363,7 @@ async def test_only_signature_input_header_falls_through_to_hmac_when_configured
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_onlyfallbackaaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -418,7 +419,7 @@ async def test_hmac_fallback_accepts_invalid_9421_when_opted_in() -> None:
         status="completed",  # type: ignore[arg-type]
         idempotency_key="whk_optinfallbackaaaaaaa",
     )
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     get_adcp_signed_headers_for_webhook(
         headers=headers, secret=secret, timestamp=ts, payload=payload
@@ -457,7 +458,7 @@ async def test_receives_revocation_notification() -> None:
         "reason": "Rights revoked",
         "effective_at": "2026-04-19T00:00:00Z",
     }
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="revocation_notification")
@@ -476,7 +477,7 @@ async def test_receives_artifact_webhook() -> None:
         "timestamp": "2026-04-19T00:00:00Z",
         "artifacts": [],
     }
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="artifact")
@@ -494,7 +495,7 @@ async def test_receives_collection_list_changed() -> None:
         "resolved_at": "2026-04-19T00:00:00Z",
         "signature": "sig",
     }
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="collection_list_changed")
@@ -512,7 +513,7 @@ async def test_receives_property_list_changed() -> None:
         "resolved_at": "2026-04-19T00:00:00Z",
         "signature": "sig",
     }
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     headers = _sign_webhook(body)
 
     receiver = _build_receiver(kind="property_list_changed")

--- a/tests/test_webhook_handling.py
+++ b/tests/test_webhook_handling.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pytest
 from a2a.types import TaskState, TaskStatusUpdateEvent
 from google.protobuf.json_format import MessageToDict as _MessageToDict
-
 from pydantic import BaseModel
 
 from adcp.client import ADCPClient
@@ -1213,24 +1212,32 @@ class TestWebhookPayloadBuilderPydanticModel:
     """
 
     def test_create_mcp_payload_accepts_pydantic_model(self):
+        from adcp.webhooks import to_wire_dict
+
         model = _DeliveryResponse(media_buy_id="mb_1", buyer_ref="ref_1")
         payload = create_mcp_webhook_payload(
             task_id="task_1",
-            task_type="media_buy_delivery",
+            task_type="create_media_buy",
             status=GeneratedTaskStatus.completed,
             result=model,
         )
-        assert payload["result"] == {"media_buy_id": "mb_1", "buyer_ref": "ref_1", "packages": []}
+        assert to_wire_dict(payload)["result"] == {
+            "media_buy_id": "mb_1",
+            "buyer_ref": "ref_1",
+            "packages": [],
+        }
 
     def test_create_mcp_payload_pydantic_model_serialized_as_json(self):
+        from adcp.webhooks import to_wire_dict
+
         model = _DeliveryResponse(media_buy_id="mb_2", buyer_ref="ref_2", packages=["pkg_a"])
         payload = create_mcp_webhook_payload(
             task_id="task_2",
-            task_type="media_buy_delivery",
+            task_type="create_media_buy",
             status=GeneratedTaskStatus.completed,
             result=model,
         )
-        result = payload["result"]
+        result = to_wire_dict(payload)["result"]
         assert isinstance(result, dict)
         assert result["packages"] == ["pkg_a"]
 

--- a/tests/test_webhook_supervisor.py
+++ b/tests/test_webhook_supervisor.py
@@ -250,6 +250,7 @@ async def test_supervisor_retries_on_5xx_then_succeeds() -> None:
     result = await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
     )
     assert result is not None and result.ok
@@ -279,6 +280,7 @@ async def test_supervisor_returns_last_failure_after_max_attempts() -> None:
     result = await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
     )
     assert result is not None
@@ -303,6 +305,7 @@ async def test_supervisor_records_exception_and_reraises_on_final_attempt() -> N
         await sup.send_mcp(
             url="https://buyer.example.com/wh",
             task_id="t1",
+            task_type="create_media_buy",
             status="completed",
         )
     assert sender.send_mcp.await_count == 3
@@ -335,6 +338,7 @@ async def test_supervisor_skips_delivery_when_circuit_open() -> None:
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
     )
     sink.calls.clear()
@@ -342,6 +346,7 @@ async def test_supervisor_skips_delivery_when_circuit_open() -> None:
     result = await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t2",
+        task_type="create_media_buy",
         status="completed",
     )
     assert result is None
@@ -374,9 +379,13 @@ async def test_supervisor_isolates_breakers_per_endpoint() -> None:
     )
 
     # Endpoint A fails enough to open its breaker (3 attempts ≥ 2).
-    await sup.send_mcp(url="https://A/wh", task_id="t1", status="completed")
+    await sup.send_mcp(
+        url="https://A/wh", task_id="t1", status="completed", task_type="create_media_buy"
+    )
     # Endpoint B should be unaffected — succeeds on first attempt.
-    result = await sup.send_mcp(url="https://B/wh", task_id="t2", status="completed")
+    result = await sup.send_mcp(
+        url="https://B/wh", task_id="t2", status="completed", task_type="create_media_buy"
+    )
     assert result is not None and result.ok
 
 
@@ -401,12 +410,14 @@ async def test_supervisor_records_sequence_number_when_key_supplied() -> None:
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
         sequence_key="media_buy:abc",
     )
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t2",
+        task_type="create_media_buy",
         status="completed",
         sequence_key="media_buy:abc",
     )
@@ -427,6 +438,7 @@ async def test_supervisor_swallows_sink_exceptions(caplog: pytest.LogCaptureFixt
     result = await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
     )
     assert result is not None and result.ok
@@ -582,6 +594,7 @@ async def test_supervisor_breaker_key_isolates_tenants_on_shared_url() -> None:
     await sup.send_mcp(
         url="https://shared/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
         breaker_key="tenant_a:https://shared/wh",
     )
@@ -593,6 +606,7 @@ async def test_supervisor_breaker_key_isolates_tenants_on_shared_url() -> None:
     result = await sup.send_mcp(
         url="https://shared/wh",
         task_id="t2",
+        task_type="create_media_buy",
         status="completed",
         breaker_key="tenant_b:https://shared/wh",
     )
@@ -613,9 +627,13 @@ async def test_supervisor_breaker_key_defaults_to_url() -> None:
         circuit=CircuitBreakerPolicy(failure_threshold=2, open_timeout_seconds=60),
     )
 
-    await sup.send_mcp(url="https://shared/wh", task_id="t1", status="completed")
+    await sup.send_mcp(
+        url="https://shared/wh", task_id="t1", status="completed", task_type="create_media_buy"
+    )
     # Same URL → same breaker → second delivery is circuit_open.
-    result = await sup.send_mcp(url="https://shared/wh", task_id="t2", status="completed")
+    result = await sup.send_mcp(
+        url="https://shared/wh", task_id="t2", status="completed", task_type="create_media_buy"
+    )
     assert result is None
 
 
@@ -639,6 +657,7 @@ async def test_supervisor_does_not_burn_sequence_on_circuit_open() -> None:
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
         sequence_key="media_buy:abc:https://buyer.example.com/wh",
     )
@@ -646,6 +665,7 @@ async def test_supervisor_does_not_burn_sequence_on_circuit_open() -> None:
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t2",
+        task_type="create_media_buy",
         status="completed",
         sequence_key="media_buy:abc:https://buyer.example.com/wh",
     )
@@ -690,6 +710,7 @@ async def test_supervisor_bounds_slow_sink_with_timeout() -> None:
     result = await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
     )
     elapsed = _time.monotonic() - started
@@ -716,6 +737,7 @@ async def test_supervisor_records_notification_type_passthrough() -> None:
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
         notification_type="scheduled",
     )
@@ -744,6 +766,7 @@ async def test_supervisor_response_time_uses_monotonic_clock() -> None:
     await sup.send_mcp(
         url="https://buyer.example.com/wh",
         task_id="t1",
+        task_type="create_media_buy",
         status="completed",
     )
     assert sink.calls[0].response_time_ms >= 10  # at least 10ms (we slept 20)

--- a/tests/test_webhook_supervisor_pg.py
+++ b/tests/test_webhook_supervisor_pg.py
@@ -256,7 +256,12 @@ class TestSendMcp:
         sup = _make_supervisor(pool, _make_sender())
         sup._worker_started = True  # suppress the warning
 
-        result = await sup.send_mcp(url="https://b.example/wh", task_id="t1", status="completed")
+        result = await sup.send_mcp(
+            url="https://b.example/wh",
+            task_id="t1",
+            status="completed",
+            task_type="create_media_buy",
+        )
         assert result is None
 
     @pytest.mark.asyncio
@@ -271,7 +276,12 @@ class TestSendMcp:
         import logging
 
         with caplog.at_level(logging.WARNING, logger="adcp.webhook_supervisor_pg"):
-            await sup.send_mcp(url="https://b.example/wh", task_id="t1", status="completed")
+            await sup.send_mcp(
+                url="https://b.example/wh",
+                task_id="t1",
+                status="completed",
+                task_type="create_media_buy",
+            )
 
         assert any("run_worker" in r.message for r in caplog.records)
 
@@ -287,8 +297,8 @@ class TestSendMcp:
         pool = _make_pool(conn_c1, conn_e1, conn_c2, conn_e2)
         sup = _make_supervisor(pool, _make_sender())
         with caplog.at_level(logging.WARNING, logger="adcp.webhook_supervisor_pg"):
-            await sup.send_mcp(url="u", task_id="t", status="s")
-            await sup.send_mcp(url="u", task_id="t", status="s")
+            await sup.send_mcp(url="u", task_id="t", status="s", task_type="create_media_buy")
+            await sup.send_mcp(url="u", task_id="t", status="s", task_type="create_media_buy")
 
         warn_msgs = [r.message for r in caplog.records if "run_worker" in r.message]
         assert len(warn_msgs) == 1
@@ -308,7 +318,12 @@ class TestSendMcp:
         sup = _make_supervisor(pool, _make_sender())
         sup._worker_started = True
 
-        result = await sup.send_mcp(url="https://b.example/wh", task_id="t", status="s")
+        result = await sup.send_mcp(
+            url="https://b.example/wh",
+            task_id="t",
+            status="s",
+            task_type="create_media_buy",
+        )
         assert result is None
         # Should NOT have called enqueue
         enqueue_calls = [
@@ -333,7 +348,12 @@ class TestSendMcp:
         sup = _make_supervisor(pool, _make_sender())
         sup._worker_started = True
 
-        result = await sup.send_mcp(url="https://b.example/wh", task_id="t", status="s")
+        result = await sup.send_mcp(
+            url="https://b.example/wh",
+            task_id="t",
+            status="s",
+            task_type="create_media_buy",
+        )
         assert result is None  # always None from send_mcp
 
         # set_half_open was called
@@ -352,6 +372,7 @@ class TestSendMcp:
         await sup.send_mcp(
             url="https://shared.example/wh",
             task_id="t",
+            task_type="create_media_buy",
             status="s",
             breaker_key="tenant-42:https://shared.example/wh",
         )
@@ -496,9 +517,7 @@ class TestWorkerFailureAndRetry:
         await sup._poll_and_process()
 
         sql_calls = conn.execute.call_args_list
-        reschedule_call = next(
-            (c for c in sql_calls if "status_str = 'retry'" in c.args[0]), None
-        )
+        reschedule_call = next((c for c in sql_calls if "status_str = 'retry'" in c.args[0]), None)
         assert reschedule_call is not None
         # sent_body and idempotency_key are positional params 3 and 4 (0-indexed)
         params = reschedule_call.args[1]

--- a/tests/test_webhooks_deliver.py
+++ b/tests/test_webhooks_deliver.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
@@ -23,6 +24,7 @@ import pytest
 from a2a.types import TaskState  # TaskState is the proto enum; still exported
 
 from adcp.signing import SSRFValidationError
+from adcp.types.generated_poc.core.mcp_webhook_payload import McpWebhookPayload
 from adcp.types.generated_poc.core.push_notification_config import (
     Authentication as PNAuthentication,
 )
@@ -37,6 +39,7 @@ from adcp.types.generated_poc.core.reporting_webhook import (
 from adcp.webhooks import (
     create_mcp_webhook_payload,
     deliver,
+    to_wire_dict,
 )
 from tests.a2a_compat_shim import Artifact, DataPart, Part, Task, TaskStatus
 
@@ -68,7 +71,7 @@ async def _capture_client(
     return httpx.AsyncClient(transport=transport), captured
 
 
-def _mcp_payload() -> dict[str, Any]:
+def _mcp_payload() -> McpWebhookPayload:
     return create_mcp_webhook_payload(
         task_id="task_123",
         task_type="create_media_buy",
@@ -386,12 +389,14 @@ async def test_body_size_cap_enforced() -> None:
         "url": "https://buyer.example/webhooks/mb",
         "authentication": {"schemes": ["Bearer"], "credentials": _BEARER_TOKEN},
     }
-    # One oversized field in the payload — 11MB of 'x'.
-    oversize = _mcp_payload()
-    oversize["result"] = {"blob": "x" * (11 * 1024 * 1024)}
+    # One oversized field in the payload — 11MB of 'x'. deliver() accepts
+    # a Mapping shape directly, so we hand-build the dict; the size cap
+    # lives in the body-bytes path, not the typed builder.
+    oversize_dict = to_wire_dict(_mcp_payload())
+    oversize_dict["result"] = {"blob": "x" * (11 * 1024 * 1024)}
     async with client:
         with pytest.raises(ValueError, match="10,485,760"):
-            await deliver(config, oversize, client=client)
+            await deliver(config, oversize_dict, client=client)
 
 
 async def test_extra_headers_count_cap() -> None:
@@ -438,7 +443,7 @@ async def test_retry_requires_caller_to_not_mutate_payload() -> None:
     async with client:
         await deliver(config, payload, client=client)
         # Caller mutates — retry bytes now differ.
-        payload["timestamp"] = "2026-01-01T00:00:00Z"
+        payload.timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
         await deliver(config, payload, client=client)
 
     assert captured[0].content != captured[1].content
@@ -460,7 +465,7 @@ async def test_signed_bytes_match_posted_bytes() -> None:
 
     # Compact separators — deliver() pins the canonical on-wire form from
     # adcontextprotocol/adcp#2478 so signer and wire bytes can never drift.
-    expected_body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    expected_body = json.dumps(to_wire_dict(payload), separators=(",", ":")).encode("utf-8")
     assert captured[0].content == expected_body
 
 

--- a/tests/test_webhooks_to_wire_dict.py
+++ b/tests/test_webhooks_to_wire_dict.py
@@ -6,9 +6,10 @@ call. The load-bearing properties:
 
 * a2a protobuf round-trips to camelCase keys (``id``, ``contextId``,
   ``artifactId``) so external A2A receivers see the on-wire shape.
-* MCP dicts pass through with the snake_case keys the MCP webhook
-  schema specifies (``task_id``, ``task_type``).
+* MCP payloads dump to snake_case keys per the MCP webhook schema
+  (``task_id``, ``task_type``).
 * Pydantic models dump to JSON-mode dicts so sub-models serialize too.
+* Plain dicts (legacy / hand-built) pass through verbatim.
 * Unsupported types raise ``TypeError`` at the seam — silent fallthrough
   to ``str(payload)`` or similar would mask integration bugs.
 """
@@ -69,7 +70,7 @@ def test_a2a_status_update_event_round_trips_to_camelcase_wire_keys() -> None:
     }
 
 
-def test_mcp_dict_passes_through_with_snake_case_keys() -> None:
+def test_mcp_payload_dumps_to_snake_case_wire_keys() -> None:
     """MCP wire shape is snake_case per mcp-webhook-payload.json."""
     payload = create_mcp_webhook_payload(
         task_id="task_123",
@@ -127,3 +128,38 @@ def test_unsupported_type_raises_type_error() -> None:
     """Silent fallthrough would mask integration bugs — fail loud."""
     with pytest.raises(TypeError, match="Unsupported webhook payload type"):
         to_wire_dict("not a payload")  # type: ignore[arg-type]
+
+
+def test_create_mcp_webhook_payload_returns_typed_instance() -> None:
+    """Builder returns ``McpWebhookPayload`` so adopters get attribute
+    access and IDE autocomplete without ``model_construct(**dict)`` ceremony."""
+    payload = create_mcp_webhook_payload(
+        task_id="task_123",
+        status="completed",
+        task_type="create_media_buy",
+        result={"media_buy_id": "mb_1"},
+        idempotency_key="whk_01HW9D2T3VXQ5M7K9N1P3R5S7U",
+    )
+
+    assert isinstance(payload, McpWebhookPayload)
+    assert payload.task_id == "task_123"
+    assert payload.idempotency_key == "whk_01HW9D2T3VXQ5M7K9N1P3R5S7U"
+    # Wire bytes match the receiver's expectations.
+    assert to_wire_dict(payload)["task_type"] == "create_media_buy"
+
+
+def test_create_mcp_webhook_payload_rejects_invalid_task_type() -> None:
+    """``task_type`` is restricted to the closed :class:`TaskType` enum.
+    Synchronous-only operations (``get_products``, ``list_creatives``)
+    are not tracked async tasks and have no business in a webhook
+    payload — fail at construction so the publisher catches the bug
+    before the receiver does."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="task_type"):
+        create_mcp_webhook_payload(
+            task_id="task_123",
+            status="completed",
+            task_type="get_products",
+            idempotency_key="whk_01HW9D2T3VXQ5M7K9N1P3R5S7U",
+        )


### PR DESCRIPTION
Closes #607.

## Summary

- `create_mcp_webhook_payload` returns a typed `McpWebhookPayload` instance instead of `dict[str, Any]`. Adopters drop the `McpWebhookPayload.model_construct(**dict)` ceremony and get attribute access + IDE autocomplete directly.
- `task_type` becomes a required `TaskType | str` argument, validated against the closed `TaskType` enum (the spec's complete set of async/tracked operations) at construction. Synchronous-only operations (`get_products`, `list_creatives`, etc.) are deliberately not in the enum and shouldn't appear in webhook payloads — failing fast at the publisher surfaces this here rather than as silent receiver rejection.
- `WebhookSender.send_mcp` and `WebhookDeliverySupervisor.send_mcp` propagate the same required `task_type`. The PG supervisor coerces the `TaskType` enum to its on-wire string before binding to psycopg, preventing `repr()` corruption of the `adcp_webhook_delivery_queue.task_type` column.

## Migration

| Old | New |
|---|---|
| `payload["task_id"]` | `payload.task_id` |
| `json=payload` (HTTP) | `json=to_wire_dict(payload)` |
| `create_mcp_webhook_payload(...)` without `task_type` | required arg |

## Reviewer findings addressed

- **Blocker (code-reviewer):** `webhook_supervisor_pg.py` had `task_type: str | None = None` diverging from the Protocol; psycopg would have written `"TaskType.create_media_buy"` (enum repr) to the queue. Mirrored the in-memory normalization at the boundary.
- **Must-fix (code-reviewer):** `webhooks.py` docstring example for `get_adcp_signed_headers_for_webhook` used `task_type="get_products"` which now raises. Updated.
- **Indentation nit (code-reviewer):** broken multi-line indent in two `test_webhook_supervisor_pg.py` callsites.

## Follow-ups (not blocking)

Surfaced by ad-tech-protocol-expert review:

1. The schema's `protocol` field exists on `McpWebhookPayload` but the builder doesn't surface it — file a separate issue to expose it as a builder kwarg.
2. `domain` (the builder accepts it; spec doesn't) may be a naming-drift duplicate of `protocol`. Confirm with adopters and pick one.
3. `token` is spec-grounded (echoed per `push-notification-config.json`) but stored via `extra='allow'` rather than as a typed field — file an upstream spec issue to promote it.
4. Cross-SDK parity check: confirm `buildTaskWebhookPayload` in `adcontextprotocol/adcp-node` enforces the same `TaskType` closure.

## Test plan

- [x] `pytest tests/ --ignore=tests/integration` — 4203 passed
- [x] `mypy src/adcp/` — no issues
- [x] `ruff check` on changed files — all checks passed
- [x] black formatting via pre-commit
- [x] New regression: `test_create_mcp_webhook_payload_returns_typed_instance` and `test_create_mcp_webhook_payload_rejects_invalid_task_type` in `tests/test_webhooks_to_wire_dict.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)