### PR TITLE
fix(compat): warn when brand_manifest non-standard path is silently flattened to domain

### DIFF
--- a/src/adcp/compat/legacy/v2_5/_media_buy_helpers.py
+++ b/src/adcp/compat/legacy/v2_5/_media_buy_helpers.py
@@ -12,9 +12,19 @@ v3 → v2 for responses.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from adcp.compat.legacy.v2_5._url import extract_brand_domain
+
+_logger = logging.getLogger(__name__)
+
+# Paths that v3 sellers reconstruct correctly — no information is lost.
+_STANDARD_BRAND_MANIFEST_PATHS = {"", "/", "/.well-known/brand.json"}
+
+# Per-URL dedup so high-RPS v2.5 buyers don't saturate the log pipeline.
+_brand_manifest_path_warned: set[str] = set()
 
 
 def adapt_brand_manifest_to_brand(payload: dict[str, Any]) -> dict[str, Any]:
@@ -34,7 +44,22 @@ def adapt_brand_manifest_to_brand(payload: dict[str, Any]) -> dict[str, Any]:
     out = dict(payload)
     manifest = out.pop("brand_manifest", None)
     if isinstance(manifest, str) and manifest and "brand" not in out:
-        out["brand"] = {"domain": extract_brand_domain(manifest)}
+        domain = extract_brand_domain(manifest)
+        parsed = urlparse(manifest.strip())
+        if (
+            parsed.hostname is not None
+            and parsed.path not in _STANDARD_BRAND_MANIFEST_PATHS
+            and manifest not in _brand_manifest_path_warned
+        ):
+            _brand_manifest_path_warned.add(manifest)
+            _logger.warning(
+                "brand_manifest at %s uses a non-standard path; "
+                "v3 sellers derive %s/.well-known/brand.json from BrandReference.domain. "
+                "Manifest fetch may 404.",
+                manifest,
+                domain,
+            )
+        out["brand"] = {"domain": domain}
     elif isinstance(manifest, dict) and "brand" not in out:
         url = manifest.get("url")
         if isinstance(url, str) and url.strip():

--- a/src/adcp/compat/legacy/v2_5/get_products.py
+++ b/src/adcp/compat/legacy/v2_5/get_products.py
@@ -36,11 +36,21 @@ Direct port (with direction inverted) of
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from adcp.compat.legacy import register_adapter
 from adcp.compat.legacy.types import AdapterPair
 from adcp.compat.legacy.v2_5._url import extract_brand_domain
+
+_logger = logging.getLogger(__name__)
+
+# Paths that v3 sellers reconstruct correctly — no information is lost.
+_STANDARD_BRAND_MANIFEST_PATHS = {"", "/", "/.well-known/brand.json"}
+
+# Per-URL dedup so high-RPS v2.5 buyers don't saturate the log pipeline.
+_brand_manifest_path_warned: set[str] = set()
 
 # v2.5 channel buckets to v3 channel slugs. Multi-mapped buckets resolve
 # to all listed v3 channels; downstream consumers can narrow further via
@@ -135,7 +145,22 @@ def adapt_request(payload: dict[str, Any]) -> dict[str, Any]:
     # v3 validation handle the missing field.
     brand_manifest = out.pop("brand_manifest", None)
     if isinstance(brand_manifest, str) and brand_manifest and "brand" not in out:
-        out["brand"] = {"domain": extract_brand_domain(brand_manifest)}
+        domain = extract_brand_domain(brand_manifest)
+        parsed = urlparse(brand_manifest.strip())
+        if (
+            parsed.hostname is not None
+            and parsed.path not in _STANDARD_BRAND_MANIFEST_PATHS
+            and brand_manifest not in _brand_manifest_path_warned
+        ):
+            _brand_manifest_path_warned.add(brand_manifest)
+            _logger.warning(
+                "brand_manifest at %s uses a non-standard path; "
+                "v3 sellers derive %s/.well-known/brand.json from BrandReference.domain. "
+                "Manifest fetch may 404.",
+                brand_manifest,
+                domain,
+            )
+        out["brand"] = {"domain": domain}
     elif isinstance(brand_manifest, dict) and "brand" not in out:
         url = brand_manifest.get("url")
         if isinstance(url, str) and url.strip():

--- a/tests/test_legacy_adapter_v2_5_get_products.py
+++ b/tests/test_legacy_adapter_v2_5_get_products.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from adcp.compat.legacy import get_legacy_adapter
@@ -137,6 +138,64 @@ def test_brand_manifest_inline_object_brand_wins_when_both_present() -> None:
     )
     assert out["brand"] == {"domain": "explicit.example.com"}
     assert "brand_manifest" not in out
