### PR TITLE
feat(decisioning): PgProposalStore + framework package derivation (#727)

### DIFF
--- a/examples/sales_proposal_mode_seller/src/proposal_manager.py
+++ b/examples/sales_proposal_mode_seller/src/proposal_manager.py
@@ -121,8 +121,19 @@ def _draft_proposal_payload(allocations: dict[str, float] | None = None) -> dict
     Required fields: ``proposal_id``, ``name``, ``allocations``. Each
     allocation entry carries ``product_id`` + ``allocation_percentage``
     (0-100). Percentages must sum to 100.
+
+    The ``pricing_option_id`` on each allocation feeds the framework's
+    package derivation (per #727) — when the buyer calls
+    ``create_media_buy(proposal_id=..., total_budget=...)`` with no
+    explicit ``packages[]``, the framework derives one package per
+    allocation using ``pricing_option_id``.
     """
     alloc = allocations or {"ctv-premium-q2": 60.0, "display-run-q2": 40.0}
+    # Map each product to the canonical pricing_option_id from _PRODUCTS.
+    pricing_option_ids = {
+        "ctv-premium-q2": "po-ctv-cpm",
+        "display-run-q2": "po-display-cpm",
+    }
     return {
         "proposal_id": PROPOSAL_ID,
         "name": "Balanced Reach Q2 — CTV-led",
@@ -132,6 +143,7 @@ def _draft_proposal_payload(allocations: dict[str, float] | None = None) -> dict
             {
                 "product_id": pid,
                 "allocation_percentage": pct,
+                "pricing_option_id": pricing_option_ids.get(pid, "po-default"),
                 "rationale": f"Indicative {pct:.0f}% allocation to {pid}.",
             }
             for pid, pct in alloc.items()
@@ -154,6 +166,9 @@ class ProposalModeProposalManager:
         # 60s grace absorbs clock skew between the seller's
         # expires_at and the buyer's create_media_buy call.
         expires_at_grace_seconds=60,
+        # #727: let the framework derive packages from the proposal's
+        # allocations when the buyer omits packages[] on create_media_buy.
+        derive_packages_from_allocations=True,
     )
 
     async def get_products(

--- a/src/adcp/decisioning/__init__.py
+++ b/src/adcp/decisioning/__init__.py
@@ -84,6 +84,7 @@ from adcp.decisioning.context import (
     AuthInfo,
     RequestContext,
 )
+from adcp.decisioning.derive_packages import derive_packages_from_proposal
 from adcp.decisioning.dispatch import validate_platform
 from adcp.decisioning.errors import (
     AccountNotFoundError,
@@ -260,7 +261,11 @@ from adcp.decisioning.validate_capabilities import (
 # ``Pg*`` convention shared with PgReplayStore / PgBuyerAgentRegistry /
 # PgWebhookDeliverySupervisor.
 try:
-    from adcp.decisioning.pg import PgTaskRegistry, PostgresTaskRegistry  # noqa: F401
+    from adcp.decisioning.pg import (  # noqa: F401
+        PgProposalStore,
+        PgTaskRegistry,
+        PostgresTaskRegistry,
+    )
 except ImportError:  # pragma: no cover — exercised by the [pg] extra tests
     from typing import ClassVar as _ClassVar
 
@@ -282,6 +287,22 @@ except ImportError:  # pragma: no cover — exercised by the [pg] extra tests
 
     # Deprecated alias preserved through 4.4.x.
     PostgresTaskRegistry: type[PgTaskRegistry] = PgTaskRegistry  # type: ignore[no-redef]
+
+    class PgProposalStore:  # type: ignore[no-redef]
+        """Stub raised when ``adcp[pg]`` isn't installed.
+
+        Attempting to instantiate raises :class:`ImportError` with the
+        install-hint text from :mod:`adcp.decisioning.pg.proposal_store`.
+        """
+
+        is_durable: _ClassVar[bool] = True
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise ImportError(
+                "PgProposalStore requires psycopg3 and psycopg-pool. "
+                "Install the 'pg' extra: `pip install 'adcp[pg]'` "
+                "(Poetry: `poetry add 'adcp[pg]'`)."
+            )
 
 
 __all__ = [
@@ -338,6 +359,7 @@ __all__ = [
     "NoAuth",
     "OAuthCredential",
     "PermissionDeniedError",
+    "PgProposalStore",
     "PgTaskRegistry",
     "LazyPlatformRouter",
     "PlatformRouter",
@@ -415,6 +437,7 @@ __all__ = [
     "create_tenant_store",
     "create_translation_map",
     "create_upstream_http_client",
+    "derive_packages_from_proposal",
     "require_account_match",
     "require_advertiser_match",
     "require_org_scope",

--- a/src/adcp/decisioning/derive_packages.py
+++ b/src/adcp/decisioning/derive_packages.py
@@ -1,0 +1,231 @@
+"""Framework-level package derivation from proposal allocations.
+
+When a buyer calls ``create_media_buy(proposal_id=..., total_budget=...)``
+without supplying ``packages[]``, the spec lets the seller derive
+packages from the committed proposal's ``allocations[]`` array via
+percentage math. Every production adopter writes essentially the same
+loop:
+
+.. code-block:: python
+
+    for allocation in proposal_payload["allocations"]:
+        pkg_budget = total_budget.amount * (allocation["allocation_percentage"] / 100.0)
+        packages.append(PackageRequest(
+            product_id=allocation["product_id"],
+            budget=pkg_budget,
+            pricing_option_id=allocation["pricing_option_id"],
+        ))
+
+The framework auto-invokes :func:`derive_packages_from_proposal` from
+:func:`adcp.decisioning.proposal_dispatch.maybe_hydrate_recipes_for_create_media_buy`
+when ``req.packages`` is empty AND the proposal has ``allocations[]``,
+so seller adapters see a normal ``create_media_buy`` with populated
+packages — they never need to write the loop.
+
+Adopters with custom derivation logic (auction pricing options needing
+``bid_price``, multi-currency proposals, capability-overlap filtering)
+override the behavior by implementing
+:meth:`ProposalManager.derive_packages` on their manager subclass; the
+framework dispatches there in preference to the built-in even-split
+derivation.
+
+Adopters with workflows outside the auto-injection path (admin-side
+inspection tools, draft-preview UIs, off-path replay) can call this
+helper directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from adcp.decisioning.types import AdcpError
+
+logger = logging.getLogger("adcp.decisioning.derive_packages")
+
+if TYPE_CHECKING:
+    from adcp.decisioning.recipe import Recipe
+    from adcp.types import PackageRequest
+
+
+def derive_packages_from_proposal(
+    proposal_payload: Mapping[str, Any],
+    total_budget: Any,
+    *,
+    recipes: Mapping[str, Recipe] | None = None,
+) -> list[PackageRequest]:
+    """Derive a ``list[PackageRequest]`` from a committed proposal's allocations.
+
+    Default even-percentage distribution per ``ProductAllocation``:
+
+    * ``budget = total_budget.amount * allocation.allocation_percentage / 100``
+    * ``product_id``, ``pricing_option_id`` copied from the allocation
+    * ``start_time`` / ``end_time`` copied when present (per-flight
+      scheduling per spec)
+    * ``pacing``, ``targeting_overlay``, ``bid_price`` etc. are NOT
+      derived — adopters whose proposals carry these per allocation
+      should override :meth:`ProposalManager.derive_packages` and emit
+      them explicitly.
+
+    **Currency.** Per spec, ``PackageRequest.budget`` is in
+    ``total_budget.currency`` (the media-buy-level unit). This helper
+    treats ``allocation_percentage`` as a unit-less multiplier; it
+    does not inspect or compare any currency carried by the proposal's
+    products' pricing_options. Multi-currency adopters should override
+    :meth:`ProposalManager.derive_packages` and apply their own FX
+    conversion before emitting packages.
+
+    :param proposal_payload: The committed proposal's wire payload
+        (typically ``ProposalRecord.proposal_payload``). Must contain
+        an ``allocations[]`` array; absent / empty allocations are
+        treated as a buyer error and surfaced as ``INVALID_REQUEST``.
+    :param total_budget: The ``TotalBudget`` (or dict-shaped equivalent
+        with ``amount`` / ``currency`` keys) from the buyer's
+        ``CreateMediaBuyRequest``. Must be non-None — the buyer must
+        supply ``total_budget`` whenever they omit ``packages``.
+    :param recipes: Unused by the built-in derivation. Threaded through
+        so the signature matches :meth:`ProposalManager.derive_packages`
+        for adopters who delegate to this helper from inside their
+        override.
+
+    :raises AdcpError: ``INVALID_REQUEST`` when the proposal payload
+        lacks ``allocations[]``, when an allocation is missing required
+        fields (``product_id``, ``pricing_option_id``,
+        ``allocation_percentage``), or when ``total_budget`` is missing.
+    """
+    # Local imports — :class:`PackageRequest` lives in adcp.types and we
+    # avoid a top-level circular when adcp.types reimports adcp helpers.
+    from adcp.types import PackageRequest
+
+    del recipes  # built-in derivation doesn't consult recipes
+
+    if total_budget is None:
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message=(
+                "create_media_buy(proposal_id=...) requires total_budget "
+                "when packages are omitted; the publisher derives package "
+                "budgets by applying the proposal's allocation_percentage "
+                "values to total_budget.amount."
+            ),
+            recovery="correctable",
+            field="total_budget",
+        )
+
+    budget_amount = _read_attr(total_budget, "amount")
+    if budget_amount is None:
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message="total_budget.amount is required for package derivation.",
+            recovery="correctable",
+            field="total_budget.amount",
+        )
+
+    allocations = (
+        proposal_payload.get("allocations") if isinstance(proposal_payload, Mapping) else None
+    )
+    if not allocations or not isinstance(allocations, list):
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message=(
+                "Cannot derive packages: the committed proposal carries no "
+                "allocations[]. The buyer must supply packages[] explicitly "
+                "or the seller must regenerate the proposal with allocations."
+            ),
+            recovery="terminal",
+            field="proposal_id",
+        )
+
+    packages: list[PackageRequest] = []
+    for idx, allocation in enumerate(allocations):
+        product_id = _read_attr(allocation, "product_id")
+        if not product_id:
+            raise AdcpError(
+                "INVALID_REQUEST",
+                message=(f"Cannot derive packages: allocations[{idx}] is missing " "product_id."),
+                recovery="terminal",
+                field=f"proposal.allocations[{idx}].product_id",
+            )
+        pct = _read_attr(allocation, "allocation_percentage")
+        if pct is None:
+            raise AdcpError(
+                "INVALID_REQUEST",
+                message=(
+                    f"Cannot derive packages: allocations[{idx}] for product "
+                    f"{product_id!r} is missing allocation_percentage."
+                ),
+                recovery="terminal",
+                field=f"proposal.allocations[{idx}].allocation_percentage",
+            )
+        pricing_option_id = _read_attr(allocation, "pricing_option_id")
+        if not pricing_option_id:
+            # Seller-side gap, NOT buyer-correctable. ProductAllocation
+            # `pricing_option_id` is optional on the wire (it's only a
+            # "recommended" pricing option) but PackageRequest requires
+            # one. The built-in even-percentage derivation has no way to
+            # pick — only the seller knows whether the product is auction-
+            # priced, has multiple options, etc. INTERNAL_ERROR signals
+            # this to the buyer as a seller bug; the seller's options
+            # are (a) populate allocation.pricing_option_id at proposal-
+            # assembly time, (b) ensure products under the proposal have
+            # exactly one pricing_options[] entry (framework auto-picks),
+            # or (c) implement ProposalManager.derive_packages for
+            # auction / multi-option semantics.
+            logger.error(
+                "Cannot derive packages from proposal allocation %d: "
+                "product %r is missing pricing_option_id. Adopter must "
+                "set allocation.pricing_option_id at proposal-assembly "
+                "time, expose a single product.pricing_options entry, "
+                "or implement ProposalManager.derive_packages. The "
+                "buyer's create_media_buy will fail until this is fixed.",
+                idx,
+                product_id,
+            )
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"Seller configuration error: proposal allocation for "
+                    f"product {product_id!r} is missing pricing_option_id. "
+                    "Contact the seller — this is not a buyer-correctable "
+                    "input."
+                ),
+                recovery="terminal",
+            )
+
+        pkg_budget = float(budget_amount) * (float(pct) / 100.0)
+        # Spec-defined per-allocation flight scheduling — when the
+        # seller's proposal carries allocation.start_time/end_time,
+        # propagate them to the derived package. ``ProductAllocation``
+        # docs them as "allows publishers to propose per-flight
+        # scheduling within a proposal." Dropping them silently would
+        # erase seller intent.
+        kwargs: dict[str, Any] = {
+            "product_id": str(product_id),
+            "budget": pkg_budget,
+            "pricing_option_id": str(pricing_option_id),
+        }
+        start_time = _read_attr(allocation, "start_time")
+        if start_time is not None:
+            kwargs["start_time"] = start_time
+        end_time = _read_attr(allocation, "end_time")
+        if end_time is not None:
+            kwargs["end_time"] = end_time
+        packages.append(PackageRequest(**kwargs))
+    return packages
+
+
+def _read_attr(obj: Any, name: str) -> Any:
+    """Read an attribute or mapping value, normalizing the two shapes.
+
+    Mirrors the helper inside :mod:`adcp.decisioning.proposal_dispatch`;
+    duplicated here to keep this module dependency-free.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, Mapping):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+__all__ = ["derive_packages_from_proposal"]

--- a/src/adcp/decisioning/pg/__init__.py
+++ b/src/adcp/decisioning/pg/__init__.py
@@ -32,12 +32,14 @@ from adcp.decisioning.pg.buyer_agent_registry import (
     PG_AVAILABLE,
     PgBuyerAgentRegistry,
 )
+from adcp.decisioning.pg.proposal_store import PgProposalStore
 from adcp.decisioning.pg.task_registry import PgTaskRegistry, PostgresTaskRegistry
 
 __all__ = [
     "DEFAULT_TABLE_NAME",
     "PG_AVAILABLE",
     "PgBuyerAgentRegistry",
+    "PgProposalStore",
     "PgTaskRegistry",
     "PostgresTaskRegistry",
 ]

--- a/src/adcp/decisioning/pg/proposal_store.py
+++ b/src/adcp/decisioning/pg/proposal_store.py
@@ -1,0 +1,947 @@
+"""PostgreSQL-backed :class:`~adcp.decisioning.ProposalStore` implementation.
+
+Durable counterpart to :class:`~adcp.decisioning.InMemoryProposalStore`:
+proposal lifecycle state survives process restarts and is safe for
+multi-worker deployments sharing a single Postgres database.
+
+The caller supplies an :class:`psycopg_pool.AsyncConnectionPool`. We
+don't open, own, or close the pool — adopters typically share an
+existing pool with their main application database.
+
+Quickstart
+----------
+
+::
+
+    from psycopg_pool import AsyncConnectionPool
+    from adcp.decisioning import PgProposalStore, serve
+    from myapp.recipes import decode_recipe
+
+    async with AsyncConnectionPool(
+        "postgresql://...",
+        min_size=2,
+        max_size=10,
+    ) as pool:
+        store = PgProposalStore(pool=pool, recipe_decoder=decode_recipe)
+        await store.create_schema()  # idempotent; safe on every boot
+        ...
+
+Recipe round-trip
+-----------------
+
+Recipes are stored as ``{product_id: model_dump(mode='json')}`` in a
+JSONB column. On read, the constructor's ``recipe_decoder`` callable
+rehydrates each entry back to a typed :class:`Recipe` subclass. The
+default decoder is :meth:`Recipe.model_validate` — it works for
+adopters using only the base ``Recipe`` (e.g. for capability_overlap)
+but raises on subclass-specific fields because the base class declares
+``extra='forbid'``.
+
+Adopters with typed Recipe subclasses (``GAMRecipe``, ``KevelRecipe``,
+etc.) MUST supply a decoder that branches on the ``recipe_kind``
+discriminator and constructs the right subclass:
+
+.. code-block:: python
+
+    def decode_recipe(payload: dict) -> Recipe:
+        kind = payload.get("recipe_kind")
+        if kind == "gam":
+            return GAMRecipe.model_validate(payload)
+        if kind == "kevel":
+            return KevelRecipe.model_validate(payload)
+        raise ValueError(f"unknown recipe_kind={kind!r}")
+
+Cross-tenant safety
+-------------------
+
+:meth:`get`, :meth:`try_reserve_consumption`, :meth:`finalize_consumption`,
+:meth:`release_consumption`, and :meth:`get_by_media_buy_id` enforce
+tenant isolation at the SQL level — ``WHERE account_id = %s`` is part
+of every query predicate, not a Python-level filter after fetch.
+
+Concurrency
+-----------
+
+:meth:`try_reserve_consumption` uses ``SELECT ... FOR UPDATE`` inside a
+single-connection transaction so two parallel ``create_media_buy``
+callers cannot both reserve the same proposal. The loser of the race
+raises ``PROPOSAL_NOT_COMMITTED`` once the winner's UPDATE commits.
+
+Schema bootstrap
+----------------
+
+Three equivalent ways to land the table, pick one:
+
+* **App-boot bootstrap** — call :meth:`PgProposalStore.create_schema`
+  on every application start. Idempotent via ``CREATE TABLE IF NOT
+  EXISTS``; honours the ``table_name`` you constructed with.
+* **Alembic / dbmate** — call
+  :meth:`PgProposalStore.migration_sql(table_name=...)` to get an
+  ``{"upgrade": "...", "downgrade": "..."}`` dict you can paste into
+  a migration revision. The classmethod honours custom table names.
+* **Raw psql / Flyway** — apply
+  :file:`src/adcp/decisioning/pg/proposal_store.sql` verbatim. Only
+  matches the default table name (``adcp_proposal_drafts``).
+
+The three sources are kept in sync by ``tests/test_pg_proposal_store_migration_sync.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from adcp.decisioning.proposal_store import (
+    ProposalRecord,
+    ProposalState,
+)
+from adcp.decisioning.recipe import Recipe
+from adcp.decisioning.types import AdcpError
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+try:
+    from psycopg_pool import AsyncConnectionPool as _AsyncConnectionPool  # noqa: F401
+
+    PG_AVAILABLE = True
+except ImportError:
+    PG_AVAILABLE = False
+
+_INSTALL_HINT = (
+    "PgProposalStore requires psycopg3 and psycopg-pool. "
+    "Install the 'pg' extra: `pip install 'adcp[pg]'` "
+    "(Poetry: `poetry add 'adcp[pg]'`)."
+)
+
+DEFAULT_TABLE_NAME = "adcp_proposal_drafts"
+
+# Same ASCII-only identifier guard used by PgBackend / PgTaskRegistry —
+# the table name is static-formatted into SQL, so this is the only
+# protection against SQL injection or Unicode homoglyph substitution.
+_SAFE_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+
+def _default_recipe_decoder(payload: Mapping[str, Any]) -> Recipe:
+    """Default decoder: base :class:`Recipe` round-trip.
+
+    Adopters using typed Recipe subclasses MUST supply their own
+    decoder; the base class declares ``extra='forbid'`` and rejects
+    subclass-specific fields.
+
+    Fail-loud when the payload has a ``recipe_kind`` field — that's a
+    deterministic signal the adopter has typed subclasses but forgot
+    to wire a decoder. The raw Pydantic ``extra='forbid'`` error
+    wouldn't mention ``recipe_decoder=``; this one does.
+    """
+    payload_dict = dict(payload)
+    if "recipe_kind" in payload_dict:
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=(
+                "PgProposalStore.get: stored recipe payload has "
+                f"recipe_kind={payload_dict.get('recipe_kind')!r} but no "
+                "recipe_decoder was supplied at construction. The default "
+                "decoder only handles the base Recipe shape; adopters with "
+                "typed Recipe subclasses (GAMRecipe, KevelRecipe, etc.) "
+                "MUST supply a `recipe_decoder=` callable that branches "
+                "on `recipe_kind` and returns the right subclass. See "
+                "PgProposalStore module docstring for the pattern."
+            ),
+            recovery="terminal",
+        )
+    return Recipe.model_validate(payload_dict)
+
+
+def _encode_recipes(recipes: Mapping[str, Recipe]) -> str:
+    """Serialize the recipes mapping to a JSONB-compatible JSON string."""
+    out: dict[str, dict[str, Any]] = {}
+    for product_id, recipe in recipes.items():
+        if isinstance(recipe, Recipe):
+            out[str(product_id)] = recipe.model_dump(mode="json")
+        elif isinstance(recipe, Mapping):
+            # Allow pre-serialized dicts; adopter tests or migrations
+            # may hand the store dict-shaped recipes directly.
+            out[str(product_id)] = dict(recipe)
+        else:
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"PgProposalStore.put_draft: recipes[{product_id!r}] must "
+                    f"be a Recipe instance or Mapping, got {type(recipe).__name__}."
+                ),
+                recovery="terminal",
+            )
+    return json.dumps(out)
+
+
+def _decode_recipes(
+    raw: Any,
+    decoder: Callable[[Mapping[str, Any]], Recipe],
+) -> dict[str, Recipe]:
+    """Rehydrate a JSONB recipes blob back into a ``{product_id: Recipe}``
+    mapping using the adopter-supplied decoder.
+
+    psycopg returns JSONB columns as already-parsed Python objects
+    (``dict``); fall back to ``json.loads`` for the string path so
+    tests that round-trip via raw psycopg cursors still work.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        parsed = json.loads(raw)
+    else:
+        parsed = raw
+    if not isinstance(parsed, dict):
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=(
+                f"PgProposalStore: recipes column returned non-object "
+                f"{type(parsed).__name__}; schema drift suspected."
+            ),
+            recovery="terminal",
+        )
+    out: dict[str, Recipe] = {}
+    for product_id, payload in parsed.items():
+        if not isinstance(payload, Mapping):
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"PgProposalStore: recipes[{product_id!r}] is "
+                    f"{type(payload).__name__}, expected object."
+                ),
+                recovery="terminal",
+            )
+        try:
+            out[str(product_id)] = decoder(payload)
+        except AdcpError:
+            raise
+        except Exception as exc:
+            # Pydantic ValidationError / arbitrary decoder failure —
+            # surface with a pointer to ``recipe_decoder=`` so adopters
+            # don't have to spelunk into framework source to figure out
+            # what to fix.
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"PgProposalStore.get: recipe_decoder failed for "
+                    f"recipes[{product_id!r}]: {exc}. If your adapter "
+                    "uses typed Recipe subclasses, supply a "
+                    "`recipe_decoder=` callable when constructing "
+                    "PgProposalStore — see the module docstring for "
+                    "the recipe_kind-branching pattern."
+                ),
+                recovery="terminal",
+            ) from exc
+    return out
+
+
+def _decode_payload(raw: Any) -> dict[str, Any]:
+    """Rehydrate the proposal_payload JSONB blob to a plain dict."""
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        parsed = json.loads(raw)
+    else:
+        parsed = raw
+    if not isinstance(parsed, dict):
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=(
+                f"PgProposalStore: proposal_payload column returned non-object "
+                f"{type(parsed).__name__}; schema drift suspected."
+            ),
+            recovery="terminal",
+        )
+    return dict(parsed)
+
+
+def _ensure_utc(dt: Any) -> datetime | None:
+    """Normalize a psycopg-returned ``TIMESTAMPTZ`` to a tz-aware datetime.
+
+    A naive datetime here means the column was created as
+    ``TIMESTAMP WITHOUT TIME ZONE`` instead of ``TIMESTAMPTZ`` — adopter
+    Alembic migration drift from the SDK schema. Fail fast rather than
+    silently coerce; silent UTC defaults will produce wrong expiry
+    windows when the server's local time is not UTC.
+    """
+    if dt is None:
+        return None
+    if not isinstance(dt, datetime):
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=(
+                f"PgProposalStore: expires_at column returned non-datetime "
+                f"{type(dt).__name__}; schema drift suspected."
+            ),
+            recovery="terminal",
+        )
+    if dt.tzinfo is None:
+        raise AdcpError(
+            "INTERNAL_ERROR",
+            message=(
+                "PgProposalStore received a naive datetime from expires_at. "
+                "This usually means the column was created as "
+                "TIMESTAMP WITHOUT TIME ZONE instead of TIMESTAMPTZ — "
+                "adopter migration drift from the SDK schema. Recreate the "
+                "column as TIMESTAMPTZ (see PgProposalStore.MIGRATION for "
+                "the canonical DDL)."
+            ),
+            recovery="terminal",
+        )
+    return dt
+
+
+class PgProposalStore:
+    """PostgreSQL-backed :class:`~adcp.decisioning.ProposalStore`.
+
+    Durable counterpart to :class:`~adcp.decisioning.InMemoryProposalStore`.
+    Set ``is_durable = True`` so production-mode gates accept it without
+    requiring the dev-mode bypass.
+
+    :param pool: ``psycopg_pool.AsyncConnectionPool`` owned by the
+        caller. Each operation acquires a short-lived connection;
+        :meth:`try_reserve_consumption` holds one for the duration of
+        its CAS transaction.
+    :param table_name: Override the default table name. Useful for
+        adopters with one Postgres serving multiple AdCP instances or
+        whose ``proposal_drafts`` table is already taken. Defaults to
+        ``adcp_proposal_drafts``.
+    :param recipe_decoder: Callable ``(payload: dict) -> Recipe`` used
+        to rehydrate stored recipe payloads back to typed
+        :class:`Recipe` instances. Adopters with subclasses
+        (``GAMRecipe``, ``KevelRecipe``, etc.) MUST supply a decoder
+        that branches on ``recipe_kind``. Defaults to
+        :meth:`Recipe.model_validate` which only works for the base
+        ``Recipe`` shape.
+
+    :raises ImportError: when psycopg/psycopg-pool are not installed.
+    :raises ValueError: when ``table_name`` is not a safe ASCII
+        identifier (``[a-z_][a-z0-9_]{0,62}``).
+    """
+
+    is_durable: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        *,
+        pool: AsyncConnectionPool,
+        table_name: str = DEFAULT_TABLE_NAME,
+        recipe_decoder: Callable[[Mapping[str, Any]], Recipe] | None = None,
+    ) -> None:
+        if not PG_AVAILABLE:
+            raise ImportError(_INSTALL_HINT)
+        if not _SAFE_IDENTIFIER_RE.fullmatch(table_name):
+            raise ValueError(
+                f"table_name must match [a-z_][a-z0-9_]{{0,62}} (ASCII only), "
+                f"got {table_name!r}"
+            )
+        self._pool = pool
+        self._table = table_name
+        self._recipe_decoder = recipe_decoder or _default_recipe_decoder
+
+        t = self._table
+        # put_draft: insert a fresh DRAFT row, or rewrite an existing DRAFT
+        # row in place. ON CONFLICT DO UPDATE is gated on state='draft' so
+        # a buyer probing put_draft against a COMMITTED/CONSUMED record
+        # falls through to a zero-row UPDATE — we then SELECT to surface
+        # the INTERNAL_ERROR with the actual current state.
+        self._sql_put_draft = (  # noqa: S608 — table name whitelisted
+            f"INSERT INTO {t} "
+            f"(account_id, proposal_id, state, recipes, proposal_payload, "
+            f" recipe_schema_version, created_at, updated_at) "
+            f"VALUES (%s, %s, 'draft', %s::jsonb, %s::jsonb, %s, now(), now()) "
+            f"ON CONFLICT (account_id, proposal_id) DO UPDATE SET "
+            f"  recipes          = EXCLUDED.recipes, "
+            f"  proposal_payload = EXCLUDED.proposal_payload, "
+            f"  recipe_schema_version = EXCLUDED.recipe_schema_version, "
+            f"  updated_at       = now() "
+            f"WHERE {t}.state = 'draft' "
+            f"RETURNING xmax = 0 AS inserted"
+        )
+        self._sql_get_state = (  # noqa: S608
+            f"SELECT state, expires_at, proposal_payload FROM {t} "
+            f"WHERE account_id = %s AND proposal_id = %s"
+        )
+        # Tenant-scoped SELECT FOR UPDATE used by commit() to lock the
+        # row before the state-machine check + UPDATE. Mirrors the
+        # try_reserve_consumption pattern.
+        self._sql_select_state_for_update = (  # noqa: S608
+            f"SELECT state, expires_at, proposal_payload FROM {t} "
+            f"WHERE account_id = %s AND proposal_id = %s FOR UPDATE"
+        )
+        self._sql_commit = (  # noqa: S608
+            f"UPDATE {t} SET "
+            f"  state            = 'committed', "
+            f"  expires_at       = %s, "
+            f"  proposal_payload = %s::jsonb, "
+            f"  updated_at       = now() "
+            f"WHERE account_id = %s AND proposal_id = %s AND state = 'draft' "
+            f"RETURNING proposal_id"
+        )
+        # try_reserve_consumption uses SELECT ... FOR UPDATE inside a tx
+        # so two parallel callers serialize on the row lock. The CAS
+        # check (state='committed') happens after the lock is held; the
+        # loser sees CONSUMING/CONSUMED and raises PROPOSAL_NOT_COMMITTED.
+        self._sql_select_for_update = (  # noqa: S608
+            f"SELECT state, recipes, proposal_payload, expires_at, "
+            f"       media_buy_id, recipe_schema_version "
+            f"FROM {t} WHERE account_id = %s AND proposal_id = %s FOR UPDATE"
+        )
+        self._sql_reserve = (  # noqa: S608
+            f"UPDATE {t} SET state = 'consuming', updated_at = now() "
+            f"WHERE account_id = %s AND proposal_id = %s AND state = 'committed'"
+        )
+        self._sql_finalize = (  # noqa: S608
+            f"UPDATE {t} SET "
+            f"  state        = 'consumed', "
+            f"  media_buy_id = %s, "
+            f"  updated_at   = now() "
+            f"WHERE account_id = %s AND proposal_id = %s AND state = 'consuming' "
+            f"RETURNING proposal_id"
+        )
+        self._sql_release = (  # noqa: S608
+            f"UPDATE {t} SET state = 'committed', updated_at = now() "
+            f"WHERE account_id = %s AND proposal_id = %s AND state = 'consuming' "
+            f"RETURNING proposal_id"
+        )
+        self._sql_mark_consumed = (  # noqa: S608
+            f"UPDATE {t} SET "
+            f"  state        = 'consumed', "
+            f"  media_buy_id = %s, "
+            f"  updated_at   = now() "
+            f"WHERE account_id = %s AND proposal_id = %s AND state = 'committed' "
+            f"RETURNING proposal_id"
+        )
+        self._sql_discard = (  # noqa: S608
+            f"DELETE FROM {t} WHERE account_id = %s AND proposal_id = %s"
+        )
+        self._sql_get_by_media_buy_id = (  # noqa: S608
+            f"SELECT proposal_id, account_id, state, recipes, proposal_payload, "
+            f"       expires_at, media_buy_id, recipe_schema_version "
+            f"FROM {t} WHERE account_id = %s AND media_buy_id = %s"
+        )
+
+    # -- schema bootstrap -----------------------------------------------
+
+    async def create_schema(self) -> None:
+        """Create the proposal store table + supporting indexes.
+
+        Honors the ``table_name`` kwarg the store was constructed with.
+        Idempotent via ``CREATE TABLE IF NOT EXISTS`` — safe to call on
+        every application boot. The equivalent raw DDL ships at
+        :file:`adcp/decisioning/pg/proposal_store.sql` in the installed
+        package for adopters using a migration tool.
+        """
+        t = self._table
+        statements = [
+            f"""CREATE TABLE IF NOT EXISTS {t} (
+                account_id              TEXT        COLLATE "C" NOT NULL,
+                proposal_id             TEXT        COLLATE "C" NOT NULL,
+                state                   TEXT        NOT NULL
+                    CHECK (state IN ('draft', 'committed', 'consuming', 'consumed')),
+                recipes                 JSONB       NOT NULL DEFAULT '{{}}'::jsonb,
+                proposal_payload        JSONB       NOT NULL,
+                expires_at              TIMESTAMPTZ,
+                media_buy_id            TEXT        COLLATE "C",
+                recipe_schema_version   INTEGER     NOT NULL DEFAULT 1,
+                created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (account_id, proposal_id)
+            )""",
+            f"""CREATE UNIQUE INDEX IF NOT EXISTS {t}_media_buy_idx
+                ON {t} (account_id, media_buy_id)
+                WHERE media_buy_id IS NOT NULL""",
+            f"""CREATE INDEX IF NOT EXISTS {t}_expires_idx
+                ON {t} (expires_at)
+                WHERE expires_at IS NOT NULL""",
+        ]
+        async with self._pool.connection() as conn:
+            for stmt in statements:
+                await conn.execute(stmt)
+
+    # -- ProposalStore Protocol -----------------------------------------
+
+    async def put_draft(
+        self,
+        *,
+        proposal_id: str,
+        account_id: str,
+        recipes: Mapping[str, Recipe],
+        proposal_payload: Mapping[str, Any],
+    ) -> None:
+        recipes_json = _encode_recipes(recipes)
+        payload_json = json.dumps(dict(proposal_payload))
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(
+                self._sql_put_draft,
+                (account_id, proposal_id, recipes_json, payload_json, 1),
+            )
+            row = await cur.fetchone()
+            if row is not None:
+                # Either inserted fresh (xmax=0) or rewrote a DRAFT.
+                return
+            # ON CONFLICT DO UPDATE matched zero rows — the record is in
+            # a non-DRAFT state. Re-fetch to surface the current state in
+            # the error message.
+            cur2 = await conn.execute(self._sql_get_state, (account_id, proposal_id))
+            existing = await cur2.fetchone()
+            if existing is None:
+                # Race: row vanished between the failed INSERT and the
+                # follow-up SELECT (concurrent discard from another
+                # worker). Surface as INTERNAL_ERROR so the framework's
+                # outer dispatcher can decide whether to retry; we don't
+                # transparently retry here because put_draft is meant to
+                # be one-shot per dispatch.
+                raise AdcpError(
+                    "INTERNAL_ERROR",
+                    message=(
+                        f"PgProposalStore.put_draft: proposal {proposal_id!r} "
+                        "vanished between conflict and refetch. Concurrent "
+                        "discard suspected."
+                    ),
+                    recovery="terminal",
+                )
+            state_str = existing[0]
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"Cannot put_draft on proposal {proposal_id!r} in "
+                    f"state {state_str!r}; refine iterations are only "
+                    "valid on draft proposals. Once committed or "
+                    "consumed, a proposal_id is immutable."
+                ),
+                recovery="terminal",
+            )
+
+    async def get(
+        self,
+        proposal_id: str,
+        *,
+        expected_account_id: str | None = None,
+    ) -> ProposalRecord | None:
+        # The Protocol allows expected_account_id=None — historically a
+        # convenience for diagnostic / admin callers. We still serve
+        # that case but route it through a separate query without the
+        # account predicate so the tenancy-aware fast path is purely
+        # parameterised; a future code reader can't accidentally pass
+        # None into a tenancy-required call.
+        if expected_account_id is None:
+            sql = (  # noqa: S608 — table name pre-validated at construction
+                f"SELECT proposal_id, account_id, state, recipes, "
+                f"proposal_payload, expires_at, media_buy_id, "
+                f"recipe_schema_version FROM {self._table} "
+                f"WHERE proposal_id = %s"
+            )
+            params: tuple[Any, ...] = (proposal_id,)
+        else:
+            sql = (  # noqa: S608
+                f"SELECT proposal_id, account_id, state, recipes, "
+                f"proposal_payload, expires_at, media_buy_id, "
+                f"recipe_schema_version FROM {self._table} "
+                f"WHERE account_id = %s AND proposal_id = %s"
+            )
+            params = (expected_account_id, proposal_id)
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(sql, params)
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return self._row_to_record(row)
+
+    async def commit(
+        self,
+        proposal_id: str,
+        *,
+        expires_at: datetime,
+        proposal_payload: Mapping[str, Any],
+        expected_account_id: str,
+    ) -> None:
+        payload_dict = dict(proposal_payload)
+        payload_json = json.dumps(payload_dict)
+        # Atomic: SELECT FOR UPDATE → state-machine check → UPDATE,
+        # all inside one transaction. The SELECT predicate is keyed on
+        # (account_id, proposal_id) so a cross-tenant probe collapses
+        # to "not in store" without touching another tenant's row.
+        # The row lock prevents a concurrent put_draft / commit from
+        # racing the validate-then-update sequence.
+        async with self._pool.connection() as conn:
+            async with conn.transaction():
+                cur = await conn.execute(
+                    self._sql_select_state_for_update,
+                    (expected_account_id, proposal_id),
+                )
+                existing = await cur.fetchone()
+                if existing is None:
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"Cannot commit proposal {proposal_id!r}: not "
+                            "in store for the expected tenant. The "
+                            "framework's finalize dispatch must put_draft "
+                            "before commit."
+                        ),
+                        recovery="terminal",
+                    )
+                current_state, current_expires_at, current_payload = existing
+                if current_state == "committed":
+                    # Idempotent only when the second commit matches the
+                    # first.
+                    same_deadline = _ensure_utc(current_expires_at) == expires_at
+                    cur_payload_dict = (
+                        current_payload
+                        if isinstance(current_payload, dict)
+                        else json.loads(current_payload) if current_payload is not None else {}
+                    )
+                    same_payload = cur_payload_dict == payload_dict
+                    if same_deadline and same_payload:
+                        return
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"Proposal {proposal_id!r} already committed "
+                            "with a different expires_at or payload — "
+                            "re-commit with different values is a developer "
+                            "bug."
+                        ),
+                        recovery="terminal",
+                    )
+                if current_state != "draft":
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"Cannot commit proposal {proposal_id!r} from "
+                            f"state {current_state!r}; commit requires "
+                            "DRAFT."
+                        ),
+                        recovery="terminal",
+                    )
+                update_cur = await conn.execute(
+                    self._sql_commit,
+                    (expires_at, payload_json, expected_account_id, proposal_id),
+                )
+                if await update_cur.fetchone() is None:
+                    # Should not happen under the row lock, but fail loud
+                    # if it does — silent zero-row UPDATE would let the
+                    # caller believe the transition landed.
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"PgProposalStore.commit: UPDATE returned zero "
+                            f"rows for proposal {proposal_id!r} despite "
+                            "passing the FOR UPDATE state check. Schema "
+                            "drift suspected."
+                        ),
+                        recovery="terminal",
+                    )
+
+    async def try_reserve_consumption(
+        self,
+        proposal_id: str,
+        *,
+        expected_account_id: str,
+    ) -> ProposalRecord:
+        # Single-connection transaction so SELECT FOR UPDATE + UPDATE
+        # serialize across parallel callers.
+        async with self._pool.connection() as conn:
+            async with conn.transaction():
+                cur = await conn.execute(
+                    self._sql_select_for_update,
+                    (expected_account_id, proposal_id),
+                )
+                row = await cur.fetchone()
+                if row is None:
+                    raise AdcpError(
+                        "PROPOSAL_NOT_FOUND",
+                        message=(f"Proposal {proposal_id!r} not found."),
+                        recovery="terminal",
+                        field="proposal_id",
+                    )
+                (
+                    state_str,
+                    recipes_raw,
+                    payload_raw,
+                    expires_at_raw,
+                    media_buy_id,
+                    recipe_schema_version,
+                ) = row
+                if state_str != "committed":
+                    raise AdcpError(
+                        "PROPOSAL_NOT_COMMITTED",
+                        message=(
+                            f"Proposal {proposal_id!r} is in state "
+                            f"{state_str!r}; create_media_buy requires a "
+                            "committed proposal that hasn't been accepted "
+                            "or reserved by another request."
+                        ),
+                        recovery="correctable",
+                        field="proposal_id",
+                    )
+                await conn.execute(
+                    self._sql_reserve,
+                    (expected_account_id, proposal_id),
+                )
+                # Build the in-memory record reflecting the transition.
+                return ProposalRecord(
+                    proposal_id=proposal_id,
+                    account_id=expected_account_id,
+                    state=ProposalState.CONSUMING,
+                    recipes=_decode_recipes(recipes_raw, self._recipe_decoder),
+                    proposal_payload=_decode_payload(payload_raw),
+                    expires_at=_ensure_utc(expires_at_raw),
+                    media_buy_id=media_buy_id,
+                    recipe_schema_version=int(recipe_schema_version or 1),
+                )
+
+    async def finalize_consumption(
+        self,
+        proposal_id: str,
+        *,
+        media_buy_id: str,
+        expected_account_id: str,
+    ) -> None:
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(
+                self._sql_finalize,
+                (media_buy_id, expected_account_id, proposal_id),
+            )
+            if await cur.fetchone() is not None:
+                return
+            # Zero rows updated. Determine why.
+            cur2 = await conn.execute(self._sql_get_state, (expected_account_id, proposal_id))
+            existing = await cur2.fetchone()
+            if existing is None:
+                raise AdcpError(
+                    "INTERNAL_ERROR",
+                    message=(
+                        f"finalize_consumption: proposal {proposal_id!r} "
+                        "not found for the expected tenant."
+                    ),
+                    recovery="terminal",
+                )
+            state_str = existing[0]
+            if state_str == "consumed":
+                # Idempotent on re-call with the same media_buy_id.
+                cur3 = await conn.execute(
+                    f"SELECT media_buy_id FROM {self._table} "  # noqa: S608
+                    f"WHERE account_id = %s AND proposal_id = %s",
+                    (expected_account_id, proposal_id),
+                )
+                row = await cur3.fetchone()
+                existing_media_buy_id = row[0] if row else None
+                if existing_media_buy_id == media_buy_id:
+                    return
+                raise AdcpError(
+                    "INTERNAL_ERROR",
+                    message=(
+                        f"Proposal {proposal_id!r} already consumed by "
+                        f"media_buy_id={existing_media_buy_id!r}; cannot "
+                        f"re-consume as {media_buy_id!r}."
+                    ),
+                    recovery="terminal",
+                )
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"finalize_consumption requires CONSUMING; "
+                    f"proposal {proposal_id!r} is in {state_str!r}. "
+                    "Framework must call try_reserve_consumption first."
+                ),
+                recovery="terminal",
+            )
+
+    async def release_consumption(
+        self,
+        proposal_id: str,
+        *,
+        expected_account_id: str,
+    ) -> None:
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(
+                self._sql_release,
+                (expected_account_id, proposal_id),
+            )
+            if await cur.fetchone() is not None:
+                return
+            # Zero rows updated. Idempotent: no-op on unknown id /
+            # cross-tenant probe, no-op on already-COMMITTED.
+            cur2 = await conn.execute(self._sql_get_state, (expected_account_id, proposal_id))
+            existing = await cur2.fetchone()
+            if existing is None:
+                # Unknown id or cross-tenant — idempotent no-op so the
+                # adapter-failure rollback path can be unconditional.
+                return
+            state_str = existing[0]
+            if state_str == "committed":
+                # Already rolled back.
+                return
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    f"release_consumption requires CONSUMING; "
+                    f"proposal {proposal_id!r} is in {state_str!r}."
+                ),
+                recovery="terminal",
+            )
+
+    async def mark_consumed(
+        self,
+        proposal_id: str,
+        *,
+        media_buy_id: str,
+        expected_account_id: str,
+    ) -> None:
+        # Tenant-scoped SELECT FOR UPDATE → state-machine check →
+        # UPDATE. Cross-tenant probes collapse to "not in store".
+        async with self._pool.connection() as conn:
+            async with conn.transaction():
+                cur = await conn.execute(
+                    f"SELECT state, media_buy_id FROM {self._table} "  # noqa: S608
+                    f"WHERE account_id = %s AND proposal_id = %s FOR UPDATE",
+                    (expected_account_id, proposal_id),
+                )
+                row = await cur.fetchone()
+                if row is None:
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"Cannot mark_consumed proposal {proposal_id!r}: "
+                            "not in store for the expected tenant."
+                        ),
+                        recovery="terminal",
+                    )
+                state_str, existing_media_buy_id = row
+                if state_str == "consumed":
+                    if existing_media_buy_id == media_buy_id:
+                        return
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"Proposal {proposal_id!r} already consumed by "
+                            f"media_buy_id={existing_media_buy_id!r}; cannot "
+                            f"re-consume as {media_buy_id!r}."
+                        ),
+                        recovery="terminal",
+                    )
+                if state_str != "committed":
+                    raise AdcpError(
+                        "INTERNAL_ERROR",
+                        message=(
+                            f"Cannot mark_consumed proposal {proposal_id!r} "
+                            f"from state {state_str!r}; mark_consumed "
+                            "requires COMMITTED."
+                        ),
+                        recovery="terminal",
+                    )
+                await conn.execute(
+                    self._sql_mark_consumed,
+                    (media_buy_id, expected_account_id, proposal_id),
+                )
+
+    async def discard(
+        self,
+        proposal_id: str,
+        *,
+        expected_account_id: str,
+    ) -> None:
+        async with self._pool.connection() as conn:
+            await conn.execute(self._sql_discard, (expected_account_id, proposal_id))
+
+    async def get_by_media_buy_id(
+        self,
+        media_buy_id: str,
+        *,
+        expected_account_id: str,
+    ) -> ProposalRecord | None:
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(
+                self._sql_get_by_media_buy_id,
+                (expected_account_id, media_buy_id),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return self._row_to_record(row)
+
+    # -- helpers --------------------------------------------------------
+
+    def _row_to_record(self, row: tuple[Any, ...]) -> ProposalRecord:
+        """Project a SELECT row tuple to a typed :class:`ProposalRecord`."""
+        (
+            proposal_id,
+            account_id,
+            state_str,
+            recipes_raw,
+            payload_raw,
+            expires_at_raw,
+            media_buy_id,
+            recipe_schema_version,
+        ) = row
+        return ProposalRecord(
+            proposal_id=proposal_id,
+            account_id=account_id,
+            state=ProposalState(state_str),
+            recipes=_decode_recipes(recipes_raw, self._recipe_decoder),
+            proposal_payload=_decode_payload(payload_raw),
+            expires_at=_ensure_utc(expires_at_raw),
+            media_buy_id=media_buy_id,
+            recipe_schema_version=int(recipe_schema_version or 1),
+        )
+
+
+def _migration_sql(table_name: str = DEFAULT_TABLE_NAME) -> dict[str, str]:
+    """Build Alembic-compatible upgrade/downgrade SQL for a given table
+    name. Public via :meth:`PgProposalStore.migration_sql`.
+
+    Validates the identifier the same way the constructor does so an
+    adopter can't accidentally land an unsafe DDL string in their
+    migration.
+    """
+    if not _SAFE_IDENTIFIER_RE.fullmatch(table_name):
+        raise ValueError(
+            f"table_name must match [a-z_][a-z0-9_]{{0,62}} (ASCII only), " f"got {table_name!r}"
+        )
+    t = table_name
+    return {
+        "upgrade": (
+            f"CREATE TABLE IF NOT EXISTS {t} (\n"
+            f'    account_id              TEXT        COLLATE "C" NOT NULL,\n'
+            f'    proposal_id             TEXT        COLLATE "C" NOT NULL,\n'
+            f"    state                   TEXT        NOT NULL\n"
+            f"        CHECK (state IN ('draft', 'committed', 'consuming', 'consumed')),\n"
+            f"    recipes                 JSONB       NOT NULL DEFAULT '{{}}'::jsonb,\n"
+            f"    proposal_payload        JSONB       NOT NULL,\n"
+            f"    expires_at              TIMESTAMPTZ,\n"
+            f'    media_buy_id            TEXT        COLLATE "C",\n'
+            f"    recipe_schema_version   INTEGER     NOT NULL DEFAULT 1,\n"
+            f"    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),\n"
+            f"    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),\n"
+            f"    PRIMARY KEY (account_id, proposal_id)\n"
+            f");\n"
+            f"CREATE UNIQUE INDEX IF NOT EXISTS {t}_media_buy_idx\n"
+            f"    ON {t} (account_id, media_buy_id)\n"
+            f"    WHERE media_buy_id IS NOT NULL;\n"
+            f"CREATE INDEX IF NOT EXISTS {t}_expires_idx\n"
+            f"    ON {t} (expires_at)\n"
+            f"    WHERE expires_at IS NOT NULL;\n"
+        ),
+        "downgrade": f"DROP TABLE IF EXISTS {t};\n",
+    }
+
+
+# Bind the helper as a classmethod on PgProposalStore so adopters can
+# call ``PgProposalStore.migration_sql(table_name="my_proposals")``
+# from Alembic without instantiating the store.
+PgProposalStore.migration_sql = classmethod(  # type: ignore[attr-defined]
+    lambda cls, table_name=DEFAULT_TABLE_NAME: _migration_sql(table_name)
+)
+
+
+__all__ = [
+    "DEFAULT_TABLE_NAME",
+    "PG_AVAILABLE",
+    "PgProposalStore",
+]

--- a/src/adcp/decisioning/pg/proposal_store.sql
+++ b/src/adcp/decisioning/pg/proposal_store.sql
@@ -1,0 +1,71 @@
+-- AdCP v1.5 proposal lifecycle — durable ProposalStore backing.
+--
+-- Run this once per deployment. Tracked by PgProposalStore; see
+-- src/adcp/decisioning/pg/proposal_store.py for the query shapes
+-- the Python code executes.
+--
+-- Alternatively, call PgProposalStore.create_schema() from
+-- application code — it runs the equivalent DDL idempotently on boot.
+--
+-- COLLATE "C" on identifier columns avoids locale-dependent case
+-- folding — on some locales "Account-A" and "account-a" compare
+-- equal, which would collapse distinct tenants into one slot.
+
+CREATE TABLE IF NOT EXISTS adcp_proposal_drafts (
+    -- Tenant-scoped composite primary key. account_id-first ordering
+    -- matches the per-tenant lookup hot path on get().
+    account_id              TEXT        COLLATE "C" NOT NULL,
+    proposal_id             TEXT        COLLATE "C" NOT NULL,
+
+    -- Lifecycle: draft / committed / consuming / consumed. The framework
+    -- enforces the state machine — this column records the current node.
+    state                   TEXT        NOT NULL
+        CHECK (state IN ('draft', 'committed', 'consuming', 'consumed')),
+
+    -- {product_id: recipe_dict} — adopters provide a recipe_decoder
+    -- at PgProposalStore construction time to rehydrate the dicts back
+    -- to typed Recipe subclasses on read.
+    recipes                 JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+    -- The wire Proposal payload returned to the buyer. Stored verbatim
+    -- so refine iterations and post-finalize replays don't need to
+    -- re-roundtrip through the manager.
+    proposal_payload        JSONB       NOT NULL,
+
+    -- Set on commit(); enforces the inventory hold window. NULL while
+    -- DRAFT.
+    expires_at              TIMESTAMPTZ,
+
+    -- Set on finalize_consumption() / mark_consumed(). NULL until the
+    -- proposal terminates at CONSUMED. Partial unique index below
+    -- enforces (account_id, media_buy_id) uniqueness for non-NULL rows
+    -- so get_by_media_buy_id() reverse-index lookups are deterministic.
+    media_buy_id            TEXT        COLLATE "C",
+
+    -- Adopter-controlled schema version captured at put_draft time.
+    -- Adopters whose Recipe subclasses add required fields bump this
+    -- and write a migration (or evict pre-bump records). Framework
+    -- reads but does not enforce.
+    recipe_schema_version   INTEGER     NOT NULL DEFAULT 1,
+
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (account_id, proposal_id)
+);
+
+-- Reverse-index for get_by_media_buy_id(). Partial unique on non-NULL
+-- media_buy_id so the index stays empty for DRAFT / COMMITTED rows.
+-- Tenant-scoped uniqueness — adopter media_buy_ids can collide across
+-- tenants (sequential IDs, deterministic test fixtures, etc.) without
+-- corrupting the reverse lookup for either tenant.
+CREATE UNIQUE INDEX IF NOT EXISTS adcp_proposal_drafts_media_buy_idx
+    ON adcp_proposal_drafts (account_id, media_buy_id)
+    WHERE media_buy_id IS NOT NULL;
+
+-- Eviction-sweep helper. Adopters running a periodic cleanup job
+-- (cron / pg_cron / app-loop) can scan by expires_at without a full
+-- table scan.
+CREATE INDEX IF NOT EXISTS adcp_proposal_drafts_expires_idx
+    ON adcp_proposal_drafts (expires_at)
+    WHERE expires_at IS NOT NULL;

--- a/src/adcp/decisioning/proposal_dispatch.py
+++ b/src/adcp/decisioning/proposal_dispatch.py
@@ -54,6 +54,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
+from adcp.decisioning.derive_packages import derive_packages_from_proposal
 from adcp.decisioning.proposal_lifecycle import (
     consumed_log,
     detect_finalize_action,
@@ -276,6 +277,7 @@ async def maybe_intercept_finalize(
                     proposal_id,
                     expires_at=success.expires_at,
                     proposal_payload=dict(success.proposal),
+                    expected_account_id=account_id,
                 )
             )
             finalize_succeeded_log(
@@ -312,6 +314,7 @@ async def maybe_intercept_finalize(
             proposal_id,
             expires_at=result.expires_at,
             proposal_payload=dict(result.proposal),
+            expected_account_id=account_id,
         )
     )
     finalize_succeeded_log(
@@ -450,6 +453,11 @@ async def maybe_persist_draft_after_get_products(
         if proposal_id is None:
             continue
         proposal_payload = _to_dict(proposal)
+        # #727: enrich allocations with the product's single
+        # pricing_option_id when missing — saves the seller from having
+        # to populate it explicitly at proposal-assembly time. Runs
+        # BEFORE the recipe collection so the enriched payload persists.
+        _enrich_allocations_with_pricing_options(proposal_payload, products)
         # Hydrate recipes from products' typed implementation_config.
         # Adopters return Recipe-typed implementation_config on Products;
         # the framework projects them into the store. v1 dict-shaped
@@ -481,8 +489,54 @@ async def maybe_persist_draft_after_get_products(
                     str(proposal_id),
                     expires_at=expires_at,
                     proposal_payload=proposal_payload,
+                    expected_account_id=ctx.account.id,
                 )
             )
+
+
+def _enrich_allocations_with_pricing_options(
+    proposal_payload: dict[str, Any],
+    products: list[Any],
+) -> None:
+    """Populate ``allocation.pricing_option_id`` from the product's
+    ``pricing_options[]`` when missing — but ONLY when the product has
+    exactly one pricing option.
+
+    The spec marks ``ProductAllocation.pricing_option_id`` as optional,
+    but :class:`PackageRequest.pricing_option_id` is required for the
+    create_media_buy adapter contract. When a product offers a single
+    pricing option, the choice is unambiguous and the framework picks
+    it for the adopter. Multi-option products require explicit
+    allocation-level selection (or a
+    :meth:`ProposalManager.derive_packages` override).
+    """
+    allocations = proposal_payload.get("allocations")
+    if not isinstance(allocations, list):
+        return
+    product_to_single_option: dict[str, str] = {}
+    for product in products:
+        product_id = _read(product, "product_id")
+        if product_id is None:
+            continue
+        pricing_options = _read(product, "pricing_options")
+        if not isinstance(pricing_options, list) or len(pricing_options) != 1:
+            continue
+        option_id = _read(pricing_options[0], "pricing_option_id")
+        if option_id:
+            product_to_single_option[str(product_id)] = str(option_id)
+    if not product_to_single_option:
+        return
+    for allocation in allocations:
+        if not isinstance(allocation, dict):
+            continue
+        if allocation.get("pricing_option_id"):
+            continue
+        pid = allocation.get("product_id")
+        if pid is None:
+            continue
+        single = product_to_single_option.get(str(pid))
+        if single:
+            allocation["pricing_option_id"] = single
 
 
 def _collect_recipes_from_products(
@@ -587,25 +641,144 @@ async def maybe_hydrate_recipes_for_create_media_buy(
     )
     record = cast("ProposalRecord", raw)
 
-    # Capability-overlap gate per D4. The buyer's packages may be empty
-    # when proposal_id is provided (the spec allows the seller to derive
-    # packages from the proposal's allocations); skip the gate in that
-    # case since there's nothing to validate against. If the gate
-    # rejects, the caller must release the reservation — handler.py
-    # wraps the entire dispatch in a try/except for that purpose.
-    packages = _read(params, "packages") or []
-    if packages:
-        validate_capability_overlap(
-            packages=list(packages),
-            recipes=record.recipes,
-            field_path_prefix="packages",
-        )
+    # Anything that raises after the reservation must release it back to
+    # COMMITTED before propagating — otherwise the proposal hangs in
+    # CONSUMING until eviction. Wrap the derivation + overlap-gate block;
+    # handler.py's adapter-failure hook covers the post-return path.
+    try:
+        # Framework-level package derivation per #727. Opt-in: either
+        # the manager declares
+        # ``ProposalCapabilities.derive_packages_from_allocations=True``
+        # (use the built-in even-percentage helper) OR implements
+        # ``derive_packages(...)`` (custom math). Default behaviour
+        # preserves pre-#727 semantics — framework leaves
+        # ``req.packages`` untouched and the seller adapter handles it
+        # from ``ctx.recipes``. Runs BEFORE the capability-overlap gate
+        # so the gate validates the derived packages.
+        packages = _read(params, "packages") or []
+        if (
+            not packages
+            and _has_allocations(record.proposal_payload)
+            and _derivation_enabled(manager)
+        ):
+            derived = _derive_packages(
+                manager=manager,
+                proposal_payload=record.proposal_payload,
+                total_budget=_read(params, "total_budget"),
+                recipes=record.recipes,
+            )
+            if derived:
+                # CreateMediaBuyRequest is a Pydantic model that
+                # accepts attribute assignment for declared fields.
+                # Setting ``params.packages`` here is what the seller
+                # adapter sees in its create_media_buy method — it
+                # never has to know the packages were derived from
+                # the proposal.
+                try:
+                    params.packages = derived
+                except (AttributeError, ValueError, TypeError):
+                    if isinstance(params, dict):
+                        params["packages"] = derived
+                    else:
+                        raise
+                packages = derived
+
+        # Capability-overlap gate per D4. The buyer's packages may be
+        # empty when proposal_id is provided AND derivation produced
+        # nothing (legacy proposal without allocations); skip the gate
+        # in that case since there's nothing to validate against.
+        if packages:
+            validate_capability_overlap(
+                packages=list(packages),
+                recipes=record.recipes,
+                field_path_prefix="packages",
+            )
+    except Exception:
+        # Narrow to Exception (not BaseException): CancelledError /
+        # SystemExit / KeyboardInterrupt skip the release path — under
+        # cancellation the next worker will read the stale reservation
+        # and eviction handles it; under shutdown we want fast exit.
+        # release_consumption is idempotent on already-COMMITTED so a
+        # release that races with a concurrent worker is harmless.
+        try:
+            await _await_maybe(
+                store.release_consumption(proposal_id, expected_account_id=ctx.account.id)
+            )
+        except Exception:
+            logger.exception(
+                "Failed to release proposal reservation %s after "
+                "post-reserve validation error; record may be stuck in "
+                "CONSUMING until eviction.",
+                proposal_id,
+            )
+        raise
 
     # Mutate ctx.recipes in place. RequestContext is a dataclass; the
     # field default is a dict, so direct assignment is safe. Keep the
     # mapping immutable for downstream code by wrapping.
     ctx.recipes = dict(record.recipes)
     return record
+
+
+def _derivation_enabled(manager: ProposalManager | None) -> bool:
+    """True when the framework should auto-derive packages from allocations.
+
+    Two opt-in paths:
+    * ``ProposalCapabilities.derive_packages_from_allocations=True`` → use
+      the built-in even-percentage helper.
+    * ``hasattr(manager, "derive_packages")`` → use the adopter override.
+
+    Default ``False`` preserves pre-#727 semantics; existing adopters
+    relying on "empty req.packages means derive yourself from
+    ctx.recipes" stay on the old path until they opt in.
+    """
+    if manager is None:
+        return False
+    if callable(getattr(manager, "derive_packages", None)):
+        return True
+    caps = getattr(manager, "capabilities", None)
+    return bool(getattr(caps, "derive_packages_from_allocations", False))
+
+
+def _has_allocations(proposal_payload: Any) -> bool:
+    """True when ``proposal_payload['allocations']`` is a non-empty list."""
+    if not isinstance(proposal_payload, dict):
+        return False
+    allocations = proposal_payload.get("allocations")
+    return isinstance(allocations, list) and len(allocations) > 0
+
+
+def _derive_packages(
+    *,
+    manager: ProposalManager | None,
+    proposal_payload: Any,
+    total_budget: Any,
+    recipes: Any,
+) -> list[Any]:
+    """Dispatch to the manager's :meth:`derive_packages` override or fall
+    back to the built-in :func:`derive_packages_from_proposal`.
+
+    Detection is duck-typed (``hasattr(manager, 'derive_packages')``)
+    rather than Protocol-membership so adopters who don't override pay
+    no boilerplate — the method is absent from
+    :class:`ProposalManager` Protocol body for the same reason
+    ``finalize_proposal`` is (Resolutions §7).
+    """
+    override = getattr(manager, "derive_packages", None) if manager is not None else None
+    if callable(override):
+        derived = override(
+            proposal_payload=proposal_payload,
+            total_budget=total_budget,
+            recipes=recipes,
+        )
+        return list(derived) if derived is not None else []
+    return list(
+        derive_packages_from_proposal(
+            proposal_payload,
+            total_budget,
+            recipes=recipes,
+        )
+    )
 
 
 async def mark_proposal_consumed(

--- a/src/adcp/decisioning/proposal_manager.py
+++ b/src/adcp/decisioning/proposal_manager.py
@@ -174,6 +174,23 @@ class ProposalCapabilities:
     multi_decisioning: bool = False
     auto_commit_on_put_draft: bool = False
     auto_commit_ttl_seconds: int = 7 * 24 * 3600  # 7 days, salesagent default
+    derive_packages_from_allocations: bool = False
+    """Opt-in: when ``True``, the framework auto-derives ``req.packages``
+    from the proposal's ``allocations[]`` array on
+    ``create_media_buy(proposal_id=..., total_budget=...)`` calls with
+    no explicit ``packages[]``. Default ``False`` preserves the pre-#727
+    semantics (framework leaves ``req.packages`` empty; seller adapter
+    handles it). Adopters whose ``create_media_buy`` adapter currently
+    reads ``ctx.recipes`` directly should leave this off; adopters who
+    want the spec-text behaviour ("publisher converts the proposal's
+    allocation percentages into packages automatically") flip it on or
+    implement :meth:`ProposalManager.derive_packages` for custom math.
+
+    Either flipping this to ``True`` OR implementing
+    ``derive_packages`` activates the framework's auto-injection. See
+    :func:`adcp.decisioning.derive_packages_from_proposal` for the
+    built-in even-percentage helper.
+    """
 
     def __post_init__(self) -> None:
         # Spec only allows the two slugs at v1. Adopter passing a
@@ -448,6 +465,29 @@ class ProposalManager(Protocol):
     # Adopters declaring ``finalize=True`` who don't implement the method
     # get a clear error at ``serve()`` time; the boot-time validator walks
     # methods like ``_is_method_overridden`` from the dispatch design D3.
+
+    # NOTE: ``derive_packages`` is also NOT a Protocol member — same
+    # ``hasattr``-detection posture as ``finalize_proposal``. Adopters
+    # opting into framework package derivation either flip
+    # :attr:`ProposalCapabilities.derive_packages_from_allocations` (for
+    # the built-in even-percentage helper) OR implement this method
+    # (for custom math: auction min-bid, multi-currency, capability-
+    # overlap filtering).
+    #
+    # Expected signature (keyword-only) when implementing the override:
+    #
+    #     def derive_packages(
+    #         self,
+    #         *,
+    #         proposal_payload: Mapping[str, Any],
+    #         total_budget: TotalBudget | None,
+    #         recipes: Mapping[str, Recipe],
+    #     ) -> list[PackageRequest]:
+    #         ...
+    #
+    # Return the list the framework should mutate onto ``req.packages``;
+    # raise :class:`adcp.decisioning.AdcpError` for buyer-fixable
+    # rejections.
 
     # Optional refine surface — capability-gated.
     def refine_products(

--- a/src/adcp/decisioning/proposal_store.py
+++ b/src/adcp/decisioning/proposal_store.py
@@ -192,12 +192,21 @@ class ProposalStore(Protocol):
         *,
         expires_at: datetime,
         proposal_payload: Mapping[str, Any],
+        expected_account_id: str,
     ) -> MaybeAsync[None]:
         """Promote ``DRAFT`` → ``COMMITTED``.
 
         Idempotent on re-call with equal ``expires_at`` +
         ``proposal_payload``. A second commit with different values
         raises ``INTERNAL_ERROR`` — adopter bug.
+
+        ``expected_account_id`` scopes the write to the calling
+        principal's tenant. Durable backings whose primary key is
+        ``(account_id, proposal_id)`` MUST use this in the SQL
+        predicate — a write keyed only on ``proposal_id`` either
+        misses (silently no-ops) or hits the wrong tenant's row.
+        Required as of v1.5.1 (#727); the previous unscoped signature
+        was a cross-tenant write surface.
         """
         ...
 
@@ -265,21 +274,35 @@ class ProposalStore(Protocol):
         proposal_id: str,
         *,
         media_buy_id: str,
+        expected_account_id: str,
     ) -> MaybeAsync[None]:
-        """Legacy direct ``COMMITTED`` → ``CONSUMED`` transition.
+        """Direct ``COMMITTED`` → ``CONSUMED`` transition.
 
-        Preserved for back-compat with v1.5 alpha adopters. New code
-        uses :meth:`try_reserve_consumption` + :meth:`finalize_consumption`
-        for the race-safe two-phase commit. This method is equivalent
-        to a reserve-and-finalize against a single thread of writes;
-        adopters MUST NOT call it from concurrent dispatch paths.
+        New code uses :meth:`try_reserve_consumption` +
+        :meth:`finalize_consumption` for the race-safe two-phase
+        commit. This method is equivalent to a reserve-and-finalize
+        against a single thread of writes; adopters MUST NOT call it
+        from concurrent dispatch paths.
+
+        ``expected_account_id`` scopes the transition to the calling
+        principal's tenant — same rationale as :meth:`commit`.
         """
         ...
 
-    def discard(self, proposal_id: str) -> MaybeAsync[None]:
-        """Rollback path. Idempotent — discarding an unknown id is a
-        no-op (no raise). Symmetric with
-        :meth:`adcp.decisioning.TaskRegistry.discard`."""
+    def discard(
+        self,
+        proposal_id: str,
+        *,
+        expected_account_id: str,
+    ) -> MaybeAsync[None]:
+        """Rollback path. Idempotent — discarding an unknown id (or
+        a cross-tenant probe) is a no-op (no raise). Symmetric with
+        :meth:`adcp.decisioning.TaskRegistry.discard`.
+
+        ``expected_account_id`` scopes the delete to the calling
+        principal's tenant; a cross-tenant probe must not delete the
+        other tenant's row.
+        """
         ...
 
     def get_by_media_buy_id(
@@ -460,17 +483,20 @@ class InMemoryProposalStore:
         *,
         expires_at: datetime,
         proposal_payload: Mapping[str, Any],
+        expected_account_id: str,
     ) -> None:
         async with self._lock:
             self._evict_expired_locked()
             record = self._records.get(proposal_id)
-            if record is None:
+            if record is None or record.account_id != expected_account_id:
+                # Cross-tenant probe collapses to "not in store" — same
+                # principal-enumeration defence as :meth:`get`.
                 raise AdcpError(
                     "INTERNAL_ERROR",
                     message=(
                         f"Cannot commit proposal {proposal_id!r}: not in "
-                        "store. The framework's finalize dispatch must "
-                        "put_draft before commit."
+                        "store for the expected tenant. The framework's "
+                        "finalize dispatch must put_draft before commit."
                     ),
                     recovery="terminal",
                 )
@@ -624,17 +650,21 @@ class InMemoryProposalStore:
         proposal_id: str,
         *,
         media_buy_id: str,
+        expected_account_id: str,
     ) -> None:
-        # Back-compat shim: equivalent to try_reserve_consumption +
-        # finalize_consumption against a single-threaded write. New
-        # dispatch code uses the two-phase methods directly.
+        # Equivalent to try_reserve_consumption + finalize_consumption
+        # against a single-threaded write. New dispatch code uses the
+        # two-phase methods directly.
         async with self._lock:
             self._evict_expired_locked()
             record = self._records.get(proposal_id)
-            if record is None:
+            if record is None or record.account_id != expected_account_id:
                 raise AdcpError(
                     "INTERNAL_ERROR",
-                    message=(f"Cannot mark_consumed proposal {proposal_id!r}: " "not in store."),
+                    message=(
+                        f"Cannot mark_consumed proposal {proposal_id!r}: "
+                        "not in store for the expected tenant."
+                    ),
                     recovery="terminal",
                 )
             if record.state == ProposalState.CONSUMED:
@@ -667,11 +697,20 @@ class InMemoryProposalStore:
             )
             self._media_buy_index[(record.account_id, media_buy_id)] = proposal_id
 
