### PR TITLE
feat(compat): AdapterPair pattern + v2.5 sync_creatives (stage 4)

### DIFF
--- a/src/adcp/compat/__init__.py
+++ b/src/adcp/compat/__init__.py
@@ -1,0 +1,7 @@
+"""AdCP wire-shape compatibility for buyers on older spec versions.
+
+The framework natively validates against the SDK's pinned major (3.x).
+Buyers on pre-3 wire shapes are handled by the per-tool adapter registry
+in :mod:`adcp.compat.legacy` — see that module's docstring for the
+``AdapterPair`` pattern and the JS-SDK parity notes.
+"""

--- a/src/adcp/compat/legacy/__init__.py
+++ b/src/adcp/compat/legacy/__init__.py
@@ -1,0 +1,122 @@
+"""Per-tool adapters for buyers on legacy AdCP wire shapes.
+
+The dispatcher consults :func:`get_legacy_adapter` when the buyer's
+``adcp_version`` / ``adcp_major_version`` resolves into
+:data:`LEGACY_ADAPTER_VERSIONS`. If an adapter is registered for the
+``(version, tool)`` pair, the request is translated to the current
+wire shape before validation + handler dispatch. If no adapter is
+registered for that tool at that version, the dispatcher surfaces
+``INVALID_REQUEST`` — the legacy version doesn't expose the tool.
+
+Architecturally this replaces the heuristic
+:func:`adcp.server.spec_compat.spec_compat_hooks` model. Each adapter
+is hand-written (or, in time, codegen'd from declarative wire-delta
+specs) and tested end-to-end so the translation is auditable rather
+than implicit.
+
+Adapters register themselves at import time via
+:func:`register_adapter`. Importing :mod:`adcp.compat.legacy.v2_5`
+populates the v2.5 registry; see that submodule's docstring for the
+list of supported tools.
+
+Mirrors ``src/lib/adapters/legacy/v2-5/`` in the TypeScript SDK
+(``getV25Adapter`` / ``listV25AdapterTools``).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from adcp.compat.legacy.types import AdapterPair
+
+#: Versions handled via the legacy-adapter path. Distinct from
+#: ``COMPATIBLE_ADCP_VERSIONS`` in :mod:`adcp._version`, which lists the
+#: versions the SDK natively validates against.
+LEGACY_ADAPTER_VERSIONS: Final[tuple[str, ...]] = ("2.5",)
+
+
+_REGISTRY: dict[tuple[str, str], AdapterPair] = {}
+
+
+def register_adapter(version: str, adapter: AdapterPair) -> None:
+    """Register an :class:`AdapterPair` under ``(version, tool_name)``.
+
+    Idempotent — re-registering the same pair (same callables) is a
+    no-op. Re-registering a *different* pair for the same key raises
+    :class:`ValueError`; tests should call :func:`_reset_registry_for_tests`
+    if they need to swap an adapter mid-suite.
+
+    Adapters self-register at module import time; the framework imports
+    :mod:`adcp.compat.legacy.v2_5` lazily on first dispatch so adopters
+    that don't speak legacy don't pay the cost.
+    """
+    if version not in LEGACY_ADAPTER_VERSIONS:
+        raise ValueError(
+            f"register_adapter: version {version!r} is not in "
+            f"LEGACY_ADAPTER_VERSIONS={list(LEGACY_ADAPTER_VERSIONS)}. "
+            "Add the version to the constant first."
+        )
+    key = (version, adapter.tool_name)
+    existing = _REGISTRY.get(key)
+    if existing is not None and existing is not adapter:
+        raise ValueError(
+            f"register_adapter: an adapter is already registered for "
+            f"{key!r} ({existing!r}); refusing to overwrite with "
+            f"{adapter!r}."
+        )
+    _REGISTRY[key] = adapter
+
+
+def get_legacy_adapter(version: str, tool_name: str) -> AdapterPair | None:
+    """Return the adapter for ``(version, tool_name)`` or ``None``.
+
+    ``None`` means "no translation registered for this tool at this
+    version" — the dispatcher converts that into ``INVALID_REQUEST``
+    because the buyer claimed a legacy version this seller doesn't
+    serve the tool on.
+    """
+    _ensure_loaded(version)
+    return _REGISTRY.get((version, tool_name))
+
+
+def list_legacy_adapter_tools(version: str) -> list[str]:
+    """Tools with a registered adapter at this legacy version."""
+    _ensure_loaded(version)
+    return sorted(tool for (v, tool) in _REGISTRY if v == version)
+
+
+def _ensure_loaded(version: str) -> None:
+    """Lazily ensure the per-version adapter package's ``AdapterPair``
+    constants are registered.
+
+    Checks the live registry rather than a one-shot ``_LOADED`` marker
+    so :func:`_reset_registry_for_tests` can wipe state and the next
+    call re-registers from the already-imported modules. Each adapter
+    module exposes ``ADAPTER`` as its registration constant; that's
+    the contract the dispatcher relies on.
+    """
+    if any(v == version for (v, _tool) in _REGISTRY):
+        return
+    if version == "2.5":
+        # Import (or hit module cache) and re-register from each
+        # module's ``ADAPTER`` constant. ``register_adapter`` is
+        # idempotent on the same pair object so this is a no-op when
+        # the registry is already populated.
+        from adcp.compat.legacy.v2_5 import sync_creatives as _sc
+
+        register_adapter("2.5", _sc.ADAPTER)
+
+
+def _reset_registry_for_tests() -> None:
+    """Test-only: drop all registrations. Subsequent lookups re-register
+    from the per-version adapter modules."""
+    _REGISTRY.clear()
+
+
+__all__ = [
+    "AdapterPair",
+    "LEGACY_ADAPTER_VERSIONS",
+    "get_legacy_adapter",
+    "list_legacy_adapter_tools",
+    "register_adapter",
+]

--- a/src/adcp/compat/legacy/types.py
+++ b/src/adcp/compat/legacy/types.py
@@ -1,0 +1,42 @@
+"""``AdapterPair`` — the typed contract for legacy-version translators.
+
+Each tool the framework supports on a legacy wire shape gets its own
+:class:`AdapterPair`. The pair owns two translations:
+
+* :attr:`adapt_request` — takes a payload validated against the legacy
+  schema and returns a dict in the current (SDK-pinned) wire shape. The
+  framework then runs current-schema validation + Pydantic ``model_validate``
+  on the output, so a buggy translator surfaces as ``INVALID_REQUEST``
+  with a field-level pointer.
+* :attr:`normalize_response` — optional reverse direction: takes a
+  current-shape response and rewrites it to the legacy shape the buyer
+  expects to see. ``None`` means "no rewriting needed" (legacy and
+  current shapes agree on the response side).
+
+Mirrors ``src/lib/adapters/legacy/v2-5/types.ts`` in the TypeScript SDK.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AdapterPair:
+    """Translation pair for one tool at one legacy version.
+
+    Adapters live under ``adcp.compat.legacy.{version_key}.{tool_name}``
+    and register themselves via :func:`adcp.compat.legacy.register_adapter`
+    at import time. The dispatcher looks them up by
+    ``(version_key, tool_name)`` once per request.
+
+    Both callables run synchronously — they are pure transformations of
+    in-memory dicts, no I/O. Heavier work (e.g., resolving format
+    references) belongs in handlers, not adapters.
+    """
+
+    tool_name: str
+    adapt_request: Callable[[dict[str, Any]], dict[str, Any]]
+    normalize_response: Callable[[dict[str, Any]], dict[str, Any]] | None = None

