### PR TITLE
feat(client): surface structured adcp_error on TaskResult

### DIFF
--- a/src/adcp/protocols/_adcp_errors.py
+++ b/src/adcp/protocols/_adcp_errors.py
@@ -1,0 +1,36 @@
+"""Shared ``adcp_error`` envelope validation for protocol adapters.
+
+The shape and size caps are spec-defined (transport-errors.mdx §The
+``adcp_error`` Object): ``code`` is a non-empty string ≤ 64 chars,
+total serialized envelope ≤ 4 KB. Both MCP and A2A transports project
+their wire-specific error envelopes onto the same shape, so the
+validation lives here rather than in either transport.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+MAX_ERROR_CODE_LEN = 64
+MAX_ERROR_SIZE_BYTES = 4096
+
+
+def validate_adcp_error(err: Any) -> dict[str, Any] | None:
+    """Return ``err`` if it's a spec-shaped ``adcp_error`` envelope, else ``None``.
+
+    Spec rules: ``code`` is a non-empty string ≤ 64 chars; the whole
+    serialized envelope is ≤ 4 KB. Non-dict input, missing code, oversize
+    payloads, and non-serializable values all fail closed (returns ``None``).
+    """
+    if not isinstance(err, dict):
+        return None
+    code = err.get("code")
+    if not isinstance(code, str) or not (0 < len(code) <= MAX_ERROR_CODE_LEN):
+        return None
+    try:
+        if len(json.dumps(err)) > MAX_ERROR_SIZE_BYTES:
+            return None
+    except (TypeError, ValueError):
+        return None
+    return err

--- a/src/adcp/protocols/a2a.py
+++ b/src/adcp/protocols/a2a.py
@@ -21,6 +21,7 @@ from adcp.exceptions import (
     IdempotencyConflictError,
     IdempotencyExpiredError,
 )
+from adcp.protocols._adcp_errors import validate_adcp_error
 from adcp.protocols.base import ProtocolAdapter
 from adcp.signing.autosign import current_operation as _signing_operation
 from adcp.types.core import AgentConfig, DebugInfo, TaskResult, TaskStatus
@@ -646,11 +647,26 @@ class A2AAdapter(ProtocolAdapter):
                 debug_info=debug_info,
             )
         elif task_state == pb.TaskState.TASK_STATE_FAILED:
-            # Protocol-level failure - extract error message from TextPart
-            error_msg = self._extract_text_from_task(task) or "Task failed"
+            # Per transport-errors.mdx §A2A Binding: a failed task carries
+            # an ``adcp_error`` DataPart alongside the human-readable
+            # TextPart. The structured envelope lands on
+            # ``TaskResult.adcp_error`` for programmatic branching; the
+            # text stays on ``error`` for humans. When the seller omits
+            # the TextPart, fall back to the structured envelope's
+            # ``message`` / ``code`` so adopters don't see the
+            # ``"Task failed"`` placeholder mask a real diagnostic.
+            text_msg = self._extract_text_from_task(task)
+            adcp_error = self._extract_adcp_error_from_task(task)
+            if text_msg:
+                error_msg: str | None = text_msg
+            elif adcp_error:
+                error_msg = adcp_error.get("message") or adcp_error.get("code")
+            else:
+                error_msg = "Task failed"
             return TaskResult[Any](
                 status=TaskStatus.FAILED,
                 error=error_msg,
+                adcp_error=adcp_error,
                 success=False,
                 debug_info=debug_info,
             )
@@ -721,6 +737,20 @@ class A2AAdapter(ProtocolAdapter):
             return data["response"]
 
         return data
+
+    def _extract_adcp_error_from_task(self, task: pb.Task) -> dict[str, Any] | None:
+        """Extract a spec-shaped ``adcp_error`` DataPart from a failed task.
+
+        Per transport-errors.mdx §A2A Binding the failed task's artifact
+        carries a DataPart wrapping ``{"adcp_error": {...}}``. Returns the
+        validated envelope or ``None`` if no spec-shaped payload is present
+        (spec-permitted: graceful sellers MAY omit the structured envelope,
+        in which case adopters fall back to ``TaskResult.error``).
+        """
+        data = self._extract_result_from_task(task)
+        if not isinstance(data, dict):
+            return None
+        return validate_adcp_error(data.get("adcp_error"))
 
     def _extract_text_from_task(self, task: pb.Task) -> str | None:
         """Extract human-readable message from TextPart if present."""

--- a/src/adcp/protocols/mcp.py
+++ b/src/adcp/protocols/mcp.py
@@ -54,6 +54,7 @@ from adcp.exceptions import (
     IdempotencyConflictError,
     IdempotencyExpiredError,
 )
+from adcp.protocols._adcp_errors import validate_adcp_error as _validate_adcp_error
 from adcp.protocols.base import ProtocolAdapter
 from adcp.signing.autosign import current_operation as _signing_operation
 from adcp.types.core import DebugInfo, TaskResult, TaskStatus
@@ -66,8 +67,6 @@ from adcp.validation.schema_validator import SchemaValidationError, format_issue
 # Spec-defined limits from docs/building/implementation/mcp-response-extraction.mdx
 # and docs/building/implementation/transport-errors.mdx.
 _MAX_TEXT_SIZE_BYTES = 1_048_576  # 1MB cap on text items before JSON.parse
-_MAX_ERROR_SIZE_BYTES = 4096  # total adcp_error JSON-serialized size
-_MAX_ERROR_CODE_LEN = 64
 
 
 def _make_signing_http_factory(
@@ -153,22 +152,6 @@ def extract_adcp_success(result: Any) -> dict[str, Any] | None:
         if isinstance(parsed, dict) and not (len(parsed) == 1 and "adcp_error" in parsed):
             return parsed
     return None
-
-
-def _validate_adcp_error(err: Any) -> dict[str, Any] | None:
-    """Per transport-errors.mdx: ``code`` must be a non-empty string ≤ 64 chars,
-    total serialized size ≤ 4KB. Returns the validated error or None."""
-    if not isinstance(err, dict):
-        return None
-    code = err.get("code")
-    if not isinstance(code, str) or not (0 < len(code) <= _MAX_ERROR_CODE_LEN):
-        return None
-    try:
-        if len(json.dumps(err)) > _MAX_ERROR_SIZE_BYTES:
-            return None
-    except (TypeError, ValueError):
-        return None
-    return err
 
 
 def extract_adcp_error(result: Any) -> dict[str, Any] | None:
@@ -611,6 +594,7 @@ class MCPAdapter(ProtocolAdapter):
                 return TaskResult[Any](
                     status=TaskStatus.FAILED,
                     error=error_message,
+                    adcp_error=adcp_error,
                     success=False,
                     debug_info=debug_info,
                     idempotency_key=idempotency_key,

--- a/src/adcp/types/core.py
+++ b/src/adcp/types/core.py
@@ -170,6 +170,12 @@ class TaskResult(BaseModel, Generic[T]):
     submitted: SubmittedInfo | None = None
     needs_input: NeedsInputInfo | None = None
     error: str | None = None
+    # Structured AdCP error per transport-errors.mdx (``adcp_error`` object:
+    # ``code``, ``message``, ``detail``, ``field_path``, ``recovery`` ...).
+    # Always populated on the MCP FAILED path when the seller returned a
+    # spec-shaped ``adcp_error`` — independent of ``debug``. Callers should
+    # branch on ``adcp_error.code`` rather than regex-matching ``error``.
+    adcp_error: dict[str, Any] | None = None
     success: bool = Field(default=True)
     metadata: dict[str, Any] | None = None
     debug_info: DebugInfo | None = None

--- a/tests/test_mcp_extraction.py
+++ b/tests/test_mcp_extraction.py
@@ -21,10 +21,14 @@ from typing import Any
 
 import pytest
 
+from adcp.protocols._adcp_errors import (
+    MAX_ERROR_SIZE_BYTES as _MAX_ERROR_SIZE_BYTES,
+)
+from adcp.protocols._adcp_errors import (
+    validate_adcp_error as _validate_adcp_error,
+)
 from adcp.protocols.mcp import (
-    _MAX_ERROR_SIZE_BYTES,
     _MAX_TEXT_SIZE_BYTES,
-    _validate_adcp_error,
     extract_adcp_error,
     extract_adcp_success,
 )
@@ -86,9 +90,7 @@ def _mcp_tool_error_vectors() -> list[dict[str, Any]]:
 class TestErrorVectorsFromSpec:
     """Replay the MCP-relevant subset of the 29 transport-error vectors."""
 
-    @pytest.mark.parametrize(
-        "vector", _mcp_tool_error_vectors(), ids=lambda v: v["id"]
-    )
+    @pytest.mark.parametrize("vector", _mcp_tool_error_vectors(), ids=lambda v: v["id"])
     def test_vector(self, vector: dict[str, Any]) -> None:
         response = _response_shim(vector["response"])
         expected = vector.get("expected_error")
@@ -96,9 +98,7 @@ class TestErrorVectorsFromSpec:
         if expected is None:
             assert got is None, f"vector {vector['id']}: expected None, got {got!r}"
         else:
-            assert got == expected, (
-                f"vector {vector['id']}: expected {expected!r}, got {got!r}"
-            )
+            assert got == expected, f"vector {vector['id']}: expected {expected!r}, got {got!r}"
 
 
 class TestSuccessExtractionEdgeCases:
@@ -115,14 +115,12 @@ class TestSuccessExtractionEdgeCases:
 
     def test_oversized_text_item_skipped(self) -> None:
         oversized = "x" * (_MAX_TEXT_SIZE_BYTES + 1)
-        resp = _response_shim(
-            {"content": [{"type": "text", "text": oversized}]}
-        )
+        resp = _response_shim({"content": [{"type": "text", "text": oversized}]})
         assert extract_adcp_success(resp) is None
 
     def test_oversized_text_skipped_then_smaller_used(self) -> None:
-        oversized = "{\"ok\":true," + "x" * _MAX_TEXT_SIZE_BYTES + "}"
-        small = "{\"status\":\"completed\"}"
+        oversized = '{"ok":true,' + "x" * _MAX_TEXT_SIZE_BYTES + "}"
+        small = '{"status":"completed"}'
         resp = _response_shim(
             {
                 "content": [
@@ -147,7 +145,7 @@ class TestSuccessExtractionEdgeCases:
             {
                 "content": [
                     {"type": "image", "data": "..."},
-                    {"type": "text", "text": "{\"status\":\"completed\"}"},
+                    {"type": "text", "text": '{"status":"completed"}'},
                 ]
             }
         )
@@ -155,17 +153,15 @@ class TestSuccessExtractionEdgeCases:
 
     def test_adcp_error_only_structured_content_returns_none(self) -> None:
         # Error response missing the isError flag — spec says treat as None.
-        resp = _response_shim(
-            {"structuredContent": {"adcp_error": {"code": "INTERNAL_ERROR"}}}
-        )
+        resp = _response_shim({"structuredContent": {"adcp_error": {"code": "INTERNAL_ERROR"}}})
         assert extract_adcp_success(resp) is None
 
     def test_adcp_error_only_text_skipped_then_valid_used(self) -> None:
         resp = _response_shim(
             {
                 "content": [
-                    {"type": "text", "text": "{\"adcp_error\":{\"code\":\"X\"}}"},
-                    {"type": "text", "text": "{\"status\":\"completed\"}"},
+                    {"type": "text", "text": '{"adcp_error":{"code":"X"}}'},
+                    {"type": "text", "text": '{"status":"completed"}'},
                 ]
             }
         )
@@ -206,9 +202,7 @@ class TestErrorExtractionPaths:
         resp = _response_shim(
             {
                 "isError": True,
-                "content": [
-                    {"type": "text", "text": "{\"adcp_error\":{\"code\":\"OTHER\"}}"}
-                ],
+                "content": [{"type": "text", "text": '{"adcp_error":{"code":"OTHER"}}'}],
                 "structuredContent": {
                     "adcp_error": {"code": "RATE_LIMITED", "recovery": "transient"}
                 },
@@ -238,9 +232,7 @@ class TestErrorExtractionPaths:
         resp = _response_shim(
             {
                 "isError": False,
-                "structuredContent": {
-                    "adcp_error": {"code": "WOULD_BE_ERROR"}
-                },
+                "structuredContent": {"adcp_error": {"code": "WOULD_BE_ERROR"}},
             }
         )
         assert extract_adcp_error(resp) is None
@@ -250,9 +242,7 @@ class TestErrorExtractionPaths:
         # multi-MB text blob must NOT be json.loads'd into memory.
         padding = "y" * _MAX_TEXT_SIZE_BYTES
         oversized = '{"adcp_error":{"code":"X","pad":"' + padding + '"}}'
-        resp = _response_shim(
-            {"isError": True, "content": [{"type": "text", "text": oversized}]}
-        )
+        resp = _response_shim({"isError": True, "content": [{"type": "text", "text": oversized}]})
         assert extract_adcp_error(resp) is None
 
     def test_invalid_error_passes_through_to_none(self) -> None:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -250,6 +250,69 @@ class TestA2AAdapter:
             assert result.success is False
             assert result.status == TaskStatus.FAILED
             assert result.error == "Authentication failed"
+            # No structured DataPart on the wire → ``adcp_error`` stays None.
+            assert result.adcp_error is None
+
+    @pytest.mark.asyncio
+    async def test_call_tool_failure_with_structured_error(self, a2a_config):
+        """A failed task carrying an ``adcp_error`` DataPart per
+        transport-errors.mdx §A2A Binding surfaces the structured envelope
+        onto ``TaskResult.adcp_error`` — independent of debug — alongside
+        the human-readable message on ``error``.
+        """
+        adapter = A2AAdapter(a2a_config)
+
+        wire_error = {
+            "code": "INVALID_REQUEST",
+            "message": "packages[0].budget must be an object",
+            "field": "packages[0].budget",
+            "details": {"expected_type": "object", "got": "number"},
+            "recovery": "correctable",
+        }
+        mock_task = create_mock_a2a_task(
+            state="failed",
+            parts=[
+                TextPart(text="packages[0].budget must be an object"),
+                DataPart(data={"adcp_error": wire_error}),
+            ],
+        )
+        mock_response = SendMessageSuccessResponse(result=mock_task)
+
+        mock_a2a_client = AsyncMock()
+        mock_a2a_client.send_message = AsyncMock(return_value=mock_response)
+
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_a2a_client):
+            result = await adapter._call_a2a_tool("create_media_buy", {})
+
+        assert adapter.agent_config.debug is False
+        assert result.status == TaskStatus.FAILED
+        assert result.adcp_error == wire_error
+        # Human-readable string preserved for back-compat callers.
+        assert "packages[0].budget" in result.error
+
+    @pytest.mark.asyncio
+    async def test_call_tool_failure_synthesizes_message_when_text_part_absent(self, a2a_config):
+        """A seller MAY omit the TextPart on a failed task. The structured
+        ``message`` from the ``adcp_error`` envelope becomes the human
+        ``error`` so adopters don't see ``"Task failed"`` placeholder.
+        """
+        adapter = A2AAdapter(a2a_config)
+
+        wire_error = {"code": "TERMS_REJECTED", "message": "terms unacceptable"}
+        mock_task = create_mock_a2a_task(
+            state="failed",
+            parts=[DataPart(data={"adcp_error": wire_error})],
+        )
+        mock_response = SendMessageSuccessResponse(result=mock_task)
+
+        mock_a2a_client = AsyncMock()
+        mock_a2a_client.send_message = AsyncMock(return_value=mock_response)
+
+        with patch.object(adapter, "_get_a2a_client", return_value=mock_a2a_client):
+            result = await adapter._call_a2a_tool("create_media_buy", {})
+
+        assert result.adcp_error == wire_error
+        assert result.error == "terms unacceptable"
 
     @pytest.mark.asyncio
     async def test_call_tool_with_task_errors(self, a2a_config):
@@ -1529,6 +1592,77 @@ class TestMCPAdapter:
             assert result.success is False
             assert result.status == TaskStatus.FAILED
             assert result.error == "brand_manifest must provide brand information"
+            # No structured envelope on the wire → ``adcp_error`` stays None.
+            assert result.adcp_error is None
+
+    @pytest.mark.asyncio
+    async def test_call_tool_structured_error_surfaces_on_task_result(self, mcp_config):
+        """A wire ``adcp_error`` envelope lands on ``TaskResult.adcp_error``
+        independent of ``debug`` — adopters can branch on ``code`` /
+        ``field`` / ``details`` without enabling debug capture.
+
+        The flat ``result.error`` string is for humans; ``result.adcp_error``
+        is for programs (alerting, version-compat probes, graders).
+        """
+        adapter = MCPAdapter(mcp_config)
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        # Spec-shaped wire envelope: structuredContent.adcp_error.
+        mock_result.content = [{"type": "text", "text": "packages[0].budget must be an object"}]
+        mock_result.structuredContent = {
+            "adcp_error": {
+                "code": "INVALID_REQUEST",
+                "message": "packages[0].budget must be an object",
+                "field": "packages[0].budget",
+                "details": {"expected_type": "object", "got": "number"},
+            }
+        }
+        mock_result.isError = True
+        mock_session.call_tool.return_value = mock_result
+
+        with patch.object(adapter, "_get_session", return_value=mock_session):
+            result = await adapter._call_mcp_tool("create_media_buy", {})
+
+        # Debug is off by default — structured error must still survive.
+        assert adapter.agent_config.debug is False
+        assert result.status == TaskStatus.FAILED
+        assert result.adcp_error is not None
+        assert result.adcp_error["code"] == "INVALID_REQUEST"
+        assert result.adcp_error["field"] == "packages[0].budget"
+        assert result.adcp_error["details"] == {
+            "expected_type": "object",
+            "got": "number",
+        }
+        # Human-readable string still present for back-compat callers.
+        assert "packages[0].budget" in result.error
+
+    @pytest.mark.asyncio
+    async def test_call_tool_structured_error_via_text_fallback(self, mcp_config):
+        """Older servers emit ``adcp_error`` inside ``content[].text`` rather
+        than ``structuredContent`` — the extractor's text-fallback path must
+        still populate ``TaskResult.adcp_error``."""
+        import json
+
+        adapter = MCPAdapter(mcp_config)
+
+        wire_error = {
+            "code": "TERMS_REJECTED",
+            "message": "terms unacceptable",
+            "recovery": "terminal",
+        }
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.content = [{"type": "text", "text": json.dumps({"adcp_error": wire_error})}]
+        mock_result.structuredContent = None
+        mock_result.isError = True
+        mock_session.call_tool.return_value = mock_result
+
+        with patch.object(adapter, "_get_session", return_value=mock_session):
+            result = await adapter._call_mcp_tool("create_media_buy", {})
+
+        assert result.status == TaskStatus.FAILED
+        assert result.adcp_error == wire_error
 
     @pytest.mark.asyncio
     async def test_call_tool_error(self, mcp_config):


### PR DESCRIPTION
## Summary

Closes the SDK's last politeness move on the buyer error path: `TaskResult.adcp_error` is now a first-class field carrying the seller's full structured error envelope, independent of `debug` mode.

Previously the SDK paraphrased a seller's structured `adcp_error` (`code`, `field`, `details`, `recovery`, ...) into a flat `error: str` and gated the structured form behind `debug=True`. That made spec-shaped errors invisible to alerting, version-compat probes, and grader assertions in production.

This is the Python analog of the JS-side issue 1679 ("flatten wire INVALID_REQUEST detail to `{}`") — same disease, slightly different shape: Python doesn't flatten to `{}`, it flattens to a string and hides the structure behind a debug flag.

### What changes

- `TaskResult.adcp_error: dict[str, Any] | None` — new public field, populated whenever the wire carried a spec-shaped envelope.
- **MCP**: FAILED-path `TaskResult` carries the already-validated `adcp_error` dict (was previously only in `debug_info.response`).
- **A2A**: FAILED-path now extracts the `adcp_error` DataPart per `transport-errors.mdx §A2A Binding`. When the seller omits the TextPart, the structured envelope's `message`/`code` synthesizes the `error` string so adopters don't see the `"Task failed"` placeholder mask a real diagnostic.
- Shared validator: `protocols/_adcp_errors.py` holds the spec-defined size/shape caps (`code` non-empty string ≤ 64 chars, total ≤ 4 KB), used by both transports.

### Adopter ergonomics

```python
result = await client.create_media_buy(...)
if result.adcp_error and result.adcp_error["code"] == "INVALID_REQUEST":
    field = result.adcp_error.get("field")
    ...
```

The flat `error: str` stays for back-compat (human messages, logging).

### Tests

- MCP: `structuredContent.adcp_error` and text-fallback both surface on `TaskResult.adcp_error` with `debug=False`.
- A2A: failed task with `adcp_error` DataPart surfaces structurally; envelope-only (no TextPart) synthesizes the human message.
- Existing "no structured envelope" tests gained an assertion that `adcp_error` stays `None`.

## Test plan

- [x] `pytest tests/test_protocols.py tests/test_mcp_structured_error.py tests/test_a2a_structured_error.py tests/test_mcp_extraction.py` — 194 passed
- [x] Broader sweep including idempotency, error-code-conformance, translate, capabilities — 361 passed
- [x] `ruff check` clean on changed files
- [x] `mypy` clean on changed files
- [x] Public API snapshot tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)