### PR TITLE
feat(server): on_startup / on_shutdown hooks on serve(transport='both')

### DIFF
--- a/examples/scheduler_lifespan.py
+++ b/examples/scheduler_lifespan.py
@@ -1,0 +1,88 @@
+"""Lifespan-tied background work via ``serve(on_startup, on_shutdown)``.
+
+Adopters running ``transport="both"`` who need lifecycle-bound background
+work — schedulers, message-queue consumers, cache warmers, connection
+pools — pass zero-arg async callables to ``on_startup`` / ``on_shutdown``.
+Hooks fire inside the SDK's composed parent lifespan: startups run after
+both MCP and A2A inner apps have initialized, shutdowns run before
+either tears down.
+
+This replaces the ASGI ``SchedulerLifespanMiddleware`` pattern adopters
+wired by hand before issue #709 — the SDK now owns the composition so
+ordering is unambiguous.
+
+Run::
+
+    uv run python examples/scheduler_lifespan.py
+
+Then the process prints scheduler start / tick / stop lines and serves
+the unified MCP+A2A binary on :3001 until you Ctrl-C.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from adcp.server import ADCPHandler, ToolContext, serve
+from adcp.server.responses import capabilities_response
+
+logger = logging.getLogger("scheduler-demo")
+
+
+class _Scheduler:
+    """Minimal stand-in for a real scheduler.
+
+    Production adopters drop in APScheduler, Celery beat, a job-queue
+    consumer loop, etc. The shape is the same: ``start()`` kicks off a
+    long-lived task, ``stop()`` cancels it. The ``serve()`` lifespan
+    hooks just call these.
+    """
+
+    def __init__(self) -> None:
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        logger.info("scheduler: starting")
+        self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                logger.info("scheduler: tick")
+                await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            logger.info("scheduler: cancelled")
+            raise
+
+    async def stop(self) -> None:
+        logger.info("scheduler: stopping")
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+
+class Agent(ADCPHandler[ToolContext]):
+    advertised_tools = {"get_adcp_capabilities"}
+
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["media_buy"])
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+    scheduler = _Scheduler()
+    serve(
+        Agent(),
+        name="scheduler-demo",
+        transport="both",
+        on_startup=[scheduler.start],
+        on_shutdown=[scheduler.stop],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scheduler_lifespan.py
+++ b/examples/scheduler_lifespan.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import ClassVar
 
 from adcp.server import ADCPHandler, ToolContext, serve
 from adcp.server.responses import capabilities_response
@@ -66,7 +67,7 @@ class _Scheduler:
 
 
 class Agent(ADCPHandler[ToolContext]):
-    advertised_tools = {"get_adcp_capabilities"}
+    advertised_tools: ClassVar[set[str]] = {"get_adcp_capabilities"}
 
     async def get_adcp_capabilities(self, params, context=None):
         return capabilities_response(["media_buy"])
@@ -74,6 +75,13 @@ class Agent(ADCPHandler[ToolContext]):
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+    # Production wiring usually looks like:
+    #   scheduler = APScheduler(...)
+    #   db_pool = asyncpg.create_pool(...)
+    #   await db_pool  # in on_startup
+    # The hook captures (``scheduler``, ``db_pool``, etc.) become the
+    # handles your tool methods reach through to do real work — stash
+    # them on ``Agent`` or in ``request.state`` via a context_factory.
     scheduler = _Scheduler()
     serve(
         Agent(),

--- a/src/adcp/server/__init__.py
+++ b/src/adcp/server/__init__.py
@@ -142,6 +142,7 @@ from adcp.server.responses import (
 from adcp.server.serve import (
     ASGIMiddlewareEntry,
     ContextFactory,
+    LifespanHook,
     RequestMetadata,
     ServeConfig,
     SkillMiddleware,
@@ -202,6 +203,7 @@ __all__ = [
     "ContextFactory",
     "DISCOVERY_METHODS",
     "DISCOVERY_TOOLS",
+    "LifespanHook",
     "MCPToolSet",
     "RequestMetadata",
     "ServeConfig",

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
@@ -832,6 +833,23 @@ def serve(
                 serve(handler, transport="a2a", public_url=resolver)
 
             Ignored for MCP transports.
+        on_startup: Optional sequence of :data:`LifespanHook` zero-arg
+            async callables fired after both inner MCP and A2A
+            lifespans have initialized. Use for adopter background
+            work that must run for the lifetime of the server —
+            schedulers, queue consumers, cache warmers, connection
+            pools. A hook raising aborts boot via
+            ``lifespan.startup.failed``. **Today honored only on**
+            ``transport="both"``; passing on any other transport
+            raises :class:`ValueError` at boot rather than silently
+            dropping the hook. See ``examples/scheduler_lifespan.py``.
+        on_shutdown: Optional sequence of :data:`LifespanHook` zero-arg
+            async callables fired before either inner lifespan tears
+            down. Every hook runs on a best-effort basis even if an
+            earlier one raised; the first failure re-raises so
+            Starlette surfaces it, later failures land in
+            ``logger.error``. Same ``transport="both"`` restriction
+            as ``on_startup``.
 
     Example (MCP):
         from adcp.server import ADCPHandler, serve
@@ -920,9 +938,10 @@ def serve(
             f"on_startup / on_shutdown hooks require transport='both', got "
             f"transport={transport!r}. The single-transport paths "
             "(streamable-http, sse, a2a, stdio) do not yet expose a "
-            "composition point for user lifespan hooks. Set transport='both' "
-            "to use this feature, or wire hooks via asgi_middleware that "
-            "intercepts the 'lifespan' scope."
+            "composition point for user lifespan hooks. Either set "
+            "transport='both' (see examples/scheduler_lifespan.py for the "
+            "pattern) or hand-wire ASGI lifespan-scope middleware. "
+            "Single-transport support is tracked as a follow-up to #709."
         )
 
     if transport == "a2a":
@@ -1771,24 +1790,48 @@ def _build_mcp_and_a2a_app(
                     # queue) want all of them attempted on a
                     # best-effort basis. Re-raise the first failure
                     # so Starlette surfaces it; log later failures
-                    # via ``logger.exception`` so the operator still
-                    # sees them in the shutdown trace.
-                    first_error: BaseException | None = None
+                    # without ``exc_info`` so adopter closure state
+                    # (DB DSNs, tokens stashed in hook captures)
+                    # doesn't end up verbatim in shutdown logs that
+                    # downstream aggregators attach locals to.
+                    #
+                    # Catch ``Exception`` only — ``CancelledError`` /
+                    # ``KeyboardInterrupt`` / ``SystemExit`` are the
+                    # exact signals uvicorn uses to drive shutdown,
+                    # and we want them to propagate immediately
+                    # rather than getting collected into ``first_error``.
+                    first_error: Exception | None = None
                     for hook in user_shutdown:
                         try:
                             await hook()
-                        except BaseException as exc:  # noqa: BLE001
+                        except Exception as exc:  # noqa: BLE001
                             if first_error is None:
                                 first_error = exc
                             else:
-                                logger.exception(
-                                    "on_shutdown hook %r raised "
+                                logger.error(
+                                    "on_shutdown hook %r raised: %s "
                                     "(suppressed; earlier hook also "
                                     "raised)",
                                     getattr(hook, "__name__", hook),
+                                    exc,
                                 )
                     if first_error is not None:
-                        raise first_error
+                        # If we reached the ``finally`` because the
+                        # body raised (framework lifespan teardown,
+                        # request handler escaping), don't overwrite
+                        # that propagation with our shutdown error —
+                        # the operator wants to see the upstream
+                        # cause, not a secondary cleanup failure.
+                        # Log the shutdown error so it isn't lost,
+                        # let the original exception keep propagating.
+                        if sys.exc_info()[0] is None:
+                            raise first_error
+                        logger.error(
+                            "on_shutdown hook raised during exception "
+                            "unwinding: %s (suppressed; the upstream "
+                            "exception takes precedence)",
+                            first_error,
+                        )
 
     parent = Starlette(lifespan=_composed_lifespan)
 

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -97,6 +97,22 @@ class RequestMetadata:
     request_context: Any = None
 
 
+LifespanHook = Callable[[], Awaitable[None]]
+"""Zero-arg async callable invoked during server startup or shutdown.
+
+Used by :func:`serve`'s ``on_startup`` and ``on_shutdown`` kwargs (and
+the corresponding :class:`ServeConfig` fields). Startup hooks run after
+the framework's own lifespan startup completes; shutdown hooks run
+before the framework's own lifespan shutdown. A hook raising during
+startup propagates as a Starlette ``lifespan.startup.failed`` event
+which aborts the server boot.
+
+Only honored on ``transport="both"`` today — single-transport paths
+(``streamable-http``, ``sse``, ``a2a``, ``stdio``) raise ``ValueError``
+when hooks are passed. See issue #709.
+"""
+
+
 @dataclass(frozen=True)
 class ServeConfig:
     """Configuration bundle for :func:`serve`.
