### PR TITLE
feat(testing): add SellerA2AClient for in-process A2A handler testing

### DIFF
--- a/src/adcp/testing/__init__.py
+++ b/src/adcp/testing/__init__.py
@@ -21,7 +21,12 @@ Example:
 from __future__ import annotations
 
 from adcp.testing.decisioning import build_asgi_app, build_test_client, make_request_context
-from adcp.testing.harness import AdcpErrorPayload, SellerTestClient, ToolInvokeResult
+from adcp.testing.harness import (
+    AdcpErrorPayload,
+    SellerA2AClient,
+    SellerTestClient,
+    ToolInvokeResult,
+)
 from adcp.testing.test_helpers import (
     CREATIVE_AGENT_CONFIG,
     TEST_AGENT_A2A_CONFIG,
@@ -40,6 +45,7 @@ from adcp.testing.test_helpers import (
 
 __all__ = [
     "AdcpErrorPayload",
+    "SellerA2AClient",
     "SellerTestClient",
     "ToolInvokeResult",
     "build_asgi_app",

--- a/src/adcp/testing/harness.py
+++ b/src/adcp/testing/harness.py
@@ -1,10 +1,11 @@
-"""SellerTestClient — in-process MCP harness for AdCP seller unit tests."""
+"""SellerTestClient / SellerA2AClient — in-process AdCP harnesses for unit tests."""
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 if TYPE_CHECKING:
     from adcp.decisioning import DecisioningPlatform
@@ -72,8 +73,9 @@ class SellerTestClient:
     or SSE framing. For HTTP-level tests (auth middleware, CORS, size
     limits), use :func:`adcp.testing.build_test_client` directly.
 
-    A2A transport is not yet supported (A2A is served via a separate
-    ASGI app; tracked as a follow-up on #662).
+    For A2A transport, use :class:`SellerA2AClient` — same call
+    shape (:meth:`SellerA2AClient.invoke`), different in-process
+    dispatch path (executor + event queue rather than MCP tool call).
 
     ``run_scenario()`` is not implemented — it requires bundled
     compliance scenario playbooks that are not yet available in this SDK.
@@ -203,4 +205,225 @@ class SellerTestClient:
         return ToolInvokeResult(data=data, adcp_error=adcp_error, structured_content=structured)
 
 
-__all__ = ["AdcpErrorPayload", "SellerTestClient", "ToolInvokeResult"]
+class SellerA2AClient:
+    """In-process A2A test client for AdCP seller implementations.
+
+    The A2A sibling to :class:`SellerTestClient`. Same call shape
+    (``await client.invoke(skill, payload)``), same return type
+    (:class:`ToolInvokeResult`), but routes through the A2A executor
+    + event-queue dispatch path instead of MCP's tool call.
+
+    Usage::
+
+        @pytest.fixture
+        def seller_a2a():
+            return SellerA2AClient(MySeller())
+
+        async def test_buy_not_found_a2a(seller_a2a):
+            result = await seller_a2a.invoke(
+                "update_media_buy", {"media_buy_id": "missing", ...}
+            )
+            assert not result.ok
+            assert result.adcp_error.code == "MEDIA_BUY_NOT_FOUND"
+
+    The harness constructs an :class:`~adcp.server.a2a_server.ADCPAgentExecutor`,
+    builds a minimal A2A :class:`~a2a.server.agent_execution.context.RequestContext`
+    carrying a ``DataPart`` with ``{"skill": ..., "parameters": ...}``,
+    runs the executor against a fresh event queue, and drains the queue
+    until a terminal Task arrives. Success payloads come from the Task's
+    first DataPart artifact; structured errors land in that same DataPart
+    keyed under ``adcp_error`` per transport-errors.mdx §A2A Binding.
+
+    Limitations (each tracked as a follow-up on #678):
+
+    * **No push-notification capture.** Adopters who need to assert on
+      outbound signed webhook delivery need a sink primitive this
+      client doesn't yet provide.
+    * **No intermediate state observation.** :meth:`invoke` drains to
+      the terminal Task and returns. Tasks that pass through
+      ``working`` / ``input_required`` are observed only at their final
+      state.
+    * **No task cancellation harness.** Once :meth:`invoke` is awaited
+      there is no handle to cancel a long-running task.
+    """
+
+    def __init__(
+        self,
+        platform: DecisioningPlatform,
+        *,
+        validation: ValidationHookConfig | None = None,
+    ) -> None:
+        """
+        Args:
+            platform: The :class:`~adcp.decisioning.DecisioningPlatform`
+                instance under test.
+            validation: Schema validation config. ``None`` (default) disables
+                validation so tests focus on handler behavior, not schema
+                conformance. Pass
+                :data:`~adcp.validation.client_hooks.SERVER_DEFAULT_VALIDATION`
+                to match production behavior.
+        """
+        self._platform = platform
+        self._validation = validation
+        self._executor: Any | None = None
+        self._executor_lock = asyncio.Lock()
+
+    def _build_executor_sync(self) -> Any:
+        from adcp.decisioning.serve import create_adcp_server_from_platform
+        from adcp.server.a2a_server import ADCPAgentExecutor
+
+        handler, _executor, _registry = create_adcp_server_from_platform(
+            self._platform,
+            auto_emit_completion_webhooks=False,
+        )
+        return ADCPAgentExecutor(handler, validation=self._validation)
+
+    async def _ensure_executor(self) -> Any:
+        async with self._executor_lock:
+            if self._executor is None:
+                # create_adcp_server_from_platform calls asyncio.run() internally
+                # (via validate_capabilities_response_shape) — must run in a thread
+                # to avoid "cannot be called from a running event loop".
+                self._executor = await asyncio.to_thread(self._build_executor_sync)
+        return self._executor
+
+    async def invoke(
+        self,
+        skill: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        timeout_seconds: float = 5.0,
+    ) -> ToolInvokeResult:
+        """Invoke a skill and return the terminal-state result.
+
+        Args:
+            skill: AdCP skill name (e.g. ``"update_media_buy"``).
+            payload: Arguments forwarded to the skill. ``None`` → empty dict.
+            timeout_seconds: Per-event dequeue timeout. The harness drains
+                the event queue waiting for a terminal Task; this caps how
+                long any single dequeue waits. Default 5s.
+
+        Returns:
+            :class:`ToolInvokeResult` — ``ok`` reflects whether the terminal
+            Task state was ``COMPLETED``; ``adcp_error`` carries the structured
+            error from a failed Task's DataPart per the A2A binding.
+        """
+        from a2a import types as pb
+        from a2a.auth.user import UnauthenticatedUser
+        from a2a.server.agent_execution.context import (
+            RequestContext as A2ARequestContext,
+        )
+        from a2a.server.context import ServerCallContext
+        from a2a.server.events.event_queue import EventQueueLegacy
+        from google.protobuf.json_format import MessageToDict, ParseDict
+        from google.protobuf.struct_pb2 import Value
+
+        executor = await self._ensure_executor()
+        kwargs = payload or {}
+
+        # Build the DataPart-shaped skill invocation that ADCPAgentExecutor's
+        # default parser accepts: {"skill": "...", "parameters": {...}}.
+        value = Value()
+        ParseDict({"skill": skill, "parameters": kwargs}, value)
+        msg = pb.Message(
+            message_id=str(uuid4()),
+            role="ROLE_USER",
+            parts=[pb.Part(data=value)],
+        )
+        call_ctx = ServerCallContext(user=UnauthenticatedUser())
+        request_ctx = A2ARequestContext(
+            call_context=call_ctx,
+            request=pb.SendMessageRequest(message=msg),
+        )
+        queue = EventQueueLegacy()
+        await executor.execute(request_ctx, queue)
+
+        # Drain the event queue until a terminal Task arrives. Bounded so a
+        # buggy handler that never publishes a terminal event can't hang the
+        # test runner — each dequeue carries `timeout_seconds`, and the loop
+        # is bounded to a small number of intermediate state events.
+        terminal_task: Any = None
+        for _ in range(32):
+            try:
+                event = await asyncio.wait_for(queue.dequeue_event(), timeout=timeout_seconds)
+            except asyncio.TimeoutError:
+                break
+            if isinstance(event, pb.Task) and event.status.state in (
+                pb.TaskState.TASK_STATE_COMPLETED,
+                pb.TaskState.TASK_STATE_FAILED,
+                pb.TaskState.TASK_STATE_CANCELED,
+            ):
+                terminal_task = event
+                break
+
+        if terminal_task is None:
+            raise RuntimeError(
+                f"A2A executor for skill={skill!r} produced no terminal Task "
+                f"within {timeout_seconds}s — check executor middleware for hangs"
+            )
+
+        # Project the terminal Task's first DataPart artifact to a dict.
+        structured: dict[str, Any] = {}
+        if terminal_task.artifacts:
+            for part in terminal_task.artifacts[0].parts:
+                if part.WhichOneof("content") == "data":
+                    projected = MessageToDict(part.data)
+                    if isinstance(projected, dict):
+                        structured = projected
+                    break
+
+        raw_error = structured.get("adcp_error")
+
+        adcp_error: AdcpErrorPayload | None = None
+        if raw_error is not None:
+            code = raw_error.get("code")
+            message = raw_error.get("message")
+            if not code:
+                raise RuntimeError(
+                    "adcp_error envelope is missing required 'code' field; "
+                    "server is non-conformant to AdCP transport-errors spec"
+                )
+            if not message:
+                raise RuntimeError(
+                    "adcp_error envelope is missing required 'message' field; "
+                    "server is non-conformant to AdCP transport-errors spec"
+                )
+            adcp_error = AdcpErrorPayload(
+                code=code,
+                message=message,
+                recovery=raw_error.get("recovery"),
+                field=raw_error.get("field"),
+                suggestion=raw_error.get("suggestion"),
+                retry_after=raw_error.get("retry_after"),
+                details=raw_error.get("details"),
+            )
+        elif terminal_task.status.state == pb.TaskState.TASK_STATE_FAILED:
+            # A2A unstructured-error path: failed Task without an `adcp_error`
+            # DataPart (unknown skill, no parseable skill, transport-layer
+            # rejection). Synthesize an envelope so callers can assert on
+            # ``result.adcp_error`` uniformly across structured/unstructured
+            # failures.
+            status_msg = ""
+            if terminal_task.status.HasField("message"):
+                for part in terminal_task.status.message.parts:
+                    if part.WhichOneof("content") == "text":
+                        status_msg = part.text
+                        break
+            adcp_error = AdcpErrorPayload(
+                code="INTERNAL_ERROR",
+                message=status_msg or "A2A task failed without structured adcp_error envelope",
+            )
+
+        data: dict[str, Any] | None = None
+        if raw_error is None and structured:
+            data = dict(structured)
+
+        return ToolInvokeResult(data=data, adcp_error=adcp_error, structured_content=structured)
+
+
+__all__ = [
+    "AdcpErrorPayload",
+    "SellerA2AClient",
+    "SellerTestClient",
+    "ToolInvokeResult",
+]

--- a/tests/test_seller_a2a_client.py
+++ b/tests/test_seller_a2a_client.py
@@ -133,6 +133,37 @@ async def test_a2a_invoke_structured_content_populated() -> None:
     assert isinstance(result.structured_content, dict)
 
 
+# ---- validation wiring round-trip --------------------------------------
+
+
+async def test_a2a_invoke_with_server_default_validation_round_trip() -> None:
+    """Proves the `validation=` parameter actually engages the validation
+    hook chain — not just that the parameter is accepted by `__init__`.
+
+    The stub `_SuccessPlatform.list_creative_formats` returns
+    ``{"creative_formats": []}`` while the AdCP spec response key is
+    ``formats``. With validation OFF (the default for tests), this
+    mismatch passes through silently. With SERVER_DEFAULT_VALIDATION
+    enabled, the response-side validator rejects the wire shape and
+    the harness surfaces a structured ``VALIDATION_ERROR``. This
+    asserts the hook actually fires end-to-end on the A2A path.
+    """
+    from adcp.validation.client_hooks import SERVER_DEFAULT_VALIDATION
+
+    client = SellerA2AClient(
+        _SuccessPlatform(),
+        validation=SERVER_DEFAULT_VALIDATION,
+    )
+    result = await client.invoke("list_creative_formats", {})
+    assert not result.ok
+    assert result.adcp_error is not None
+    assert result.adcp_error.code == "VALIDATION_ERROR"
+    # The validator names the response side and the missing field, so
+    # the round-trip surface is visible to adopters reading the result.
+    assert result.adcp_error.details is not None
+    assert result.adcp_error.details.get("side") == "response"
+
+
 # ---- public import path -------------------------------------------------
 
 

--- a/tests/test_seller_a2a_client.py
+++ b/tests/test_seller_a2a_client.py
@@ -1,0 +1,144 @@
+"""Tests for adcp.testing.SellerA2AClient."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    SingletonAccounts,
+)
+from adcp.decisioning.types import AdcpError
+from adcp.testing import AdcpErrorPayload, SellerA2AClient, ToolInvokeResult
+
+
+class _SuccessPlatform(DecisioningPlatform):
+    capabilities = DecisioningCapabilities(
+        specialisms=["sales-non-guaranteed"],
+        supported_billing=("operator",),
+    )
+    accounts = SingletonAccounts(account_id="test")
+
+    def get_products(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"products": [{"id": "p1", "name": "Banner"}]}
+
+    def create_media_buy(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"media_buy_id": "mb_1", "status": "active"}
+
+    def update_media_buy(self, mid: Any, p: Any, ctx: Any) -> dict[str, Any]:
+        return {"media_buy_id": mid, "status": "active"}
+
+    def sync_creatives(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"creatives": []}
+
+    def get_media_buy_delivery(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"media_buy_deliveries": []}
+
+    def get_media_buys(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"media_buys": []}
+
+    def list_creative_formats(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"creative_formats": []}
+
+    def list_creatives(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"creatives": []}
+
+    def provide_performance_feedback(self, req: Any, ctx: Any) -> dict[str, Any]:
+        return {"acknowledged": True}
+
+
+class _ErrorPlatform(_SuccessPlatform):
+    def get_products(self, req: Any, ctx: Any) -> dict[str, Any]:
+        raise AdcpError(
+            "PRODUCT_NOT_FOUND",
+            message="no products available",
+            recovery="terminal",
+            field="brief",
+        )
+
+
+_GET_PRODUCTS_PAYLOAD = {"buying_mode": "brief"}
+
+
+# ---- happy path ---------------------------------------------------------
+
+
+async def test_a2a_invoke_success_returns_ok_result() -> None:
+    client = SellerA2AClient(_SuccessPlatform())
+    result = await client.invoke("get_products", _GET_PRODUCTS_PAYLOAD)
+    assert result.ok
+    assert result.adcp_error is None
+
+
+async def test_a2a_invoke_success_data_populated() -> None:
+    client = SellerA2AClient(_SuccessPlatform())
+    result = await client.invoke("get_products", _GET_PRODUCTS_PAYLOAD)
+    assert result.data is not None
+    assert "products" in result.data
+    assert result.data["products"][0]["id"] == "p1"
+
+
+# ---- structured-error path (AdcpError raised by handler) ----------------
+
+
+async def test_a2a_invoke_structured_error_marks_not_ok() -> None:
+    client = SellerA2AClient(_ErrorPlatform())
+    result = await client.invoke("get_products", _GET_PRODUCTS_PAYLOAD)
+    assert not result.ok
+
+
+async def test_a2a_invoke_structured_error_code_extracted() -> None:
+    client = SellerA2AClient(_ErrorPlatform())
+    result = await client.invoke("get_products", _GET_PRODUCTS_PAYLOAD)
+    assert result.adcp_error is not None
+    assert result.adcp_error.code == "PRODUCT_NOT_FOUND"
+    assert result.adcp_error.message == "no products available"
+    assert result.adcp_error.recovery == "terminal"
+    assert result.adcp_error.field == "brief"
+
+
+async def test_a2a_invoke_structured_error_data_is_none() -> None:
+    client = SellerA2AClient(_ErrorPlatform())
+    result = await client.invoke("get_products", _GET_PRODUCTS_PAYLOAD)
+    assert result.data is None
+
+
+# ---- unstructured-error path (unknown skill) ----------------------------
+
+
+async def test_a2a_invoke_unknown_skill_surfaces_failure() -> None:
+    """An unknown skill produces a FAILED Task with no `adcp_error` DataPart.
+    The harness synthesizes an AdcpErrorPayload so `result.ok` is uniform."""
+    client = SellerA2AClient(_SuccessPlatform())
+    result = await client.invoke("nonexistent_skill", {})
+    assert not result.ok
+    assert result.adcp_error is not None
+    # Synthesized envelope code for unstructured A2A failures.
+    assert result.adcp_error.code == "INTERNAL_ERROR"
+
+
+# ---- shape + caching ----------------------------------------------------
+
+
+async def test_a2a_invoke_none_payload_uses_empty_dict() -> None:
+    client = SellerA2AClient(_SuccessPlatform())
+    result = await client.invoke("get_products", None)
+    assert isinstance(result, ToolInvokeResult)
+
+
+async def test_a2a_invoke_structured_content_populated() -> None:
+    client = SellerA2AClient(_SuccessPlatform())
+    result = await client.invoke("get_products", _GET_PRODUCTS_PAYLOAD)
+    assert isinstance(result.structured_content, dict)
+
+
+# ---- public import path -------------------------------------------------
+
+
+def test_a2a_public_import_from_adcp_testing() -> None:
+    import adcp.testing as pkg
+
+    assert pkg.SellerA2AClient is SellerA2AClient
+    assert pkg.AdcpErrorPayload is AdcpErrorPayload
+    assert pkg.ToolInvokeResult is ToolInvokeResult


### PR DESCRIPTION
Refs #678.

## Why

\`SellerTestClient\` shipped in #666 killed the JSON-RPC envelope + \`structuredContent\` extraction boilerplate every MCP-adopting test file was rewriting by hand. Adopters who ship A2A in production today (salesagent, the v3 reference seller in this SDK) have been rewriting the exact same shape of boilerplate against the A2A executor — building proto Messages with DataParts, plumbing a SendMessageRequest into RequestContext, draining an EventQueueLegacy, projecting the terminal Task's first artifact back to a dict, and handling structured vs. unstructured failure modes separately.

\`SellerA2AClient\` collapses that into the same one-call shape as the MCP version.

## What this PR ships

\`\`\`python
from adcp.testing import SellerA2AClient

@pytest.fixture
def seller_a2a():
    return SellerA2AClient(MySeller())

async def test_buy_not_found(seller_a2a):
    result = await seller_a2a.invoke(
        "update_media_buy", {"media_buy_id": "missing", ...}
    )
    assert not result.ok
    assert result.adcp_error.code == "MEDIA_BUY_NOT_FOUND"
\`\`\`

- New \`SellerA2AClient\` in \`adcp.testing\`. Same constructor shape as \`SellerTestClient\` (takes a \`DecisioningPlatform\`, optional \`validation\` config).
- Reuses \`ToolInvokeResult\` and \`AdcpErrorPayload\` — assertion grammar is identical across MCP and A2A test suites.
- Drains the A2A event queue with a bounded loop + per-event timeout (default 5s). A buggy handler that never publishes a terminal event raises a clear \`RuntimeError\` instead of hanging the test runner.
- Structured A2A errors (AdcpError raised by handler, \`adcp_error\` in failed-Task DataPart per transport-errors.mdx §A2A Binding) extract identically to MCP.
- **Unstructured A2A errors** (unknown skill, unparseable message — FAILED Task with no \`adcp_error\` payload) synthesize into an \`INTERNAL_ERROR\`-coded \`AdcpErrorPayload\` so callers can assert on \`result.adcp_error\` uniformly across structured/unstructured failures.

## What this PR does NOT ship (deferred to follow-ups on #678)

These are the genuinely A2A-shaped concerns that motivated the original issue framing:

- **Push-notification capture sink** — assertion grammar for "did the seller emit the completion webhook? was it RFC 9421-signed with the right key id? was the body shape correct?"
- **Intermediate-state observer** — assertion on \`working\` / \`input_required\` transitions.
- **Task cancel / resume harness** — drive a task mid-flight, cancel, assert on resulting state and cleanup.

All three depend on the TaskStore + push-notification + middleware hooks that are themselves deferred per the framework's A2A roadmap. Shipping basic \`invoke()\` now buys adopters the boilerplate elimination they need today; the lifecycle harness arrives when the framework hooks do.

## What was tested

- \`pytest tests/test_seller_a2a_client.py -v\` — 9 new tests covering success path, structured error extraction (code/message/recovery/field), unstructured-failure synthesis (unknown skill), data=None on error, structured_content always populated, public import path.
- \`ruff check src/adcp/testing/\` — clean.
- \`mypy src/adcp/testing/harness.py --ignore-missing-imports\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)