### PR TITLE
fix(compat): handle inline BrandManifest object in v2.5 adapters

### DIFF
--- a/src/adcp/compat/legacy/v2_5/_media_buy_helpers.py
+++ b/src/adcp/compat/legacy/v2_5/_media_buy_helpers.py
@@ -37,7 +37,7 @@ def adapt_brand_manifest_to_brand(payload: dict[str, Any]) -> dict[str, Any]:
         out["brand"] = {"domain": extract_brand_domain(manifest)}
     elif isinstance(manifest, dict) and "brand" not in out:
         url = manifest.get("url")
-        if isinstance(url, str) and url:
+        if isinstance(url, str) and url.strip():
             out["brand"] = {"domain": extract_brand_domain(url)}
     return out
 

--- a/src/adcp/compat/legacy/v2_5/_media_buy_helpers.py
+++ b/src/adcp/compat/legacy/v2_5/_media_buy_helpers.py
@@ -18,9 +18,14 @@ from adcp.compat.legacy.v2_5._url import extract_brand_domain
 
 
 def adapt_brand_manifest_to_brand(payload: dict[str, Any]) -> dict[str, Any]:
-    """Rewrite v2.5 ``brand_manifest`` (URL string) to v3 ``brand``
-    ``{domain: ...}``.  Caller-supplied ``brand`` wins when both fields
-    are present (half-migrated buyer).
+    """Rewrite v2.5 ``brand_manifest`` (URL string or inline BrandManifest
+    object) to v3 ``brand`` ``{domain: ...}``.  Caller-supplied ``brand``
+    wins when both fields are present (half-migrated buyer).
+
+    v2.5 ``brand-manifest-ref.json`` is a oneOf: either a URL string or an
+    inline BrandManifest object.  For the inline case, the ``url`` field is
+    optional; when absent there is no derivable hostname, so ``brand`` is
+    omitted and v3 validation decides whether to reject.
 
     Uses ``extract_brand_domain`` to isolate the hostname from full URLs
     (e.g. ``"https://acme.com/.well-known/brand.json"`` → ``"acme.com"``)
@@ -30,6 +35,10 @@ def adapt_brand_manifest_to_brand(payload: dict[str, Any]) -> dict[str, Any]:
     manifest = out.pop("brand_manifest", None)
     if isinstance(manifest, str) and manifest and "brand" not in out:
         out["brand"] = {"domain": extract_brand_domain(manifest)}
+    elif isinstance(manifest, dict) and "brand" not in out:
+        url = manifest.get("url")
+        if isinstance(url, str) and url:
+            out["brand"] = {"domain": extract_brand_domain(url)}
     return out
 
 

--- a/src/adcp/compat/legacy/v2_5/get_products.py
+++ b/src/adcp/compat/legacy/v2_5/get_products.py
@@ -127,14 +127,19 @@ def adapt_request(payload: dict[str, Any]) -> dict[str, Any]:
     """Translate a v2.5 ``get_products`` request to v3 shape."""
     out = dict(payload)
 
-    # brand_manifest (v2.5 URL string) → brand.domain (v3 BrandReference).
-    # v2.5 spec documents brand_manifest as a URL to a JSON file, so paths
-    # are the expected input shape.  extract_brand_domain uses urlparse to
-    # isolate the hostname so the result satisfies BrandReference.domain's
-    # hostname-only regex.
+    # brand_manifest (v2.5 URL string or inline BrandManifest object) →
+    # brand.domain (v3 BrandReference).
+    # v2.5 brand-manifest-ref.json is a oneOf: either a URL string or an
+    # inline BrandManifest object. The inline schema has url as optional;
+    # when absent there is no derivable hostname, so we skip brand and let
+    # v3 validation handle the missing field.
     brand_manifest = out.pop("brand_manifest", None)
     if isinstance(brand_manifest, str) and brand_manifest and "brand" not in out:
         out["brand"] = {"domain": extract_brand_domain(brand_manifest)}
+    elif isinstance(brand_manifest, dict) and "brand" not in out:
+        url = brand_manifest.get("url")
+        if isinstance(url, str) and url:
+            out["brand"] = {"domain": extract_brand_domain(url)}
 
     # promoted_offerings → catalog
     promoted = out.pop("promoted_offerings", None)