@@ -155,6 +171,10 @@ class ServeConfig:
     base_url: str | None = None
     specialisms: list[str] | None = None
     description: str | None = None
+
+    # --- Lifespan hooks (transport="both" only today) ---
+    on_startup: Sequence[LifespanHook] | None = None
+    on_shutdown: Sequence[LifespanHook] | None = None
 
     # --- Debug endpoints ---
     enable_debug_endpoints: bool = False
@@ -588,6 +608,8 @@ def serve(
     enable_dns_rebinding_protection: bool | None = None,
     auth: BearerTokenAuth | None = None,
     public_url: str | PublicUrlResolver | None = None,
+    on_startup: Sequence[LifespanHook] | None = None,
+    on_shutdown: Sequence[LifespanHook] | None = None,
 ) -> None:
     """Start an MCP or A2A server from an ADCP handler or server builder.
 
@@ -863,6 +885,8 @@ def serve(
         specialisms = config.specialisms
         description = config.description
         public_url = config.public_url
+        on_startup = config.on_startup
+        on_shutdown = config.on_shutdown
 
     # Accept ADCPServerBuilder from adcp_server() decorator pattern
     from adcp.server.builder import ADCPServerBuilder
@@ -883,6 +907,23 @@ def serve(
         enable_debug_endpoints=enable_debug_endpoints,
         debug_traffic_source=debug_traffic_source,
     )
+
+    # Lifespan hooks ship today only for transport="both" because that's
+    # the path with an SDK-owned parent Starlette where composition is
+    # straightforward (see :func:`_build_mcp_and_a2a_app`). For single-
+    # transport paths, FastMCP / a2a-sdk own their inner Starlette and
+    # we would have to mutate vendor internals to weave hooks in. Fail
+    # closed here so adopters get a clear error at boot instead of
+    # silently dropped hooks at runtime.
+    if (on_startup or on_shutdown) and transport != "both":
+        raise ValueError(
+            f"on_startup / on_shutdown hooks require transport='both', got "
+            f"transport={transport!r}. The single-transport paths "
+            "(streamable-http, sse, a2a, stdio) do not yet expose a "
+            "composition point for user lifespan hooks. Set transport='both' "
+            "to use this feature, or wire hooks via asgi_middleware that "
+            "intercepts the 'lifespan' scope."
+        )
 
     if transport == "a2a":
         _serve_a2a(
@@ -965,6 +1006,8 @@ def serve(
             enable_dns_rebinding_protection=enable_dns_rebinding_protection,
             auth=auth,
             public_url=public_url,
+            on_startup=on_startup,
+            on_shutdown=on_shutdown,
         )
     else:
         valid = ", ".join(sorted(("a2a", "both", "streamable-http", "sse", "stdio")))
@@ -1592,6 +1635,8 @@ def _build_mcp_and_a2a_app(
     enable_dns_rebinding_protection: bool | None = None,
     auth: BearerTokenAuth | None = None,
     public_url: str | PublicUrlResolver | None = None,
+    on_startup: Sequence[LifespanHook] | None = None,
+    on_shutdown: Sequence[LifespanHook] | None = None,
 ) -> Any:
     """Build the unified MCP+A2A ASGI app without starting a server.
 
