### PR TITLE
test(compat): autouse fixture + cross-adapter dedup test for brand_manifest warning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,22 @@ def _a2a_compat_send_and_aggregate(
     _a2a_compat_shim.patch_send_and_aggregate(monkeypatch)
 
 
+@pytest.fixture(autouse=True)
+def _reset_brand_manifest_path_warned() -> None:
+    """Reset the v2.5 ``brand_manifest`` non-standard-path warning dedup
+    between tests.
+
+    The dedup lives in module-level state on ``adcp.compat.legacy.v2_5._url``
+    and is shared across both legacy adapters. Without this reset, a test
+    that fires the warning would suppress a subsequent test's expected
+    warning, producing order-dependent flakes. Autouse means tests don't
+    have to remember the boilerplate.
+    """
+    from adcp.compat.legacy.v2_5 import _url as _url_mod
+
+    _url_mod._brand_manifest_path_warned.clear()
+
+
 _adapter_cache: dict[type | UnionType, TypeAdapter[Any]] = {}
 
 

--- a/tests/test_legacy_adapter_v2_5_get_products.py
+++ b/tests/test_legacy_adapter_v2_5_get_products.py
@@ -147,12 +147,9 @@ def test_brand_manifest_inline_object_brand_wins_when_both_present() -> None:
 _URL_LOGGER = "adcp.compat.legacy.v2_5._url"
 
 
-def test_brand_manifest_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_brand_manifest_cdn_url_warns(caplog) -> None:  # type: ignore[no-untyped-def]
     """CDN brand_manifest with non-standard path emits a WARNING about the
     information loss so operators can debug downstream 404s."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         out = _adapt({"brand_manifest": "https://cdn.acmecorp.com/brand-manifest.json"})
     assert out["brand"] == {"domain": "cdn.acmecorp.com"}
@@ -163,33 +160,24 @@ def test_brand_manifest_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ign
     assert "cdn.acmecorp.com" in msg
 
 
-def test_brand_manifest_well_known_path_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_brand_manifest_well_known_path_no_warning(caplog) -> None:  # type: ignore[no-untyped-def]
     """Standard /.well-known/brand.json path does NOT warn — v3 derives the
     same URL that the buyer originally pointed at."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         _adapt({"brand_manifest": "https://acme.com/.well-known/brand.json"})
     assert not any(r.name == _URL_LOGGER for r in caplog.records)
 
 
-def test_brand_manifest_bare_domain_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_brand_manifest_bare_domain_no_warning(caplog) -> None:  # type: ignore[no-untyped-def]
     """Bare domain brand_manifest (no scheme) does not false-positive — urlparse
     returns hostname=None for schemeless strings so we skip the path check."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         _adapt({"brand_manifest": "acme.com"})
     assert not any(r.name == _URL_LOGGER for r in caplog.records)
 
 
-def test_brand_manifest_cdn_url_warns_once_dedup(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_brand_manifest_cdn_url_warns_once_dedup(caplog) -> None:  # type: ignore[no-untyped-def]
     """Same CDN URL repeated across requests only logs one warning (dedup)."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     url = "https://cdn.acmecorp.com/brand-manifest.json"
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         _adapt({"brand_manifest": url})
@@ -198,12 +186,9 @@ def test_brand_manifest_cdn_url_warns_once_dedup(caplog, monkeypatch) -> None:  
     assert len(records) == 1
 
 
-def test_brand_manifest_inline_object_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_brand_manifest_inline_object_cdn_url_warns(caplog) -> None:  # type: ignore[no-untyped-def]
     """Inline BrandManifest object with a CDN url also warns — same
     information loss as the URL-string branch (regression for #687)."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         out = _adapt(
             {
@@ -219,11 +204,8 @@ def test_brand_manifest_inline_object_cdn_url_warns(caplog, monkeypatch) -> None
     assert "cdn.acmecorp.com" in records[0].getMessage()
 
 
-def test_brand_manifest_inline_object_well_known_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_brand_manifest_inline_object_well_known_no_warning(caplog) -> None:  # type: ignore[no-untyped-def]
     """Inline object with canonical /.well-known/brand.json url does NOT warn."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         _adapt(
             {

--- a/tests/test_legacy_adapter_v2_5_media_buy.py
+++ b/tests/test_legacy_adapter_v2_5_media_buy.py
@@ -127,12 +127,9 @@ def test_create_media_buy_brand_manifest_inline_object_brand_wins_when_both_pres
 _URL_LOGGER = "adcp.compat.legacy.v2_5._url"
 
 
-def test_create_media_buy_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_create_media_buy_cdn_url_warns(caplog) -> None:  # type: ignore[no-untyped-def]
     """CDN brand_manifest with non-standard path emits a WARNING about the
     information loss so operators can debug downstream 404s."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         out = v2_5_cmb.adapt_request(
             {"brand_manifest": "https://cdn.acmecorp.com/brand-manifest.json"}
@@ -145,31 +142,22 @@ def test_create_media_buy_cdn_url_warns(caplog, monkeypatch) -> None:  # type: i
     assert "cdn.acmecorp.com" in msg
 
 
-def test_create_media_buy_well_known_path_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_create_media_buy_well_known_path_no_warning(caplog) -> None:  # type: ignore[no-untyped-def]
     """Standard /.well-known/brand.json path does NOT warn."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         v2_5_cmb.adapt_request({"brand_manifest": "https://acme.com/.well-known/brand.json"})
     assert not any(r.name == _URL_LOGGER for r in caplog.records)
 
 
-def test_create_media_buy_bare_domain_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_create_media_buy_bare_domain_no_warning(caplog) -> None:  # type: ignore[no-untyped-def]
     """Bare domain brand_manifest (no scheme) does not false-positive."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         v2_5_cmb.adapt_request({"brand_manifest": "acme.com"})
     assert not any(r.name == _URL_LOGGER for r in caplog.records)
 
 
-def test_create_media_buy_cdn_url_warns_once_dedup(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_create_media_buy_cdn_url_warns_once_dedup(caplog) -> None:  # type: ignore[no-untyped-def]
     """Same CDN URL repeated across requests only logs one warning (dedup)."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     url = "https://cdn.acmecorp.com/brand-manifest.json"
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         v2_5_cmb.adapt_request({"brand_manifest": url})
@@ -178,12 +166,9 @@ def test_create_media_buy_cdn_url_warns_once_dedup(caplog, monkeypatch) -> None:
     assert len(records) == 1
 
 
-def test_create_media_buy_inline_object_cdn_url_warns(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_create_media_buy_inline_object_cdn_url_warns(caplog) -> None:  # type: ignore[no-untyped-def]
     """Inline BrandManifest object with a CDN url also warns — same
     information loss as the URL-string branch (regression for #687)."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         out = v2_5_cmb.adapt_request(
             {
@@ -199,11 +184,8 @@ def test_create_media_buy_inline_object_cdn_url_warns(caplog, monkeypatch) -> No
     assert "cdn.acmecorp.com" in records[0].getMessage()
 
 
-def test_create_media_buy_inline_object_well_known_no_warning(caplog, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_create_media_buy_inline_object_well_known_no_warning(caplog) -> None:  # type: ignore[no-untyped-def]
     """Inline object with canonical url does NOT warn."""
-    import adcp.compat.legacy.v2_5._url as _url_mod
-
-    monkeypatch.setattr(_url_mod, "_brand_manifest_path_warned", set())
     with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
         v2_5_cmb.adapt_request(
             {
@@ -214,6 +196,23 @@ def test_create_media_buy_inline_object_well_known_no_warning(caplog, monkeypatc
             }
         )
     assert not any(r.name == _URL_LOGGER for r in caplog.records)
+
+
+def test_brand_manifest_dedup_is_cross_adapter(caplog) -> None:  # type: ignore[no-untyped-def]
+    """The dedup set is shared across all v2.5 adapters — the same offending
+    URL coming through ``get_products`` and then ``create_media_buy`` warns
+    only once per process (regression for #689)."""
+    from adcp.compat.legacy.v2_5 import get_products as v2_5_gp
+
+    url = "https://cdn.acmecorp.com/brand-manifest.json"
+    with caplog.at_level(logging.WARNING, logger=_URL_LOGGER):
+        v2_5_gp.adapt_request({"brand_manifest": url, "promoted_offerings": {}})
+        v2_5_cmb.adapt_request({"brand_manifest": url})
+    records = [r for r in caplog.records if r.name == _URL_LOGGER]
+    assert len(records) == 1, (
+        "expected the shared dedup set to suppress the second adapter's warning; "
+        f"got {len(records)} records — dedup state may have regressed to per-module"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #689. Test-hygiene follow-ups flagged on the #688 review.

- Autouse fixture in ``tests/conftest.py`` clears ``adcp.compat.legacy.v2_5._url._brand_manifest_path_warned`` between every test. The 10 existing warning tests drop their ``monkeypatch.setattr(...)`` boilerplate. A future test that forgets the reset can no longer flake on inherited state.
- New ``test_brand_manifest_dedup_is_cross_adapter`` documents the shared-state semantic introduced in #687 — same offending URL through ``get_products`` then ``create_media_buy`` warns exactly once per process. Catches a regression back to per-module dedup.

## Verification

- ``pytest tests/test_legacy_adapter_v2_5_*.py`` — 65 passed (was 64; +1 cross-adapter test, no net loss from the removed monkeypatch calls).
- Manually simulated the per-module regression (``_brand_manifest_path_warned.clear()`` between adapter calls): two warnings emitted, confirming the new test would catch that change.
- ``ruff check`` + ``mypy`` clean.

## Out of scope

Other nits flagged across this cluster but not addressed (intentional — small or theoretical):

- Bounded dedup cache (``_brand_manifest_path_warned`` is an unbounded ``set``). Per-deployment cardinality of distinct ``brand_manifest`` URLs is small in practice; revisit if a real growth signal appears.
- ``strip_url_scheme`` rename (now a bare-domain fallback for ``extract_brand_domain``) — cosmetic.
- IPv6 silent failure on ``extract_brand_domain`` (``[::1]`` → ``"::1"`` fails ``BrandReference.domain`` regex without typed error) — theoretical for ``brand_manifest`` URLs in practice.