@@ -235,9 +240,9 @@ def normalize_response(response: dict[str, Any]) -> dict[str, Any]:
 
 def is_legacy_shape(payload: dict[str, Any]) -> bool:
     """v2.5 ``get_products`` carries either ``brand_manifest`` (URL
-    string field that v3 doesn't have) or ``promoted_offerings``
-    (nested object replaced by ``catalog`` in v3). Either is a
-    strong signal."""
+    string or inline object — v3 has no ``brand_manifest`` key) or
+    ``promoted_offerings`` (nested object replaced by ``catalog`` in v3).
+    Either is a strong signal."""
     return "brand_manifest" in payload or "promoted_offerings" in payload
 
 

--- a/src/adcp/compat/legacy/v2_5/get_products.py
+++ b/src/adcp/compat/legacy/v2_5/get_products.py
@@ -138,7 +138,7 @@ def adapt_request(payload: dict[str, Any]) -> dict[str, Any]:
         out["brand"] = {"domain": extract_brand_domain(brand_manifest)}
     elif isinstance(brand_manifest, dict) and "brand" not in out:
         url = brand_manifest.get("url")
-        if isinstance(url, str) and url:
+        if isinstance(url, str) and url.strip():
             out["brand"] = {"domain": extract_brand_domain(url)}
 
     # promoted_offerings → catalog

--- a/tests/test_legacy_adapter_v2_5_get_products.py
+++ b/tests/test_legacy_adapter_v2_5_get_products.py
@@ -84,6 +84,62 @@ def test_brand_field_takes_precedence_over_manifest() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Request: brand_manifest as inline BrandManifest object (#684)
+# ---------------------------------------------------------------------------
+
+
+def test_brand_manifest_inline_object_with_url_becomes_brand_domain() -> None:
+    """Inline BrandManifest object with url extracts hostname for brand.domain."""
+    out = _adapt(
+        {
+            "brand_manifest": {
+                "url": "https://acme.example.com",
+                "name": "ACME Corp",
+            }
+        }
+    )
+    assert out["brand"] == {"domain": "acme.example.com"}
+    assert "brand_manifest" not in out
+
+
+def test_brand_manifest_inline_object_url_with_path_extracts_hostname() -> None:
+    """Inline object url may be a full URL with path — only hostname survives."""
+    out = _adapt(
+        {
+            "brand_manifest": {
+                "url": "https://acme.com/.well-known/brand.json",
+                "name": "ACME Corp",
+            }
+        }
+    )
+    assert out["brand"] == {"domain": "acme.com"}
+    assert "brand_manifest" not in out
+
+
+def test_brand_manifest_inline_object_no_url_skips_brand() -> None:
+    """Inline object without url has no derivable hostname; brand is omitted.
+
+    The BrandManifest schema marks url as optional (only name is required).
+    The adapter skips brand and lets v3 validation decide — it does not raise.
+    """
+    out = _adapt({"brand_manifest": {"name": "Great Value"}})
+    assert "brand" not in out
+    assert "brand_manifest" not in out
+
+
+def test_brand_manifest_inline_object_brand_wins_when_both_present() -> None:
+    """Half-migrated buyer sends explicit brand alongside inline object — keep brand."""
+    out = _adapt(
+        {
+            "brand_manifest": {"url": "https://acme.example.com", "name": "ACME Corp"},
+            "brand": {"domain": "explicit.example.com"},
+        }
+    )
+    assert out["brand"] == {"domain": "explicit.example.com"}
+    assert "brand_manifest" not in out
+
+
+# ---------------------------------------------------------------------------
 # Request: promoted_offerings → catalog
 # ---------------------------------------------------------------------------
 

--- a/tests/test_legacy_adapter_v2_5_media_buy.py
+++ b/tests/test_legacy_adapter_v2_5_media_buy.py
@@ -75,6 +75,51 @@ def test_create_media_buy_no_brand_manifest_passes_through() -> None:
 
 
 # ---------------------------------------------------------------------------
+# create_media_buy request: brand_manifest as inline object (#684)
+# ---------------------------------------------------------------------------
+
+
+def test_create_media_buy_brand_manifest_inline_object_with_url() -> None:
+    """Inline BrandManifest object with url extracts hostname for brand.domain."""
+    out = v2_5_cmb.adapt_request(
+        {"brand_manifest": {"url": "https://acme.example.com", "name": "ACME Corp"}}
+    )
+    assert out["brand"] == {"domain": "acme.example.com"}
+    assert "brand_manifest" not in out
+
+
+def test_create_media_buy_brand_manifest_inline_object_url_with_path() -> None:
+    out = v2_5_cmb.adapt_request(
+        {
+            "brand_manifest": {
+                "url": "https://acme.com/.well-known/brand.json",
+                "name": "ACME Corp",
+            }
+        }
+    )
+    assert out["brand"] == {"domain": "acme.com"}
+    assert "brand_manifest" not in out
+
+
+def test_create_media_buy_brand_manifest_inline_object_no_url_skips_brand() -> None:
+    """Inline object without url (spec-valid) omits brand; no exception raised."""
+    out = v2_5_cmb.adapt_request({"brand_manifest": {"name": "Great Value"}})
+    assert "brand" not in out
+    assert "brand_manifest" not in out
+
+
+def test_create_media_buy_brand_manifest_inline_object_brand_wins_when_both_present() -> None:
+    out = v2_5_cmb.adapt_request(
+        {
+            "brand_manifest": {"url": "https://acme.example.com", "name": "ACME Corp"},
+            "brand": {"domain": "explicit.example.com"},
+        }
+    )
+    assert out["brand"] == {"domain": "explicit.example.com"}
+    assert "brand_manifest" not in out
+
+
+# ---------------------------------------------------------------------------
 # Package request: creative_ids → creative_assignments (both tools)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #684

## Summary

The v2.5 `brand-manifest-ref.json` schema defines `brand_manifest` as a `oneOf` — either a URL string **or** an inline `BrandManifest` object. Both adapters (`get_products` and `create_media_buy`) only handled the string branch. When a v2.5 buyer sent an inline object, the field was popped but `brand` was never set — causing either a silent no-brand request or a confusing v3 validation failure downstream.

This PR adds the dict branch at both call sites:

- **Inline object with `url`:** extract hostname via existing `extract_brand_domain()`, set `brand: {domain}`. Guard uses `url.strip()` to prevent whitespace-only strings producing `{"domain": ""}`.
- **Inline object without `url`:** silently omit `brand` and let v3 validation decide. The `BrandManifest` schema marks `url` as optional (only `name` is required), so `{"name": "Great Value"}` is spec-valid input that cannot yield a hostname — raising here would reject spec-valid payloads.
- **Caller-supplied `brand` wins** over either form of `brand_manifest` (same precedence as the existing string branch).

`update_media_buy` intentionally does not translate `brand_manifest` and is unaffected.

## What was tested

- `pytest tests/test_legacy_adapter_v2_5_get_products.py tests/test_legacy_adapter_v2_5_media_buy.py -v` — **52 passed** (8 new tests: inline-with-url, url-with-path, no-url-skips-brand, brand-wins-over-inline, at both call sites)
- `ruff check src/adcp/compat/legacy/v2_5/` — no issues
- `mypy src/adcp/compat/legacy/v2_5/ --ignore-missing-imports` — no issues

## Nits surfaced by pre-PR review (not fixed in this PR)

- **Asymmetric required-field behavior (protocol expert):** `brand` is required in v3 `create_media_buy` but optional in v3 `get_products`. When an inline object has no `url`, the adapter silently omits `brand` at both sites. For `get_products` this is genuinely safe; for `create_media_buy` the request will still fail downstream with a v3 validation error. This is a deliberate "let v3 validate" posture — see discussion in #684 — but is worth noting for reviewers.
- **Module-level docstrings** in `create_media_buy.py` and `get_products.py` still say "URL string" for `brand_manifest`; in-function comments were updated but the top-level module docstring wire-shape tables were not.
- **Mutation-safety test** for the dict branch not added (the `out = dict(payload)` shallow copy is read-only for `.get("url")`, so no actual mutation risk, but coverage gap exists).

## Pre-PR review

- code-reviewer: approved — no blockers; whitespace-only `url` guard issue (blocker candidate) fixed before PR creation via `url.strip()`; nits noted above
- ad-tech-protocol-expert: approved — non-breaking per spec; `oneOf` handling correct; silent-skip for no-url is the only defensible behavior for an adapter that cannot fabricate a hostname; nit on asymmetric required-field behavior between call sites noted above

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Nz3E58qfSW4X6fdJngTxKt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz3E58qfSW4X6fdJngTxKt)_