### PR TITLE
feat(compat): v2.5 get_products adapter (stage 5b)

### DIFF
--- a/src/adcp/compat/legacy/__init__.py
+++ b/src/adcp/compat/legacy/__init__.py
@@ -48,6 +48,7 @@ _VERSION_MODULES: Final[dict[str, tuple[str, tuple[str, ...]]]] = {
             "sync_creatives",
             "list_creative_formats",
             "preview_creative",
+            "get_products",
         ),
     ),
 }

--- a/src/adcp/compat/legacy/v2_5/__init__.py
+++ b/src/adcp/compat/legacy/v2_5/__init__.py
@@ -26,9 +26,15 @@ creative-adapter helpers which are substantial standalone ports.
 from __future__ import annotations
 
 from adcp.compat.legacy.v2_5 import (  # noqa: F401
+    get_products,
     list_creative_formats,
     preview_creative,
     sync_creatives,
 )
 
-__all__ = ["list_creative_formats", "preview_creative", "sync_creatives"]
+__all__ = [
+    "get_products",
+    "list_creative_formats",
+    "preview_creative",
+    "sync_creatives",
+]

--- a/src/adcp/compat/legacy/v2_5/get_products.py
+++ b/src/adcp/compat/legacy/v2_5/get_products.py
@@ -1,0 +1,250 @@
+"""v2.5 → v3 adapter for ``get_products``.
+
+This is the inverse of the JS SDK's ``adaptGetProductsRequestForV2`` /
+``normalizeGetProductsResponse`` helpers — the JS direction is *client*
+side (v3 client → v2 server). Server side flips both arrows:
+
+* **Request (v2.5 → v3):** the buyer sent a v2.5 shape; rewrite to v3
+  so the handler's typed code sees the canonical model.
+* **Response (v3 → v2.5):** the handler produced a v3 shape; rewrite
+  to the v2.5 shape the buyer expects on the wire.
+
+Field deltas the adapter handles:
+
+* **``brand_manifest`` (v2.5 URL string) ↔ ``brand`` (v3 BrandReference).**
+  v2.5 sent ``brand_manifest: "https://example.com"``; v3 expects
+  ``brand: {domain: "example.com"}``.
+* **``promoted_offerings`` (v2.5 nested object) ↔ ``catalog`` (v3
+  discriminated union).** v2.5's product-selectors / offerings nesting
+  collapses to v3's ``catalog.type = 'product' | 'offering'`` shape.
+* **Channels.** v2.5 used coarser buckets (``video``, ``audio``,
+  ``native``, ``retail``); v3 splits them (``video`` → ``olv``+``ctv``,
+  ``audio`` → ``streaming_audio``, etc.). The buyer-direction mapping
+  fans out; the response-direction mapping collapses — both are
+  inherently lossy when traffic mixes the buckets. The translation
+  defers ambiguity to the canonical mappings documented in the JS
+  SDK and falls through unknown channels unchanged.
+* **Pricing options.** Per pricing option:
+  ``rate`` ↔ ``fixed_price`` (and ``is_fixed`` discriminator gone in v3),
+  ``price_guidance.floor`` ↔ ``floor_price`` (floor moves out of
+  guidance). Percentile fields (``p25``/``p50``/``p75``/``p90``) stay
+  in ``price_guidance`` in both versions.
+
+Direct port (with direction inverted) of
+``src/lib/utils/pricing-adapter.ts``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adcp.compat.legacy import register_adapter
+from adcp.compat.legacy.types import AdapterPair
+
+# v2.5 channel buckets to v3 channel slugs. Multi-mapped buckets resolve
+# to all listed v3 channels; downstream consumers can narrow further via
+# ``filters.channels`` if needed.
+_V2_TO_V3_CHANNEL: dict[str, tuple[str, ...]] = {
+    "video": ("olv", "ctv"),
+    "audio": ("streaming_audio",),
+    "native": ("display",),
+    "retail": ("retail_media",),
+}
+
+# v3 channel slugs to v2.5 buckets. Inverse of ``_V2_TO_V3_CHANNEL``,
+# collapsing many-to-one. Channels v3 added with no v2.5 equivalent map
+# to themselves (the v2.5 buyer simply hasn't heard of them; pass the
+# raw slug through so they can choose to ignore).
+_V3_TO_V2_CHANNEL: dict[str, str] = {
+    "olv": "video",
+    "ctv": "video",
+    "streaming_audio": "audio",
+    "retail_media": "retail",
+}
+
+
+def _normalize_pricing_option(option: dict[str, Any]) -> dict[str, Any]:
+    """v2.5 → v3 for one pricing option.
+
+    Mirrors ``normalizePricingOption`` in the JS SDK.
+    """
+    # Already v3 shape — leave alone (idempotent on half-migrated input).
+    if "fixed_price" in option or "floor_price" in option:
+        if "rate" not in option and "is_fixed" not in option:
+            return option
+
+    rest = {k: v for k, v in option.items() if k not in {"rate", "is_fixed", "price_guidance"}}
+    rate = option.get("rate")
+    is_fixed = option.get("is_fixed")
+    price_guidance = option.get("price_guidance")
+
+    if rate is not None and (is_fixed is True or is_fixed is None):
+        rest["fixed_price"] = rate
+
+    if isinstance(price_guidance, dict):
+        floor = price_guidance.get("floor")
+        percentiles = {k: v for k, v in price_guidance.items() if k != "floor"}
+        if floor is not None:
+            rest["floor_price"] = floor
+        if percentiles:
+            rest["price_guidance"] = percentiles
+
+    return rest
+
+
+def _adapt_pricing_option_for_v2(option: dict[str, Any]) -> dict[str, Any]:
+    """v3 → v2.5 for one pricing option.
+
+    Mirrors ``adaptPricingOptionForV2`` in the JS SDK.
+    """
+    has_v3 = "fixed_price" in option or "floor_price" in option
+    if not has_v3:
+        return option
+
+    rest = {
+        k: v for k, v in option.items() if k not in {"fixed_price", "floor_price", "price_guidance"}
+    }
+    fixed_price = option.get("fixed_price")
+    floor_price = option.get("floor_price")
+    percentiles = option.get("price_guidance") or {}
+
+    if fixed_price is not None:
+        rest["rate"] = fixed_price
+        rest["is_fixed"] = True
+    else:
+        rest["is_fixed"] = False
+        if floor_price is not None or percentiles:
+            v2_guidance = dict(percentiles)
+            if floor_price is not None:
+                v2_guidance["floor"] = floor_price
+            rest["price_guidance"] = v2_guidance
+
+    return rest
+
+
+def _strip_url_scheme(url: str) -> str:
+    """Extract a bare domain from a brand-manifest URL (``https://x.com`` → ``x.com``).
+
+    v2.5 buyers historically sent the full URL; v3 expects just the
+    domain. Tolerates schemes that are missing or non-https.
+    """
+    s = url.strip()
+    for prefix in ("https://", "http://"):
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+            break
+    return s.rstrip("/")
+
+
+def adapt_request(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate a v2.5 ``get_products`` request to v3 shape."""
+    out = dict(payload)
+
+    # brand_manifest (v2.5 URL string) → brand.domain (v3 BrandReference)
+    brand_manifest = out.pop("brand_manifest", None)
+    if isinstance(brand_manifest, str) and brand_manifest and "brand" not in out:
+        out["brand"] = {"domain": _strip_url_scheme(brand_manifest)}
+
+    # promoted_offerings → catalog
+    promoted = out.pop("promoted_offerings", None)
+    if isinstance(promoted, dict) and "catalog" not in out:
+        product_selectors = promoted.get("product_selectors")
+        if isinstance(product_selectors, dict):
+            catalog: dict[str, Any] = {"type": "product"}
+            ps = product_selectors
+            if "manifest_gtins" in ps:
+                catalog["gtins"] = ps["manifest_gtins"]
+            if "manifest_skus" in ps:
+                catalog["ids"] = ps["manifest_skus"]
+            if "manifest_tags" in ps:
+                catalog["tags"] = ps["manifest_tags"]
+            if "manifest_category" in ps:
+                catalog["category"] = ps["manifest_category"]
+            if "manifest_query" in ps:
+                catalog["query"] = ps["manifest_query"]
+            out["catalog"] = catalog
+        elif "offerings" in promoted:
+            out["catalog"] = {"type": "offering", "items": promoted["offerings"]}
+
+    # Channel-bucket fan-out in filters.
+    filters = out.get("filters")
+    if isinstance(filters, dict) and isinstance(filters.get("channels"), list):
+        expanded: list[str] = []
+        seen: set[str] = set()
+        for ch in filters["channels"]:
+            if not isinstance(ch, str):
+                continue
+            mapped = _V2_TO_V3_CHANNEL.get(ch, (ch,))
+            for slug in mapped:
+                if slug not in seen:
+                    seen.add(slug)
+                    expanded.append(slug)
+        out["filters"] = {**filters, "channels": expanded}
+
+    return out
+
+
+def _normalize_product_channels(product: dict[str, Any]) -> dict[str, Any]:
+    """v3 → v2.5 channel collapse for a single product."""
+    channels = product.get("channels")
+    if not isinstance(channels, list):
+        return product
+    collapsed: list[str] = []
+    seen: set[str] = set()
+    for ch in channels:
+        if not isinstance(ch, str):
+            continue
+        mapped = _V3_TO_V2_CHANNEL.get(ch, ch)
+        if mapped not in seen:
+            seen.add(mapped)
+            collapsed.append(mapped)
+    return {**product, "channels": collapsed}
+
+
+def _normalize_product_pricing_v3_to_v2(product: dict[str, Any]) -> dict[str, Any]:
+    """v3 → v2.5 pricing-option rewrite for a single product."""
+    options = product.get("pricing_options")
+    if not isinstance(options, list):
+        return product
+    return {
+        **product,
+        "pricing_options": [
+            _adapt_pricing_option_for_v2(o) if isinstance(o, dict) else o for o in options
+        ],
+    }
+
+
+def normalize_response(response: dict[str, Any]) -> dict[str, Any]:
+    """Translate a v3 ``get_products`` response back to v2.5 shape.
+
+    Mirrors ``adaptGetProductsResponseForV2`` (the inverse of the JS
+    ``normalizeGetProductsResponse``). For each product:
+
+    * Collapse v3 channel slugs to v2.5 buckets (lossy — ``olv`` and
+      ``ctv`` both collapse to ``video``).
+    * Rewrite each pricing option's ``fixed_price`` / ``floor_price``
+      back to ``rate`` / ``price_guidance.floor`` with the ``is_fixed``
+      discriminator restored.
+    """
+    products = response.get("products")
+    if not isinstance(products, list):
+        return response
+    return {
+        **response,
+        "products": [
+            (
+                _normalize_product_pricing_v3_to_v2(_normalize_product_channels(p))
+                if isinstance(p, dict)
+                else p
+            )
+            for p in products
+        ],
+    }
+
+
+ADAPTER = AdapterPair(
+    tool_name="get_products",
+    adapt_request=adapt_request,
+    normalize_response=normalize_response,
+)
+register_adapter("2.5", ADAPTER)

--- a/tests/test_dispatcher_legacy_adapter_routing.py
+++ b/tests/test_dispatcher_legacy_adapter_routing.py
@@ -96,17 +96,32 @@ async def test_v2_5_sync_creatives_infers_asset_type_before_handler() -> None:
 
 @pytest.mark.asyncio
 async def test_v2_5_tool_without_adapter_raises_invalid_request() -> None:
-    """``get_products`` doesn't have a v2.5 adapter yet — the dispatcher
-    surfaces ``INVALID_REQUEST`` before the handler runs."""
-    handler = _GetProductsHandler()
-    caller = create_tool_caller(handler, "get_products")
+    """A v2.5 buyer calling a tool with no registered adapter sees
+    ``INVALID_REQUEST`` before the handler runs.
+
+    ``create_media_buy`` is one of the tools Stage 5c still has to
+    port — pick that as a known-unsupported until Stage 5c lands.
+    """
+
+    class _CreateMediaBuyHandler(ADCPHandler[Any]):
+        def __init__(self) -> None:
+            self.received: list[dict[str, Any]] = []
+
+        async def create_media_buy(
+            self, params: dict[str, Any], ctx: ToolContext
+        ) -> dict[str, Any]:
+            self.received.append(params)
+            return {"media_buy_id": "mb-1"}
+
+    handler = _CreateMediaBuyHandler()
+    caller = create_tool_caller(handler, "create_media_buy")
 
     with pytest.raises(ADCPTaskError) as exc_info:
-        await caller({"adcp_version": "2.5", "brief": "Q4"})
+        await caller({"adcp_version": "2.5"})
 
     err = exc_info.value.errors[0]
     assert err.code == "INVALID_REQUEST"
-    assert "get_products" in err.message
+    assert "create_media_buy" in err.message
     assert "2.5" in err.message
     assert err.details is not None
     assert err.details.get("legacy_version") == "2.5"

--- a/tests/test_legacy_adapter_v2_5_get_products.py
+++ b/tests/test_legacy_adapter_v2_5_get_products.py
@@ -242,23 +242,36 @@ def test_response_preserves_non_pricing_fields() -> None:
 
 
 def test_normalize_pricing_option_idempotent_on_v3_already_shape() -> None:
-    """If a buyer sent v3-shaped pricing in a v2.5 request (half-migrated),
-    don't double-translate."""
-    payload = {
-        "pricing_options": [
-            {
-                "pricing_option_id": "po1",
-                "pricing_model": "cpm",
-                "currency": "USD",
-                "fixed_price": 10.0,
-            }
-        ]
+    """If a server (or half-migrated buyer) emits v3-shaped pricing in a
+    v2.5 envelope, don't double-translate."""
+    option = {
+        "pricing_option_id": "po1",
+        "pricing_model": "cpm",
+        "currency": "USD",
+        "fixed_price": 10.0,
     }
-    # Request-direction normalize via the response-direction adapter
-    # path goes through ``_normalize_pricing_option`` indirectly when
-    # a v2.5 buyer's payload has v3-shape pricing inside. Verify via
-    # the helper directly.
-    out = v2_5_gp._normalize_pricing_option(payload["pricing_options"][0])
+    out = v2_5_gp._normalize_pricing_option(option)
     assert out["fixed_price"] == 10.0
+    assert "rate" not in out
+    assert "is_fixed" not in out
+
+
+def test_normalize_pricing_option_mixed_v2_and_v3_keys_v2_wins() -> None:
+    """When both v2 (``rate``) and v3 (``fixed_price``) fields are present —
+    the v2.5→v3 normalizer's job is to translate v2 input, so v2 wins.
+    Pin the precedence so a future refactor doesn't quietly flip it."""
+    option = {
+        "pricing_option_id": "po1",
+        "pricing_model": "cpm",
+        "currency": "USD",
+        "rate": 5.0,  # v2 wire shape
+        "is_fixed": True,
+        "fixed_price": 10.0,  # v3 field also present (server bug or migration race)
+    }
+    out = v2_5_gp._normalize_pricing_option(option)
+    # v2 ``rate`` wins — the function exists to normalize FROM v2.
+    assert out["fixed_price"] == 5.0
+    assert "rate" not in out
+    assert "is_fixed" not in out
     assert "rate" not in out
     assert "is_fixed" not in out

--- a/tests/test_legacy_adapter_v2_5_get_products.py
+++ b/tests/test_legacy_adapter_v2_5_get_products.py
@@ -1,0 +1,264 @@
+"""Tests for the v2.5 ↔ v3 ``get_products`` adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adcp.compat.legacy import get_legacy_adapter
+from adcp.compat.legacy.v2_5 import get_products as v2_5_gp
+
+
+def _adapt(payload: dict[str, Any]) -> dict[str, Any]:
+    return v2_5_gp.ADAPTER.adapt_request(payload)
+
+
+def _normalize(response: Any) -> Any:
+    assert v2_5_gp.ADAPTER.normalize_response is not None
+    return v2_5_gp.ADAPTER.normalize_response(response)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_registered_for_v2_5() -> None:
+    adapter = get_legacy_adapter("2.5", "get_products")
+    assert adapter is not None
+    assert adapter.tool_name == "get_products"
+    assert adapter.normalize_response is not None
+
+
+def test_adapt_request_does_not_mutate_input() -> None:
+    payload = {"brand_manifest": "https://example.com", "brief": "Q4"}
+    original = dict(payload)
+    _adapt(payload)
+    assert payload == original
+
+
+# ---------------------------------------------------------------------------
+# Request: brand_manifest → brand
+# ---------------------------------------------------------------------------
+
+
+def test_brand_manifest_url_becomes_brand_domain() -> None:
+    out = _adapt({"brand_manifest": "https://acme.example.com"})
+    assert out["brand"] == {"domain": "acme.example.com"}
+    assert "brand_manifest" not in out
+
+
+def test_brand_manifest_strips_http_scheme() -> None:
+    out = _adapt({"brand_manifest": "http://acme.example.com/"})
+    assert out["brand"] == {"domain": "acme.example.com"}
+
+
+def test_brand_manifest_strips_trailing_slash() -> None:
+    out = _adapt({"brand_manifest": "https://acme.example.com///"})
+    assert out["brand"] == {"domain": "acme.example.com"}
+
+
+def test_brand_field_takes_precedence_over_manifest() -> None:
+    """Half-migrated buyer sends both — keep the v3 field."""
+    out = _adapt(
+        {
+            "brand_manifest": "https://acme.example.com",
+            "brand": {"domain": "explicit.example.com"},
+        }
+    )
+    assert out["brand"] == {"domain": "explicit.example.com"}
+    assert "brand_manifest" not in out
+
+
+# ---------------------------------------------------------------------------
+# Request: promoted_offerings → catalog
+# ---------------------------------------------------------------------------
+
+
+def test_promoted_offerings_product_selectors_become_catalog_product() -> None:
+    out = _adapt(
+        {
+            "promoted_offerings": {
+                "product_selectors": {
+                    "manifest_gtins": ["123"],
+                    "manifest_skus": ["sku-1"],
+                    "manifest_tags": ["holiday"],
+                    "manifest_category": "apparel",
+                    "manifest_query": "blue jacket",
+                }
+            }
+        }
+    )
+    assert out["catalog"] == {
+        "type": "product",
+        "gtins": ["123"],
+        "ids": ["sku-1"],
+        "tags": ["holiday"],
+        "category": "apparel",
+        "query": "blue jacket",
+    }
+    assert "promoted_offerings" not in out
+
+
+def test_promoted_offerings_offerings_become_catalog_offering() -> None:
+    out = _adapt({"promoted_offerings": {"offerings": [{"name": "x"}, {"name": "y"}]}})
+    assert out["catalog"] == {
+        "type": "offering",
+        "items": [{"name": "x"}, {"name": "y"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Request: channel bucket fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_channels_video_fans_out_to_olv_and_ctv() -> None:
+    out = _adapt({"filters": {"channels": ["video"]}})
+    assert out["filters"]["channels"] == ["olv", "ctv"]
+
+
+def test_channels_audio_maps_to_streaming_audio() -> None:
+    out = _adapt({"filters": {"channels": ["audio"]}})
+    assert out["filters"]["channels"] == ["streaming_audio"]
+
+
+def test_channels_unknown_pass_through() -> None:
+    out = _adapt({"filters": {"channels": ["display", "future_channel"]}})
+    assert out["filters"]["channels"] == ["display", "future_channel"]
+
+
+def test_channels_dedup_after_expansion() -> None:
+    """If a buyer already includes olv/ctv alongside video, expand
+    without duplicating."""
+    out = _adapt({"filters": {"channels": ["video", "olv"]}})
+    assert out["filters"]["channels"] == ["olv", "ctv"]
+
+
+def test_filters_other_fields_preserved() -> None:
+    out = _adapt({"filters": {"channels": ["video"], "format_ids": ["x"]}})
+    assert out["filters"]["channels"] == ["olv", "ctv"]
+    assert out["filters"]["format_ids"] == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# Response: pricing v3 → v2.5
+# ---------------------------------------------------------------------------
+
+
+def test_response_fixed_price_becomes_rate_and_is_fixed_true() -> None:
+    response = {
+        "products": [
+            {
+                "product_id": "p1",
+                "pricing_options": [
+                    {
+                        "pricing_option_id": "po1",
+                        "pricing_model": "cpm",
+                        "currency": "USD",
+                        "fixed_price": 10.0,
+                    }
+                ],
+            }
+        ]
+    }
+    out = _normalize(response)
+    opt = out["products"][0]["pricing_options"][0]
+    assert opt["rate"] == 10.0
+    assert opt["is_fixed"] is True
+    assert "fixed_price" not in opt
+
+
+def test_response_floor_price_moves_into_price_guidance() -> None:
+    response = {
+        "products": [
+            {
+                "product_id": "p1",
+                "pricing_options": [
+                    {
+                        "pricing_option_id": "po1",
+                        "pricing_model": "cpm",
+                        "currency": "USD",
+                        "floor_price": 5.0,
+                        "price_guidance": {"p50": 7.0},
+                    }
+                ],
+            }
+        ]
+    }
+    out = _normalize(response)
+    opt = out["products"][0]["pricing_options"][0]
+    assert opt["is_fixed"] is False
+    assert opt["price_guidance"] == {"p50": 7.0, "floor": 5.0}
+    assert "floor_price" not in opt
+
+
+def test_response_channels_collapse_to_v2_buckets() -> None:
+    response = {"products": [{"product_id": "p1", "channels": ["olv", "ctv", "streaming_audio"]}]}
+    out = _normalize(response)
+    # olv + ctv both collapse to "video" — deduped.
+    assert out["products"][0]["channels"] == ["video", "audio"]
+
+
+def test_response_unknown_channels_pass_through() -> None:
+    response = {"products": [{"product_id": "p1", "channels": ["display", "future"]}]}
+    out = _normalize(response)
+    assert out["products"][0]["channels"] == ["display", "future"]
+
+
+def test_response_passes_through_when_no_products() -> None:
+    response = {"errors": [{"code": "boom"}]}
+    out = _normalize(response)
+    assert out == response
+
+
+def test_response_preserves_non_pricing_fields() -> None:
+    response = {
+        "products": [
+            {
+                "product_id": "p1",
+                "name": "Holiday Display",
+                "channels": ["olv"],
+                "pricing_options": [
+                    {
+                        "pricing_option_id": "po1",
+                        "pricing_model": "cpm",
+                        "currency": "USD",
+                        "fixed_price": 8.0,
+                        "min_spend_per_package": 1000,
+                    }
+                ],
+            }
+        ]
+    }
+    out = _normalize(response)
+    product = out["products"][0]
+    assert product["name"] == "Holiday Display"
+    assert product["pricing_options"][0]["min_spend_per_package"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Pricing-option idempotency (v3-already-shape input)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_pricing_option_idempotent_on_v3_already_shape() -> None:
+    """If a buyer sent v3-shaped pricing in a v2.5 request (half-migrated),
+    don't double-translate."""
+    payload = {
+        "pricing_options": [
+            {
+                "pricing_option_id": "po1",
+                "pricing_model": "cpm",
+                "currency": "USD",
+                "fixed_price": 10.0,
+            }
+        ]
+    }
+    # Request-direction normalize via the response-direction adapter
+    # path goes through ``_normalize_pricing_option`` indirectly when
+    # a v2.5 buyer's payload has v3-shape pricing inside. Verify via
+    # the helper directly.
+    out = v2_5_gp._normalize_pricing_option(payload["pricing_options"][0])
+    assert out["fixed_price"] == 10.0
+    assert "rate" not in out
+    assert "is_fixed" not in out


### PR DESCRIPTION
Stage 5b of the versioned-schema-validation port. Follow-up to #667 (Stage 5).

## Summary

Port of ``src/lib/utils/pricing-adapter.ts`` (inverted from the JS direction) plus brand/catalog/channel translation for ``get_products``.

The JS adapter is **v3→v2** (client side, talking to v2 servers); our server-side use case is **v2→v3** (buyer claims v2.5, server speaks v3 internally), so request and response swap roles.

### Translations

* ``brand_manifest`` (v2.5 URL string) ↔ ``brand`` (v3 BrandReference)
* ``promoted_offerings`` (v2.5 nested) ↔ ``catalog`` (v3 discriminated union)
* Channels — **lossy** in both directions:
  - Request: ``video`` fans out to ``olv``+``ctv``, ``audio`` → ``streaming_audio``, etc.
  - Response: ``olv``+``ctv`` collapse back to ``video`` (deduped)
* Pricing options:
  - ``rate`` + ``is_fixed`` ↔ ``fixed_price``
  - ``price_guidance.floor`` ↔ ``floor_price``
  - Percentile fields stay in ``price_guidance``

## Stage 5c will

Port the remaining v2.5 adapters (``create_media_buy``, ``update_media_buy``) which depend on the JS ``creative-adapter.ts`` helpers (~300 lines covering ``creative_ids``↔``creative_assignments`` and proposal-mode lossy handling).

## Test plan

- [x] ``pytest tests/ -q --ignore=tests/integration`` — 4495 passed
- [x] 20 new tests both directions + v3-already-shape idempotency
- [x] ``ruff check`` + ``mypy``

🤖 Generated with [Claude Code](https://claude.com/claude-code)