@@ -1699,11 +1744,51 @@ def _build_mcp_and_a2a_app(
     # Compose both inner lifespans on a parent Starlette; the
     # dispatcher routes ``lifespan`` scope events to the parent so
     # both initializers run before any request lands.
+    #
+    # User-supplied ``on_startup`` / ``on_shutdown`` hooks run *inside*
+    # both framework lifespans — startup hooks fire after MCP+A2A have
+    # finished their own initialization, so user code can rely on the
+    # framework being ready; shutdown hooks fire before the framework
+    # tears down, so user code can still use framework state. Startup
+    # hook exceptions abort boot via Starlette's
+    # ``lifespan.startup.failed`` event; shutdown hooks run inside a
+    # ``finally`` so a failing earlier hook does not block the rest.
+    user_startup = tuple(on_startup or ())
+    user_shutdown = tuple(on_shutdown or ())
+
     @contextlib.asynccontextmanager
     async def _composed_lifespan(_app):  # type: ignore[no-untyped-def]
         async with mcp_inner.router.lifespan_context(mcp_inner):
             async with a2a_inner.router.lifespan_context(a2a_inner):
-                yield
+                for hook in user_startup:
+                    await hook()
+                try:
+                    yield
+                finally:
+                    # Run every shutdown hook even if an earlier one
+                    # raised — adopters that wire multiple cleanup
+                    # hooks (close DB pool, stop scheduler, drain
+                    # queue) want all of them attempted on a
+                    # best-effort basis. Re-raise the first failure
+                    # so Starlette surfaces it; log later failures
+                    # via ``logger.exception`` so the operator still
+                    # sees them in the shutdown trace.
+                    first_error: BaseException | None = None
+                    for hook in user_shutdown:
+                        try:
+                            await hook()
+                        except BaseException as exc:  # noqa: BLE001
+                            if first_error is None:
+                                first_error = exc
+                            else:
+                                logger.exception(
+                                    "on_shutdown hook %r raised "
+                                    "(suppressed; earlier hook also "
+                                    "raised)",
+                                    getattr(hook, "__name__", hook),
+                                )
+                    if first_error is not None:
+                        raise first_error
 
     parent = Starlette(lifespan=_composed_lifespan)
 
@@ -1777,6 +1862,8 @@ def _serve_mcp_and_a2a(
     enable_dns_rebinding_protection: bool | None = None,
     auth: BearerTokenAuth | None = None,
     public_url: str | PublicUrlResolver | None = None,
+    on_startup: Sequence[LifespanHook] | None = None,
+    on_shutdown: Sequence[LifespanHook] | None = None,
 ) -> None:
     """Serve MCP and A2A on a single port via path dispatch.
 
@@ -1827,6 +1914,8 @@ def _serve_mcp_and_a2a(
         enable_dns_rebinding_protection=enable_dns_rebinding_protection,
         auth=auth,
         public_url=public_url,
+        on_startup=on_startup,
+        on_shutdown=on_shutdown,
     )
     app = _apply_asgi_middleware(app, asgi_middleware)
 

--- a/tests/test_serve_lifespan_hooks.py
+++ b/tests/test_serve_lifespan_hooks.py
@@ -1,0 +1,220 @@
+"""Tests for ``serve(on_startup=..., on_shutdown=...)`` (issue #709).
+
+Covers the ``transport="both"`` path — the only transport that honors
+the hooks today — and the boot-time guard that prevents silent
+mis-wiring on single-transport paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+starlette = pytest.importorskip("starlette")
+
+from starlette.testclient import TestClient
+
+from adcp.server import ADCPHandler, ToolContext
+from adcp.server.responses import capabilities_response
+from adcp.server.serve import _build_mcp_and_a2a_app
+
+
+class _Handler(ADCPHandler[ToolContext]):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["media_buy"])
+
+
+def _build_app(*, on_startup=None, on_shutdown=None):
+    return _build_mcp_and_a2a_app(
+        _Handler(),
+        name="lifespan-test",
+        port=3001,
+        host="127.0.0.1",
+        instructions=None,
+        test_controller=None,
+        on_startup=on_startup,
+        on_shutdown=on_shutdown,
+    )
+
+
+# ----- Happy path -------------------------------------------------------
+
+
+def test_on_startup_fires_after_framework_startup() -> None:
+    """``on_startup`` hooks run after both inner MCP and A2A
+    lifespans have entered — the FastMCP session-manager task group
+    is already initialized when user hooks run, so user code can
+    safely use it."""
+    events: list[str] = []
+
+    async def hook_a() -> None:
+        events.append("a")
+
+    async def hook_b() -> None:
+        events.append("b")
+
+    app = _build_app(on_startup=[hook_a, hook_b])
+    with TestClient(app) as client:
+        # Sanity: requests still work — confirms framework lifespans
+        # also ran successfully.
+        resp = client.get("/.well-known/agent.json")
+        assert resp.status_code == 200
+
+    assert events == ["a", "b"]
+
+
+def test_on_shutdown_fires_in_order_after_yield() -> None:
+    """``on_shutdown`` hooks run when the parent lifespan exits — in
+    order, and before the inner framework lifespans tear down."""
+    events: list[str] = []
+
+    async def hook_a() -> None:
+        events.append("a")
+
+    async def hook_b() -> None:
+        events.append("b")
+
+    app = _build_app(on_shutdown=[hook_a, hook_b])
+    with TestClient(app):
+        assert events == []  # not fired during request phase
+    assert events == ["a", "b"]
+
+
+def test_startup_and_shutdown_ordering_around_yield() -> None:
+    """Combined: startup hooks fire before the yield (during boot);
+    shutdown hooks fire after the yield (during teardown). Inside
+    the ``with`` block, only startup events are visible."""
+    events: list[str] = []
+
+    async def startup() -> None:
+        events.append("startup")
+
+    async def shutdown() -> None:
+        events.append("shutdown")
+
+    app = _build_app(on_startup=[startup], on_shutdown=[shutdown])
+    with TestClient(app):
+        assert events == ["startup"]
+    assert events == ["startup", "shutdown"]
+
+
+# ----- Failure modes ----------------------------------------------------
+
+
+def test_startup_hook_failure_aborts_boot() -> None:
+    """A startup hook raising propagates out of the parent lifespan
+    — TestClient surfaces it on context entry (either directly or
+    wrapped in an ExceptionGroup from FastMCP's task-group), mirroring
+    what uvicorn does in production (process exits). What we care
+    about is that the original error message reaches the caller; the
+    exact wrapping is an asyncio detail."""
+
+    async def boom() -> None:
+        raise RuntimeError("boot-time wiring broke")
+
+    app = _build_app(on_startup=[boom])
+    with pytest.raises(BaseException) as exc_info:
+        with TestClient(app):
+            pass
+    # Walk the exception chain (including ExceptionGroup leaves) for
+    # our marker. Whatever the framing, the cause must be visible.
+    assert "boot-time wiring broke" in _flatten_exception_text(exc_info.value)
+
+
+def _flatten_exception_text(exc: BaseException) -> str:
+    """Collect ``str(exc)`` plus every cause / context / group leaf."""
+    parts: list[str] = []
+    seen: set[int] = set()
+
+    def walk(e: BaseException | None) -> None:
+        if e is None or id(e) in seen:
+            return
+        seen.add(id(e))
+        parts.append(str(e))
+        walk(e.__cause__)
+        walk(e.__context__)
+        for sub in getattr(e, "exceptions", ()) or ():
+            walk(sub)
+
+    walk(exc)
+    return "\n".join(parts)
+
+
+def test_shutdown_hooks_all_attempted_when_one_raises() -> None:
+    """Adopters wiring multiple cleanup hooks (DB close, scheduler
+    stop, queue drain) want all of them attempted on a best-effort
+    basis — a failure in one must not abort the rest. The first
+    error re-raises so Starlette surfaces it; later errors land in
+    logs."""
+    events: list[str] = []
+
+    async def first_ok() -> None:
+        events.append("first")
+
+    async def middle_raises() -> None:
+        events.append("middle")
+        raise RuntimeError("scheduler stop failed")
+
+    async def last_ok() -> None:
+        events.append("last")
+
+    app = _build_app(on_shutdown=[first_ok, middle_raises, last_ok])
+    # Starlette propagates a shutdown error from TestClient on exit;
+    # we accept either the raw error or a wrapping RuntimeError —
+    # the contract is "every hook ran", which we verify via ``events``.
+    try:
+        with TestClient(app):
+            pass
+    except Exception:
+        pass
+
+    assert events == ["first", "middle", "last"]
+
+
+# ----- Boot-time validation --------------------------------------------
+
+
+def test_on_startup_rejected_on_single_transport_paths() -> None:
+    """Lifespan hooks ship only for ``transport='both'`` today.
+    Passing them with another transport raises ValueError at boot
+    rather than silently dropping the hooks at runtime."""
+    from adcp.server import serve
+
+    async def hook() -> None:
+        pass
+
+    for transport in ("streamable-http", "sse", "a2a", "stdio"):
+        with pytest.raises(ValueError, match="transport='both'"):
+            serve(_Handler(), transport=transport, on_startup=[hook])
+        with pytest.raises(ValueError, match="transport='both'"):
+            serve(_Handler(), transport=transport, on_shutdown=[hook])
+
+
+def test_no_hooks_is_a_no_op() -> None:
+    """``on_startup=None`` / ``on_shutdown=None`` (the defaults) must
+    not change anything observable about the unified app's lifespan
+    composition. Belt-and-suspenders regression guard."""
+    app = _build_app()
+    with TestClient(app) as client:
+        resp = client.get("/.well-known/agent.json")
+        assert resp.status_code == 200
+
+
+# ----- ServeConfig surface ----------------------------------------------
+
+
+def test_serveconfig_passes_hooks_through() -> None:
+    """``ServeConfig(on_startup=..., on_shutdown=...)`` propagates
+    into ``_serve_mcp_and_a2a`` via the config-unwrap branch of
+    ``serve()``. Verify by calling ``serve()`` with a single-transport
+    bundle and confirming the boot-time guard fires — that proves the
+    field actually reached the dispatch path rather than being silently
+    swallowed during config extraction."""
+    from adcp.server import serve
+    from adcp.server.serve import ServeConfig
+
+    async def hook() -> None:
+        pass
+
+    cfg = ServeConfig(transport="streamable-http", on_startup=[hook])
+    with pytest.raises(ValueError, match="transport='both'"):
+        serve(_Handler(), config=cfg)

--- a/tests/test_serve_lifespan_hooks.py
+++ b/tests/test_serve_lifespan_hooks.py
@@ -144,7 +144,13 @@ def test_shutdown_hooks_all_attempted_when_one_raises() -> None:
     stop, queue drain) want all of them attempted on a best-effort
     basis — a failure in one must not abort the rest. The first
     error re-raises so Starlette surfaces it; later errors land in
