### PR TITLE
feat(testing): forward pre_validation_hooks through build_asgi_app

### DIFF
--- a/src/adcp/testing/decisioning.py
+++ b/src/adcp/testing/decisioning.py
@@ -36,7 +36,7 @@ from adcp.validation.client_hooks import SERVER_DEFAULT_VALIDATION as DEFAULT_VA
 from adcp.validation.client_hooks import ValidationHookConfig
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Mapping, Sequence
+    from collections.abc import AsyncIterator, Callable, Mapping, Sequence
     from datetime import datetime
 
     import httpx
@@ -150,6 +150,7 @@ def build_asgi_app(
     max_request_size: int | None = None,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
     discovery_base_url: str | None = None,
+    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
     **factory_kwargs: Any,
 ) -> Any:
     """Build a Starlette ASGI app for in-process integration tests.
@@ -221,6 +222,13 @@ def build_asgi_app(
         ``/.well-known/adcp-agents.json`` discovery endpoint using this
         as the advertised base URL (e.g. ``"http://test"``). ``None`` →
         discovery endpoint not mounted.
+    :param pre_validation_hooks: Optional dict mapping AdCP tool name to
+        a ``(tool_name, raw_args) -> raw_args`` callable. Forwarded to
+        :func:`create_mcp_server`, identical semantics to
+        :func:`adcp.decisioning.serve`'s ``pre_validation_hooks`` param.
+        Use to install the same coercion hooks your production
+        :func:`serve` call uses so in-process tests see the same
+        validation surface as production. ``None`` → no hooks (default).
     :param factory_kwargs: Forwarded to
         :func:`create_adcp_server_from_platform`. Accepted keys:
         ``executor``, ``registry``, ``webhook_sender``,
@@ -259,6 +267,7 @@ def build_asgi_app(
         streaming_responses=streaming_responses,
         enable_dns_rebinding_protection=enable_dns_rebinding_protection,
         validation=validation,
+        pre_validation_hooks=pre_validation_hooks,
     )
     # Mirror the wrapping chain from _run_mcp_http (adcp.server.serve).
     # auth must be innermost so its JSON-RPC body-peek runs before the
@@ -300,6 +309,7 @@ async def build_test_client(
     max_request_size: int | None = None,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
     discovery_base_url: str | None = None,
+    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
     **factory_kwargs: Any,
 ) -> AsyncIterator[httpx.AsyncClient]:
     """Async context manager yielding an ``httpx.AsyncClient`` wired against
@@ -356,6 +366,9 @@ async def build_test_client(
         When ``None`` (default), the discovery endpoint is not mounted.
         Pass ``base_url`` here if your tests exercise
         ``/.well-known/adcp-agents.json``.
+    :param pre_validation_hooks: Forwarded to :func:`build_asgi_app`.
+        Install the same hooks your production :func:`serve` call uses
+        so in-process tests see the same validation surface.
     :param factory_kwargs: Forwarded to
         :func:`create_adcp_server_from_platform` via :func:`build_asgi_app`
         (executor, registry, webhook_sender, etc.).
@@ -391,6 +404,7 @@ async def build_test_client(
         max_request_size=max_request_size,
         validation=validation,
         discovery_base_url=discovery_base_url,
+        pre_validation_hooks=pre_validation_hooks,
         **factory_kwargs,
     )
     async with LifespanManager(app):

--- a/tests/test_testing_decisioning.py
+++ b/tests/test_testing_decisioning.py
@@ -516,10 +516,8 @@ def test_build_asgi_app_forwards_pre_validation_hooks() -> None:
     from typing import Any
 
     platform = _SalesPlatformWithMethods()
-    hook_calls: list[str] = []
 
     def my_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
-        hook_calls.append(tool_name)
         return {**args, "buying_mode": "brief"}
 
     app = build_asgi_app(

--- a/tests/test_testing_decisioning.py
+++ b/tests/test_testing_decisioning.py
@@ -505,3 +505,42 @@ def test_build_test_client_raises_import_error_without_asgi_lifespan() -> None:
             import asyncio
 
             asyncio.run(build_test_client(platform).__aenter__())
+
+
+# ---- build_asgi_app: pre_validation_hooks ----
+
+
+def test_build_asgi_app_forwards_pre_validation_hooks() -> None:
+    """``pre_validation_hooks=`` is accepted and forwarded to ``create_mcp_server``
+    — construction succeeds and the app is callable."""
+    from typing import Any
+
+    platform = _SalesPlatformWithMethods()
+    hook_calls: list[str] = []
+
+    def my_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        hook_calls.append(tool_name)
+        return {**args, "buying_mode": "brief"}
+
+    app = build_asgi_app(
+        platform,
+        pre_validation_hooks={"get_products": my_hook},
+    )
+    assert callable(app)
+
+
+async def test_build_test_client_forwards_pre_validation_hooks() -> None:
+    """``pre_validation_hooks=`` is forwarded through ``build_test_client``
+    — construction succeeds and the context manager yields a client."""
+    from typing import Any
+
+    platform = _SalesPlatformWithMethods()
+
+    def buying_mode_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {**args, "buying_mode": args.get("buying_mode", "brief")}
+
+    async with build_test_client(
+        platform,
+        pre_validation_hooks={"get_products": buying_mode_hook},
+    ) as client:
+        assert client is not None


### PR DESCRIPTION
Closes #651

## Summary

`build_asgi_app` and `build_test_client` were missing `pre_validation_hooks` from their signatures. Because `create_mcp_server` already accepts this parameter, in-process ASGI tests silently got a different validation surface than production `serve()` calls — pre-v3 buyer payloads that `serve(pre_validation_hooks=...)` would coerce were rejected by `build_asgi_app`-driven tests, causing false-red test failures and false-green production gaps.

This PR adds `pre_validation_hooks: dict[str, Callable[..., Any]] | None = None` to both helpers and forwards it to the existing `create_mcp_server` call. No change to internals — pure forwarding, fully backwards-compatible.

## What was tested

- `pytest tests/test_testing_decisioning.py tests/test_pre_validation_hooks.py` → **41 passed**
- `pytest tests/ -k "not test_real_tls" --ignore=tests/integration` → **4318 passed** (TLS test is a pre-existing network-dependent failure unrelated to this change)
- `ruff check src/adcp/testing/decisioning.py` → all checks passed
- `mypy src/adcp/testing/` → no new errors

## Pre-PR review

- **code-reviewer**: approved — no blockers; 1 nit fixed (dropped dead `hook_calls` variable from smoke test)
- **dx-expert**: approved — no blockers; 1 nit fixed (same)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01H8Trwexkgv1VyFJwDdZMoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8Trwexkgv1VyFJwDdZMoa)_