--- a/src/adcp/compat/legacy/v2_5/__init__.py
+++ b/src/adcp/compat/legacy/v2_5/__init__.py
@@ -1,0 +1,26 @@
+"""Adapters for buyers on the AdCP 2.5 wire shape.
+
+Each submodule defines an :class:`AdapterPair` for one tool and
+registers it under version ``"2.5"`` via
+:func:`adcp.compat.legacy.register_adapter`. Importing this package
+fires every registration at once.
+
+Current coverage:
+
+* ``sync_creatives`` — wraps bare ``format_id`` strings, infers
+  ``asset_type`` discriminators, demotes mis-typed ``image`` assets
+  to ``url`` when dimensions are missing. The three coercions match
+  the spec text on the v3 ``sync_creatives`` schema's pre-v3
+  compatibility section.
+
+The full v2.5 catalog (``get_products``, ``create_media_buy``,
+``update_media_buy``, ``list_creative_formats``, ``preview_creative``)
+ports incrementally — each tool ships as its own commit so reviewers
+can audit translations one at a time.
+"""
+
+from __future__ import annotations
+
+from adcp.compat.legacy.v2_5 import sync_creatives  # noqa: F401
+
+__all__ = ["sync_creatives"]

--- a/src/adcp/compat/legacy/v2_5/sync_creatives.py
+++ b/src/adcp/compat/legacy/v2_5/sync_creatives.py
@@ -1,0 +1,137 @@
+"""v2.5 → v3 adapter for ``sync_creatives``.
+
+Three wire-shape changes between v2.5 and v3:
+
+1. **``format_id`` shape.** v2.5 buyers sent a bare string
+   (``"display_300x250"``); v3 requires the structured form
+   ``{"agent_url": "...", "id": "display_300x250"}``. We inject the
+   canonical creative-agent URL (the AdCP standard registry) when the
+   value is a string.
+2. **``asset_type`` discriminator.** v3 requires every asset to declare
+   its type explicitly. v2.5 relied on the asset key as the type hint
+   (``{"image": {...}}``) or on field presence (``url`` + dims →
+   image). The adapter infers the discriminator using the same rules
+   the spec documents for backwards compatibility.
+3. **``image`` → ``url`` demotion.** v3's image variant requires
+   ``width`` and ``height``. A v2.5 asset typed as ``image`` but
+   missing dims is semantically a URL reference; demote rather than
+   reject.
+
+Each rule is reversible in principle, but :attr:`AdapterPair.normalize_response`
+is left ``None`` here — the response shape didn't change between v2.5
+and v3 for ``sync_creatives``.
+
+Direct port of ``src/lib/adapters/legacy/v2-5/sync_creatives.ts`` /
+``src/lib/utils/sync-creatives-adapter.ts``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adcp.compat.legacy import register_adapter
+from adcp.compat.legacy.types import AdapterPair
+
+#: Canonical ``agent_url`` injected when wrapping a bare ``format_id``.
+#: Mirrors ``adcp.server.spec_compat.CANONICAL_CREATIVE_AGENT_URL``.
+_CANONICAL_CREATIVE_AGENT_URL = "https://creative.adcontextprotocol.org"
+
+# Asset type discriminators the spec defines. Used by the key-based
+# inference path — only exact key matches resolve to a type. Substring
+# matches (``hero_image``) are intentionally excluded; they're asset
+# IDs, not type hints.
+_KNOWN_ASSET_TYPES: frozenset[str] = frozenset(
+    {
+        "image",
+        "video",
+        "audio",
+        "vast",
+        "text",
+        "url",
+        "html",
+        "javascript",
+        "webhook",
+        "css",
+        "daast",
+        "markdown",
+        "brief",
+        "catalog",
+    }
+)
+
+
+def _infer_asset_type(asset_key: str, asset: dict[str, Any]) -> str | None:
+    """Infer ``asset_type`` from key + field presence. ``None`` if ambiguous."""
+    if asset_key in _KNOWN_ASSET_TYPES:
+        return asset_key
+    if "url" in asset:
+        if "width" in asset and "height" in asset:
+            return "image"
+        return "url"
+    if "content" in asset:
+        return "text"
+    return None
+
+
+def _coerce_asset(asset_key: str, asset: dict[str, Any]) -> dict[str, Any]:
+    """Apply the v2.5 → v3 coercions to a single asset dict."""
+    out = dict(asset)
+    if "asset_type" not in out:
+        inferred = _infer_asset_type(asset_key, out)
+        if inferred is not None:
+            out["asset_type"] = inferred
+
+    # ``image`` without both dims → demote to ``url`` (only when ``url``
+    # is actually present; otherwise the asset is structurally invalid
+    # either way, and current-schema validation reports it).
+    if out.get("asset_type") == "image" and not ("width" in out and "height" in out):
+        if "url" in out:
+            out.pop("width", None)
+            out.pop("height", None)
+            out["asset_type"] = "url"
+    return out
+
+
+def adapt_request(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate a v2.5 ``sync_creatives`` request to v3 shape.
+
+    Returns a new dict — callers can rely on the original being
+    untouched (idempotency under retry).
+    """
+    out = dict(payload)
+    creatives = out.get("creatives")
+    if not isinstance(creatives, list):
+        return out
+
+    new_creatives: list[Any] = []
+    for creative in creatives:
+        if not isinstance(creative, dict):
+            new_creatives.append(creative)
+            continue
+
+        new_creative = dict(creative)
+
+        # Hook 1: bare format_id string → structured.
+        fid = new_creative.get("format_id")
+        if isinstance(fid, str):
+            new_creative["format_id"] = {
+                "agent_url": _CANONICAL_CREATIVE_AGENT_URL,
+                "id": fid,
+            }
+
+        # Hooks 2 + 3: per-asset coercions.
+        assets = new_creative.get("assets")
+        if isinstance(assets, dict):
+            new_creative["assets"] = {
+                key: _coerce_asset(key, value) if isinstance(value, dict) else value
+                for key, value in assets.items()
+            }
+
+        new_creatives.append(new_creative)
+
+    out["creatives"] = new_creatives
+    return out
+
+
+ADAPTER = AdapterPair(tool_name="sync_creatives", adapt_request=adapt_request)
+register_adapter("2.5", ADAPTER)

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -1943,6 +1943,7 @@ def create_tool_caller(
     """
     from pydantic import ValidationError
 
+    from adcp.compat.legacy import LEGACY_ADAPTER_VERSIONS, get_legacy_adapter
     from adcp.exceptions import ADCPTaskError
     from adcp.server.helpers import inject_context
     from adcp.types import Error
@@ -2026,8 +2027,54 @@ def create_tool_caller(
             )
             wire_version = None
 
+        # Legacy-version routing: if the buyer claims a version handled
+        # via the adapter path (e.g. ``"2.5"``), translate the request
+        # to current-version shape before validation. The output is then
+        # validated against the SDK pin's schema, so a buggy translator
+        # surfaces as ``INVALID_REQUEST`` with a field-level pointer.
+        legacy_adapter: Any = None
+        if wire_version in LEGACY_ADAPTER_VERSIONS:
+            legacy_adapter = get_legacy_adapter(wire_version, method_name)
+            if legacy_adapter is None:
+                raise ADCPTaskError(
+                    operation=method_name,
+                    errors=[
+                        Error(
+                            code="INVALID_REQUEST",
+                            message=(
+                                f"Tool {method_name!r} is not available on "
+                                f"AdCP {wire_version}; upgrade to a "
+                                f"supported version or call a tool exposed "
+                                f"on this legacy surface."
+                            ),
+                            details={"legacy_version": wire_version},
+                        )
+                    ],
+                )
+            try:
+                params = legacy_adapter.adapt_request(params)
+            except Exception as exc:
+                raise ADCPTaskError(
+                    operation=method_name,
+                    errors=[
+                        Error(
+                            code="INVALID_REQUEST",
+                            message=(
+                                f"Legacy adapter for {method_name!r} at "
+                                f"AdCP {wire_version} failed: "
+                                f"{type(exc).__name__}: {exc}"
+                            ),
+                        )
+                    ],
+                ) from exc
+            # Adapter output is in current-version shape — validate
+            # against the SDK pin, not the buyer's claimed version.
+            effective_version: str | None = None
+        else:
+            effective_version = wire_version
+
         if request_mode is not None and request_mode != "off":
-            outcome = validate_request(method_name, params, version=wire_version)
+            outcome = validate_request(method_name, params, version=effective_version)
             if not outcome.valid:
                 summary = format_issues(outcome.issues)
                 if request_mode == "strict":
@@ -2122,7 +2169,7 @@ def create_tool_caller(
             # per-tool response schema would false-positive on it and
             # convert a real protocol error into a fake VALIDATION_ERROR.
             if "adcp_error" not in result:
-                outcome = validate_response(method_name, result, version=wire_version)
+                outcome = validate_response(method_name, result, version=effective_version)
                 if not outcome.valid:
                     summary = format_issues(outcome.issues)
                     logger.warning(
@@ -2138,6 +2185,32 @@ def create_tool_caller(
                             operation=method_name,
                             errors=[Error(**payload)],
                         )
+
+        # Legacy adapter response rewrite: when the buyer is on a legacy
+        # wire shape and the adapter declares a ``normalize_response``
+        # callable, translate the current-shape response back so the
+        # buyer sees the dict shape they expected. Runs *after*
+        # validation (which validated the current shape) so a malformed
+        # legacy rewrite doesn't mask handler bugs.
+        if legacy_adapter is not None and legacy_adapter.normalize_response is not None:
+            if isinstance(result, dict) and "adcp_error" not in result:
+                try:
+                    result = legacy_adapter.normalize_response(result)
+                except Exception as exc:
+                    raise ADCPTaskError(
+                        operation=method_name,
+                        errors=[
+                            Error(
+                                code="INTERNAL_ERROR",
+                                message=(
+                                    f"Legacy response normalizer for "
+                                    f"{method_name!r} at AdCP "
+                                    f"{wire_version} failed: "
+                                    f"{type(exc).__name__}: {exc}"
+                                ),
+                            )
+                        ],
+                    ) from exc
         return result
 
     return call_tool

--- a/src/adcp/validation/envelope.py
+++ b/src/adcp/validation/envelope.py
@@ -24,6 +24,16 @@ from __future__ import annotations
 from typing import Any
 
 from adcp._version import COMPATIBLE_ADCP_VERSIONS, normalize_to_release_precision
+from adcp.compat.legacy import LEGACY_ADAPTER_VERSIONS
+
+#: Every version the server speaks — natively-validated majors plus
+#: legacy versions handled via the adapter path. Used as the default
+#: ``supported`` set for :func:`detect_wire_version` so the dispatcher
+#: accepts both shapes.
+SUPPORTED_WIRE_VERSIONS: tuple[str, ...] = (
+    *COMPATIBLE_ADCP_VERSIONS,
+    *LEGACY_ADAPTER_VERSIONS,
+)
 
 
 class UnsupportedVersionError(ValueError):
@@ -45,7 +55,7 @@ class UnsupportedVersionError(ValueError):
 def detect_wire_version(
     payload: Any,
     *,
-    supported: tuple[str, ...] = COMPATIBLE_ADCP_VERSIONS,
+    supported: tuple[str, ...] = SUPPORTED_WIRE_VERSIONS,
 ) -> str | None:
     """Return the release-precision version a request claims, or ``None``.
 

--- a/tests/test_dispatcher_legacy_adapter_routing.py
+++ b/tests/test_dispatcher_legacy_adapter_routing.py
@@ -1,0 +1,191 @@
+"""Stage 4 tests: dispatcher routes legacy versions through the adapter.
+
+Three end-to-end scenarios:
+
+1. v2.5 buyer + registered adapter → request is translated, handler
+   receives v3-shape params, response goes back unchanged (sync_creatives
+   has no normalize_response).
+2. v2.5 buyer + unregistered tool → ``INVALID_REQUEST`` *before* the
+   handler runs (legacy version doesn't expose this tool).
+3. v3 buyer → adapter path skipped; existing behaviour intact.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.exceptions import ADCPTaskError
+from adcp.server.base import ADCPHandler, ToolContext
+from adcp.server.mcp_tools import create_tool_caller
+
+_CANONICAL_URL = "https://creative.adcontextprotocol.org"
+
+
+class _SyncCreativesHandler(ADCPHandler[Any]):
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    async def sync_creatives(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
+        self.received.append(params)
+        return {"creatives": []}
+
+
+class _GetProductsHandler(ADCPHandler[Any]):
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    async def get_products(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
+        self.received.append(params)
+        return {"products": []}
+
+
+@pytest.mark.asyncio
+async def test_v2_5_sync_creatives_translates_format_id_before_handler() -> None:
+    """A v2.5 buyer sending a bare ``format_id`` string sees the
+    structured form in the handler — proof the adapter ran before
+    dispatch."""
+    handler = _SyncCreativesHandler()
+    caller = create_tool_caller(handler, "sync_creatives")
+    await caller(
+        {
+            "adcp_version": "2.5",
+            "creatives": [
+                {
+                    "creative_id": "c1",
+                    "name": "Banner",
+                    "format_id": "display_300x250",  # bare string (v2.5)
+                    "assets": {
+                        "image": {
+                            "asset_type": "image",
+                            "url": "https://cdn.example.com/i.jpg",
+                            "width": 300,
+                            "height": 250,
+                        }
+                    },
+                }
+            ],
+        }
+    )
+    assert len(handler.received) == 1
+    received_fid = handler.received[0]["creatives"][0]["format_id"]
+    assert received_fid == {"agent_url": _CANONICAL_URL, "id": "display_300x250"}
+
+
+@pytest.mark.asyncio
+async def test_v2_5_sync_creatives_infers_asset_type_before_handler() -> None:
+    """v2.5 asset without ``asset_type`` discriminator is inferred from key."""
+    handler = _SyncCreativesHandler()
+    caller = create_tool_caller(handler, "sync_creatives")
+    await caller(
+        {
+            "adcp_version": "2.5",
+            "creatives": [
+                {
+                    "creative_id": "c1",
+                    "name": "Banner",
+                    "format_id": {"agent_url": _CANONICAL_URL, "id": "display"},
+                    "assets": {"video": {"url": "https://cdn.example.com/v.mp4"}},
+                }
+            ],
+        }
+    )
+    assert handler.received[0]["creatives"][0]["assets"]["video"]["asset_type"] == "video"
+
+
+@pytest.mark.asyncio
+async def test_v2_5_tool_without_adapter_raises_invalid_request() -> None:
+    """``get_products`` doesn't have a v2.5 adapter yet — the dispatcher
+    surfaces ``INVALID_REQUEST`` before the handler runs."""
+    handler = _GetProductsHandler()
+    caller = create_tool_caller(handler, "get_products")
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"adcp_version": "2.5", "brief": "Q4"})
+
+    err = exc_info.value.errors[0]
+    assert err.code == "INVALID_REQUEST"
+    assert "get_products" in err.message
+    assert "2.5" in err.message
+    assert err.details is not None
+    assert err.details.get("legacy_version") == "2.5"
+    assert handler.received == []
+
+
+@pytest.mark.asyncio
+async def test_v3_buyer_bypasses_adapter_path() -> None:
+    """A current-version buyer's request is dispatched verbatim — adapter
+    coercions don't fire on v3 payloads."""
+    handler = _SyncCreativesHandler()
+    caller = create_tool_caller(handler, "sync_creatives")
+    await caller(
+        {
+            "adcp_version": "3.0",
+            "creatives": [
+                {
+                    "creative_id": "c1",
+                    "name": "Banner",
+                    "format_id": "should_not_be_wrapped",  # v3 buyer's bug
+                    "assets": {},
+                }
+            ],
+        }
+    )
+    # Adapter would have wrapped this to {agent_url, id}; instead the
+    # bare string is passed through (and would fail v3 schema
+    # validation if validation were enabled — that's a buyer bug, not
+    # the framework's job to fix on a v3 wire shape).
+    assert handler.received[0]["creatives"][0]["format_id"] == "should_not_be_wrapped"
+
+
+@pytest.mark.asyncio
+async def test_v2_5_buyer_handler_dispatched_after_translation() -> None:
+    """End-to-end: v2.5 wire shape comes in, handler runs, response goes
+    out — confirms the full pipeline runs cleanly."""
+    handler = _SyncCreativesHandler()
+    caller = create_tool_caller(handler, "sync_creatives")
+    result = await caller(
+        {
+            "adcp_version": "2.5",
+            "creatives": [],
+        }
+    )
+    assert result == {"creatives": []}
+    assert len(handler.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_adapter_raising_surfaces_as_invalid_request() -> None:
+    """If a legacy adapter raises, the dispatcher converts to
+    ``INVALID_REQUEST`` with the adapter context. Uses a registered
+    rogue adapter rather than patching the shipped v2.5 sync_creatives
+    (the dataclass is frozen, so patching its bound attribute is brittle).
+    """
+    from adcp.compat.legacy import (
+        AdapterPair,
+        _reset_registry_for_tests,
+        register_adapter,
+    )
+
+    def boom(_payload: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("translator blew up")
+
+    _reset_registry_for_tests()
+    try:
+        register_adapter(
+            "2.5",
+            AdapterPair(tool_name="sync_creatives", adapt_request=boom),
+        )
+
+        handler = _SyncCreativesHandler()
+        caller = create_tool_caller(handler, "sync_creatives")
+        with pytest.raises(ADCPTaskError) as exc_info:
+            await caller({"adcp_version": "2.5", "creatives": []})
+
+        err = exc_info.value.errors[0]
+        assert err.code == "INVALID_REQUEST"
+        assert "translator blew up" in err.message
+        assert handler.received == []
+    finally:
+        _reset_registry_for_tests()

--- a/tests/test_dispatcher_version_routing.py
+++ b/tests/test_dispatcher_version_routing.py
@@ -164,6 +164,10 @@ async def test_unsupported_major_version_raises_version_unsupported(
 async def test_unsupported_adcp_version_string_raises_version_unsupported(
     strict_version_envelope: None,
 ) -> None:
+    """A version outside both ``COMPATIBLE_ADCP_VERSIONS`` and
+    ``LEGACY_ADAPTER_VERSIONS`` raises VERSION_UNSUPPORTED. v2.5 is
+    handled via the legacy adapter path (Stage 4) — pick an unsupported
+    version that's neither native nor legacy. Requires strict mode."""
     handler = _RecorderHandler()
     caller = create_tool_caller(handler, "get_products")
 

--- a/tests/test_legacy_adapter_registry.py
+++ b/tests/test_legacy_adapter_registry.py
@@ -1,0 +1,247 @@
+"""Tests for the legacy-adapter registry and the v2.5 sync_creatives adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.compat.legacy import (
+    LEGACY_ADAPTER_VERSIONS,
+    AdapterPair,
+    _reset_registry_for_tests,
+    get_legacy_adapter,
+    list_legacy_adapter_tools,
+    register_adapter,
+)
+from adcp.compat.legacy.v2_5 import sync_creatives as v2_5_sync_creatives
+
+# ---------------------------------------------------------------------------
+# Registry contract
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_adapter_versions_contains_2_5() -> None:
+    assert "2.5" in LEGACY_ADAPTER_VERSIONS
+
+
+def test_get_legacy_adapter_returns_registered_pair() -> None:
+    adapter = get_legacy_adapter("2.5", "sync_creatives")
+    assert adapter is not None
+    assert adapter.tool_name == "sync_creatives"
+    assert callable(adapter.adapt_request)
+
+
+def test_get_legacy_adapter_unknown_tool_returns_none() -> None:
+    assert get_legacy_adapter("2.5", "no_such_tool") is None
+
+
+def test_list_legacy_adapter_tools_lists_v2_5_tools() -> None:
+    tools = list_legacy_adapter_tools("2.5")
+    assert "sync_creatives" in tools
+
+
+def test_register_adapter_rejects_unknown_version() -> None:
+    pair = AdapterPair(tool_name="x", adapt_request=lambda p: p)
+    with pytest.raises(ValueError, match="not in LEGACY_ADAPTER_VERSIONS"):
+        register_adapter("9.9", pair)
+
+
+def test_register_adapter_rejects_overwrite() -> None:
+    """Re-registering a different pair for the same key raises."""
+    _reset_registry_for_tests()
+    # Reload the v2.5 registrations so other tests don't see an empty registry.
+    try:
+        # Trigger v2.5 load via the public surface.
+        get_legacy_adapter("2.5", "sync_creatives")
+
+        rogue = AdapterPair(
+            tool_name="sync_creatives",
+            adapt_request=lambda p: {**p, "rogue": True},
+        )
+        with pytest.raises(ValueError, match="already registered"):
+            register_adapter("2.5", rogue)
+    finally:
+        _reset_registry_for_tests()
+
+
+def test_register_adapter_idempotent_on_same_pair() -> None:
+    """Re-registering the same pair object is a no-op (import retry safe)."""
+    pair = get_legacy_adapter("2.5", "sync_creatives")
+    assert pair is not None
+    register_adapter("2.5", pair)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# v2.5 sync_creatives adapter — wire-shape coercions
+# ---------------------------------------------------------------------------
+
+
+_CANONICAL_URL = "https://creative.adcontextprotocol.org"
+_MIN_CREATIVE: dict[str, Any] = {"creative_id": "c1", "name": "Test"}
+
+
+def _adapt(payload: dict[str, Any]) -> dict[str, Any]:
+    return v2_5_sync_creatives.adapt_request(payload)
+
+
+def test_v2_5_format_id_string_wrapped_as_structured() -> None:
+    payload = {"creatives": [{**_MIN_CREATIVE, "format_id": "display_300x250"}]}
+    out = _adapt(payload)
+    assert out["creatives"][0]["format_id"] == {
+        "agent_url": _CANONICAL_URL,
+        "id": "display_300x250",
+    }
+
+
+def test_v2_5_format_id_structured_left_unchanged() -> None:
+    structured = {"agent_url": "https://example.com", "id": "x"}
+    payload = {"creatives": [{**_MIN_CREATIVE, "format_id": structured}]}
+    out = _adapt(payload)
+    assert out["creatives"][0]["format_id"] == structured
+
+
+def test_v2_5_asset_type_inferred_from_key() -> None:
+    payload = {
+        "creatives": [
+            {
+                **_MIN_CREATIVE,
+                "format_id": {"agent_url": _CANONICAL_URL, "id": "x"},
+                "assets": {
+                    "video": {"url": "https://cdn.example.com/v.mp4"},
+                    "text": {"content": "Hello"},
+                },
+            }
+        ]
+    }
+    out = _adapt(payload)
+    assets = out["creatives"][0]["assets"]
+    assert assets["video"]["asset_type"] == "video"
+    assert assets["text"]["asset_type"] == "text"
+
+
+def test_v2_5_image_with_dims_kept_as_image() -> None:
+    payload = {
+        "creatives": [
+            {
+                **_MIN_CREATIVE,
+                "format_id": {"agent_url": _CANONICAL_URL, "id": "x"},
+                "assets": {
+                    "banner": {
+                        "asset_type": "image",
+                        "url": "https://cdn.example.com/i.jpg",
+                        "width": 300,
+                        "height": 250,
+                    }
+                },
+            }
+        ]
+    }
+    out = _adapt(payload)
+    assert out["creatives"][0]["assets"]["banner"]["asset_type"] == "image"
+
+
+def test_v2_5_image_without_dims_demoted_to_url() -> None:
+    payload = {
+        "creatives": [
+            {
+                **_MIN_CREATIVE,
+                "format_id": {"agent_url": _CANONICAL_URL, "id": "x"},
+                "assets": {
+                    "banner": {
+                        "asset_type": "image",
+                        "url": "https://cdn.example.com/i.jpg",
+                    }
+                },
+            }
+        ]
+    }
+    out = _adapt(payload)
+    asset = out["creatives"][0]["assets"]["banner"]
+    assert asset["asset_type"] == "url"
+    assert "width" not in asset
+
+
+def test_v2_5_image_partial_dims_demoted_strips_orphan_dim() -> None:
+    payload = {
+        "creatives": [
+            {
+                **_MIN_CREATIVE,
+                "format_id": {"agent_url": _CANONICAL_URL, "id": "x"},
+                "assets": {
+                    "banner": {
+                        "asset_type": "image",
+                        "url": "https://cdn.example.com/i.jpg",
+                        "width": 300,
+                    }
+                },
+            }
+        ]
+    }
+    out = _adapt(payload)
+    asset = out["creatives"][0]["assets"]["banner"]
+    assert asset["asset_type"] == "url"
+    assert "width" not in asset
+
+
+def test_v2_5_image_without_url_left_invalid() -> None:
+    """No url, no dims → structurally unusable, leave for current-schema
+    validation to reject."""
+    payload = {
+        "creatives": [
+            {
+                **_MIN_CREATIVE,
+                "format_id": {"agent_url": _CANONICAL_URL, "id": "x"},
+                "assets": {"banner": {"asset_type": "image"}},
+            }
+        ]
+    }
+    out = _adapt(payload)
+    asset = out["creatives"][0]["assets"]["banner"]
+    assert asset["asset_type"] == "image"  # unchanged
+    assert "url" not in asset
+
+
+def test_v2_5_no_substring_key_inference() -> None:
+    """``hero_image`` contains 'image' but is not the type — leave unchanged."""
+    payload = {
+        "creatives": [
+            {
+                **_MIN_CREATIVE,
+                "format_id": {"agent_url": _CANONICAL_URL, "id": "x"},
+                "assets": {"hero_image": {"some_field": "value"}},
+            }
+        ]
+    }
+    out = _adapt(payload)
+    assert "asset_type" not in out["creatives"][0]["assets"]["hero_image"]
+
+
+def test_v2_5_adapter_does_not_mutate_input() -> None:
+    """Idempotency under retry: callers can re-adapt the same payload."""
+    payload = {"creatives": [{**_MIN_CREATIVE, "format_id": "display"}]}
+    original = {
+        "creatives": [{**_MIN_CREATIVE, "format_id": "display"}],
+    }
+    _adapt(payload)
+    assert payload == original
+
+
+def test_v2_5_adapter_handles_missing_creatives_key() -> None:
+    out = _adapt({"adcp_major_version": 2})
+    assert out == {"adcp_major_version": 2}
+
+
+def test_v2_5_adapter_handles_non_list_creatives() -> None:
+    out = _adapt({"creatives": "not_a_list"})
+    assert out == {"creatives": "not_a_list"}
+
+
+def test_v2_5_adapter_normalize_response_unset() -> None:
+    """v2.5 ``sync_creatives`` doesn't need a reverse rewrite — the
+    response shape is unchanged. Adapter declares this by leaving
+    ``normalize_response=None``.
+    """
+    adapter = get_legacy_adapter("2.5", "sync_creatives")
+    assert adapter is not None
+    assert adapter.normalize_response is None


### PR DESCRIPTION
Stacked on #660 (which is stacked on #659).

## Summary

Stage 4 of the versioned-schema-validation port. Replaces the heuristic ``spec_compat_hooks()`` model with a typed per-tool adapter registry.

* New package ``adcp.compat.legacy`` with ``AdapterPair`` dataclass, registry, and ``LEGACY_ADAPTER_VERSIONS = (\"2.5\",)`` — mirrors the TS SDK's ``src/lib/adapters/legacy/v2-5/``.
* First concrete adapter: ``adcp.compat.legacy.v2_5.sync_creatives``. Three wire-shape coercions: bare ``format_id`` → structured, ``asset_type`` inference, ``image``-without-dims → ``url`` demotion.
* Envelope helper accepts both native + legacy versions in its supported set.
* ``create_tool_caller`` routes legacy-versioned requests through the adapter before current-schema validation. Missing adapter for a tool at a legacy version → ``INVALID_REQUEST`` before handler dispatch.

## Why this works

The adapter sits between wire decoding and current-schema validation. A v2.5 buyer sends their wire shape, the adapter rewrites it to v3 shape, and the existing v3 schema + Pydantic model validation runs. A buggy translator surfaces as ``INVALID_REQUEST`` with a field-level pointer — the same error mode adopters already know — instead of leaking through as opaque data.

Response side runs ``normalize_response`` (if the adapter declares one) after validation, so the buyer sees their expected shape. ``sync_creatives`` doesn't need this; later adapters (``preview_creative``) will.

## Deferred to Stage 4b

Real v2.5 schema bundle. Upstream CDN (``adcontextprotocol.org/protocol/``) doesn't ship v2.5 tarballs; the JS SDK pins to a GitHub commit SHA. Wire that fetch in a follow-up. Today the adapter validates against v3 output only.

## Test plan

- [x] ``pytest tests/`` — 4453 passed (one unrelated flaky timing test deselected)
- [x] 25 new tests across two new files
- [x] ``ruff check`` + ``mypy``
- [x] No regressions on existing dispatcher behaviour: v3 buyers bypass the adapter path

## Stage 5 will

Port the remaining v2.5 adapters (``get_products``, ``create_media_buy``, ``update_media_buy``, ``list_creative_formats``, ``preview_creative``) and add a deprecation warning on ``spec_compat_hooks()`` pointing at the new layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)