### PR TITLE
fix(types): make account optional in CreateMediaBuyRequest and SyncCreativesRequest

### DIFF
--- a/schemas/cache/bundled/creative/sync-creatives-request.json
+++ b/schemas/cache/bundled/creative/sync-creatives-request.json
@@ -4916,7 +4916,6 @@
   },
   "required": [
     "idempotency_key",
-    "account",
     "creatives"
   ],
   "additionalProperties": true,

--- a/schemas/cache/bundled/media-buy/create-media-buy-request.json
+++ b/schemas/cache/bundled/media-buy/create-media-buy-request.json
@@ -7445,7 +7445,6 @@
   },
   "required": [
     "idempotency_key",
-    "account",
     "brand",
     "start_time",
     "end_time"

--- a/schemas/cache/creative/sync-creatives-request.json
+++ b/schemas/cache/creative/sync-creatives-request.json
@@ -108,7 +108,6 @@
   },
   "required": [
     "idempotency_key",
-    "account",
     "creatives"
   ],
   "additionalProperties": true,

--- a/schemas/cache/media-buy/create-media-buy-request.json
+++ b/schemas/cache/media-buy/create-media-buy-request.json
@@ -206,7 +206,6 @@
   },
   "required": [
     "idempotency_key",
-    "account",
     "brand",
     "start_time",
     "end_time"

--- a/src/adcp/types/generated_poc/creative/sync_creatives_request.py
+++ b/src/adcp/types/generated_poc/creative/sync_creatives_request.py
@@ -53,8 +53,11 @@ class SyncCreativesRequest(AdCPBaseModel):
         ),
     ] = None
     account: Annotated[
-        account_ref.AccountReference, Field(description='Account that owns these creatives.')
-    ]
+        account_ref.AccountReference | None,
+        Field(
+            description='Account that owns these creatives. May be omitted when the seller uses implicit or derived resolution mode — account identity is then resolved from the verified auth chain.'
+        ),
+    ] = None
     creatives: Annotated[
         list[creative_asset.CreativeAsset],
         Field(

--- a/src/adcp/types/generated_poc/media_buy/create_media_buy_request.py
+++ b/src/adcp/types/generated_poc/media_buy/create_media_buy_request.py
@@ -152,11 +152,11 @@ class CreateMediaBuyRequest(AdCPBaseModel):
         ),
     ] = None
     account: Annotated[
-        account_ref.AccountReference,
+        account_ref.AccountReference | None,
         Field(
-            description='Account to bill for this media buy. Pass a natural key (brand, operator, optional sandbox) or a seller-assigned account_id from list_accounts.'
+            description='Account to bill for this media buy. Pass a natural key (brand, operator, optional sandbox) or a seller-assigned account_id from list_accounts. May be omitted when the seller uses implicit or derived resolution mode — account identity is then resolved from the verified auth chain.'
         ),
-    ]
+    ] = None
     proposal_id: Annotated[
         str | None,
         Field(

--- a/tests/test_issue_623_implicit_account_optional.py
+++ b/tests/test_issue_623_implicit_account_optional.py
@@ -1,0 +1,174 @@
+"""Regression tests for issue #623.
+
+The typed dispatcher was rejecting valid requests on ``create_media_buy``
+and ``sync_creatives`` when the buyer omitted ``account``. Per the AdCP
+3.0.6+ spec, ``account`` is optional when the seller uses implicit or
+derived resolution mode — account identity is resolved from the verified
+auth chain instead.
+
+Root cause: the generated Pydantic models for those two request types had
+``account`` as a required field (no default). This file ensures they stay
+optional and that the end-to-end wire path accepts requests without
+``account`` when the platform uses ``SingletonAccounts`` (derived mode).
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    InMemoryTaskRegistry,
+    SingletonAccounts,
+)
+from adcp.decisioning.handler import PlatformHandler
+from adcp.server.mcp_tools import create_tool_caller
+from adcp.types import CreateMediaBuyRequest, SyncCreativesRequest
+
+# ---------------------------------------------------------------------------
+# Model-level: account is optional (Pydantic validation)
+# ---------------------------------------------------------------------------
+
+
+def test_create_media_buy_request_accepts_missing_account() -> None:
+    """``CreateMediaBuyRequest`` must not raise when ``account`` is absent."""
+    # Use model_construct to bypass other required-field checks — this test
+    # is specifically about account optionality, not the full request shape.
+    req = CreateMediaBuyRequest.model_construct(
+        idempotency_key="test-idem-key-abcdef01234",
+    )
+    assert req.account is None
+
+
+def test_sync_creatives_request_accepts_missing_account() -> None:
+    """``SyncCreativesRequest`` must not raise when ``account`` is absent."""
+    from adcp.types.generated_poc.core.creative_asset import CreativeAsset
+
+    req = SyncCreativesRequest.model_construct(
+        idempotency_key="test-idem-key-abcdef01234",
+        creatives=[
+            CreativeAsset.model_construct(
+                creative_id="cr_1",
+                name="test",
+                format_id="banner_300x250",
+            )
+        ],
+    )
+    assert req.account is None
+
+
+def test_create_media_buy_account_field_not_required() -> None:
+    """``model_fields['account'].is_required()`` must be False after patching."""
+    fi = CreateMediaBuyRequest.model_fields["account"]
+    assert not fi.is_required(), (
+        "CreateMediaBuyRequest.account must not be required — "
+        "implicit/derived adopters omit it and resolve from auth chain"
+    )
+
+
+def test_sync_creatives_account_field_not_required() -> None:
+    """``model_fields['account'].is_required()`` must be False after patching."""
+    fi = SyncCreativesRequest.model_fields["account"]
+    assert not fi.is_required(), (
+        "SyncCreativesRequest.account must not be required — "
+        "implicit/derived adopters omit it and resolve from auth chain"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wire path: SingletonAccounts (derived mode) + no account on wire
+# ---------------------------------------------------------------------------
+
+
+class _DerivedModePlatform(DecisioningPlatform):
+    """Minimal platform using ``SingletonAccounts`` (resolution='derived')."""
+
+    capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+    accounts = SingletonAccounts(account_id="derived-acc")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[tuple[str, object]] = []
+
+    def get_products(self, req, ctx):
+        self.calls.append(("get_products", req))
+        return {"products": []}
+
+    def create_media_buy(self, req, ctx):
+        self.calls.append(("create_media_buy", req))
+        return {"media_buy_id": "mb_1", "status": "active"}
+
+    def update_media_buy(self, media_buy_id, patch, ctx):
+        self.calls.append(("update_media_buy", (media_buy_id, patch)))
+        return {"media_buy_id": media_buy_id, "status": "active"}
+
+    def sync_creatives(self, req, ctx):
+        self.calls.append(("sync_creatives", req))
+        return {"creatives": []}
+
+    def get_media_buy_delivery(self, req, ctx):
+        self.calls.append(("get_media_buy_delivery", req))
+        return {"media_buy_deliveries": []}
+
+
+@pytest.fixture
+def executor():
+    pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-623-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_wire_dispatch_without_account(executor) -> None:
+    """Wire dispatch for ``create_media_buy`` must succeed when ``account``
+    is absent and the platform uses derived (SingletonAccounts) resolution."""
+    platform = _DerivedModePlatform()
+    handler = PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    caller = create_tool_caller(handler, "create_media_buy")
+    wire_payload = {
+        "idempotency_key": "test-idem-key-abcdef01234",
+        "brand": {"domain": "example.com"},
+        "start_time": "asap",
+        "end_time": "2030-12-31T00:00:00+00:00",
+        # No 'account' field — valid for implicit/derived adopters
+    }
+    result = await caller(wire_payload)
+    assert platform.calls and platform.calls[0][0] == "create_media_buy"
+    assert "media_buy_id" in result
+
+
+@pytest.mark.asyncio
+async def test_sync_creatives_wire_dispatch_without_account(executor) -> None:
+    """Wire dispatch for ``sync_creatives`` must succeed when ``account``
+    is absent and the platform uses derived (SingletonAccounts) resolution."""
+    platform = _DerivedModePlatform()
+    handler = PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    caller = create_tool_caller(handler, "sync_creatives")
+    wire_payload = {
+        "idempotency_key": "test-idem-key-abcdef01234",
+        "creatives": [
+            {
+                "creative_id": "cr_1",
+                "name": "banner ad",
+                "format_id": {
+                    "agent_url": "https://formats.example.com",
+                    "id": "banner_300x250",
+                },
+                "assets": {},
+            }
+        ],
+        # No 'account' field — valid for implicit/derived adopters
+    }
+    await caller(wire_payload)
+    assert platform.calls and platform.calls[0][0] == "sync_creatives"

--- a/tests/test_issue_623_implicit_account_optional.py
+++ b/tests/test_issue_623_implicit_account_optional.py
@@ -21,6 +21,7 @@ import pytest
 from adcp.decisioning import (
     DecisioningCapabilities,
     DecisioningPlatform,
+    ExplicitAccounts,
     InMemoryTaskRegistry,
     SingletonAccounts,
 )
@@ -34,28 +35,39 @@ from adcp.types import CreateMediaBuyRequest, SyncCreativesRequest
 
 
 def test_create_media_buy_request_accepts_missing_account() -> None:
-    """``CreateMediaBuyRequest`` must not raise when ``account`` is absent."""
-    # Use model_construct to bypass other required-field checks — this test
-    # is specifically about account optionality, not the full request shape.
-    req = CreateMediaBuyRequest.model_construct(
-        idempotency_key="test-idem-key-abcdef01234",
+    """``CreateMediaBuyRequest.model_validate`` must not raise when ``account``
+    is absent from the wire payload — this is the actual failure mode from #623."""
+    req = CreateMediaBuyRequest.model_validate(
+        {
+            "idempotency_key": "test-idem-key-abcdef01234",
+            "brand": {"domain": "example.com"},
+            "start_time": "asap",
+            "end_time": "2030-12-31T00:00:00+00:00",
+            # No 'account' key — valid for implicit/derived adopters
+        }
     )
     assert req.account is None
 
 
 def test_sync_creatives_request_accepts_missing_account() -> None:
-    """``SyncCreativesRequest`` must not raise when ``account`` is absent."""
-    from adcp.types.generated_poc.core.creative_asset import CreativeAsset
-
-    req = SyncCreativesRequest.model_construct(
-        idempotency_key="test-idem-key-abcdef01234",
-        creatives=[
-            CreativeAsset.model_construct(
-                creative_id="cr_1",
-                name="test",
-                format_id="banner_300x250",
-            )
-        ],
+    """``SyncCreativesRequest.model_validate`` must not raise when ``account``
+    is absent from the wire payload — this is the actual failure mode from #623."""
+    req = SyncCreativesRequest.model_validate(
+        {
+            "idempotency_key": "test-idem-key-abcdef01234",
+            "creatives": [
+                {
+                    "creative_id": "cr_1",
+                    "name": "banner ad",
+                    "format_id": {
+                        "agent_url": "https://formats.example.com",
+                        "id": "banner_300x250",
+                    },
+                    "assets": {},
+                }
+            ],
+            # No 'account' key — valid for implicit/derived adopters
+        }
     )
     assert req.account is None
 
@@ -172,3 +184,59 @@ async def test_sync_creatives_wire_dispatch_without_account(executor) -> None:
     }
     await caller(wire_payload)
     assert platform.calls and platform.calls[0][0] == "sync_creatives"
+
+
+# ---------------------------------------------------------------------------
+# ExplicitAccounts: fail-closed when account omitted on wire
+# ---------------------------------------------------------------------------
+
+
+class _ExplicitModePlatform(DecisioningPlatform):
+    """Platform using ``ExplicitAccounts`` (resolution='explicit')."""
+
+    capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+    accounts = ExplicitAccounts(loader=lambda account_id: None)  # type: ignore[arg-type]
+
+    def get_products(self, req, ctx):
+        return {"products": []}
+
+    def create_media_buy(self, req, ctx):
+        return {"media_buy_id": "mb_1", "status": "active"}
+
+    def update_media_buy(self, media_buy_id, patch, ctx):
+        return {"media_buy_id": media_buy_id, "status": "active"}
+
+    def sync_creatives(self, req, ctx):
+        return {"creatives": []}
+
+    def get_media_buy_delivery(self, req, ctx):
+        return {"media_buy_deliveries": []}
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_explicit_mode_rejects_missing_account(executor) -> None:
+    """Wire dispatch for ``create_media_buy`` must surface ``ACCOUNT_NOT_FOUND``
+    (not a 500) when ``account`` is omitted against an ``ExplicitAccounts``
+    platform — preserves fail-closed behavior for explicit-mode adopters."""
+    from adcp.decisioning.types import AdcpError
+
+    platform = _ExplicitModePlatform()
+    handler = PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    caller = create_tool_caller(handler, "create_media_buy")
+    wire_payload = {
+        "idempotency_key": "test-idem-key-abcdef01234",
+        "brand": {"domain": "example.com"},
+        "start_time": "asap",
+        "end_time": "2030-12-31T00:00:00+00:00",
+        # No 'account' — explicit-mode sellers must reject this
+    }
+    with pytest.raises(AdcpError) as exc_info:
+        await caller(wire_payload)
+    assert exc_info.value.code == "ACCOUNT_NOT_FOUND", (
+        f"Expected ACCOUNT_NOT_FOUND for missing account in explicit mode, "
+        f"got {exc_info.value.code}"
+    )

--- a/tests/test_mcp_schema_drift.py
+++ b/tests/test_mcp_schema_drift.py
@@ -137,10 +137,15 @@ def test_spot_check_real_fields_reach_clients() -> None:
     create_media_buy = tool_schemas["create_media_buy"]
     for field in ("account", "brand", "start_time", "end_time", "packages"):
         assert field in create_media_buy["properties"], f"create_media_buy missing field {field!r}"
-    for req in ("account", "brand", "start_time", "end_time", "idempotency_key"):
+    # account is intentionally optional: sellers in implicit/derived resolution mode
+    # derive identity from the auth chain rather than the wire field (issue #623).
+    for req in ("brand", "start_time", "end_time", "idempotency_key"):
         assert req in create_media_buy.get(
             "required", []
         ), f"create_media_buy should require {req!r}"
+    assert "account" not in create_media_buy.get("required", []), (
+        "create_media_buy.account must not be required — implicit/derived adopters omit it"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #623

## Summary

The typed dispatcher was rejecting valid `create_media_buy` and `sync_creatives` requests when the buyer omitted `account`. Per AdCP 3.0.6+, `account` is optional when the seller uses implicit or derived resolution mode — account identity is resolved from the verified auth chain instead of the wire field.

Root cause: `CreateMediaBuyRequest.account` and `SyncCreativesRequest.account` were defined as required Pydantic fields (no default). Pydantic rejected the request with `INVALID_REQUEST` before the handler could call `AccountStore.resolve`, which already accepts `ref=None` and correctly derives account identity for implicit/derived mode.

Changes:
- `src/adcp/types/generated_poc/media_buy/create_media_buy_request.py`: `account: AccountReference` → `account: AccountReference | None = None`
- `src/adcp/types/generated_poc/creative/sync_creatives_request.py`: same
- `schemas/cache/{media-buy,creative}/` + `bundled/` variants: removed `account` from `required[]` so `generate_types.py` regen reproduces the optional field on next stable-tag run
- `tests/test_issue_623_implicit_account_optional.py`: 7 regression tests (model-level + wire dispatch for derived mode + explicit-mode fail-closed)
- `tests/test_mcp_schema_drift.py`: updated spot-check to assert `account` is NOT in `create_media_buy.required`

`GetProductsRequest.account` was already `AccountReference | None = None` — this change aligns the other two request types with that existing pattern.

`ExplicitAccounts.resolve` still raises `ACCOUNT_NOT_FOUND` when `ref=None`, preserving fail-closed behavior for explicit-mode adopters without any handler changes.

## What was tested

- `ruff check src/` — clean
- `mypy` on changed files — no new errors (pre-existing import-not-found for httpx/a2a stubs unrelated)
- `pytest tests/test_issue_623_implicit_account_optional.py` — 7/7 passed
- `pytest tests/test_mcp_schema_drift.py` — 19/19 passed
- `pytest tests/ --ignore=tests/conformance/signing/` — 3773 passed, 24 skipped, 1 xfailed (pre-existing TLS network test unrelated to this change)

## Pre-PR review

- code-reviewer: approved after 2-round review — both blockers fixed (schema cache `required[]` + model_construct→model_validate tests); no new blockers
- ad-tech-protocol-expert: sound — change aligns with `GetProductsRequest` precedent; `AccountStore.resolve(ref=None)` contract already correct for implicit/derived; `ExplicitAccounts` fail-closed path preserved

**Nits surfaced (not fixed):**
- `lambda account_id: None` in `_ExplicitModePlatform` fixture could be `lambda _: None`
- Local `from adcp.decisioning.types import AdcpError` import inside test function could move to module-level imports
- `test_mcp_schema_drift.py` spot-check has no parallel `sync_creatives` assertion (covered by model-level test instead)
- `idempotency_key` description still reads "unique per (seller, request) pair" — with implicit mode the scope is actually `(store_qualname, account.id)` where `account.id` is synthesized by the store (pre-existing description, out of this PR's scope)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01JX6bQ9FK2YxLefGnUSkg6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX6bQ9FK2YxLefGnUSkg6x)_