### PR TITLE
fix(server): Authorization: Bearer always accepted; legacy headers additive (#720)

### DIFF
--- a/src/adcp/server/auth.py
+++ b/src/adcp/server/auth.py
@@ -80,7 +80,7 @@ import inspect
 import json
 import logging
 import warnings
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Mapping, Sequence
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
@@ -717,8 +717,8 @@ def validator_from_token_map(
 
 
 def _merge_alias_sources(
-    cross_aliases: tuple[str, ...] | None,
-    leg_aliases: tuple[str, ...] | None,
+    cross_aliases: Sequence[str] | None,
+    leg_aliases: Sequence[str] | None,
     cross_legacy_header: str | None,
     leg_legacy_header: str | None,
 ) -> list[str]:
@@ -727,10 +727,14 @@ def _merge_alias_sources(
     De-duplicates on lowercased name to keep the wire-check loop tight
     when adopters happen to specify the same header twice (e.g.
     legacy ``mcp_header_name="x-adcp-auth"`` plus new-shape
-    ``mcp_legacy_header_aliases=("X-ADCP-Auth",)``). The canonical
-    ``authorization`` header is filtered out here even if an adopter
-    lists it — it's accepted unconditionally by the middleware and
-    listing it as an alias is a no-op.
+    ``mcp_legacy_header_aliases=("X-ADCP-Auth",)``). First occurrence
+    wins; the preserved casing is **display-only** (the middleware
+    lowercases every alias before wire matching at
+    :meth:`BearerTokenAuthMiddleware.__init__`). The canonical
+    ``authorization`` header is filtered out as belt-and-suspenders —
+    ``__post_init__`` already rejects listing it as an alias, this
+    catches anything that bypasses validation (e.g. the legacy
+    ``header_name`` shim folding values into the resolved list).
     """
     raw: list[str] = []
     for src in (cross_aliases, leg_aliases):
@@ -799,13 +803,14 @@ class BearerTokenAuth:
     **``x-adcp-auth`` is a legacy-compat alias, not a recommended
     default.** Some early MCP adopters baked in a custom ``x-adcp-auth``
     header carrying a raw token (no scheme prefix) before the spec
-    settled. Sellers with deployed clients that can't be updated can
-    opt in per-leg::
+    settled. Sellers with deployed clients that can't be updated opt
+    in additively — ``Authorization: Bearer`` is still accepted, the
+    alias is consulted only when the canonical header is absent::
 
+        # Recommended new-shape (#720). Accepts both wire carriers.
         BearerTokenAuth(
             validate_token=...,
-            mcp_header_name="x-adcp-auth",          # legacy MCP clients only
-            mcp_bearer_prefix_required=False,
+            mcp_legacy_header_aliases=["x-adcp-auth"],   # MCP additive
             # A2A keeps the canonical RFC 6750 carrier by default
         )
 
@@ -846,9 +851,21 @@ class BearerTokenAuth:
     # additive opt-in for adopters mid-migration from custom headers.
     # Resolution order on each request: ``Authorization: Bearer``
     # first; if absent, each alias in order, first non-empty wins.
-    legacy_header_aliases: tuple[str, ...] | None = None
-    mcp_legacy_header_aliases: tuple[str, ...] | None = None
-    a2a_legacy_header_aliases: tuple[str, ...] | None = None
+    #
+    # Pick cross-leg ``legacy_header_aliases`` when both MCP and A2A
+    # adopters send the same custom header (most common case during
+    # migration). Pick per-leg ``mcp_legacy_header_aliases`` /
+    # ``a2a_legacy_header_aliases`` when only one transport had
+    # legacy clients (e.g. MCP rolled out earlier, A2A always used
+    # the spec carrier). Both can coexist; per-leg values are
+    # appended to the cross-leg list during resolution.
+    #
+    # Typed ``Sequence[str]`` so adopters can pass lists or tuples —
+    # ``__post_init__`` rejects bare strings (the trailing-comma
+    # tuple foot-gun: ``("x-adcp-auth")`` is a string, not a tuple).
+    legacy_header_aliases: Sequence[str] | None = None
+    mcp_legacy_header_aliases: Sequence[str] | None = None
+    a2a_legacy_header_aliases: Sequence[str] | None = None
     legacy_aliases_bearer_prefix_required: bool = False
 
     def __post_init__(self) -> None:
@@ -897,6 +914,49 @@ class BearerTokenAuth:
                     "custom header name (e.g. 'x-adcp-auth') for raw-token "
                     "schemes."
                 )
+
+        # #720: validate the new ``*_legacy_header_aliases`` fields
+        # at construction so silent misconfig fails loudly.
+        for alias_field in (
+            "legacy_header_aliases",
+            "mcp_legacy_header_aliases",
+            "a2a_legacy_header_aliases",
+        ):
+            value = getattr(self, alias_field)
+            if value is None:
+                continue
+            if isinstance(value, str):
+                # Bare string: the trailing-comma tuple foot-gun.
+                # ``mcp_legacy_header_aliases="x-adcp-auth"`` is a
+                # str, which is iterable letter-by-letter — the
+                # resolver would happily treat each letter as a
+                # separate alias. Fail loudly instead.
+                raise ValueError(
+                    f"BearerTokenAuth: {alias_field} must be a list/tuple "
+                    f"of header names, got bare str {value!r}. Did you "
+                    f"forget the trailing comma? Use "
+                    f"``{alias_field}=({value!r},)`` for a single-item "
+                    f"tuple, or ``{alias_field}=[{value!r}]`` for a list."
+                )
+            for name in value:
+                if not isinstance(name, str) or not name.strip():
+                    raise ValueError(
+                        f"BearerTokenAuth: {alias_field} entries must be "
+                        f"non-empty strings, got {name!r}."
+                    )
+                if name.lower() == "authorization":
+                    # ``Authorization`` is always accepted by the
+                    # middleware (the spec-canonical carrier per RFC
+                    # 6750). Listing it as a legacy alias is a no-op,
+                    # so flagging the misconfig loudly here is
+                    # friendlier than silently dropping it.
+                    raise ValueError(
+                        f"BearerTokenAuth: {alias_field} cannot include "
+                        "'authorization' — the spec-canonical header is "
+                        "always accepted by the middleware unconditionally. "
+                        "Listing it as a legacy alias is a no-op and "
+                        "almost always a config error."
+                    )
 
         # #720: deprecate the EXCLUSIVE per-leg / cross-leg header_name
         # kwargs in favor of additive ``*_legacy_header_aliases``.

--- a/src/adcp/server/auth.py
+++ b/src/adcp/server/auth.py
@@ -79,6 +79,7 @@ import hmac
 import inspect
 import json
 import logging
+import warnings
 from collections.abc import Awaitable, Mapping
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -301,21 +302,35 @@ class BearerTokenAuthMiddleware(BaseHTTPMiddleware):
     :param validate_token: Your token lookup. See :data:`TokenValidator`.
     :param unauthenticated_response: Optional override for the 401
         response body. Default is ``{"error": "unauthenticated"}``.
-    :param header_name: Which HTTP header carries the credential.
-        Default ``"authorization"`` (the spec-canonical bearer header).
-        Adopters with legacy clients sending tokens via a custom header
-        (e.g. ``"x-adcp-auth"``) override this. Header lookup is
-        case-insensitive (Starlette normalizes).
-    :param bearer_prefix_required: When ``True`` (default), the
-        middleware strips a ``"Bearer "`` prefix and rejects headers
-        without it. When ``False``, the raw header value is passed
-        verbatim to ``validate_token`` — appropriate for non-OAuth
-        custom-header schemes (``X-Api-Key: <token>``,
-        ``x-adcp-auth: <token>``, etc.). Adopters changing
-        ``header_name`` to a non-standard value usually want this set
-        to ``False``. **Security note:** setting this to ``False``
-        removes the prefix pre-filter; ``validate_token`` must be
-        defensive about unexpected input shapes and unbounded lengths.
+    :param legacy_header_aliases: Optional list of legacy header names
+        to accept in addition to the spec-canonical ``Authorization:
+        Bearer``. Resolution order on every request: ``Authorization:
+        Bearer <token>`` first; if absent, each alias in order; first
+        non-empty wins. The aliases path is for adopters mid-migration
+        from a custom header (e.g. ``x-adcp-auth``) — both work
+        simultaneously so no flag-day cutover is needed. **The
+        spec-canonical header is always accepted; aliases are
+        purely additive.**
+    :param legacy_aliases_bearer_prefix_required: Whether legacy alias
+        headers must carry a ``"Bearer "`` prefix. Default ``False``
+        — legacy custom-header schemes (``x-adcp-auth: <token>``)
+        carry the raw token. RFC 6750 ``Authorization`` always
+        requires the prefix regardless of this flag.
+    :param header_name: **DEPRECATED.** Set to a custom header name to
+        accept that header as a legacy alias. Maps internally to
+        ``legacy_header_aliases=[header_name]``. The historical
+        EXCLUSIVE behavior — "accept only this header, reject
+        Authorization" — was a foot-gun: every spec-compliant client
+        (browsers, every off-the-shelf HTTP library, the SDK's
+        ``security_baseline/probe_api_key`` probe) sends
+        ``Authorization: Bearer`` and was getting 401 against valid
+        tokens. The new behavior is ADDITIVE; pass
+        ``legacy_header_aliases=[...]`` explicitly for new code.
+        See #720.
+    :param bearer_prefix_required: **DEPRECATED.** Maps to
+        ``legacy_aliases_bearer_prefix_required`` when ``header_name``
+        is also set. Ignored when ``header_name`` is the canonical
+        ``"authorization"`` (which always requires ``Bearer``).
     """
 
     def __init__(
@@ -324,17 +339,51 @@ class BearerTokenAuthMiddleware(BaseHTTPMiddleware):
         *,
         validate_token: TokenValidator,
         unauthenticated_response: dict[str, Any] | None = None,
-        header_name: str = "authorization",
-        bearer_prefix_required: bool = True,
+        legacy_header_aliases: list[str] | None = None,
+        legacy_aliases_bearer_prefix_required: bool = False,
+        header_name: str | None = None,
+        bearer_prefix_required: bool | None = None,
     ) -> None:
         super().__init__(app)
         self._validate_token = validate_token
         self._unauth_body = unauthenticated_response or {"error": "unauthenticated"}
-        # Lower-cased once at construction so the per-request lookup
-        # avoids the normalization. Starlette's Headers does
-        # case-insensitive matching, so this is belt-and-suspenders.
-        self._header_name = header_name.lower()
-        self._bearer_prefix_required = bearer_prefix_required
+
+        # Back-compat shim for ``header_name`` / ``bearer_prefix_required``:
+        # the old EXCLUSIVE semantics ("only this header is accepted")
+        # broke every spec-compliant client because the middleware
+        # silently ignored ``Authorization: Bearer``. The new ADDITIVE
+        # model treats a custom ``header_name`` as a legacy alias — the
+        # canonical ``Authorization: Bearer`` stays accepted alongside.
+        # Emit a deprecation warning so adopters migrate to the explicit
+        # ``legacy_header_aliases`` kwarg.
+        aliases: list[str] = list(legacy_header_aliases or [])
+        alias_prefix_required = legacy_aliases_bearer_prefix_required
+        if header_name is not None and header_name.lower() != "authorization":
+            warnings.warn(
+                "BearerTokenAuthMiddleware(header_name=...) is deprecated. "
+                "Pass legacy_header_aliases=[header_name] instead. The new "
+                "shape is ADDITIVE — ``Authorization: Bearer`` is always "
+                "accepted alongside the alias, fixing the silent-401 bug "
+                "spec-compliant clients hit against the old EXCLUSIVE "
+                "behavior. See #720.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if header_name not in aliases:
+                aliases.insert(0, header_name)
+            if bearer_prefix_required is not None:
+                alias_prefix_required = bearer_prefix_required
+        elif bearer_prefix_required is not None:
+            warnings.warn(
+                "BearerTokenAuthMiddleware(bearer_prefix_required=...) is "
+                "deprecated. Pass legacy_aliases_bearer_prefix_required "
+                "for alias headers; ``Authorization: Bearer`` always "
+                "requires the ``Bearer`` prefix regardless. See #720.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self._alias_header_names = tuple(h.lower() for h in aliases)
+        self._alias_prefix_required = alias_prefix_required
 
     async def dispatch(self, request: Request, call_next: Any) -> Any:
         method, tool = await self._peek_jsonrpc(request)
@@ -350,15 +399,7 @@ class BearerTokenAuthMiddleware(BaseHTTPMiddleware):
                 _set_request_state(request, None, None, None)
                 return await call_next(request)
 
-            raw_header = request.headers.get(self._header_name, "")
-            if self._bearer_prefix_required:
-                bearer = _parse_bearer_header(raw_header)
-            else:
-                # Custom-header schemes (X-Api-Key, x-adcp-auth, etc.) —
-                # pass the raw value through unchanged. Strip whitespace
-                # since copy-paste tokens often pick up trailing newlines.
-                stripped = raw_header.strip()
-                bearer = stripped or None
+            bearer = self._extract_bearer(request)
             if not bearer:
                 return self._unauthenticated()
 
@@ -407,6 +448,38 @@ class BearerTokenAuthMiddleware(BaseHTTPMiddleware):
                 current_tenant.reset(tenant_token)
             if metadata_token is not None:
                 current_principal_metadata.reset(metadata_token)
+
+    def _extract_bearer(self, request: Request) -> str | None:
+        """Resolve the token from incoming headers.
+
+        Per RFC 6750 §2.1 the canonical carrier is ``Authorization:
+        Bearer <token>``; check that first. If absent, walk the
+        configured ``legacy_header_aliases`` in order — first non-empty
+        wins. Legacy aliases carry raw tokens (no scheme prefix) unless
+        ``legacy_aliases_bearer_prefix_required=True``. Both paths
+        coexist so adopters mid-migration can move clients from a
+        custom header to ``Authorization: Bearer`` without a flag day
+        (#720).
+        """
+        # 1. Spec-canonical first.
+        canonical = request.headers.get("authorization", "")
+        bearer = _parse_bearer_header(canonical)
+        if bearer:
+            return bearer
+
+        # 2. Legacy aliases — additive opt-in.
+        for alias in self._alias_header_names:
+            raw = request.headers.get(alias, "")
+            if not raw:
+                continue
+            if self._alias_prefix_required:
+                token = _parse_bearer_header(raw)
+            else:
+                token = raw.strip() or None
+            if token:
+                return token
+
+        return None
 
     def is_discovery_request(self, method: str | None, tool: str | None) -> bool:
         """True when the request should bypass auth.
@@ -643,6 +716,42 @@ def validator_from_token_map(
 # ---------------------------------------------------------------------------
 
 
+def _merge_alias_sources(
+    cross_aliases: tuple[str, ...] | None,
+    leg_aliases: tuple[str, ...] | None,
+    cross_legacy_header: str | None,
+    leg_legacy_header: str | None,
+) -> list[str]:
+    """Compose the effective legacy-alias list from #720's four sources.
+
+    De-duplicates on lowercased name to keep the wire-check loop tight
+    when adopters happen to specify the same header twice (e.g.
+    legacy ``mcp_header_name="x-adcp-auth"`` plus new-shape
+    ``mcp_legacy_header_aliases=("X-ADCP-Auth",)``). The canonical
+    ``authorization`` header is filtered out here even if an adopter
+    lists it — it's accepted unconditionally by the middleware and
+    listing it as an alias is a no-op.
+    """
+    raw: list[str] = []
+    for src in (cross_aliases, leg_aliases):
+        if src:
+            raw.extend(src)
+    for legacy in (cross_legacy_header, leg_legacy_header):
+        if legacy is not None and legacy.lower() != "authorization":
+            raw.append(legacy)
+    out: list[str] = []
+    seen: set[str] = set()
+    for name in raw:
+        normalized = name.lower()
+        if normalized == "authorization":
+            continue
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append(name)
+    return out
+
+
 @dataclass(frozen=True)
 class BearerTokenAuth:
     """Cross-transport bearer-token auth config for :func:`adcp.server.serve`.
@@ -732,6 +841,15 @@ class BearerTokenAuth:
     a2a_header_name: str | None = None
     a2a_bearer_prefix_required: bool | None = None
     unauthenticated_response: dict[str, Any] | None = None
+    # NEW (#720) — additive legacy aliases. ``Authorization: Bearer``
+    # is ALWAYS accepted regardless of these fields; this is purely
+    # additive opt-in for adopters mid-migration from custom headers.
+    # Resolution order on each request: ``Authorization: Bearer``
+    # first; if absent, each alias in order, first non-empty wins.
+    legacy_header_aliases: tuple[str, ...] | None = None
+    mcp_legacy_header_aliases: tuple[str, ...] | None = None
+    a2a_legacy_header_aliases: tuple[str, ...] | None = None
+    legacy_aliases_bearer_prefix_required: bool = False
 
     def __post_init__(self) -> None:
         if self.header_name is not None and (
@@ -778,6 +896,32 @@ class BearerTokenAuth:
                     "(Authorization carries '<scheme> <credentials>'). Use a "
                     "custom header name (e.g. 'x-adcp-auth') for raw-token "
                     "schemes."
+                )
+
+        # #720: deprecate the EXCLUSIVE per-leg / cross-leg header_name
+        # kwargs in favor of additive ``*_legacy_header_aliases``.
+        # Setting any of them maps the value into the resolved alias
+        # list AND keeps ``Authorization: Bearer`` accepted — fixes
+        # the silent-401 against spec-compliant clients (security
+        # baseline ``probe_api_key`` storyboard).
+        _legacy_to_new = {
+            "header_name": "legacy_header_aliases",
+            "mcp_header_name": "mcp_legacy_header_aliases",
+            "a2a_header_name": "a2a_legacy_header_aliases",
+        }
+        for legacy_field, new_field in _legacy_to_new.items():
+            value = getattr(self, legacy_field)
+            if value is not None and value.lower() != "authorization":
+                warnings.warn(
+                    f"BearerTokenAuth({legacy_field}={value!r}) is "
+                    "deprecated — the EXCLUSIVE single-header model "
+                    "silently rejects spec-compliant clients sending "
+                    f"``Authorization: Bearer``. Migrate to "
+                    f"``{new_field}=({value!r},)``: the new shape ADDS "
+                    "your custom header as an alias while keeping the "
+                    "RFC 6750 canonical header accepted. See #720.",
+                    DeprecationWarning,
+                    stacklevel=3,
                 )
 
     def resolved_mcp_header_name(self) -> str:
@@ -838,6 +982,40 @@ class BearerTokenAuth:
         if self.a2a_bearer_prefix_required is not None:
             return self.a2a_bearer_prefix_required
         return True
+
+    def resolved_mcp_legacy_aliases(self) -> list[str]:
+        """Effective MCP legacy-alias list after legacy + new-shape merge.
+
+        Per #720, ``Authorization: Bearer`` is ALWAYS accepted; this
+        method returns the additional header names accepted alongside.
+        Sources, in order:
+
+        1. ``legacy_header_aliases`` (cross-leg, new-shape).
+        2. ``mcp_legacy_header_aliases`` (per-leg, new-shape).
+        3. Deprecated ``header_name`` when set to a non-canonical
+           value (folded in as an alias for back-compat).
+        4. Deprecated ``mcp_header_name`` when set to a non-canonical
+           value (same).
+
+        Returns an empty list when the adopter wants spec-canonical
+        only (no legacy clients to keep working).
+        """
+        return _merge_alias_sources(
+            self.legacy_header_aliases,
+            self.mcp_legacy_header_aliases,
+            self.header_name,
+            self.mcp_header_name,
+        )
+
+    def resolved_a2a_legacy_aliases(self) -> list[str]:
+        """Effective A2A legacy-alias list — analog of
+        :meth:`resolved_mcp_legacy_aliases` for the A2A leg. See #720."""
+        return _merge_alias_sources(
+            self.legacy_header_aliases,
+            self.a2a_legacy_header_aliases,
+            self.header_name,
+            self.a2a_header_name,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -1122,12 +1122,29 @@ def _wrap_mcp_with_auth(app: Any, auth: BearerTokenAuth | None) -> Any:
     # FastMCP's ``streamable_http_app()`` returns a Starlette instance;
     # ``add_middleware`` wraps the inner app in place and preserves
     # FastMCP's lifespan + routing without a parallel Starlette.
+    #
+    # Per #720, ``Authorization: Bearer`` is always accepted; any
+    # legacy custom header configured on ``BearerTokenAuth`` is folded
+    # in as an additive alias. The legacy single-knob path (the
+    # ``BearerTokenAuthMiddleware`` deprecation warnings on
+    # ``header_name=`` / ``bearer_prefix_required=``) is bypassed here
+    # — the dataclass already absorbed those into the alias list.
     app.add_middleware(
         BearerTokenAuthMiddleware,
         validate_token=auth.validate_token,
         unauthenticated_response=auth.unauthenticated_response,
-        header_name=auth.resolved_mcp_header_name(),
-        bearer_prefix_required=auth.resolved_mcp_bearer_prefix_required(),
+        legacy_header_aliases=auth.resolved_mcp_legacy_aliases(),
+        legacy_aliases_bearer_prefix_required=(
+            # If adopter configured legacy bearer-prefix via the old
+            # kwargs, honor that on the alias path. New-shape adopters
+            # set this directly on the dataclass.
+            auth.resolved_mcp_bearer_prefix_required()
+            if (
+                auth.bearer_prefix_required is not None
+                or auth.mcp_bearer_prefix_required is not None
+            )
+            else auth.legacy_aliases_bearer_prefix_required
+        ),
     )
     return app
 

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -1128,7 +1128,11 @@ def _wrap_mcp_with_auth(app: Any, auth: BearerTokenAuth | None) -> Any:
     # in as an additive alias. The legacy single-knob path (the
     # ``BearerTokenAuthMiddleware`` deprecation warnings on
     # ``header_name=`` / ``bearer_prefix_required=``) is bypassed here
-    # — the dataclass already absorbed those into the alias list.
+    # — the dataclass's ``__post_init__`` already emits the
+    # deprecation warning (one warning per adopter, fired at config
+    # construction). Threading through the alias path keeps the
+    # middleware-level deprecation suppressed; the adopter sees a
+    # single coherent migration signal at one site.
     app.add_middleware(
         BearerTokenAuthMiddleware,
         validate_token=auth.validate_token,

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -752,8 +752,11 @@ async def test_custom_header_strips_whitespace() -> None:
 
 
 @pytest.mark.asyncio
-async def test_custom_header_rejects_missing_credential() -> None:
-    """Custom-header mode still 401s when the configured header isn't present."""
+async def test_custom_header_rejects_when_no_credential_present() -> None:
+    """Alias-only mode still 401s when neither the configured alias nor
+    ``Authorization: Bearer`` is present. Sends no auth header at all
+    so the test isolates "missing credential" from the #720 additive-
+    Authorization behavior covered separately."""
 
     def validator(token: str) -> Principal | None:
         return Principal(caller_identity="alice")
@@ -765,12 +768,10 @@ async def test_custom_header_rejects_missing_credential() -> None:
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
         ) as client:
-            # Send an Authorization header — but the middleware is configured
-            # to look at x-adcp-auth, so this must be rejected.
             resp = await client.post(
                 "/",
                 json={"method": "tools/call", "params": {"name": "get_products"}},
-                headers={"authorization": "Bearer tok_alice"},
+                # No Authorization, no x-adcp-auth.
             )
     assert resp.status_code == 401
 
@@ -810,14 +811,17 @@ async def test_custom_header_with_bearer_prefix_still_required() -> None:
 
 
 @pytest.mark.asyncio
-async def test_custom_header_is_exclusive_no_fallback_to_authorization() -> None:
-    """Custom header_name is exclusive — Authorization is never consulted.
+async def test_authorization_wins_when_both_headers_present() -> None:
+    """Per #720, ``Authorization: Bearer`` is the spec-canonical
+    carrier and is always checked first. When both ``Authorization:
+    Bearer X`` and the legacy alias ``x-adcp-auth: Y`` are present,
+    ``X`` wins — the alias is the fallback path, not a competing
+    primary.
 
-    When both ``Authorization: Bearer X`` and ``x-adcp-auth: Y`` are
-    present and the middleware is configured for ``x-adcp-auth``, only
-    ``Y`` reaches the validator. There is no fallback to the standard
-    header. Closes the "I expected fallback to Authorization" footgun for
-    adopters who set header_name accidentally.
+    (This test replaces the pre-#720 exclusive-mode assertion that
+    pinned the silent-401 bug — adopters with ``header_name`` set
+    used to reject every spec-compliant client; now those clients
+    are accepted on the canonical header.)
     """
     received: list[str] = []
 
@@ -841,7 +845,7 @@ async def test_custom_header_is_exclusive_no_fallback_to_authorization() -> None
                 },
             )
     assert resp.status_code == 200
-    assert received == ["tok_y"]  # x-adcp-auth wins; Authorization is ignored
+    assert received == ["tok_x"]  # Authorization: Bearer wins per #720
 
 
 @pytest.mark.asyncio
@@ -865,3 +869,187 @@ async def test_default_header_unchanged_for_existing_adopters() -> None:
                 headers={"authorization": "Bearer tok_alice"},
             )
     assert resp.status_code == 200
+
+
+# ===========================================================================
+# #720: legacy_header_aliases — Authorization always accepted; aliases additive
+# ===========================================================================
+
+
+def _build_app_with_aliases(
+    validator: Any,
+    *,
+    legacy_header_aliases: list[str] | None = None,
+    legacy_aliases_bearer_prefix_required: bool = False,
+) -> Starlette:
+    app = Starlette(routes=[Route("/", _echo_handler, methods=["POST"])])
+    app.add_middleware(
+        BearerTokenAuthMiddleware,
+        validate_token=validator,
+        legacy_header_aliases=legacy_header_aliases,
+        legacy_aliases_bearer_prefix_required=legacy_aliases_bearer_prefix_required,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_authorization_bearer_always_accepted_alongside_alias() -> None:
+    """Per #720 the spec-canonical ``Authorization: Bearer`` is always
+    accepted regardless of whether legacy aliases are configured.
+    Adopters who set ``legacy_header_aliases=["x-adcp-auth"]`` get
+    BOTH paths working — no flag-day cutover."""
+    received: list[str] = []
+
+    def validator(token: str) -> Principal | None:
+        received.append(token)
+        return Principal(caller_identity="alice")
+
+    app = _build_app_with_aliases(validator, legacy_header_aliases=["x-adcp-auth"])
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r_auth = await client.post(
+                "/",
+                json={"method": "tools/call", "params": {"name": "get_products"}},
+                headers={"Authorization": "Bearer canonical-token"},
+            )
+            r_alias = await client.post(
+                "/",
+                json={"method": "tools/call", "params": {"name": "get_products"}},
+                headers={"x-adcp-auth": "legacy-token"},
+            )
+
+    assert r_auth.status_code == 200
+    assert r_alias.status_code == 200
+    assert received == ["canonical-token", "legacy-token"]
+
+
+@pytest.mark.asyncio
+async def test_alias_falls_through_when_authorization_missing() -> None:
+    """The alias path is the fallback — only consulted when
+    ``Authorization`` is absent or empty. Confirms the resolution
+    order is canonical-first."""
+    received: list[str] = []
+
+    def validator(token: str) -> Principal | None:
+        received.append(token)
+        return Principal(caller_identity="alice")
+
+    app = _build_app_with_aliases(validator, legacy_header_aliases=["x-adcp-auth"])
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/",
+                json={"method": "tools/call", "params": {"name": "get_products"}},
+                headers={"x-adcp-auth": "fallback-token"},
+            )
+
+    assert resp.status_code == 200
+    assert received == ["fallback-token"]
+
+
+@pytest.mark.asyncio
+async def test_empty_authorization_falls_through_to_alias() -> None:
+    """``Authorization: `` (empty value) shouldn't short-circuit the
+    chain — adopters mid-migration sometimes have a client that sets
+    the header to an empty string in error. The alias path must still
+    be consulted."""
+    received: list[str] = []
+
+    def validator(token: str) -> Principal | None:
+        received.append(token)
+        return Principal(caller_identity="alice")
+
+    app = _build_app_with_aliases(validator, legacy_header_aliases=["x-adcp-auth"])
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/",
+                json={"method": "tools/call", "params": {"name": "get_products"}},
+                headers={
+                    "Authorization": "",  # empty — shouldn't 401 by itself
+                    "x-adcp-auth": "fallback-token",
+                },
+            )
+
+    assert resp.status_code == 200
+    assert received == ["fallback-token"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_aliases_walked_in_order() -> None:
+    """When two aliases are configured and both are present on the
+    request, the first one in the list wins. Adopters with multiple
+    legacy carriers (different generations of clients) get
+    deterministic resolution."""
+    received: list[str] = []
+
+    def validator(token: str) -> Principal | None:
+        received.append(token)
+        return Principal(caller_identity="alice")
+
+    app = _build_app_with_aliases(validator, legacy_header_aliases=["x-adcp-auth", "x-api-key"])
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/",
+                json={"method": "tools/call", "params": {"name": "get_products"}},
+                headers={
+                    "x-adcp-auth": "first-alias",
+                    "x-api-key": "second-alias",
+                },
+            )
+
+    assert resp.status_code == 200
+    assert received == ["first-alias"]  # first alias in the list wins
+
+
+@pytest.mark.asyncio
+async def test_legacy_header_name_kwarg_emits_deprecation() -> None:
+    """The pre-#720 ``header_name=`` kwarg is deprecated. Construction
+    must emit a ``DeprecationWarning`` naming the new replacement so
+    adopters get a clear migration signal at server boot."""
+
+    def validator(token: str) -> Principal | None:
+        return Principal(caller_identity="alice")
+
+    with pytest.warns(DeprecationWarning, match="legacy_header_aliases"):
+        # Building the middleware via Starlette's add_middleware doesn't
+        # surface the warning at construction time (it builds lazily).
+        # Build the class directly to capture it.
+        BearerTokenAuthMiddleware(
+            app=Starlette(),
+            validate_token=validator,
+            header_name="x-adcp-auth",
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_aliases_no_authorization_returns_401() -> None:
+    """The baseline check: no headers at all → 401. Documents that
+    the additive resolution still 401s on missing credentials —
+    aliases don't relax the auth requirement, they just widen the
+    accepted carriers."""
+
+    def validator(token: str) -> Principal | None:
+        return Principal(caller_identity="alice")
+
+    app = _build_app_with_aliases(validator, legacy_header_aliases=["x-adcp-auth"])
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/",
+                json={"method": "tools/call", "params": {"name": "get_products"}},
+                # No headers.
+            )
+
+    assert resp.status_code == 401

--- a/tests/test_auth_per_leg_headers.py
+++ b/tests/test_auth_per_leg_headers.py
@@ -156,15 +156,33 @@ class TestLegacyHeaderAliases:
                 mcp_header_name="x-adcp-auth",
             )
 
-    def test_alias_deduplicates_canonical_authorization(self):
-        """``Authorization`` listed as an alias is a no-op — it's
-        accepted by the middleware unconditionally. The resolved list
-        filters it out so the wire-check loop stays tight."""
-        cfg = BearerTokenAuth(
-            validate_token=_validator(),
-            legacy_header_aliases=("authorization", "x-adcp-auth"),
-        )
-        assert cfg.resolved_mcp_legacy_aliases() == ["x-adcp-auth"]
+    def test_canonical_authorization_in_resolved_aliases_filtered(self):
+        """Belt-and-suspenders: ``_merge_alias_sources`` filters
+        ``authorization`` out of the resolved list. ``__post_init__``
+        rejects it on the new-shape fields (see
+        ``test_rejects_authorization_listed_as_alias``), but the legacy
+        ``header_name="authorization"`` shim path is allowed at
+        construction (it's the spec-canonical default) and would
+        otherwise flow into the alias list as a no-op.
+
+        Verifies the filter triggers even when the value bypasses the
+        new-shape validation gate — i.e. the wire-loop stays tight
+        regardless of which migration path the adopter is on.
+        """
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cfg = BearerTokenAuth(
+                validate_token=_validator(),
+                # Legacy header_name="authorization" is allowed (it's
+                # the spec default); the resolved list filters it out
+                # to keep the alias loop empty.
+                header_name="authorization",
+                bearer_prefix_required=True,
+            )
+        assert cfg.resolved_mcp_legacy_aliases() == []
+        assert cfg.resolved_a2a_legacy_aliases() == []
 
     def test_alias_deduplicates_repeats_across_sources(self):
         """When a header appears via both cross-leg and per-leg fields
@@ -177,6 +195,71 @@ class TestLegacyHeaderAliases:
             mcp_legacy_header_aliases=("x-adcp-auth",),
         )
         assert cfg.resolved_mcp_legacy_aliases() == ["X-ADCP-Auth"]
+
+    def test_rejects_bare_string_alias_trailing_comma_foot_gun(self):
+        """``mcp_legacy_header_aliases="x-adcp-auth"`` (forgot trailing
+        comma → str, not tuple) would walk letter-by-letter under the
+        resolver. Fail loudly at construction with a hint pointing at
+        the fix. (See PR #721 review — the DX trap an agent generating
+        config can fall into.)"""
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="trailing comma"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                mcp_legacy_header_aliases="x-adcp-auth",  # type: ignore[arg-type]
+            )
+
+    def test_rejects_authorization_listed_as_alias(self):
+        """``Authorization`` is the always-accepted canonical header.
+        Listing it as a legacy alias is a no-op AND almost always a
+        config error (adopter likely meant a sibling field). Fail
+        loudly at construction rather than silently dropping."""
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="cannot include 'authorization'"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                legacy_header_aliases=("authorization",),
+            )
+
+    def test_rejects_empty_alias_string(self):
+        """Empty strings can't possibly match a wire header. Loud-fail
+        matches the existing empty-string check on ``header_name``."""
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="non-empty strings"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                legacy_header_aliases=("",),
+            )
+
+    def test_accepts_list_form(self):
+        """``legacy_header_aliases=[...]`` (list, not tuple) works the
+        same — the field is typed ``Sequence[str]`` so adopters and
+        agents that generate list literals don't hit a type error.
+        Pairs with the trailing-comma foot-gun guard."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            legacy_header_aliases=["x-adcp-auth", "x-api-key"],
+        )
+        assert cfg.resolved_mcp_legacy_aliases() == ["x-adcp-auth", "x-api-key"]
+
+    def test_new_shape_emits_no_deprecation_warning(self):
+        """The whole point of the new-shape API: adopters using
+        ``*_legacy_header_aliases=`` get no DeprecationWarning. Pin
+        this so a future refactor that accidentally widens the
+        warning trigger gets caught."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            # If this raises, a DeprecationWarning fired and the test
+            # fails — exactly what we want.
+            BearerTokenAuth(
+                validate_token=_validator(),
+                mcp_legacy_header_aliases=("x-adcp-auth",),
+            )
 
 
 class TestConflictingKnobsRejected:

--- a/tests/test_auth_per_leg_headers.py
+++ b/tests/test_auth_per_leg_headers.py
@@ -97,6 +97,88 @@ class TestResolvedDefaults:
         assert cfg.resolved_a2a_bearer_prefix_required() is True
 
 
+class TestLegacyHeaderAliases:
+    """#720: ``Authorization: Bearer`` is always accepted; legacy
+    custom headers become additive opt-in aliases. The dataclass
+    surface is the explicit ``*_legacy_header_aliases`` fields."""
+
+    def test_default_has_no_aliases(self):
+        """Default config — adopters get spec-canonical only."""
+        cfg = BearerTokenAuth(validate_token=_validator())
+        assert cfg.resolved_mcp_legacy_aliases() == []
+        assert cfg.resolved_a2a_legacy_aliases() == []
+
+    def test_per_leg_aliases_apply(self):
+        """Per-leg explicit aliases — preferred new-shape API."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            mcp_legacy_header_aliases=("x-adcp-auth",),
+            a2a_legacy_header_aliases=("x-api-key",),
+        )
+        assert cfg.resolved_mcp_legacy_aliases() == ["x-adcp-auth"]
+        assert cfg.resolved_a2a_legacy_aliases() == ["x-api-key"]
+
+    def test_cross_leg_aliases_apply_to_both(self):
+        """Cross-leg ``legacy_header_aliases`` applies to MCP + A2A."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            legacy_header_aliases=("x-adcp-auth",),
+        )
+        assert cfg.resolved_mcp_legacy_aliases() == ["x-adcp-auth"]
+        assert cfg.resolved_a2a_legacy_aliases() == ["x-adcp-auth"]
+
+    def test_legacy_header_name_folds_into_aliases(self):
+        """Back-compat: the deprecated ``mcp_header_name`` kwarg is
+        absorbed into the alias list so old configs keep working
+        through the additive path. The ``DeprecationWarning`` from
+        ``__post_init__`` is the migration signal."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cfg = BearerTokenAuth(
+                validate_token=_validator(),
+                mcp_header_name="x-adcp-auth",
+            )
+        assert cfg.resolved_mcp_legacy_aliases() == ["x-adcp-auth"]
+        # A2A leg gets no alias when only ``mcp_header_name`` is set.
+        assert cfg.resolved_a2a_legacy_aliases() == []
+
+    def test_legacy_header_name_emits_deprecation_warning(self):
+        """Setting any ``*_header_name`` (other than ``authorization``)
+        emits a ``DeprecationWarning`` naming the new replacement so
+        adopters get a clear migration signal at server boot."""
+        import pytest as _pytest
+
+        with _pytest.warns(DeprecationWarning, match="legacy_header_aliases"):
+            BearerTokenAuth(
+                validate_token=_validator(),
+                mcp_header_name="x-adcp-auth",
+            )
+
+    def test_alias_deduplicates_canonical_authorization(self):
+        """``Authorization`` listed as an alias is a no-op — it's
+        accepted by the middleware unconditionally. The resolved list
+        filters it out so the wire-check loop stays tight."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            legacy_header_aliases=("authorization", "x-adcp-auth"),
+        )
+        assert cfg.resolved_mcp_legacy_aliases() == ["x-adcp-auth"]
+
+    def test_alias_deduplicates_repeats_across_sources(self):
+        """When a header appears via both cross-leg and per-leg fields
+        (case-insensitive), the resolved list keeps only the first
+        occurrence — keeps the dispatch loop tight under config
+        copy-paste."""
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            legacy_header_aliases=("X-ADCP-Auth",),
+            mcp_legacy_header_aliases=("x-adcp-auth",),
+        )
+        assert cfg.resolved_mcp_legacy_aliases() == ["X-ADCP-Auth"]
+
+
 class TestConflictingKnobsRejected:
     """Setting both legacy and per-leg knobs for the same axis is
     ambiguous — fail closed at construction so misconfigurations don't
@@ -267,19 +349,27 @@ class TestA2AMiddlewareHonorsPerLegConfig:
 @pytest.mark.asyncio
 async def test_mcp_per_leg_header_routes_through_middleware() -> None:
     """End-to-end: ``mcp_header_name="x-adcp-auth"`` +