-    logs."""
+    logs.
+
+    Verifies BOTH halves of the contract:
+    1. every hook ran (via ``events`` list)
+    2. the first error actually propagated out (caught here and
+       inspected for the marker message)
+    """
     events: list[str] = []
 
     async def first_ok() -> None:
@@ -158,16 +164,18 @@ def test_shutdown_hooks_all_attempted_when_one_raises() -> None:
         events.append("last")
 
     app = _build_app(on_shutdown=[first_ok, middle_raises, last_ok])
-    # Starlette propagates a shutdown error from TestClient on exit;
-    # we accept either the raw error or a wrapping RuntimeError —
-    # the contract is "every hook ran", which we verify via ``events``.
+    raised: BaseException | None = None
     try:
         with TestClient(app):
             pass
-    except Exception:
-        pass
+    except BaseException as exc:
+        raised = exc
 
     assert events == ["first", "middle", "last"]
+    assert raised is not None, (
+        "TestClient context exit should have surfaced the first " "shutdown hook error"
+    )
+    assert "scheduler stop failed" in _flatten_exception_text(raised)
 
 
 # ----- Boot-time validation --------------------------------------------


### PR DESCRIPTION
Closes #709.

## Summary

- Adds `on_startup` and `on_shutdown` kwargs to `serve()` (and the mirror fields on `ServeConfig`), threaded through `_serve_mcp_and_a2a()` → `_build_mcp_and_a2a_app()` → `_composed_lifespan`.
- Hooks are zero-arg async callables; startups fire after both inner MCP and A2A lifespans have initialized, shutdowns fire before either tears down. Failing startup hook aborts boot via `lifespan.startup.failed`; shutdown hooks all run best-effort, first failure re-raises, later failures log via `logger.exception`.
- Ships for `transport="both"` only — single-transport paths raise `ValueError` at boot rather than silently drop hooks. Rationale documented in code and error message.
- New `LifespanHook = Callable[[], Awaitable[None]]` alias in `adcp.server.serve` with its own docstring.
- Example `examples/scheduler_lifespan.py` shows the salesagent pattern (start/stop a scheduler tied to lifecycle) — replaces the 61-LOC `SchedulerLifespanMiddleware` adopters had to write before.

## Test plan

- [x] `tests/test_serve_lifespan_hooks.py` covers happy-path ordering (startups before yield, shutdowns after), failure propagation (startup raise aborts boot), shutdown best-effort (all hooks run even if one raises), boot-time validation on non-`both` transports, no-op default, and `ServeConfig` plumbing.
- [x] Existing `tests/test_unified_mcp_a2a.py` still passes — the unified app builds the same way when no hooks are supplied.
- [x] `ruff check src/`, `mypy src/adcp/`, pre-commit hooks all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)