-    async def discard(self, proposal_id: str) -> None:
+    async def discard(
+        self,
+        proposal_id: str,
+        *,
+        expected_account_id: str,
+    ) -> None:
         async with self._lock:
-            record = self._records.pop(proposal_id, None)
+            record = self._records.get(proposal_id)
+            if record is None or record.account_id != expected_account_id:
+                # Idempotent — unknown id or cross-tenant probe is a no-op.
+                return
+            self._records.pop(proposal_id, None)
             self._creation_times.pop(proposal_id, None)
-            if record is not None and record.media_buy_id is not None:
+            if record.media_buy_id is not None:
                 self._media_buy_index.pop((record.account_id, record.media_buy_id), None)
 
     async def get_by_media_buy_id(

--- a/tests/conformance/decisioning/test_pg_proposal_store.py
+++ b/tests/conformance/decisioning/test_pg_proposal_store.py
@@ -1,0 +1,337 @@
+"""Conformance tests for :class:`adcp.decisioning.pg.PgProposalStore`.
+
+Requires a real PostgreSQL instance. To run locally::
+
+    docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=pg postgres:16
+    export ADCP_PG_TEST_URL=postgresql://postgres:pg@localhost:5432/postgres
+    pytest tests/conformance/decisioning/test_pg_proposal_store.py -v
+
+The entire module skips when ``ADCP_PG_TEST_URL`` is unset. Each test
+runs against a freshly-created ``adcp_proposal_drafts_<random>`` table
+so parallel runs don't collide.
+
+These tests mirror the behavioural guarantees of
+``tests/test_proposal_store.py`` (InMemoryProposalStore) against a real
+Postgres engine to catch SQL-level divergence — especially the
+``SELECT ... FOR UPDATE`` CAS in :meth:`try_reserve_consumption` that
+has no equivalent in the in-memory ref.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+psycopg_pool = pytest.importorskip("psycopg_pool")
+
+TEST_URL = os.environ.get("ADCP_PG_TEST_URL")
+if not TEST_URL:
+    pytest.skip(
+        "ADCP_PG_TEST_URL not set — skipping PgProposalStore conformance tests",
+        allow_module_level=True,
+    )
+
+from adcp.decisioning.pg import PgProposalStore  # noqa: E402
+from adcp.decisioning.proposal_store import ProposalState  # noqa: E402
+from adcp.decisioning.recipe import Recipe  # noqa: E402
+from adcp.decisioning.types import AdcpError  # noqa: E402
+
+
+def _utc(dt_str: str) -> datetime:
+    return datetime.fromisoformat(dt_str).replace(tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+async def store() -> AsyncIterator[PgProposalStore]:
+    table = f"adcp_proposals_{secrets.token_hex(6)}"
+    async with psycopg_pool.AsyncConnectionPool(
+        TEST_URL,
+        min_size=2,
+        max_size=8,
+        open=False,
+    ) as pool:
+        await pool.open()
+        s = PgProposalStore(pool=pool, table_name=table)
+        await s.create_schema()
+        try:
+            yield s
+        finally:
+            async with pool.connection() as conn:
+                await conn.execute(f"DROP TABLE IF EXISTS {table}")  # noqa: S608
+
+
+# -- put_draft / get -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_draft_then_get_round_trips(store: PgProposalStore) -> None:
+    recipes = {"prod_1": Recipe()}
+    payload = {"proposal_id": "p1", "v": 1}
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes=recipes,
+        proposal_payload=payload,
+    )
+    record = await store.get("p1")
+    assert record is not None
+    assert record.proposal_id == "p1"
+    assert record.account_id == "acct_a"
+    assert record.state == ProposalState.DRAFT
+    assert "prod_1" in record.recipes
+    assert record.proposal_payload == payload
+
+
+@pytest.mark.asyncio
+async def test_get_cross_tenant_returns_none(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    assert await store.get("p1", expected_account_id="acct_b") is None
+    assert await store.get("p1", expected_account_id="acct_a") is not None
+
+
+@pytest.mark.asyncio
+async def test_commit_promotes_draft_to_committed(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    expires = _utc("2099-01-02T00:00:00")
+    await store.commit(
+        "p1",
+        expires_at=expires,
+        proposal_payload={"committed": True},
+        expected_account_id="acct_a",
+    )
+    record = await store.get("p1")
+    assert record is not None
+    assert record.state == ProposalState.COMMITTED
+    assert record.expires_at == expires
+    assert record.proposal_payload == {"committed": True}
+
+
+@pytest.mark.asyncio
+async def test_commit_rejects_cross_tenant(store: PgProposalStore) -> None:
+    """commit() called with a mismatched expected_account_id MUST fail —
+    the cross-tenant write surface (#727 security)."""
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    with pytest.raises(AdcpError) as exc:
+        await store.commit(
+            "p1",
+            expires_at=_utc("2099-01-02T00:00:00"),
+            proposal_payload={},
+            expected_account_id="acct_b",
+        )
+    assert exc.value.code == "INTERNAL_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_commit_idempotent_on_equal_values(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    expires = _utc("2099-01-02T00:00:00")
+    payload = {"committed": True}
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload=payload, expected_account_id="acct_a"
+    )
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload=payload, expected_account_id="acct_a"
+    )
+    record = await store.get("p1")
+    assert record is not None
+    assert record.state == ProposalState.COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_commit_rejects_diverging_values(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={"v": 1},
+        expected_account_id="acct_a",
+    )
+    with pytest.raises(AdcpError) as exc:
+        await store.commit(
+            "p1",
+            expires_at=_utc("2099-01-03T00:00:00"),
+            proposal_payload={"v": 1},
+            expected_account_id="acct_a",
+        )
+    assert exc.value.code == "INTERNAL_ERROR"
+
+
+# -- try_reserve_consumption + finalize / release -------------------------
+
+
+@pytest.mark.asyncio
+async def test_reserve_finalize_round_trip(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    reserved = await store.try_reserve_consumption("p1", expected_account_id="acct_a")
+    assert reserved.state == ProposalState.CONSUMING
+    await store.finalize_consumption("p1", media_buy_id="mb_1", expected_account_id="acct_a")
+    record = await store.get("p1")
+    assert record is not None
+    assert record.state == ProposalState.CONSUMED
+    assert record.media_buy_id == "mb_1"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reserve_serializes(store: PgProposalStore) -> None:
+    """Two parallel try_reserve_consumption calls — exactly one wins."""
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+
+    async def attempt() -> tuple[bool, str | None]:
+        try:
+            await store.try_reserve_consumption("p1", expected_account_id="acct_a")
+            return (True, None)
+        except AdcpError as e:
+            return (False, e.code)
+
+    results = await asyncio.gather(attempt(), attempt())
+    successes = [r for r in results if r[0]]
+    failures = [r for r in results if not r[0]]
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert failures[0][1] == "PROPOSAL_NOT_COMMITTED"
+
+
+@pytest.mark.asyncio
+async def test_reserve_cross_tenant_collapses_to_not_found(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    with pytest.raises(AdcpError) as exc:
+        await store.try_reserve_consumption("p1", expected_account_id="acct_b")
+    assert exc.value.code == "PROPOSAL_NOT_FOUND"
+
+
+# -- discard cross-tenant safety ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discard_cross_tenant_is_noop(store: PgProposalStore) -> None:
+    """discard() with a cross-tenant expected_account_id must NOT delete
+    the row (#727 security)."""
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.discard("p1", expected_account_id="acct_b")
+    record = await store.get("p1", expected_account_id="acct_a")
+    assert record is not None  # not deleted
+
+
+@pytest.mark.asyncio
+async def test_discard_same_tenant_removes(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.discard("p1", expected_account_id="acct_a")
+    assert await store.get("p1", expected_account_id="acct_a") is None
+
+
+# -- get_by_media_buy_id ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_by_media_buy_id_after_finalize(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    await store.try_reserve_consumption("p1", expected_account_id="acct_a")
+    await store.finalize_consumption("p1", media_buy_id="mb_1", expected_account_id="acct_a")
+    record = await store.get_by_media_buy_id("mb_1", expected_account_id="acct_a")
+    assert record is not None
+    assert record.proposal_id == "p1"
+
+
+# -- expires_at round-trips with UTC ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expires_at_round_trip_preserves_utc(store: PgProposalStore) -> None:
+    await store.put_draft(
+        proposal_id="p1",
+        account_id="acct_a",
+        recipes={},
+        proposal_payload={},
+    )
+    expires = datetime.now(timezone.utc) + timedelta(days=7)
+    await store.commit("p1", expires_at=expires, proposal_payload={}, expected_account_id="acct_a")
+    record = await store.get("p1")
+    assert record is not None
+    assert record.expires_at is not None
+    assert record.expires_at.tzinfo is not None
+    assert abs((record.expires_at - expires).total_seconds()) < 1

--- a/tests/test_decisioning_pg_proposal_store.py
+++ b/tests/test_decisioning_pg_proposal_store.py
@@ -1,0 +1,251 @@
+"""Unit tests for adcp.decisioning.pg.PgProposalStore.
+
+These tests run without a PostgreSQL instance — they cover:
+
+* Stub import path (``from adcp.decisioning import PgProposalStore``)
+* ``is_durable = True`` marker (class-level)
+* ``ImportError`` raised on instantiation when ``[pg]`` extra is absent
+* Protocol structural matching when psycopg IS installed
+* ``MIGRATION`` upgrade/downgrade strings present
+* ``table_name`` validation rejects unsafe identifiers
+* Helper encode/decode round-trips for recipes and payloads
+
+Real-database behavioral tests live in
+``tests/conformance/decisioning/test_pg_proposal_store.py`` — they skip
+unless ``ADCP_PG_TEST_URL`` is set.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# -- Stub always importable -----------------------------------------------
+
+
+def test_pg_proposal_store_importable_from_decisioning() -> None:
+    from adcp.decisioning import PgProposalStore  # noqa: F401
+
+    assert PgProposalStore is not None
+
+
+def test_pg_proposal_store_is_durable_stub() -> None:
+    from adcp.decisioning import PgProposalStore
+
+    assert getattr(PgProposalStore, "is_durable", None) is True
+
+
+def test_pg_proposal_store_stub_raises_import_error_without_pg() -> None:
+    import importlib.util
+
+    if importlib.util.find_spec("psycopg_pool") is not None:
+        pytest.skip("psycopg_pool is installed — stub not in effect")
+
+    from adcp.decisioning import PgProposalStore
+
+    with pytest.raises(ImportError, match=r"adcp\[pg\]"):
+        PgProposalStore(pool=None)  # type: ignore[arg-type]
+
+
+# -- Tests requiring psycopg (structural, no real DB) ---------------------
+
+
+psycopg_pool = pytest.importorskip(
+    "psycopg_pool",
+    reason="psycopg_pool not installed — skipping structural pg tests",
+)
+
+
+def test_pg_proposal_store_satisfies_protocol() -> None:
+    from unittest.mock import MagicMock
+
+    from adcp.decisioning import PgProposalStore
+    from adcp.decisioning.proposal_store import ProposalStore
+
+    store = PgProposalStore(pool=MagicMock())
+    assert isinstance(store, ProposalStore)
+
+
+def test_pg_proposal_store_is_durable_class_var() -> None:
+    """is_durable must be class-level, not instance-level — production-mode
+    gates inspect ``type(store).is_durable``."""
+    from adcp.decisioning.pg import PgProposalStore
+
+    assert PgProposalStore.is_durable is True
+    assert "is_durable" in PgProposalStore.__dict__
+
+
+def test_pg_proposal_store_migration_sql_default_table() -> None:
+    """Adopters wiring an Alembic / dbmate migration paste the upgrade
+    string. Default-table variant must include the canonical name."""
+    from adcp.decisioning.pg import PgProposalStore
+
+    migration = PgProposalStore.migration_sql()
+    assert "upgrade" in migration
+    assert "downgrade" in migration
+    upgrade = migration["upgrade"]
+    assert "adcp_proposal_drafts" in upgrade
+    assert "PRIMARY KEY (account_id, proposal_id)" in upgrade
+    assert "media_buy_idx" in upgrade
+    assert migration["downgrade"].startswith("DROP TABLE")
+
+
+def test_pg_proposal_store_migration_sql_honors_custom_table_name() -> None:
+    """An adopter who constructed PgProposalStore with a custom
+    table_name MUST also be able to ask for migration SQL keyed to
+    that same name — otherwise the docs-emitted DDL would create the
+    wrong table."""
+    from adcp.decisioning.pg import PgProposalStore
+
+    migration = PgProposalStore.migration_sql(table_name="my_app_proposals")
+    assert "my_app_proposals" in migration["upgrade"]
+    assert "adcp_proposal_drafts" not in migration["upgrade"]
+    assert "my_app_proposals_media_buy_idx" in migration["upgrade"]
+    assert "DROP TABLE IF EXISTS my_app_proposals" in migration["downgrade"]
+
+
+def test_pg_proposal_store_migration_sql_rejects_unsafe_table_name() -> None:
+    """SQL identifier guard applies to the migration API too."""
+    from adcp.decisioning.pg import PgProposalStore
+
+    with pytest.raises(ValueError, match="table_name must match"):
+        PgProposalStore.migration_sql(table_name="bad-name")
+
+
+def test_pg_proposal_store_rejects_unsafe_table_name() -> None:
+    """SQL identifier guard — ``table_name`` must match the ASCII-only
+    pattern. Non-ASCII letters, hyphens, or quote characters get
+    rejected at construction time."""
+    from unittest.mock import MagicMock
+
+    from adcp.decisioning.pg import PgProposalStore
+
+    with pytest.raises(ValueError, match="table_name must match"):
+        PgProposalStore(pool=MagicMock(), table_name="bad-name")
+    with pytest.raises(ValueError, match="table_name must match"):
+        PgProposalStore(pool=MagicMock(), table_name="proposals; DROP TABLE")
+    with pytest.raises(ValueError, match="table_name must match"):
+        PgProposalStore(pool=MagicMock(), table_name="Α_unicode_alpha")  # noqa: RUF001
+
+
+def test_pg_proposal_store_accepts_custom_table_name() -> None:
+    """Adopters with one Postgres serving multiple AdCP instances or
+    whose ``proposal_drafts`` table is already taken pass a custom
+    table_name."""
+    from unittest.mock import MagicMock
+
+    from adcp.decisioning.pg import PgProposalStore
+
+    store = PgProposalStore(pool=MagicMock(), table_name="my_app_proposals")
+    assert "my_app_proposals" in store._sql_get_state  # type: ignore[attr-defined]
+
+
+# -- helper round-trip tests -----------------------------------------------
+
+
+def test_encode_decode_recipes_round_trip() -> None:
+    """A recipe → JSON → recipe round-trip preserves all typed fields
+    using the default decoder (base ``Recipe``)."""
+    from adcp.decisioning.pg.proposal_store import (
+        _decode_recipes,
+        _default_recipe_decoder,
+        _encode_recipes,
+    )
+    from adcp.decisioning.recipe import CapabilityOverlap, Recipe
+
+    overlap = CapabilityOverlap(pricing_models=frozenset({"cpm"}))
+    recipes = {"prod_1": Recipe(capability_overlap=overlap)}
+    encoded = _encode_recipes(recipes)
+    decoded = _decode_recipes(encoded, _default_recipe_decoder)
+    assert "prod_1" in decoded
+    # The default decoder returns a base Recipe with capability_overlap
+    # rehydrated to a CapabilityOverlap dataclass.
+    assert decoded["prod_1"].capability_overlap is not None
+    # Default decoder strips arbitrary types (frozenset → list via JSON);
+    # adopters who want exact frozenset round-trips supply a typed
+    # decoder. Confirm at minimum that the dict shape survives.
+
+
+def test_encode_recipes_accepts_dict_shaped_passthrough() -> None:
+    """Adopter migrations may seed the store with pre-serialized dicts;
+    confirm the encoder accepts them without requiring a Recipe instance."""
+    from adcp.decisioning.pg.proposal_store import _encode_recipes
+
+    encoded = _encode_recipes({"prod_1": {"recipe_kind": "gam", "x": 1}})  # type: ignore[dict-item]
+    assert "recipe_kind" in encoded
+    assert "gam" in encoded
+
+
+def test_decode_payload_accepts_dict_and_string() -> None:
+    """psycopg may return JSONB as a dict (preferred) or string (older
+    drivers); both must round-trip cleanly."""
+    from adcp.decisioning.pg.proposal_store import _decode_payload
+
+    assert _decode_payload({"k": "v"}) == {"k": "v"}
+    assert _decode_payload('{"k": "v"}') == {"k": "v"}
+    assert _decode_payload(None) == {}
+
+
+def test_ensure_utc_rejects_naive_datetime() -> None:
+    """Naive datetimes from the column indicate adopter migration drift
+    (column declared as ``TIMESTAMP WITHOUT TIME ZONE``). Fail fast."""
+    from datetime import datetime
+
+    from adcp.decisioning.pg.proposal_store import _ensure_utc
+    from adcp.decisioning.types import AdcpError
+
+    with pytest.raises(AdcpError, match="naive datetime"):
+        _ensure_utc(datetime(2026, 1, 1))
+
+
+def test_ensure_utc_none_passthrough() -> None:
+    from adcp.decisioning.pg.proposal_store import _ensure_utc
+
+    assert _ensure_utc(None) is None
+
+
+# -- migration_sql ↔ proposal_store.sql drift guard ------------------------
+
+
+def _normalize_sql(text: str) -> str:
+    """Strip comments and collapse whitespace so the migration_sql()
+    output and the .sql file can be compared semantically."""
+    out_lines = []
+    for line in text.splitlines():
+        stripped = line.split("--", 1)[0].rstrip()
+        if not stripped.strip():
+            continue
+        out_lines.append(" ".join(stripped.split()))
+    return "\n".join(out_lines)
+
+
+def test_migration_sql_matches_proposal_store_sql_file() -> None:
+    """The Python ``migration_sql()`` upgrade string and the shipped
+    ``proposal_store.sql`` file MUST stay in sync. If you change one,
+    change both — adopters wire either depending on their migration
+    tool."""
+    from pathlib import Path
+
+    from adcp.decisioning.pg import PgProposalStore
+
+    py_upgrade = PgProposalStore.migration_sql()["upgrade"]
+    sql_path = (
+        Path(__file__).parent.parent / "src" / "adcp" / "decisioning" / "pg" / "proposal_store.sql"
+    )
+    file_text = sql_path.read_text()
+    assert _normalize_sql(py_upgrade) == _normalize_sql(file_text)
+
+
+# -- default recipe_decoder fail-loud --------------------------------------
+
+
+def test_default_decoder_fails_loud_on_typed_payload() -> None:
+    """When the stored payload has a ``recipe_kind`` field, the default
+    decoder MUST raise with a clear pointer to ``recipe_decoder=`` —
+    not the raw Pydantic ``extra='forbid'`` message."""
+    from adcp.decisioning.pg.proposal_store import _default_recipe_decoder
+    from adcp.decisioning.types import AdcpError
+
+    with pytest.raises(AdcpError) as exc:
+        _default_recipe_decoder({"recipe_kind": "gam", "line_item_id": "li_1"})
+    assert "recipe_decoder" in str(exc.value)
+    assert exc.value.code == "INTERNAL_ERROR"

--- a/tests/test_derive_packages.py
+++ b/tests/test_derive_packages.py
@@ -1,0 +1,556 @@
+"""Tests for framework-level package derivation from proposal allocations.
+
+Covers:
+
+* :func:`derive_packages_from_proposal` — pure-function derivation math.
+* Error handling — missing fields surface as ``INVALID_REQUEST``.
+* Integration with ``maybe_hydrate_recipes_for_create_media_buy``:
+    * Auto-derivation runs when ``req.packages`` is empty.
+    * ``ProposalManager.derive_packages`` override is preferred.
+    * Failed derivation releases the reservation back to COMMITTED.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    AdcpError,
+    InMemoryProposalStore,
+    ProposalCapabilities,
+    derive_packages_from_proposal,
+)
+from adcp.decisioning.context import AuthInfo, RequestContext
+from adcp.decisioning.proposal_dispatch import (
+    maybe_hydrate_recipes_for_create_media_buy,
+)
+from adcp.decisioning.registry import ApiKeyCredential
+from adcp.decisioning.types import Account
+
+
+def _utc(dt_str: str) -> datetime:
+    return datetime.fromisoformat(dt_str).replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# derive_packages_from_proposal — pure-function tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_packages_even_split() -> None:
+    payload = {
+        "allocations": [
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 60.0,
+                "pricing_option_id": "po_a",
+            },
+            {
+                "product_id": "prod_2",
+                "allocation_percentage": 40.0,
+                "pricing_option_id": "po_b",
+            },
+        ]
+    }
+    total_budget = {"amount": 1000.0, "currency": "USD"}
+    packages = derive_packages_from_proposal(payload, total_budget)
+    assert len(packages) == 2
+    assert packages[0].product_id == "prod_1"
+    assert packages[0].budget == 600.0
+    assert packages[0].pricing_option_id == "po_a"
+    assert packages[1].product_id == "prod_2"
+    assert packages[1].budget == 400.0
+    assert packages[1].pricing_option_id == "po_b"
+
+
+def test_derive_packages_propagates_allocation_flight_times() -> None:
+    """When the seller's allocation carries start_time / end_time,
+    the derived package MUST inherit them — they encode per-flight
+    scheduling within the proposal (spec)."""
+    payload = {
+        "allocations": [
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 100.0,
+                "pricing_option_id": "po_a",
+                "start_time": "2026-04-01T00:00:00Z",
+                "end_time": "2026-04-30T23:59:59Z",
+            }
+        ]
+    }
+    packages = derive_packages_from_proposal(payload, {"amount": 1000.0, "currency": "USD"})
+    assert packages[0].start_time is not None
+    assert packages[0].end_time is not None
+
+
+def test_derive_packages_accepts_typed_total_budget() -> None:
+    """Typed ``TotalBudget`` from the wire model works the same as a dict."""
+    from adcp.types import PackageRequest
+    from adcp.types.generated_poc.media_buy.create_media_buy_request import TotalBudget
+
+    payload = {
+        "allocations": [
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 100.0,
+                "pricing_option_id": "po_a",
+            },
+        ]
+    }
+    total_budget = TotalBudget(amount=500.0, currency="USD")
+    packages = derive_packages_from_proposal(payload, total_budget)
+    assert isinstance(packages[0], PackageRequest)
+    assert packages[0].budget == 500.0
+
+
+def test_derive_packages_missing_total_budget_raises() -> None:
+    payload = {"allocations": [{"product_id": "p1", "allocation_percentage": 100.0}]}
+    with pytest.raises(AdcpError) as exc:
+        derive_packages_from_proposal(payload, None)
+    assert exc.value.code == "INVALID_REQUEST"
+    assert exc.value.field == "total_budget"
+
+
+def test_derive_packages_empty_allocations_raises() -> None:
+    with pytest.raises(AdcpError) as exc:
+        derive_packages_from_proposal({"allocations": []}, {"amount": 100.0, "currency": "USD"})
+    assert exc.value.code == "INVALID_REQUEST"
+    assert exc.value.field == "proposal_id"
+
+
+def test_derive_packages_missing_allocations_key_raises() -> None:
+    with pytest.raises(AdcpError) as exc:
+        derive_packages_from_proposal({}, {"amount": 100.0, "currency": "USD"})
+    assert exc.value.code == "INVALID_REQUEST"
+
+
+def test_enrich_allocations_picks_single_pricing_option() -> None:
+    """When a product has exactly one pricing_options[] entry and the
+    allocation omits pricing_option_id, the framework picks the single
+    option at proposal-persist time. The downstream derivation then
+    sees a fully-populated allocation."""
+    from adcp.decisioning.proposal_dispatch import (
+        _enrich_allocations_with_pricing_options,
+    )
+
+    payload = {
+        "allocations": [
+            {"product_id": "prod_a", "allocation_percentage": 100.0},
+        ]
+    }
+    products = [
+        {
+            "product_id": "prod_a",
+            "pricing_options": [{"pricing_option_id": "po_only"}],
+        },
+    ]
+    _enrich_allocations_with_pricing_options(payload, products)
+    assert payload["allocations"][0]["pricing_option_id"] == "po_only"
+
+
+def test_enrich_allocations_skips_multi_option_products() -> None:
+    """Multi-option products are ambiguous — framework leaves the
+    allocation alone so the seller's derive_packages override (or
+    proposal-assembly logic) handles selection."""
+    from adcp.decisioning.proposal_dispatch import (
+        _enrich_allocations_with_pricing_options,
+    )
+
+    payload = {
+        "allocations": [
+            {"product_id": "prod_a", "allocation_percentage": 100.0},
+        ]
+    }
+    products = [
+        {
+            "product_id": "prod_a",
+            "pricing_options": [
+                {"pricing_option_id": "po_one"},
+                {"pricing_option_id": "po_two"},
+            ],
+        },
+    ]
+    _enrich_allocations_with_pricing_options(payload, products)
+    assert "pricing_option_id" not in payload["allocations"][0]
+
+
+def test_derive_packages_missing_pricing_option_raises_seller_error() -> None:
+    """ProductAllocation.pricing_option_id is optional on the wire but
+    PackageRequest.pricing_option_id is required. When the seller's
+    proposal omits it AND the framework can't auto-pick (multiple
+    pricing options, no product context), surface as INTERNAL_ERROR —
+    not buyer-correctable. The buyer can't fix a seller-side gap."""
+    payload = {
+        "allocations": [
+            {"product_id": "prod_1", "allocation_percentage": 100.0},
+        ]
+    }
+    with pytest.raises(AdcpError) as exc:
+        derive_packages_from_proposal(payload, {"amount": 1000.0, "currency": "USD"})
+    assert exc.value.code == "INTERNAL_ERROR"
+    assert "Seller configuration error" in str(exc.value)
+
+
+def test_derive_packages_missing_product_id_raises() -> None:
+    payload = {
+        "allocations": [
+            {"allocation_percentage": 100.0, "pricing_option_id": "po"},
+        ]
+    }
+    with pytest.raises(AdcpError) as exc:
+        derive_packages_from_proposal(payload, {"amount": 1000.0, "currency": "USD"})
+    assert exc.value.code == "INVALID_REQUEST"
+    assert "product_id" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Integration — auto-derivation in maybe_hydrate_recipes_for_create_media_buy
+# ---------------------------------------------------------------------------
+
+
+class _DerivingManager:
+    """Bare-minimum manager that opts into framework derivation via
+    ``derive_packages_from_allocations``. Tests covering the built-in
+    helper path use this; tests covering the override path subclass it
+    to add a ``derive_packages`` method.
+    """
+
+    capabilities = ProposalCapabilities(
+        sales_specialism="sales-non-guaranteed",
+        derive_packages_from_allocations=True,
+    )
+
+
+class _Platform:
+    """Minimal platform exposing per-tenant store / manager hooks.
+
+    Mirrors the duck-typed router introspection in
+    :func:`_resolve_manager_and_store`.
+    """
+
+    def __init__(
+        self,
+        store: InMemoryProposalStore,
+        manager: Any | None = None,
+    ) -> None:
+        self._store = store
+        # Default to a manager that opts into derivation so the bulk of
+        # tests exercise the auto-injection path. Tests covering the
+        # "off" semantics pass ``manager=None`` or a manager without
+        # the flag.
+        self._manager = manager if manager is not None else _DerivingManager()
+
+    def proposal_store_for_tenant(self, tenant_id: str) -> InMemoryProposalStore:
+        del tenant_id
+        return self._store
+
+    def proposal_manager_for_tenant(self, tenant_id: str) -> Any | None:
+        del tenant_id
+        return self._manager
+
+
+def _ctx(account_id: str = "acct_a", tenant_id: str = "t1") -> RequestContext[Any]:
+    """Build a RequestContext with the tenant_id metadata the dispatcher
+    looks up."""
+    return RequestContext(
+        account=Account(id=account_id, metadata={"tenant_id": tenant_id}),
+        auth_info=AuthInfo(
+            kind="api_key",
+            key_id="kid_1",
+            principal="agent.example.com",
+            credential=ApiKeyCredential(kind="api_key", key_id="kid_1"),
+        ),
+    )
+
+
+async def _seed_committed_proposal(
+    store: InMemoryProposalStore,
+    *,
+    proposal_id: str = "p1",
+    account_id: str = "acct_a",
+    allocations: list[dict[str, Any]] | None = None,
+) -> None:
+    payload = {"proposal_id": proposal_id, "proposal_status": "committed"}
+    if allocations is not None:
+        payload["allocations"] = allocations
+    await store.put_draft(
+        proposal_id=proposal_id,
+        account_id=account_id,
+        recipes={},
+        proposal_payload=payload,
+    )
+    await store.commit(
+        proposal_id,
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload=payload,
+        expected_account_id=account_id,
+    )
+
+
+class _CreateMediaBuyParams:
+    """Minimal duck-typed stand-in for ``CreateMediaBuyRequest``.
+
+    The auto-derivation block mutates ``packages``; we verify the
+    assignment happens. Using a plain class keeps the test independent
+    of the full Pydantic model (which carries many required fields like
+    ``brand`` / ``idempotency_key`` we don't need to exercise the
+    derivation path).
+    """
+
+    def __init__(
+        self,
+        proposal_id: str,
+        total_budget: Any | None,
+        packages: list[Any] | None = None,
+    ) -> None:
+        self.proposal_id = proposal_id
+        self.total_budget = total_budget
+        self.packages = packages
+
+
+@pytest.mark.asyncio
+async def test_derivation_off_by_default_no_manager() -> None:
+    """Without a manager wired, the framework does not auto-derive —
+    preserves pre-#727 semantics for adopters who haven't opted in."""
+
+    class _BareLookup:
+        def __init__(self, store: InMemoryProposalStore) -> None:
+            self._store = store
+
+        def proposal_store_for_tenant(self, _tid: str) -> InMemoryProposalStore:
+            return self._store
+
+        def proposal_manager_for_tenant(self, _tid: str) -> Any | None:
+            return None
+
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(
+        store,
+        allocations=[
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 100.0,
+                "pricing_option_id": "po_a",
+            }
+        ],
+    )
+    platform = _BareLookup(store)
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget={"amount": 1000.0, "currency": "USD"},
+        packages=None,
+    )
+    await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    # Derivation did NOT run.
+    assert params.packages is None
+
+
+@pytest.mark.asyncio
+async def test_derivation_off_by_default_when_flag_false() -> None:
+    """A manager without the opt-in flag and without a derive_packages
+    override does not trigger derivation."""
+
+    class _OffManager:
+        capabilities = ProposalCapabilities(sales_specialism="sales-non-guaranteed")
+
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(
+        store,
+        allocations=[
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 100.0,
+                "pricing_option_id": "po_a",
+            }
+        ],
+    )
+    platform = _Platform(store, manager=_OffManager())
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget={"amount": 1000.0, "currency": "USD"},
+        packages=None,
+    )
+    await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    assert params.packages is None
+
+
+@pytest.mark.asyncio
+async def test_auto_derives_packages_from_allocations() -> None:
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(
+        store,
+        allocations=[
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 70.0,
+                "pricing_option_id": "po_a",
+            },
+            {
+                "product_id": "prod_2",
+                "allocation_percentage": 30.0,
+                "pricing_option_id": "po_b",
+            },
+        ],
+    )
+    platform = _Platform(store)
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget={"amount": 1000.0, "currency": "USD"},
+        packages=None,
+    )
+    record = await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    assert record is not None
+    assert params.packages is not None
+    assert len(params.packages) == 2
+    assert params.packages[0].product_id == "prod_1"
+    assert params.packages[0].budget == 700.0
+    assert params.packages[1].budget == 300.0
+
+
+@pytest.mark.asyncio
+async def test_existing_packages_are_not_overridden() -> None:
+    """Buyer-supplied packages take precedence — no derivation runs."""
+    from adcp.types import PackageRequest
+
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(
+        store,
+        allocations=[
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 100.0,
+                "pricing_option_id": "po_a",
+            }
+        ],
+    )
+    platform = _Platform(store)
+    explicit = [PackageRequest(product_id="other", budget=42.0, pricing_option_id="po_x")]
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget={"amount": 1000.0, "currency": "USD"},
+        packages=list(explicit),
+    )
+    await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    assert params.packages is not None
+    assert len(params.packages) == 1
+    assert params.packages[0].product_id == "other"
+    assert params.packages[0].budget == 42.0
+
+
+@pytest.mark.asyncio
+async def test_proposal_without_allocations_is_a_noop() -> None:
+    """Legacy proposals without ``allocations[]`` skip derivation; the
+    buyer's empty packages stay empty (adapter handles)."""
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(store, allocations=None)
+    platform = _Platform(store)
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget=None,
+        packages=None,
+    )
+    record = await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    assert record is not None
+    assert params.packages is None  # untouched
+
+
+@pytest.mark.asyncio
+async def test_derivation_failure_releases_reservation() -> None:
+    """Derivation raises (e.g. missing pricing_option_id) → the proposal
+    must roll back to COMMITTED so the buyer can retry."""
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(
+        store,
+        allocations=[
+            # Missing pricing_option_id — triggers INVALID_REQUEST.
+            {"product_id": "prod_1", "allocation_percentage": 100.0},
+        ],
+    )
+    platform = _Platform(store)
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget={"amount": 1000.0, "currency": "USD"},
+        packages=None,
+    )
+    with pytest.raises(AdcpError) as exc:
+        await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    assert exc.value.code == "INTERNAL_ERROR"
+    # Reservation released back to COMMITTED.
+    from adcp.decisioning.proposal_store import ProposalState
+
+    record = await store.get("p1", expected_account_id="acct_a")
+    assert record is not None
+    assert record.state == ProposalState.COMMITTED
+
+
+# ---------------------------------------------------------------------------
+# Override hook — ProposalManager.derive_packages
+# ---------------------------------------------------------------------------
+
+
+class _CustomDerivationManager:
+    """Manager declaring a ``derive_packages`` override that uses
+    auction-style ``bid_price`` instead of even-percentage split."""
+
+    capabilities = ProposalCapabilities(sales_specialism="sales-non-guaranteed")
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def derive_packages(
+        self,
+        *,
+        proposal_payload: Mapping[str, Any],
+        total_budget: Any,
+        recipes: Mapping[str, Any],
+    ) -> list[Any]:
+        from adcp.types import PackageRequest
+
+        self.calls.append({"proposal_payload": dict(proposal_payload)})
+        del recipes
+        budget = total_budget["amount"] if total_budget else 100.0
+        return [
+            PackageRequest(
+                product_id=str(a["product_id"]),
+                budget=budget,  # custom: full budget per product, not split
+                pricing_option_id="po_custom",
+                bid_price=5.0,
+            )
+            for a in proposal_payload["allocations"]
+        ]
+
+
+@pytest.mark.asyncio
+async def test_manager_derive_packages_override_is_preferred() -> None:
+    """When the manager declares ``derive_packages``, the framework
+    dispatches there instead of the built-in helper."""
+    store = InMemoryProposalStore()
+    await _seed_committed_proposal(
+        store,
+        allocations=[
+            {
+                "product_id": "prod_1",
+                "allocation_percentage": 100.0,
+                # Note: no pricing_option_id — would fail the default
+                # helper but the override supplies one.
+            },
+        ],
+    )
+    manager = _CustomDerivationManager()
+    platform = _Platform(store, manager=manager)
+    params = _CreateMediaBuyParams(
+        proposal_id="p1",
+        total_budget={"amount": 1000.0, "currency": "USD"},
+        packages=None,
+    )
+    await maybe_hydrate_recipes_for_create_media_buy(platform, params, _ctx())
+    assert len(manager.calls) == 1
+    assert params.packages is not None
+    assert len(params.packages) == 1
+    assert params.packages[0].budget == 1000.0
+    assert params.packages[0].pricing_option_id == "po_custom"
+    assert params.packages[0].bid_price == 5.0