+
+
+# ---------------------------------------------------------------------------
+# Request: brand_manifest non-standard-path warning (issue #683)
+# ---------------------------------------------------------------------------
+
+_GP_LOGGER = "adcp.compat.legacy.v2_5.get_products"
+
+
+def test_brand_manifest_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """CDN brand_manifest with non-standard path emits a WARNING about the
+    information loss so operators can debug downstream 404s."""
+    import adcp.compat.legacy.v2_5.get_products as _gp
+
+    monkeypatch.setattr(_gp, "_brand_manifest_path_warned", set())
+    with caplog.at_level(logging.WARNING, logger=_GP_LOGGER):
+        out = _adapt({"brand_manifest": "https://cdn.acmecorp.com/brand-manifest.json"})
+    assert out["brand"] == {"domain": "cdn.acmecorp.com"}
+    records = [r for r in caplog.records if r.name == _GP_LOGGER]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "non-standard path" in msg
+    assert "cdn.acmecorp.com" in msg
+
+
+def test_brand_manifest_well_known_path_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Standard /.well-known/brand.json path does NOT warn — v3 derives the
+    same URL that the buyer originally pointed at."""
+    import adcp.compat.legacy.v2_5.get_products as _gp
+
+    monkeypatch.setattr(_gp, "_brand_manifest_path_warned", set())
+    with caplog.at_level(logging.WARNING, logger=_GP_LOGGER):
+        _adapt({"brand_manifest": "https://acme.com/.well-known/brand.json"})
+    assert not any(r.name == _GP_LOGGER for r in caplog.records)
+
+
+def test_brand_manifest_bare_domain_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Bare domain brand_manifest (no scheme) does not false-positive — urlparse
+    returns hostname=None for schemeless strings so we skip the path check."""
+    import adcp.compat.legacy.v2_5.get_products as _gp
+
+    monkeypatch.setattr(_gp, "_brand_manifest_path_warned", set())
+    with caplog.at_level(logging.WARNING, logger=_GP_LOGGER):
+        _adapt({"brand_manifest": "acme.com"})
+    assert not any(r.name == _GP_LOGGER for r in caplog.records)
+
+
+def test_brand_manifest_cdn_url_warns_once_dedup(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Same CDN URL repeated across requests only logs one warning (dedup)."""
+    import adcp.compat.legacy.v2_5.get_products as _gp
+
+    monkeypatch.setattr(_gp, "_brand_manifest_path_warned", set())
+    url = "https://cdn.acmecorp.com/brand-manifest.json"
+    with caplog.at_level(logging.WARNING, logger=_GP_LOGGER):
+        _adapt({"brand_manifest": url})
+        _adapt({"brand_manifest": url})
+    records = [r for r in caplog.records if r.name == _GP_LOGGER]
+    assert len(records) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_adapter_v2_5_media_buy.py
+++ b/tests/test_legacy_adapter_v2_5_media_buy.py
@@ -7,6 +7,7 @@ additionally translates ``brand_manifest`` ↔ ``brand``.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from adcp.compat.legacy import get_legacy_adapter
@@ -117,6 +118,66 @@ def test_create_media_buy_brand_manifest_inline_object_brand_wins_when_both_pres
     )
     assert out["brand"] == {"domain": "explicit.example.com"}
     assert "brand_manifest" not in out
+
+
+# ---------------------------------------------------------------------------
+# create_media_buy: brand_manifest non-standard-path warning (issue #683)
+# ---------------------------------------------------------------------------
+
+_MB_HELPERS_LOGGER = "adcp.compat.legacy.v2_5._media_buy_helpers"
+
+
+def test_create_media_buy_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """CDN brand_manifest with non-standard path emits a WARNING about the
+    information loss so operators can debug downstream 404s."""
+    import adcp.compat.legacy.v2_5._media_buy_helpers as _mbh
+
+    monkeypatch.setattr(_mbh, "_brand_manifest_path_warned", set())
+    with caplog.at_level(logging.WARNING, logger=_MB_HELPERS_LOGGER):
+        out = v2_5_cmb.adapt_request(
+            {"brand_manifest": "https://cdn.acmecorp.com/brand-manifest.json"}
+        )
+    assert out["brand"] == {"domain": "cdn.acmecorp.com"}
+    records = [r for r in caplog.records if r.name == _MB_HELPERS_LOGGER]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "non-standard path" in msg
+    assert "cdn.acmecorp.com" in msg
+
+
+def test_create_media_buy_well_known_path_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Standard /.well-known/brand.json path does NOT warn."""
+    import adcp.compat.legacy.v2_5._media_buy_helpers as _mbh
+
+    monkeypatch.setattr(_mbh, "_brand_manifest_path_warned", set())
+    with caplog.at_level(logging.WARNING, logger=_MB_HELPERS_LOGGER):
+        v2_5_cmb.adapt_request(
+            {"brand_manifest": "https://acme.com/.well-known/brand.json"}
+        )
+    assert not any(r.name == _MB_HELPERS_LOGGER for r in caplog.records)
+
+
+def test_create_media_buy_bare_domain_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Bare domain brand_manifest (no scheme) does not false-positive."""
+    import adcp.compat.legacy.v2_5._media_buy_helpers as _mbh
+
+    monkeypatch.setattr(_mbh, "_brand_manifest_path_warned", set())
+    with caplog.at_level(logging.WARNING, logger=_MB_HELPERS_LOGGER):
+        v2_5_cmb.adapt_request({"brand_manifest": "acme.com"})
+    assert not any(r.name == _MB_HELPERS_LOGGER for r in caplog.records)
+
+
+def test_create_media_buy_cdn_url_warns_once_dedup(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Same CDN URL repeated across requests only logs one warning (dedup)."""
+    import adcp.compat.legacy.v2_5._media_buy_helpers as _mbh
+
+    monkeypatch.setattr(_mbh, "_brand_manifest_path_warned", set())
+    url = "https://cdn.acmecorp.com/brand-manifest.json"
+    with caplog.at_level(logging.WARNING, logger=_MB_HELPERS_LOGGER):
+        v2_5_cmb.adapt_request({"brand_manifest": url})
+        v2_5_cmb.adapt_request({"brand_manifest": url})
+    records = [r for r in caplog.records if r.name == _MB_HELPERS_LOGGER]
+    assert len(records) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #683

## Summary

After PR #679, the v2.5→v3 adapter correctly extracts the hostname from `brand_manifest` URLs, but silently drops any non-standard path. A buyer hosting at `https://cdn.acmecorp.com/brand-manifest.json` gets translated to `{domain: "cdn.acmecorp.com"}`, and the v3 seller then fetches `https://cdn.acmecorp.com/.well-known/brand.json` — which typically 404s with no diagnostic signal in the SDK.

This PR adds a `logging.WARNING` at both adapter call sites (`get_products.adapt_request` and `_media_buy_helpers.adapt_brand_manifest_to_brand`) when the input URL carries a non-standard path. No behavior change; pure observability improvement.

Design decisions:
- **Emitted at call sites, not in `extract_brand_domain`** — the utility is stateless string transformation; diagnostic responsibility belongs to the callers that have request context.
- **Per-URL dedup via module-level set** — prevents log saturation for high-RPS v2.5 buyers sending the same manifest URL on every request.
- **Bare-domain guard** (`parsed.hostname is not None`) — `urlparse` returns `hostname=None` for schemeless strings like `"acme.com"`, which would otherwise false-positive since `urlparse("acme.com").path == "acme.com"`.
- **Both original URL and extracted domain in message** — operator needs to see what the v3 seller will actually fetch.

## What was tested

- `pytest tests/test_legacy_adapter_v2_5_get_products.py tests/test_legacy_adapter_v2_5_media_buy.py -v` — **52 passed**
- `ruff check src/adcp/compat/` — no issues
- `mypy src/adcp/compat/` — no issues in compat files (pre-existing pydantic stubs missing in env; unrelated to this change)

New tests cover: CDN URL warns, standard `/.well-known/brand.json` does not warn, bare domain does not warn, same URL warns exactly once (dedup).

## Nits surfaced by pre-PR review (not fixed in this PR)

- `extract_brand_domain` (in `_url.py`) also calls `urlparse` internally, so both call sites do a second `urlparse` to read `.hostname` and `.path`. Harmless but redundant — refactoring `extract_brand_domain` to accept/return a `ParseResult` would avoid the double call.
- Dedup key is the raw (unstripped) `manifest` string; `urlparse` is called on `manifest.strip()`. A manifest string with surrounding whitespace would escape dedup. Pathological input, no real-world impact.
- Warning logic is duplicated verbatim between `get_products.py` and `_media_buy_helpers.py`. A `_warn_if_nonstandard_brand_manifest_path(manifest, domain)` helper in `_media_buy_helpers.py` would unify them (dx-expert's main nit).

## Pre-PR review

- code-reviewer: approved — no blockers; double urlparse call and dedup-key normalization noted as nits
- dx-expert: approved — merge-ready; code duplication between call sites is the main nit (15-line extraction, not a blocker)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01X44xueoHmfHRYeKL8giv2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01X44xueoHmfHRYeKL8giv2F)_