### PR TITLE
fix(server): serve(transport="both", public_url=callable) crashes at startup

### DIFF
--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -1130,7 +1130,7 @@ def create_a2a_server(
         # _build_mcp_and_a2a_app's lifespan composer so it can reach
         # .router.lifespan_context without exposing .router on a plain
         # async function.  See serve.py:_composed_lifespan.
-        app._starlette_app = starlette_app  # type: ignore[attr-defined]
+        app._starlette_app = starlette_app
     else:
         # Static card path: existing behaviour — card built once at
         # server init and served unchanged on every card request.

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -882,6 +882,9 @@ def _wrap_with_per_request_card(
             return
         await inner(scope, receive, send)
 
+    # Note: create_a2a_server attaches ._starlette_app = inner on the returned
+    # function so _build_mcp_and_a2a_app's lifespan composer can reach inner's
+    # router without exposing .router on a plain function.
     return _middleware
 
 

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -1109,9 +1109,9 @@ def create_a2a_server(
         )
         jsonrpc_kwargs["request_handler"] = request_handler
         routes = list(create_jsonrpc_routes(**jsonrpc_kwargs))
-        app = Starlette(routes=routes)
+        starlette_app = Starlette(routes=routes)
         app = _wrap_with_per_request_card(
-            app,
+            starlette_app,
             resolver=resolved_public_url,
             handler=handler,
             name=name,
@@ -1123,6 +1123,11 @@ def create_a2a_server(
             push_notifications_supported=_push_supported,
             auth=auth,
         )
+        # Back-reference to the inner Starlette app used by
+        # _build_mcp_and_a2a_app's lifespan composer so it can reach
+        # .router.lifespan_context without exposing .router on a plain
+        # async function.  See serve.py:_composed_lifespan.
+        app._starlette_app = starlette_app  # type: ignore[attr-defined]
     else:
         # Static card path: existing behaviour — card built once at
         # server init and served unchanged on every card request.

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -1701,8 +1701,14 @@ def _build_mcp_and_a2a_app(
     # both initializers run before any request lands.
     @contextlib.asynccontextmanager
     async def _composed_lifespan(_app):  # type: ignore[no-untyped-def]
+        # When a2a_inner is the _wrap_with_per_request_card middleware wrapper
+        # (callable public_url path), it carries a ._starlette_app back-reference
+        # to the inner Starlette app whose router holds the lifespan handlers.
+        # Fall back to a2a_inner itself for the static/None path where it IS a
+        # Starlette app already.
+        a2a_lifespan_src = getattr(a2a_inner, "_starlette_app", a2a_inner)
         async with mcp_inner.router.lifespan_context(mcp_inner):
-            async with a2a_inner.router.lifespan_context(a2a_inner):
+            async with a2a_lifespan_src.router.lifespan_context(a2a_lifespan_src):
                 yield
 
     parent = Starlette(lifespan=_composed_lifespan)

--- a/tests/test_a2a_public_url_resolver.py
+++ b/tests/test_a2a_public_url_resolver.py
@@ -253,3 +253,36 @@ def test_public_url_resolver_is_exported() -> None:
     from adcp.server import PublicUrlResolver as ImportedResolver  # noqa: N814
 
     assert ImportedResolver is PublicUrlResolver
+
+
+# ---------------------------------------------------------------------------
+# Regression: callable public_url + transport="both" (#676)
+# ---------------------------------------------------------------------------
+
+
+async def test_callable_public_url_transport_both_no_startup_crash() -> None:
+    """Regression for #676: serve(transport="both", public_url=callable) must
+    not crash at lifespan startup with AttributeError: 'function' object has
+    no attribute 'router'.
+
+    The bug: create_a2a_server with a callable public_url returned a plain
+    ASGI middleware function, and _build_mcp_and_a2a_app's lifespan composer
+    tried to call .router.lifespan_context() on it.
+    """
+    from adcp.server.serve import _build_mcp_and_a2a_app
+
+    def resolver(request) -> str:  # type: ignore[no-untyped-def]
+        host = request.headers.get("host", "localhost")
+        return f"https://{host}/"
+
+    app = _build_mcp_and_a2a_app(
+        _OkHandler(),
+        name="test-agent",
+        port=3001,
+        host="127.0.0.1",
+        instructions=None,
+        test_controller=None,
+        public_url=resolver,
+    )
+    async with LifespanManager(app):
+        pass  # must not raise AttributeError

--- a/tests/test_a2a_public_url_resolver.py
+++ b/tests/test_a2a_public_url_resolver.py
@@ -260,6 +260,7 @@ def test_public_url_resolver_is_exported() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
 async def test_callable_public_url_transport_both_no_startup_crash() -> None:
     """Regression for #676: serve(transport="both", public_url=callable) must
     not crash at lifespan startup with AttributeError: 'function' object has


### PR DESCRIPTION
Closes #676

## Summary

`serve(transport="both", public_url=callable)` exited 0 at startup with `AttributeError: 'function' object has no attribute 'router'` in `_composed_lifespan`.

**Root cause:** When `public_url` is a callable, `create_a2a_server` builds a Starlette app then wraps it with `_wrap_with_per_request_card`, which returns a plain `async def _middleware(scope, receive, send)` function — not a Starlette app. The lifespan composer in `_build_mcp_and_a2a_app` then called `a2a_inner.router.lifespan_context(a2a_inner)`, which crashes because plain functions have no `.router`. The string and `None` cases return a Starlette app directly, which is why they were unaffected.

**Fix:**
- `a2a_server.py`: in the callable branch of `create_a2a_server`, keep the Starlette app in a local (`starlette_app`) before wrapping, then attach `._starlette_app = starlette_app` on the returned middleware function.
- `serve.py` `_composed_lifespan`: use `getattr(a2a_inner, "_starlette_app", a2a_inner)` to reach the inner Starlette app's router. Falls back to `a2a_inner` itself for the static/`None` path — no behaviour change there.
- Added `_wrap_with_per_request_card` comment noting the post-hoc attribute attachment.

## What was tested

- `pytest tests/test_a2a_public_url_resolver.py tests/test_unified_mcp_a2a.py tests/test_serve_auth_both.py -v` — **56 passed** (including new regression test)
- `ruff check src/adcp/server/a2a_server.py src/adcp/server/serve.py` — no issues
- `mypy src/adcp/server/a2a_server.py src/adcp/server/serve.py --ignore-missing-imports` — no new errors in changed files

## Nits surfaced by pre-PR review (not fixed in this PR)

- No test for `auth=BearerTokenAuth(...)` + `public_url=callable` on `transport="both"` together — fix logic is auth-independent but the coverage gap exists; follow-up issue recommended
- `._starlette_app` as a duck-typed cross-module attribute is fragile if `_wrap_with_per_request_card` is ever converted to a class without reading the comment; a `Protocol` would make the contract explicit

## Pre-PR review

- code-reviewer: approved — no blockers; fix correctly passes `starlette_app` (not middleware wrapper) as the `lifespan_context` argument; nits noted above
- dx-expert: approved — fix is correct and minimal; `@pytest.mark.asyncio` added for consistency per nit

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01He3UUyDxcy4pmyExJKCHNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01He3UUyDxcy4pmyExJKCHNY)_