-    ``mcp_bearer_prefix_required=False`` thread the resolved values
-    into the MCP-side ``BearerTokenAuthMiddleware``. A request carrying
-    the raw token in ``x-adcp-auth`` passes; a request carrying it in
-    ``Authorization`` (the legacy default carrier) is rejected.
+    ``mcp_bearer_prefix_required=False`` thread the configured legacy
+    header into the MCP-side ``BearerTokenAuthMiddleware`` as an
+    ADDITIVE alias. Per #720, the spec-canonical
+    ``Authorization: Bearer`` is always accepted alongside — adopters
+    mid-migration get both wire carriers working simultaneously
+    without a flag-day cutover.
     """
+    import warnings
+
     from adcp.server import create_mcp_server
     from adcp.server.serve import _wrap_mcp_with_auth
 
-    cfg = BearerTokenAuth(
-        validate_token=_validator(),
-        mcp_header_name="x-adcp-auth",
-        mcp_bearer_prefix_required=False,
-    )
+    with warnings.catch_warnings():
+        # ``mcp_header_name=`` is deprecated per #720 — the test
+        # exercises the back-compat path, so suppress the warning here.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        cfg = BearerTokenAuth(
+            validate_token=_validator(),
+            mcp_header_name="x-adcp-auth",
+            mcp_bearer_prefix_required=False,
+        )
     mcp = create_mcp_server(_Handler(), name="t", validation=None)
     mcp_app = mcp.streamable_http_app()
     app = _wrap_mcp_with_auth(mcp_app, cfg)
@@ -313,12 +403,12 @@ async def test_mcp_per_leg_header_routes_through_middleware() -> None:
                     "Authorization": "Bearer good-token",
                 },
             )
-    # x-adcp-auth carrier accepted — anything except 401 means auth
-    # passed through to the inner handler.
+    # Both carriers must work — the legacy alias for early adopters,
+    # the canonical Authorization for spec-compliant clients. #720
+    # is exactly the bug-fix that flipped the prior assertion that
+    # ``Authorization`` would be rejected.
     assert resp_x_adcp.status_code != 401, resp_x_adcp.text
-    # Authorization carrier rejected — the per-leg config moved the
-    # carrier off the legacy default.
-    assert resp_authz.status_code == 401
+    assert resp_authz.status_code != 401, resp_authz.text
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #720.

## Summary

``BearerTokenAuthMiddleware`` previously took an EXCLUSIVE ``header_name`` kwarg — setting it to a custom value (e.g. ``x-adcp-auth``) silently rejected every request carrying the spec-canonical ``Authorization: Bearer`` header. Every spec-compliant client (browsers, off-the-shelf HTTP libraries, the AdCP ``security_baseline/probe_api_key`` storyboard) failed against the middleware named for RFC 6750 because the middleware actively ignored the RFC 6750 carrier.

This PR inverts the semantics: **``Authorization: Bearer`` is always accepted; legacy custom headers become additive opt-in aliases.**

## Surface changes

- **``BearerTokenAuthMiddleware``** — new ``legacy_header_aliases: list[str] | None`` + ``legacy_aliases_bearer_prefix_required: bool`` kwargs. Old ``header_name`` / ``bearer_prefix_required`` deprecated, folded into the alias list internally; behavior shifts from EXCLUSIVE → ADDITIVE.
- **``BearerTokenAuth`` dataclass** — new ``legacy_header_aliases`` / ``mcp_legacy_header_aliases`` / ``a2a_legacy_header_aliases`` fields. New ``resolved_mcp_legacy_aliases()`` / ``resolved_a2a_legacy_aliases()`` accessors. Per-leg ``mcp_header_name`` / ``a2a_header_name`` emit ``DeprecationWarning``.
- **``_wrap_mcp_with_auth``** threads the resolved alias list to the middleware instead of the legacy single-header kwarg.

## Behavior change (changelog-worthy)

Pre-#720: ``mcp_header_name=\"x-adcp-auth\"`` made the middleware ONLY check ``x-adcp-auth``. Spec-compliant clients silently 401'd.

Post-#720: same config makes ``x-adcp-auth`` an additive alias; ``Authorization: Bearer`` is also accepted. Existing legacy clients keep working; spec-compliant clients start working. The deprecation warning surfaces the migration.

## Adopter migration

```python
# Was: rejects spec-compliant clients silently
BearerTokenAuth(
    validate_token=...,
    mcp_header_name=\"x-adcp-auth\",
    mcp_bearer_prefix_required=False,
)

# Is: both wire carriers work simultaneously
BearerTokenAuth(
    validate_token=...,
    mcp_legacy_header_aliases=(\"x-adcp-auth\",),
)
```

## Test plan

- [x] 7 new middleware-level tests + 6 new dataclass-level tests covering the additive contract, alias resolution order, deprecation warnings, dedup edge cases.
- [x] 3 existing tests updated for the new ADDITIVE contract (renamed where they pinned the bug).
- [x] All 106 auth tests pass locally; full sweep 4267 tests pass.
- [x] ``ruff`` + ``mypy`` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)