--- a/tests/test_proposal_lifecycle.py
+++ b/tests/test_proposal_lifecycle.py
@@ -78,7 +78,12 @@ async def test_expiry_cross_tenant_returns_not_found() -> None:
     as missing-id so principal-enumeration via id probing fails."""
     store = InMemoryProposalStore()
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
     with pytest.raises(AdcpError) as exc:
         await enforce_proposal_expiry(
             "p1",
@@ -112,7 +117,7 @@ async def test_expiry_past_deadline_raises_expired() -> None:
     store = InMemoryProposalStore(clock=lambda: fixed)
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     expires = _utc("2099-06-01T01:00:00")  # 1 hour in the store's "future"
-    await store.commit("p1", expires_at=expires, proposal_payload={})
+    await store.commit("p1", expires_at=expires, proposal_payload={}, expected_account_id="acct_a")
 
     # Lifecycle checks against ``now`` 1 hour past expires — the
     # adopter's grace is 0 → PROPOSAL_EXPIRED.
@@ -136,7 +141,7 @@ async def test_expiry_within_grace_returns_record() -> None:
     store = InMemoryProposalStore()
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     expires = _utc("2099-01-01T00:00:00")
-    await store.commit("p1", expires_at=expires, proposal_payload={})
+    await store.commit("p1", expires_at=expires, proposal_payload={}, expected_account_id="acct_a")
     now = expires + timedelta(minutes=4)
     record = await enforce_proposal_expiry(
         "p1",
@@ -153,7 +158,9 @@ async def test_expiry_inside_window_returns_record() -> None:
     store = InMemoryProposalStore()
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     expires = _utc("2099-12-31T00:00:00")
-    await store.commit("p1", expires_at=expires, proposal_payload={"committed": True})
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload={"committed": True}, expected_account_id="acct_a"
+    )
     record = await enforce_proposal_expiry(
         "p1",
         proposal_store=store,

--- a/tests/test_proposal_lifecycle_e2e.py
+++ b/tests/test_proposal_lifecycle_e2e.py
@@ -487,6 +487,7 @@ async def test_expired_proposal_rejected(
         "expired_proposal",
         expires_at=past,
         proposal_payload={"proposal_id": "expired_proposal", "proposal_status": "committed"},
+        expected_account_id="acct_demo",
     )
 
     cmb_req = CreateMediaBuyRequest.model_validate(
@@ -532,6 +533,7 @@ async def test_within_grace_window_accepted(
         "grace_proposal",
         expires_at=near,
         proposal_payload={"proposal_id": "grace_proposal", "proposal_status": "committed"},
+        expected_account_id="acct_demo",
     )
 
     cmb_req = CreateMediaBuyRequest.model_validate(

--- a/tests/test_proposal_store.py
+++ b/tests/test_proposal_store.py
@@ -170,6 +170,7 @@ async def test_put_draft_rejects_overwrite_of_committed(store: InMemoryProposalS
         "p1",
         expires_at=_utc("2099-01-02T00:00:00"),
         proposal_payload={"committed": True},
+        expected_account_id="acct_a",
     )
     with pytest.raises(AdcpError) as exc:
         await store.put_draft(
@@ -195,7 +196,9 @@ async def test_commit_promotes_draft_to_committed(store: InMemoryProposalStore) 
         proposal_payload={"v": 1},
     )
     expires = _utc("2099-01-02T00:00:00")
-    await store.commit("p1", expires_at=expires, proposal_payload={"committed": True})
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload={"committed": True}, expected_account_id="acct_a"
+    )
     record = await store.get("p1")
     assert record is not None
     assert record.state == ProposalState.COMMITTED
@@ -207,9 +210,13 @@ async def test_commit_promotes_draft_to_committed(store: InMemoryProposalStore) 
 async def test_commit_idempotent_on_equal_payload(store: InMemoryProposalStore) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     expires = _utc("2099-01-02T00:00:00")
-    await store.commit("p1", expires_at=expires, proposal_payload={"x": 1})
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload={"x": 1}, expected_account_id="acct_a"
+    )
     # Same args → no-op.
-    await store.commit("p1", expires_at=expires, proposal_payload={"x": 1})
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload={"x": 1}, expected_account_id="acct_a"
+    )
     record = await store.get("p1")
     assert record is not None
     assert record.state == ProposalState.COMMITTED
@@ -219,9 +226,13 @@ async def test_commit_idempotent_on_equal_payload(store: InMemoryProposalStore) 
 async def test_commit_rejects_diverging_payload(store: InMemoryProposalStore) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     expires = _utc("2099-01-02T00:00:00")
-    await store.commit("p1", expires_at=expires, proposal_payload={"x": 1})
+    await store.commit(
+        "p1", expires_at=expires, proposal_payload={"x": 1}, expected_account_id="acct_a"
+    )
     with pytest.raises(AdcpError) as exc:
-        await store.commit("p1", expires_at=expires, proposal_payload={"x": 2})
+        await store.commit(
+            "p1", expires_at=expires, proposal_payload={"x": 2}, expected_account_id="acct_a"
+        )
     assert exc.value.code == "INTERNAL_ERROR"
 
 
@@ -232,6 +243,7 @@ async def test_commit_unknown_proposal_raises(store: InMemoryProposalStore) -> N
             "p-missing",
             expires_at=_utc("2099-01-02T00:00:00"),
             proposal_payload={},
+            expected_account_id="acct_a",
         )
     assert exc.value.code == "INTERNAL_ERROR"
 
@@ -244,13 +256,15 @@ async def test_commit_from_consumed_raises(store: InMemoryProposalStore) -> None
         "p1",
         expires_at=_utc("2099-01-02T00:00:00"),
         proposal_payload={},
+        expected_account_id="acct_a",
     )
-    await store.mark_consumed("p1", media_buy_id="mb_1")
+    await store.mark_consumed("p1", media_buy_id="mb_1", expected_account_id="acct_a")
     with pytest.raises(AdcpError) as exc:
         await store.commit(
             "p1",
             expires_at=_utc("2099-01-02T00:00:00"),
             proposal_payload={},
+            expected_account_id="acct_a",
         )
     assert exc.value.code == "INTERNAL_ERROR"
 
@@ -265,8 +279,13 @@ async def test_mark_consumed_records_media_buy_back_reference(
     store: InMemoryProposalStore,
 ) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
-    await store.mark_consumed("p1", media_buy_id="mb_42")
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    await store.mark_consumed("p1", media_buy_id="mb_42", expected_account_id="acct_a")
     record = await store.get("p1")
     assert record is not None
     assert record.state == ProposalState.CONSUMED
@@ -284,10 +303,15 @@ async def test_mark_consumed_idempotent_on_same_media_buy_id(
     store: InMemoryProposalStore,
 ) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
-    await store.mark_consumed("p1", media_buy_id="mb_42")
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    await store.mark_consumed("p1", media_buy_id="mb_42", expected_account_id="acct_a")
     # Same media_buy_id → no-op.
-    await store.mark_consumed("p1", media_buy_id="mb_42")
+    await store.mark_consumed("p1", media_buy_id="mb_42", expected_account_id="acct_a")
 
 
 @pytest.mark.asyncio
@@ -295,10 +319,15 @@ async def test_mark_consumed_different_media_buy_id_raises(
     store: InMemoryProposalStore,
 ) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
-    await store.mark_consumed("p1", media_buy_id="mb_42")
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    await store.mark_consumed("p1", media_buy_id="mb_42", expected_account_id="acct_a")
     with pytest.raises(AdcpError) as exc:
-        await store.mark_consumed("p1", media_buy_id="mb_99")
+        await store.mark_consumed("p1", media_buy_id="mb_99", expected_account_id="acct_a")
     assert exc.value.code == "INTERNAL_ERROR"
 
 
@@ -308,7 +337,7 @@ async def test_mark_consumed_from_draft_raises(store: InMemoryProposalStore) -> 
     before marking consumed."""
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     with pytest.raises(AdcpError) as exc:
-        await store.mark_consumed("p1", media_buy_id="mb_1")
+        await store.mark_consumed("p1", media_buy_id="mb_1", expected_account_id="acct_a")
     assert exc.value.code == "INTERNAL_ERROR"
 
 
