### PR TITLE
feat(server): TenantRegistry.as_platform() adapter for serve() integration

### DIFF
--- a/src/adcp/decisioning/platform_router.py
+++ b/src/adcp/decisioning/platform_router.py
@@ -1112,11 +1112,11 @@ class _RegistryPlatformAdapter(DecisioningPlatform):
                 recovery="transient",
                 details={"tenant_id": tenant_id, "health": health},
             )
-        # This guard only fires for the explicit get_products method — synthesized
-        # delegates are built from _all_specialism_methods() which already reflects
-        # the known protocol surface, so they always find their method on a
-        # well-formed DecisioningPlatform. The guard here catches cases where the
-        # child platform doesn't implement get_products at all.
+        # Guard catches tenants whose resolved platform doesn't implement the
+        # requested specialism method (e.g. a tenant registered as a
+        # SignalsPlatform-only seller being asked for get_products). It fires
+        # for any method_name dispatched via _make_delegate, not just
+        # get_products.
         method = getattr(resolution.platform, method_name, None)
         if method is None or not callable(method):
             raise AdcpError(

--- a/src/adcp/decisioning/platform_router.py
+++ b/src/adcp/decisioning/platform_router.py
@@ -1034,4 +1034,161 @@ def _select_proposal_method(
     return "refine_products"
 
 
+class _RegistryPlatformAdapter(DecisioningPlatform):
+    """DecisioningPlatform adapter backed by a :class:`TenantRegistry`.
+
+    Returned by :meth:`TenantRegistry.as_platform`. Not part of the
+    public API — the return type annotation on that method is the
+    :class:`DecisioningPlatform` base class.
+
+    Per-request dispatch:
+
+    1. Extract ``ctx.tenant_id`` (set by the transport layer from the
+       ``Host`` header or URL path in multi-tenant deployments).
+    2. Await :meth:`~TenantRegistry.resolve_by_id` — triggers lazy
+       platform construction on first hit for
+       :meth:`~TenantRegistry.register_lazy` tenants.
+    3. Gate on health: raise ``SERVICE_UNAVAILABLE`` for states not
+       in ``serve_states`` (default: ``pending`` and ``disabled``
+       are blocked; ``healthy`` and ``unverified`` serve).
+    4. Forward the method call to the resolved platform, honouring
+       async/sync detection the same way as :class:`PlatformRouter`.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry: Any,  # TenantRegistry at runtime; Any avoids circular import
+        accounts: Any,
+        capabilities: DecisioningCapabilities,
+        serve_states: frozenset[Any],
+    ) -> None:
+        self.accounts = accounts
+        self.capabilities = capabilities
+        self._registry = registry
+        self._serve_states = frozenset(serve_states)
+
+        for method_name in sorted(_all_specialism_methods()):
+            if method_name in _ACCOUNT_STORE_METHODS:
+                continue
+            if method_name == "get_products":
+                continue
+            self.__dict__[method_name] = self._make_delegate(method_name)
+
+    async def _resolve_tenant_platform(
+        self, ctx: RequestContext[Any], method_name: str
+    ) -> DecisioningPlatform:
+        """Resolve tenant, gate on health, return the child platform."""
+        tenant_id = ctx.tenant_id
+        if not tenant_id:
+            raise AdcpError(
+                "ACCOUNT_NOT_FOUND",
+                message=(
+                    "RegistryPlatformAdapter: ctx.tenant_id is unset. The transport "
+                    "layer must populate tenant_id (typically from the Host header) "
+                    "before dispatch. Check your SubdomainTenantMiddleware or "
+                    "context_factory wiring."
+                ),
+                recovery="terminal",
+                field="ctx.tenant_id",
+            )
+        resolution = await self._registry.resolve_by_id(tenant_id)
+        # Intentional topology hiding: unregistered tenants produce
+        # SERVICE_UNAVAILABLE rather than ACCOUNT_NOT_FOUND, matching the
+        # behaviour when a tenant is known but health-gated. From the buyer's
+        # perspective, "doesn't exist" and "temporarily unavailable" are
+        # indistinguishable — this avoids leaking which tenant_ids are
+        # enrolled with this seller. (Contrast: PlatformRouter raises
+        # ACCOUNT_NOT_FOUND for unknown tenants because its platform list is
+        # a closed static set, not a dynamic registry.)
+        if resolution is None or resolution.health not in self._serve_states:
+            health = resolution.health if resolution is not None else None
+            raise AdcpError(
+                "SERVICE_UNAVAILABLE",
+                message=(
+                    f"RegistryPlatformAdapter: tenant {tenant_id!r} is not available "
+                    f"(health={health!r}). Allowed states: {sorted(self._serve_states)}."
+                ),
+                recovery="transient",
+                details={"tenant_id": tenant_id, "health": health},
+            )
+        # This guard only fires for the explicit get_products method — synthesized
+        # delegates are built from _all_specialism_methods() which already reflects
+        # the known protocol surface, so they always find their method on a
+        # well-formed DecisioningPlatform. The guard here catches cases where the
+        # child platform doesn't implement get_products at all.
+        method = getattr(resolution.platform, method_name, None)
+        if method is None or not callable(method):
+            raise AdcpError(
+                "UNSUPPORTED_FEATURE",
+                message=(
+                    f"RegistryPlatformAdapter: tenant {tenant_id!r}'s platform "
+                    f"({type(resolution.platform).__name__!r}) does not implement "
+                    f"{method_name!r}."
+                ),
+                recovery="terminal",
+            )
+        return resolution.platform  # type: ignore[no-any-return]
+
+    def _make_delegate(self, method_name: str) -> Any:
+        adapter = self
+
+        async def _delegate(*args: Any, **kwargs: Any) -> Any:
+            ctx = _resolve_ctx_from_args(args, kwargs)
+            platform = await adapter._resolve_tenant_platform(ctx, method_name)
+            method = getattr(platform, method_name)
+            if inspect.iscoroutinefunction(method):
+                return await method(*args, **kwargs)
+            return await asyncio.to_thread(method, *args, **kwargs)
+
+        _delegate.__name__ = method_name
+        _delegate.__qualname__ = f"_RegistryPlatformAdapter.{method_name}"
+        return _delegate
+
+    async def refine_get_products(self, *args: Any, **kwargs: Any) -> Any:
+        """Refine entry point — delegates to get_products.
+
+        Mirrors :meth:`PlatformRouter.refine_get_products` so the
+        handler's refine dispatch path works correctly.
+        """
+        return await self.get_products(*args, **kwargs)
+
+    async def get_products(self, *args: Any, **kwargs: Any) -> Any:
+        """Per-tenant get_products dispatch.
+
+        Explicit override (not synthesized) to mirror PlatformRouter's
+        pattern — keeps the refine_get_products / get_products chain
+        intact without proposal_manager support (which the registry
+        adapter doesn't need).
+        """
+        ctx = _resolve_ctx_from_args(args, kwargs)
+        platform = await self._resolve_tenant_platform(ctx, "get_products")
+        method = getattr(platform, "get_products")
+        if inspect.iscoroutinefunction(method):
+            return await method(*args, **kwargs)
+        return await asyncio.to_thread(method, *args, **kwargs)
+
+
+def _make_registry_platform_adapter(
+    registry: Any,
+    *,
+    accounts: Any,
+    capabilities: DecisioningCapabilities,
+    serve_states: frozenset[Any],
+) -> DecisioningPlatform:
+    """Factory for :meth:`TenantRegistry.as_platform`.
+
+    Accepts the registry as ``Any`` to avoid a circular import at module
+    load time — :mod:`adcp.server.tenant_registry` calls this function
+    lazily from inside :meth:`TenantRegistry.as_platform`, not at import
+    time, so no circular dependency arises.
+    """
+    return _RegistryPlatformAdapter(
+        registry=registry,
+        accounts=accounts,
+        capabilities=capabilities,
+        serve_states=serve_states,
+    )
+
+
 __all__ = ["LazyPlatformRouter", "PlatformRouter"]

--- a/src/adcp/server/tenant_registry.py
+++ b/src/adcp/server/tenant_registry.py
@@ -38,12 +38,18 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-    from adcp.decisioning.platform import DecisioningPlatform
+    from adcp.decisioning.accounts import AccountStore
+    from adcp.decisioning.platform import DecisioningCapabilities, DecisioningPlatform
 
 logger = logging.getLogger(__name__)
 
 #: Per-tenant health state. See :class:`TenantRegistry` for semantics.
 TenantHealthState = Literal["pending", "healthy", "unverified", "disabled"]
+
+#: Default health states that the :meth:`TenantRegistry.as_platform` adapter
+#: will serve. ``healthy`` and ``unverified`` allow traffic; ``pending`` and
+#: ``disabled`` raise ``SERVICE_UNAVAILABLE``.
+_DEFAULT_SERVE_STATES: frozenset[TenantHealthState] = frozenset({"healthy", "unverified"})
 
 #: Validator callable. Takes ``(tenant_id, agent_url)`` and returns
 #: ``True`` when the tenant is valid, ``False`` otherwise.
@@ -126,7 +132,29 @@ class TenantRegistry:
     :param default_serve_options: Optional dict of defaults to store for
         adopter convenience. Retrieve via :attr:`serve_options`.
 
-    Example (eager boot-time registration)::
+    Example (using :meth:`as_platform` — recommended path for
+    :func:`~adcp.decisioning.serve` integration)::
+
+        from adcp.server import TenantRegistry
+        from adcp.decisioning import serve
+
+        registry = TenantRegistry(validator=check_jwks)
+
+        for tenant in load_tenants_from_db():
+            # await_first_validation=True pre-warms tenants at boot so the
+            # first request doesn't see health='pending'.
+            await registry.register_lazy(
+                tenant.id,
+                agent_url=tenant.agent_url,
+                factory=build_platform_for_tenant,
+                await_first_validation=True,
+            )
+
+        # Returns a DecisioningPlatform that routes per-request via
+        # ctx.tenant_id (set from the Host header by SubdomainTenantMiddleware).
+        serve(registry.as_platform(accounts=my_account_store), port=8080)
+
+    Example (escape-hatch — manual resolve() when you need custom dispatch)::
 
         from adcp.server import TenantRegistry
 
@@ -141,24 +169,9 @@ class TenantRegistry:
             )
 
         async def resolve(ctx):
-            resolved = await registry.resolve(ctx.host)
-            if resolved is None or resolved.health in ("pending", "disabled"):
-                raise HTTPException(503)
-            return resolved.platform
-
-    Example (lazy registration — defers platform construction to first request)::
-
-        registry = TenantRegistry(validator=check_jwks)
-
-        for tenant in load_tenants_from_db():
-            await registry.register_lazy(
-                tenant.id,
-                agent_url=tenant.agent_url,
-                factory=build_platform_for_tenant,  # called on first resolve()
-            )
-
-        async def resolve(ctx):
-            resolved = await registry.resolve(ctx.host)  # triggers factory on first hit
+            # Use resolve_by_id when tenant_id is already known (e.g. from
+            # ctx.tenant_id); use resolve(host) for host-based lookup.
+            resolved = await registry.resolve_by_id(ctx.tenant_id)
             if resolved is None or resolved.health in ("pending", "disabled"):
                 raise HTTPException(503)
             return resolved.platform
@@ -621,6 +634,203 @@ class TenantRegistry:
                 self._health[tenant_id] = "disabled"
                 self._factories.pop(tenant_id, None)
                 return None
+
+    async def resolve_by_id(self, tenant_id: str) -> TenantResolution | None:
+        """Async lookup by ``tenant_id``; builds lazy platforms on first hit.
+
+        Equivalent to :meth:`resolve` but accepts a ``tenant_id`` string
+        directly instead of a ``Host`` header value. Used by the
+        :meth:`as_platform` adapter to resolve per-request platforms keyed
+        on ``ctx.tenant_id`` (set by the transport layer from the Host
+        header) rather than re-doing the host → tenant_id lookup.
+
+        For eager tenants this is a synchronous in-memory lookup wrapped in
+        a coroutine — no I/O occurs. For lazy tenants (registered via
+        :meth:`register_lazy`) the factory is invoked on the first call and
+        the result is cached, with concurrent first-hit calls serialised on
+        the per-tenant lock.
+
+        Returns ``None`` when the tenant is not registered or when a lazy
+        tenant's factory or validator fails.
+
+        Returns a :class:`TenantResolution` — which may have any health
+        state — when the platform is available. **Always check
+        ``result.health`` before serving.**
+
+        :param tenant_id: Stable tenant identifier as registered via
+            :meth:`register` or :meth:`register_lazy`.
+        """
+        if tenant_id not in self._health:
+            return None
+
+        # Fast path: platform already built (eager or previously resolved lazy).
+        platform = self._platforms.get(tenant_id)
+        if platform is not None:
+            health = self._health.get(tenant_id, "pending")
+            return TenantResolution(tenant_id=tenant_id, health=health, platform=platform)
+
+        # No factory either — lazy tenant that disabled or cleared itself.
+        if tenant_id not in self._factories:
+            return None
+
+        # Lazy path: mirrors resolve()'s concurrent first-hit serialisation,
+        # skipping the host_map lookup since we already have the tenant_id.
+        lock = self._get_lock(tenant_id)
+        async with lock:
+            platform = self._platforms.get(tenant_id)
+            if platform is not None:
+                health = self._health.get(tenant_id, "pending")
+                return TenantResolution(
+                    tenant_id=tenant_id, health=health, platform=platform
+                )
+
+            if tenant_id not in self._health:
+                return None
+
+            factory = self._factories.get(tenant_id)
+            if factory is None:
+                return None
+
+            try:
+                platform = await factory(tenant_id)
+            except Exception:
+                logger.warning(
+                    "TenantRegistry.resolve_by_id: factory raised for tenant %r; "
+                    "health=disabled",
+                    tenant_id,
+                    exc_info=True,
+                )
+                if tenant_id in self._health:
+                    self._health[tenant_id] = "disabled"
+                    self._factories.pop(tenant_id, None)
+                return None
+
+            try:
+                ok = await self._run_validator(tenant_id)
+            except Exception:
+                logger.warning(
+                    "TenantRegistry.resolve_by_id: validator raised for tenant %r; "
+                    "health=disabled",
+                    tenant_id,
+                    exc_info=True,
+                )
+                if tenant_id in self._health:
+                    self._health[tenant_id] = "disabled"
+                    self._factories.pop(tenant_id, None)
+                return None
+
+            if tenant_id not in self._health:
+                return None
+
+            if ok:
+                self._platforms[tenant_id] = platform
+                self._health[tenant_id] = "healthy"
+                self._factories.pop(tenant_id, None)
+                return TenantResolution(
+                    tenant_id=tenant_id, health="healthy", platform=platform
+                )
+            else:
+                self._health[tenant_id] = "disabled"
+                self._factories.pop(tenant_id, None)
+                return None
+
+    def as_platform(
+        self,
+        *,
+        accounts: AccountStore[Any],
+        capabilities: DecisioningCapabilities | None = None,
+        serve_states: frozenset[TenantHealthState] = _DEFAULT_SERVE_STATES,
+    ) -> DecisioningPlatform:
+        """Return a :class:`~adcp.decisioning.DecisioningPlatform` backed by this registry.
+
+        The returned platform resolves the per-request tenant via
+        ``ctx.tenant_id`` (populated by the transport layer from the
+        ``Host`` header or URL path), applies health gating, and forwards
+        every specialism method call to the resolved tenant's platform.
+        Pass it directly to :func:`adcp.decisioning.serve`::
+
+            registry = TenantRegistry(validator=check_jwks)
+            for tenant in load_tenants():
+                await registry.register_lazy(
+                    tenant.id, agent_url=tenant.url, factory=build_platform
+                )
+
+            serve(registry.as_platform(accounts=my_account_store), port=8080)
+
+        **Tenant resolution.** The adapter reads ``ctx.tenant_id``, which
+        the transport layer sets from the ``Host`` header (via
+        :class:`~adcp.server.SubdomainTenantMiddleware`) or your custom
+        ``context_factory``. **This value must equal the ``tenant_id``
+        string you passed as the first argument to** :meth:`register` **/**
+        :meth:`register_lazy`. The host itself (e.g. ``"acme.example.com"``)
+        is NOT used — only the registry key (e.g. ``"acme"``).
+
+        If you use :class:`~adcp.server.SubdomainTenantMiddleware`, wire
+        ``tenant_id`` in your ``context_factory`` like this::
+
+            from adcp.server import current_tenant
+
+            def context_factory(request):
+                t = current_tenant()
+                return {"tenant_id": t.id if t else None}
+
+        The ``Tenant.id`` value (from your
+        :class:`~adcp.server.SubdomainTenantRouter`) must match the key
+        you registered — ``register_lazy("acme", ...)`` requires
+        ``Tenant(id="acme", ...)``, not ``Tenant(id="acme.example.com", ...)``.
+        A mismatch silently produces ``SERVICE_UNAVAILABLE`` with
+        ``health=None`` on every request.
+
+        **Health gating.** By default the adapter serves ``healthy`` and
+        ``unverified`` tenants, and raises ``SERVICE_UNAVAILABLE`` for
+        ``pending`` and ``disabled`` tenants. Override via
+        ``serve_states`` for fail-closed behaviour::
+
+            # Serve only fully-validated tenants (fail-closed):
+            registry.as_platform(
+                accounts=store,
+                serve_states=frozenset({"healthy"}),
+            )
+
+        **``accounts`` parameter.** :func:`~adcp.decisioning.serve` validates
+        ``platform.accounts`` at boot time before any request arrives. Pass
+        the same tenant-aware :class:`~adcp.decisioning.AccountStore` you
+        would pass to :class:`~adcp.decisioning.PlatformRouter` — typically
+        one that reads ``tenant_id`` from the resolved account's metadata or
+        from the transport-layer ``current_tenant`` ContextVar.
+
+        **``capabilities`` parameter.** Should be the union of all tenants'
+        specialisms. The adapter cannot introspect child platforms at
+        boot time, so the adopter is the source of truth. Defaults to an
+        empty :class:`~adcp.decisioning.DecisioningCapabilities` (no
+        specialisms advertised) — pass the full union for accurate
+        ``tools/list`` projection.
+
+        :param accounts: The :class:`~adcp.decisioning.AccountStore` for the
+            returned platform. Required by framework boot-time validation.
+        :param capabilities: Capability declaration for the adapter. Defaults
+            to an empty :class:`~adcp.decisioning.DecisioningCapabilities`.
+        :param serve_states: Health states for which requests proceed.
+            Default is ``frozenset({"healthy", "unverified"})``.
+        :returns: A :class:`~adcp.decisioning.DecisioningPlatform` suitable
+            for passing to :func:`adcp.decisioning.serve`.
+        """
+        from adcp.decisioning.platform import DecisioningCapabilities as _DecisioningCapabilities
+        from adcp.decisioning.platform_router import _make_registry_platform_adapter
+
+        if capabilities is None:
+            logger.warning(
+                "TenantRegistry.as_platform: no capabilities= passed; tools/list will "
+                "advertise no tools. Pass capabilities=DecisioningCapabilities(specialisms=[...]) "
+                "for accurate tools/list projection."
+            )
+        cap = capabilities if capabilities is not None else _DecisioningCapabilities()
+        return _make_registry_platform_adapter(
+            self,
+            accounts=accounts,
+            capabilities=cap,
+            serve_states=frozenset(serve_states),
+        )
 
     @property
     def serve_options(self) -> dict[str, Any]:

--- a/tests/test_tenant_registry.py
+++ b/tests/test_tenant_registry.py
@@ -758,3 +758,370 @@ async def test_unregister_lazy_tenant_removes_factory() -> None:
 
     assert registry.health("acme") is None
     assert await registry.resolve("acme.example.com") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_by_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_eager_pending() -> None:
+    """resolve_by_id returns pending resolution for a newly registered tenant."""
+    registry = TenantRegistry(validator=None)
+    platform = _mock_platform()
+    await registry.register("acme", agent_url="https://acme.example.com", platform=platform)
+
+    result = await registry.resolve_by_id("acme")
+    assert result is not None
+    assert result.tenant_id == "acme"
+    assert result.health == "pending"
+    assert result.platform is platform
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_eager_healthy() -> None:
+    """resolve_by_id returns healthy resolution after await_first_validation."""
+    registry = TenantRegistry(validator=None)
+    platform = _mock_platform()
+    await registry.register(
+        "acme", agent_url="https://acme.example.com", platform=platform,
+        await_first_validation=True,
+    )
+
+    result = await registry.resolve_by_id("acme")
+    assert result is not None
+    assert result.health == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_unknown_returns_none() -> None:
+    """resolve_by_id returns None for an unknown tenant_id."""
+    registry = TenantRegistry()
+    assert await registry.resolve_by_id("no-such-tenant") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_unregistered_returns_none() -> None:
+    """resolve_by_id returns None after unregister."""
+    registry = TenantRegistry(validator=None)
+    await registry.register("acme", agent_url="https://acme.example.com",
+                            platform=_mock_platform(), await_first_validation=True)
+    registry.unregister("acme")
+    assert await registry.resolve_by_id("acme") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_lazy_triggers_factory() -> None:
+    """resolve_by_id triggers lazy factory on first call."""
+    call_count = 0
+    platform = _mock_platform()
+
+    async def factory(tid: str) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return platform
+
+    registry = TenantRegistry(validator=None)
+    await registry.register_lazy("acme", agent_url="https://acme.example.com", factory=factory)
+
+    result = await registry.resolve_by_id("acme")
+    assert call_count == 1
+    assert result is not None
+    assert result.health == "healthy"
+    assert result.platform is platform
+
+    # Second call: factory NOT invoked again.
+    result2 = await registry.resolve_by_id("acme")
+    assert call_count == 1
+    assert result2 is not None
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_lazy_factory_failure_disables() -> None:
+    """resolve_by_id sets health=disabled when factory raises."""
+    async def bad_factory(tid: str) -> Any:
+        raise RuntimeError("boom")
+
+    registry = TenantRegistry()
+    await registry.register_lazy("acme", agent_url="https://acme.example.com",
+                                  factory=bad_factory)
+
+    result = await registry.resolve_by_id("acme")
+    assert result is None
+    assert registry.health("acme") == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_concurrent_serialises() -> None:
+    """Concurrent resolve_by_id calls for same lazy tenant invoke factory once."""
+    call_count = 0
+    platform = _mock_platform()
+
+    async def slow_factory(tid: str) -> Any:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.05)
+        return platform
+
+    registry = TenantRegistry(validator=None)
+    await registry.register_lazy("acme", agent_url="https://acme.example.com",
+                                  factory=slow_factory)
+
+    results = await asyncio.gather(
+        registry.resolve_by_id("acme"),
+        registry.resolve_by_id("acme"),
+        registry.resolve_by_id("acme"),
+    )
+    assert call_count == 1
+    assert all(r is not None for r in results)
+
+
+# ---------------------------------------------------------------------------
+# as_platform
+# ---------------------------------------------------------------------------
+
+
+def _minimal_account_store() -> Any:
+    """Return a minimal mock AccountStore (resolve + is_durable marker)."""
+    store = MagicMock()
+    store.resolve = MagicMock(return_value=MagicMock(id="acme"))
+    return store
+
+
+@pytest.mark.asyncio
+async def test_as_platform_returns_decisioning_platform() -> None:
+    """as_platform() returns a DecisioningPlatform subclass."""
+    from adcp.decisioning.platform import DecisioningPlatform
+
+    registry = TenantRegistry(validator=None)
+    platform = registry.as_platform(accounts=_minimal_account_store())
+    assert isinstance(platform, DecisioningPlatform)
+
+
+@pytest.mark.asyncio
+async def test_as_platform_healthy_tenant_dispatches_method() -> None:
+    """as_platform adapter dispatches a method to the resolved tenant platform."""
+    from adcp.decisioning.context import RequestContext
+
+    inner_platform = MagicMock()
+    inner_platform.get_products = MagicMock(return_value={"products": []})
+
+    registry = TenantRegistry(validator=None)
+    await registry.register(
+        "acme", agent_url="https://acme.example.com",
+        platform=inner_platform, await_first_validation=True,
+    )
+
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+    result = await adapter.get_products(MagicMock(), ctx)
+    assert result == {"products": []}
+    inner_platform.get_products.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_as_platform_pending_tenant_raises_service_unavailable() -> None:
+    """as_platform raises SERVICE_UNAVAILABLE for pending tenants (default)."""
+    from adcp.decisioning.context import RequestContext
+    from adcp.decisioning.types import AdcpError
+
+    inner_platform = MagicMock()
+    registry = TenantRegistry(validator=None)
+    await registry.register(
+        "acme", agent_url="https://acme.example.com",
+        platform=inner_platform,
+        # await_first_validation=False → health stays 'pending'
+    )
+
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+
+    with pytest.raises(AdcpError) as exc_info:
+        await adapter.get_products(MagicMock(), ctx)
+    assert exc_info.value.code == "SERVICE_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_as_platform_disabled_tenant_raises_service_unavailable() -> None:
+    """as_platform raises SERVICE_UNAVAILABLE for disabled tenants."""
+    from adcp.decisioning.context import RequestContext
+    from adcp.decisioning.types import AdcpError
+
+    registry = TenantRegistry(validator=lambda tid, url: False)
+    await registry.register(
+        "acme", agent_url="https://acme.example.com",
+        platform=MagicMock(), await_first_validation=True,
+    )
+    assert registry.health("acme") == "disabled"
+
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+
+    with pytest.raises(AdcpError) as exc_info:
+        await adapter.get_products(MagicMock(), ctx)
+    assert exc_info.value.code == "SERVICE_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_as_platform_unverified_tenant_serves_by_default() -> None:
+    """as_platform serves 'unverified' tenants (default serve_states)."""
+    from adcp.decisioning.context import RequestContext
+
+    inner_platform = MagicMock()
+    inner_platform.get_products = MagicMock(return_value={"products": []})
+
+    # Start healthy, then recheck fails → unverified.
+    call_count = 0
+
+    def flaky_validator(tid: str, url: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count == 1  # first call True, subsequent False
+
+    registry = TenantRegistry(validator=flaky_validator)
+    await registry.register(
+        "acme", agent_url="https://acme.example.com",
+        platform=inner_platform, await_first_validation=True,
+    )
+    assert registry.health("acme") == "healthy"
+    await registry.recheck("acme")  # second validator call → False → unverified
+    assert registry.health("acme") == "unverified"
+
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+
+    result = await adapter.get_products(MagicMock(), ctx)
+    assert result == {"products": []}
+
+
+@pytest.mark.asyncio
+async def test_as_platform_custom_serve_states_fail_closed() -> None:
+    """as_platform with serve_states={'healthy'} blocks unverified tenants."""
+    from adcp.decisioning.context import RequestContext
+    from adcp.decisioning.types import AdcpError
+
+    call_count = 0
+
+    def flaky_validator(tid: str, url: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count == 1
+
+    inner_platform = MagicMock()
+    registry = TenantRegistry(validator=flaky_validator)
+    await registry.register(
+        "acme", agent_url="https://acme.example.com",
+        platform=inner_platform, await_first_validation=True,
+    )
+    await registry.recheck("acme")
+    assert registry.health("acme") == "unverified"
+
+    adapter = registry.as_platform(
+        accounts=_minimal_account_store(),
+        serve_states=frozenset({"healthy"}),
+    )
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+
+    with pytest.raises(AdcpError) as exc_info:
+        await adapter.get_products(MagicMock(), ctx)
+    assert exc_info.value.code == "SERVICE_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_as_platform_unknown_tenant_raises_service_unavailable() -> None:
+    """as_platform raises SERVICE_UNAVAILABLE for an unknown ctx.tenant_id.
+
+    Unknown tenants produce SERVICE_UNAVAILABLE (not ACCOUNT_NOT_FOUND) to
+    avoid leaking registry topology — buyers can't distinguish "tenant doesn't
+    exist" from "tenant is temporarily unhealthy".
+    """
+    from adcp.decisioning.context import RequestContext
+    from adcp.decisioning.types import AdcpError
+
+    registry = TenantRegistry(validator=None)
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+
+    ctx = RequestContext()
+    ctx.tenant_id = "no-such-tenant"  # type: ignore[assignment]
+
+    with pytest.raises(AdcpError) as exc_info:
+        await adapter.get_products(MagicMock(), ctx)
+    assert exc_info.value.code == "SERVICE_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_as_platform_missing_tenant_id_raises_account_not_found() -> None:
+    """as_platform raises ACCOUNT_NOT_FOUND when ctx.tenant_id is unset."""
+    from adcp.decisioning.context import RequestContext
+    from adcp.decisioning.types import AdcpError
+
+    registry = TenantRegistry(validator=None)
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+
+    ctx = RequestContext()
+    # tenant_id is None by default on RequestContext
+
+    with pytest.raises(AdcpError) as exc_info:
+        await adapter.get_products(MagicMock(), ctx)
+    assert exc_info.value.code == "ACCOUNT_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_as_platform_lazy_tenant_dispatches_on_first_request() -> None:
+    """as_platform triggers lazy factory on first request."""
+    from adcp.decisioning.context import RequestContext
+
+    inner_platform = MagicMock()
+    inner_platform.get_products = MagicMock(return_value={"products": ["p1"]})
+    call_count = 0
+
+    async def factory(tid: str) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return inner_platform
+
+    registry = TenantRegistry(validator=None)
+    await registry.register_lazy("acme", agent_url="https://acme.example.com",
+                                  factory=factory)
+
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+
+    result = await adapter.get_products(MagicMock(), ctx)
+    assert call_count == 1
+    assert result == {"products": ["p1"]}
+
+    # Second request: factory not called again.
+    await adapter.get_products(MagicMock(), ctx)
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_as_platform_synthesized_method_dispatches() -> None:
+    """as_platform synthesises delegates for non-get_products specialism methods."""
+    from adcp.decisioning.context import RequestContext
+
+    inner_platform = MagicMock()
+    inner_platform.create_media_buy = MagicMock(return_value={"media_buy_id": "mb1"})
+
+    registry = TenantRegistry(validator=None)
+    await registry.register(
+        "acme", agent_url="https://acme.example.com",
+        platform=inner_platform, await_first_validation=True,
+    )
+
+    adapter = registry.as_platform(accounts=_minimal_account_store())
+    ctx = RequestContext()
+    ctx.tenant_id = "acme"  # type: ignore[assignment]
+
+    result = await adapter.create_media_buy(MagicMock(), ctx)
+    assert result == {"media_buy_id": "mb1"}
+    inner_platform.create_media_buy.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #645

Three adopter teams independently hit the gap between `TenantRegistry` (introduced in 5.0, #619) and `adcp.decisioning.serve()` — there was no standard way to connect the two without writing a boilerplate `DecisioningPlatform` subclass per deployment. This PR bridges that gap.

### Changes

**`src/adcp/server/tenant_registry.py`**
- Adds `resolve_by_id(tenant_id: str) -> TenantResolution | None` — async lookup by registry key, triggers lazy factory construction the same way `resolve()` does but skips the host-map path
- Adds `as_platform(*, accounts, capabilities, serve_states) -> DecisioningPlatform` — returns a `_RegistryPlatformAdapter` that can be passed directly to `serve()`; lazy-imports from `platform_router` to avoid circular imports
- Adds `_DEFAULT_SERVE_STATES = frozenset({"healthy", "unverified"})` constant
- Updates class docstring: `as_platform()` is the primary example; adds explicit `context_factory` snippet showing how to wire `SubdomainTenantMiddleware` so `ctx.tenant_id` matches the registry key; notes `Tenant.id` must equal the string passed to `register_lazy()`

**`src/adcp/decisioning/platform_router.py`**
- Adds `_RegistryPlatformAdapter(DecisioningPlatform)` — synthesizes delegate methods using the same `_all_specialism_methods()` + `_make_delegate()` pattern as `PlatformRouter`/`LazyPlatformRouter`
- Adds `_make_registry_platform_adapter()` factory (called by `as_platform()`)
- Topology-hiding: unknown or unhealthy tenants raise `SERVICE_UNAVAILABLE`, not `ACCOUNT_NOT_FOUND`, to avoid leaking which tenant IDs are enrolled (deliberate departure from `PlatformRouter`'s static-set rationale, documented in code)
- `get_products`/`refine_get_products` implemented explicitly (same pattern as `PlatformRouter`) rather than synthesised

**`tests/test_tenant_registry.py`**
- 17 new tests covering `resolve_by_id` and `as_platform` paths (58 total)
- Key cases: eager/lazy happy paths, factory failure → disabled health, concurrent serialisation, pending/disabled → `SERVICE_UNAVAILABLE`, unverified serves by default, custom `serve_states` fail-closed, unknown tenant → `SERVICE_UNAVAILABLE` (not `ACCOUNT_NOT_FOUND`), missing `tenant_id` → `ACCOUNT_NOT_FOUND`, synthesised method dispatch

### Before / after

```python
# Before — adopters wrote this for every deployment
class MyRegistryPlatform(DecisioningPlatform):
    def __init__(self, registry, accounts):
        self.accounts = accounts
        self._registry = registry

    async def get_products(self, *args, **kwargs):
        ctx = _resolve_ctx_from_args(args, kwargs)
        resolution = await self._registry.resolve(ctx.request.host)
        if resolution is None or resolution.health != "healthy":
            raise AdcpError("SERVICE_UNAVAILABLE", ...)
        return await resolution.platform.get_products(*args, **kwargs)
    # ... repeated for every specialism method

serve(MyRegistryPlatform(registry, accounts), ...)
```

```python
# After — one line
serve(registry.as_platform(accounts=accounts, capabilities=caps), ...)
```

### Usage note — tenant_id wiring

`as_platform()` reads `ctx.tenant_id` (set from the transport layer, e.g. `Host` header via `SubdomainTenantMiddleware`). That value must equal the string key passed to `register_lazy()`. If using `SubdomainTenantMiddleware`, wire it like this:

```python
from adcp.server import current_tenant

def context_factory(request):
    t = current_tenant()
    return {"tenant_id": t.id if t else None}

serve(registry.as_platform(accounts=accounts, capabilities=caps),
      context_factory=context_factory, ...)
```

### Test results

```
4333 passed, 1 pre-existing failure (unrelated to this change)
```

Ruff and mypy clean on Python 3.10–3.13.

### Pre-PR review sign-offs

**code-reviewer** ✓ approved after fixes:
- Renamed `test_as_platform_unknown_tenant_raises_account_not_found` → `test_as_platform_unknown_tenant_raises_service_unavailable` (name matched wrong error; implementation was already correct)
- Added topology-hiding comment in `_resolve_tenant_platform` documenting the `SERVICE_UNAVAILABLE` vs `ACCOUNT_NOT_FOUND` choice
- Changed `getattr(ctx, "tenant_id", None)` → `ctx.tenant_id` (declared field, defensive form was misleading)

**dx-expert** ✓ approved after fixes:
- Added `context_factory` snippet + `Tenant.id` ↔ registry key mismatch warning to class docstring (silent `SERVICE_UNAVAILABLE` foot-gun)
- Added `logger.warning` when `capabilities=None` to surface misconfiguration early

---

> **Triage-managed PR** — opened automatically by the issue triage routine for issue #645.
> Human review required before merge.
>
> https://claude.ai/code/session_01DboS2SpnZYd9zC87Mk3juT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DboS2SpnZYd9zC87Mk3juT)_