### PR TITLE
chore(a2a): migrate off EventQueueLegacy (#699)

### DIFF
--- a/src/adcp/testing/harness.py
+++ b/src/adcp/testing/harness.py
@@ -308,6 +308,13 @@ class SellerA2AClient:
             Task state was ``COMPLETED``; ``adcp_error`` carries the structured
             error from a failed Task's DataPart per the A2A binding.
         """
+        # TODO(#699): Migrate off EventQueueLegacy when a2a-sdk ships a
+        # type-clean successor. a2aproject/a2a-python#944 split the class
+        # into an abstract EventQueue base + concrete EventQueueLegacy; the
+        # base's __new__ redirects EventQueue() to EventQueueLegacy() at
+        # runtime, but mypy correctly flags abstract instantiation and
+        # a2a-sdk's own internals still use EventQueueLegacy. Tracked
+        # upstream at a2aproject/a2a-python#1064.
         from a2a import types as pb
         from a2a.auth.user import UnauthenticatedUser
         from a2a.server.agent_execution.context import (

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -10,7 +10,9 @@ from typing import Any
 import pytest
 from a2a import types as pb
 from a2a.server.agent_execution.context import RequestContext
-from a2a.server.events.event_queue import EventQueueLegacy as EventQueue
+from a2a.server.events.event_queue import (
+    EventQueueLegacy as EventQueue,
+)  # TODO(#699): drop alias when a2aproject/a2a-python#1064 lands a type-clean EventQueue successor
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 from google.protobuf.json_format import ParseDict
 from google.protobuf.struct_pb2 import Value
@@ -452,12 +454,12 @@ def test_create_a2a_server_creates_starlette_app():
     assert hasattr(app, "routes")
     route_paths = [r.path for r in app.routes]
     # Both the 1.0 canonical path and the 0.3 alias must be registered.
-    assert any(p.startswith("/.well-known/agent-card") for p in route_paths), (
-        "canonical /.well-known/agent-card.json route missing"
-    )
-    assert "/.well-known/agent.json" in route_paths, (
-        "0.3 alias /.well-known/agent.json route missing from create_a2a_server"
-    )
+    assert any(
+        p.startswith("/.well-known/agent-card") for p in route_paths
+    ), "canonical /.well-known/agent-card.json route missing"
+    assert (
+        "/.well-known/agent.json" in route_paths
+    ), "0.3 alias /.well-known/agent.json route missing from create_a2a_server"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_a2a_structured_error.py
+++ b/tests/test_a2a_structured_error.py
@@ -25,7 +25,9 @@ from typing import Any
 import pytest
 from a2a import types as pb
 from a2a.server.agent_execution.context import RequestContext as _RealRequestContext
-from a2a.server.events.event_queue import EventQueueLegacy as EventQueue
+from a2a.server.events.event_queue import (
+    EventQueueLegacy as EventQueue,
+)  # TODO(#699): drop alias when a2aproject/a2a-python#1064 lands a type-clean EventQueue successor
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 from google.protobuf.json_format import ParseDict
 from google.protobuf.struct_pb2 import Value

--- a/tests/test_handler_typevar.py
+++ b/tests/test_handler_typevar.py
@@ -283,7 +283,9 @@ async def test_typed_handler_works_under_a2a_executor():
     promise: adding the TypeVar didn't break the A2A dispatch path."""
     from a2a import types as pb
     from a2a.server.agent_execution.context import RequestContext
-    from a2a.server.events.event_queue import EventQueueLegacy as EventQueue
+    from a2a.server.events.event_queue import (
+        EventQueueLegacy as EventQueue,
+    )  # TODO(#699): drop alias when a2aproject/a2a-python#1064 lands a type-clean EventQueue successor
 
     from tests.a2a_compat_shim import DataPart, Message, Part, Role, Task
 
@@ -361,7 +363,9 @@ async def test_account_aware_context_flows_through_a2a_executor():
     plumbing against the shipped subclass."""
     from a2a import types as pb
     from a2a.server.agent_execution.context import RequestContext
-    from a2a.server.events.event_queue import EventQueueLegacy as EventQueue
+    from a2a.server.events.event_queue import (
+        EventQueueLegacy as EventQueue,
+    )  # TODO(#699): drop alias when a2aproject/a2a-python#1064 lands a type-clean EventQueue successor
 
     from tests.a2a_compat_shim import DataPart, Message, Part, Role, Task
 


### PR DESCRIPTION
## Summary

Closes #699. Audit-only: in a2a-sdk 1.0.1 there is no type-clean successor to `EventQueueLegacy`. `EventQueue` is `ABC` + `@abstractmethod`, so `EventQueue()` is a mypy error (and the abstract type lacks `dequeue_event`/`tap`/`close`/etc). The class's `__new__` redirects to `EventQueueLegacy` at runtime, but the redirect is invisible to type-checkers, and a2a-sdk's own internals all still use `EventQueueLegacy` directly.

Filed upstream issue [a2aproject/a2a-python#1064](https://github.com/a2aproject/a2a-python/issues/1064) asking for one of: concrete `EventQueue`, new `DefaultEventQueue`, or doc-only acknowledgement. Added `TODO(#699)` comments at each call site pointing at #1064 so the rename is a one-pass change when upstream lands. No version pin bump.

## Audit findings

- a2a-sdk version: pinned `>=1.0.1,<1.0.2`
- `*Legacy` symbols found in a2a-sdk:
  - `a2a.server.events.event_queue.EventQueueLegacy` — used in `harness.py` and three test files in this repo
  - `a2a.server.request_handlers.default_request_handler.LegacyRequestHandler` — **not used** in this repo (we use `DefaultRequestHandler`)
- Type-clean successor available in current pin: **no** (`EventQueue` abstract base lacks the concrete method surface; mypy rejects abstract instantiation)
- Sites carrying `TODO(#699)` → a2aproject/a2a-python#1064:
  - `src/adcp/testing/harness.py` (SellerA2AClient.invoke, the #694 site that motivated #699)
  - `tests/test_a2a_server.py`
  - `tests/test_a2a_structured_error.py`
  - `tests/test_handler_typevar.py` (two occurrences)

## Test plan

- [x] `pytest tests/ -k a2a -v` passes (260 passed, 6 skipped, 1 xfailed)
- [x] `ruff check src/` clean
- [x] `mypy src/adcp/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)