@@ -339,8 +368,13 @@ async def test_get_by_media_buy_id_cross_tenant_returns_none(
     store: InMemoryProposalStore,
 ) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
-    await store.mark_consumed("p1", media_buy_id="mb_42")
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    await store.mark_consumed("p1", media_buy_id="mb_42", expected_account_id="acct_a")
     assert await store.get_by_media_buy_id("mb_42", expected_account_id="other") is None
     assert await store.get_by_media_buy_id("mb_42", expected_account_id="acct_a") is not None
 
@@ -356,7 +390,12 @@ async def test_try_reserve_consumption_transitions_to_consuming(
 ) -> None:
     """Atomic CAS COMMITTED → CONSUMING; record returned, state visible."""
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
 
     reserved = await store.try_reserve_consumption("p1", expected_account_id="acct_a")
     assert reserved.state == ProposalState.CONSUMING
@@ -377,7 +416,12 @@ async def test_try_reserve_consumption_concurrent_only_one_wins(
     import asyncio
 
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
 
     async def _try() -> str:
         try:
@@ -399,7 +443,12 @@ async def test_release_consumption_rolls_back_to_committed(
     """Rollback path for adapter failure: CONSUMING → COMMITTED. The
     buyer can retry without PROPOSAL_NOT_COMMITTED blocking them."""
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
     await store.try_reserve_consumption("p1", expected_account_id="acct_a")
 
     await store.release_consumption("p1", expected_account_id="acct_a")
@@ -420,7 +469,12 @@ async def test_release_consumption_idempotent_on_committed(
     Lets the adapter-failure rollback path be unconditional even when
     something else has already rolled back."""
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
     # No reserve — just release. Should not raise.
     await store.release_consumption("p1", expected_account_id="acct_a")
     record = await store.get("p1", expected_account_id="acct_a")
@@ -434,7 +488,12 @@ async def test_finalize_consumption_promotes_to_consumed(
     """Happy path: reserve + finalize_consumption transitions to
     CONSUMED with the media_buy_id back-reference."""
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
     await store.try_reserve_consumption("p1", expected_account_id="acct_a")
     await store.finalize_consumption("p1", media_buy_id="mb_42", expected_account_id="acct_a")
     record = await store.get("p1", expected_account_id="acct_a")
@@ -454,7 +513,12 @@ async def test_finalize_consumption_from_committed_raises(
     """Calling finalize_consumption without first reserving is a
     framework bug and surfaces as INTERNAL_ERROR."""
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p1", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
+    await store.commit(
+        "p1",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
     with pytest.raises(AdcpError) as exc:
         await store.finalize_consumption("p1", media_buy_id="mb_1", expected_account_id="acct_a")
     assert exc.value.code == "INTERNAL_ERROR"
@@ -470,13 +534,23 @@ async def test_media_buy_id_collision_across_tenants_does_not_clobber(
     entry is preserved when tenant B writes the same id."""
     # Tenant A consumes proposal p_a with media_buy_id "mb_001".
     await store.put_draft(proposal_id="p_a", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.commit("p_a", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
-    await store.mark_consumed("p_a", media_buy_id="mb_001")
+    await store.commit(
+        "p_a",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_a",
+    )
+    await store.mark_consumed("p_a", media_buy_id="mb_001", expected_account_id="acct_a")
 
     # Tenant B consumes proposal p_b with the SAME media_buy_id "mb_001".
     await store.put_draft(proposal_id="p_b", account_id="acct_b", recipes={}, proposal_payload={})
-    await store.commit("p_b", expires_at=_utc("2099-01-02T00:00:00"), proposal_payload={})
-    await store.mark_consumed("p_b", media_buy_id="mb_001")
+    await store.commit(
+        "p_b",
+        expires_at=_utc("2099-01-02T00:00:00"),
+        proposal_payload={},
+        expected_account_id="acct_b",
+    )
+    await store.mark_consumed("p_b", media_buy_id="mb_001", expected_account_id="acct_b")
 
     # Both reverse-index lookups still resolve correctly under their
     # authenticated tenant. Without the tuple key, tenant A would lose
@@ -495,14 +569,14 @@ async def test_media_buy_id_collision_across_tenants_does_not_clobber(
 @pytest.mark.asyncio
 async def test_discard_removes_record(store: InMemoryProposalStore) -> None:
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
-    await store.discard("p1")
+    await store.discard("p1", expected_account_id="acct_a")
     assert await store.get("p1") is None
 
 
 @pytest.mark.asyncio
 async def test_discard_unknown_is_noop(store: InMemoryProposalStore) -> None:
     """Mirrors TaskRegistry.discard — discarding an unknown id is a no-op."""
-    await store.discard("never-existed")  # no raise
+    await store.discard("never-existed", expected_account_id="acct_a")  # no raise
 
 
 # ---------------------------------------------------------------------------
@@ -535,7 +609,7 @@ async def test_committed_evicted_past_grace(fixed_clock: Any) -> None:
     )
     await store.put_draft(proposal_id="p1", account_id="acct_a", recipes={}, proposal_payload={})
     expires = fixed_clock() + timedelta(hours=1)
-    await store.commit("p1", expires_at=expires, proposal_payload={})
+    await store.commit("p1", expires_at=expires, proposal_payload={}, expected_account_id="acct_a")
     # 1h past commit — committed window not even reached.
     fixed_clock.advance(timedelta(hours=2))
     assert await store.get("p1") is not None
@@ -600,7 +674,7 @@ class _SyncStubStore:
             return None
         return record
 
-    def commit(self, proposal_id, *, expires_at, proposal_payload):
+    def commit(self, proposal_id, *, expires_at, proposal_payload, expected_account_id):
         return None
 
     def try_reserve_consumption(self, proposal_id, *, expected_account_id):
@@ -615,10 +689,10 @@ class _SyncStubStore:
     def release_consumption(self, proposal_id, *, expected_account_id):
         return None
 
-    def mark_consumed(self, proposal_id, *, media_buy_id):
+    def mark_consumed(self, proposal_id, *, media_buy_id, expected_account_id):
         return None
 
-    def discard(self, proposal_id):
+    def discard(self, proposal_id, *, expected_account_id):
         return None
 
     def get_by_media_buy_id(self, media_buy_id, *, expected_account_id):


### PR DESCRIPTION
## Summary

Closes #727. Two patterns moved upstream from the salesagent fork ([bokelley/salesagent#390](https://github.com/bokelley/salesagent/pull/390)):

### 1. `PgProposalStore` — durable `ProposalStore` Protocol implementation
- Mirrors the existing `PgTaskRegistry` / `IdempotencyStore.PgBackend` patterns (pool injection, `is_durable=True`, `create_schema()` idempotent bootstrap, ASCII-safe identifier guards).
- `try_reserve_consumption` CAS uses `SELECT ... FOR UPDATE` inside a transaction; `commit()` does the same to close a SELECT-then-UPDATE race that the security/python reviewers caught mid-PR.
- `PgProposalStore.migration_sql(table_name=...)` classmethod for Alembic/dbmate adopters (honours custom table names — previous hardcoded `MIGRATION` constant was a footgun).
- `recipe_decoder` callable for adopters with typed `Recipe` subclasses; default decoder fails loudly with a pointer to `recipe_decoder=` when a typed payload is detected.

### 2. Framework package derivation from proposal allocations
- Opt-in via `ProposalCapabilities.derive_packages_from_allocations=True` OR by implementing `ProposalManager.derive_packages(...)` — default off preserves pre-#727 semantics for existing adopters who read `ctx.recipes` directly.
- When enabled and the buyer omits `packages[]` on `create_media_buy(proposal_id=..., total_budget=...)`, framework mutates `req.packages` from the proposal's `allocations[]` via percentage math. `start_time` / `end_time` propagate per spec ("per-flight scheduling within a proposal").
- Standalone `adcp.decisioning.derive_packages_from_proposal(...)` helper for off-path workflows (admin tools, draft-preview UIs).
- Auto-picks the product's single `pricing_options[]` entry at proposal-persist time when an allocation omits `pricing_option_id` (unambiguous case); multi-option products require explicit allocation-level selection or a `derive_packages` override.

### Security
Closes the cross-tenant write surface on `commit()` / `mark_consumed()` / `discard()` by adding required `expected_account_id` to the Protocol. Without it, the PG store's `(account_id, proposal_id)` PK could be hit on the wrong tenant's row via colliding `proposal_id`s. All three methods now scope at the SQL level.

### Reviewer rollcall
Reviewed by `code-reviewer`, `security-reviewer`, `ad-tech-protocol-expert`, `adtech-product-expert`, `python-expert`, `dx-expert`. All Must-Fix items addressed; a few Should-Fix items deferred to follow-ups (`is_durable` boot-gate parity for ProposalStore; `Recipe.from_kind_payload` registry to eliminate `recipe_decoder` from the hello-world path).

## Test plan
- [x] Full unit suite passes (4328 passed locally; 1 unrelated flaky timing test on `test_pg_idempotency_backend`)
- [x] Mypy clean across 805 source files
- [x] Ruff clean across changed files
- [x] New unit tests: `tests/test_decisioning_pg_proposal_store.py` (structural, no DB)
- [x] New conformance tests: `tests/conformance/decisioning/test_pg_proposal_store.py` (real-PG; skips without `ADCP_PG_TEST_URL`) — includes the cross-tenant rejection and the `SELECT ... FOR UPDATE` concurrency race
- [x] New unit tests: `tests/test_derive_packages.py` (pure-function math + integration with `maybe_hydrate_recipes_for_create_media_buy`)
- [x] Existing `tests/test_proposal_lifecycle_e2e.py` (21 tests) passes with the opt-in flag flipped on the example seller's manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)