### PR TITLE
docs(decisioning): document AccountStore.resolve() as the multi-tenant encoding seam

### DIFF
--- a/src/adcp/decisioning/accounts.py
+++ b/src/adcp/decisioning/accounts.py
@@ -163,6 +163,11 @@ class AccountStore(Protocol, Generic[TMeta]):
 
     **Multi-tenant deployments — Account.id is the encoding seam.**
 
+    Applies to seller-side adopters resolving incoming AdCP requests.
+    DSP-side adopters wiring this SDK as a client construct
+    :class:`~adcp.types.AccountReference` directly for outbound calls
+    and don't go through this seam.
+
     Buyers send a per-tenant ``account_ref`` on the wire; sellers don't
     control what string a buyer picks, and the same ``account_ref``
     ("acme", "default", sequential ids) may arrive from buyers calling
@@ -197,6 +202,14 @@ class AccountStore(Protocol, Generic[TMeta]):
     re-derive what ``resolve()`` already knows, and adopter
     encoding-convention changes silently break every downstream
     Protocol call site.
+
+    **Pick a stable tenant identifier.** The tenant value baked into
+    ``Account.id`` lives forever in every downstream store's row keys
+    and the framework's idempotency cache. Use a UUID or immutable
+    slug, not a user-facing display name — a tenant rename (vanity
+    URL change, white-label rebrand) that mutates the prefix would
+    orphan every proposal, task, and cached response keyed under the
+    old value.
 
     :func:`~adcp.decisioning.create_tenant_store` ships this pattern as
     a typed factory with a baked-in per-entry tenant-isolation gate —

--- a/src/adcp/decisioning/accounts.py
+++ b/src/adcp/decisioning/accounts.py
@@ -160,6 +160,47 @@ class AccountStore(Protocol, Generic[TMeta]):
     ``'explicit'`` (wire ref drives lookup), ``'implicit'`` (verified
     auth principal drives lookup), ``'derived'`` (single-platform with
     per-principal id synthesis).
+
+    **Multi-tenant deployments — Account.id is the encoding seam.**
+
+    Buyers send a per-tenant ``account_ref`` on the wire; sellers don't
+    control what string a buyer picks, and the same ``account_ref``
+    ("acme", "default", sequential ids) may arrive from buyers calling
+    different seller tenants. The transport sets ``tenant_id`` from the
+    Host header (via :class:`~adcp.server.SubdomainTenantMiddleware`),
+    and ``resolve()`` is the single layer that mints ``Account.id`` —
+    the framework treats that id as opaque from here onward and
+    threads it into every downstream store
+    (:class:`~adcp.decisioning.ProposalStore`,
+    :class:`~adcp.decisioning.TaskRegistry`, framework idempotency
+    cache, future media-buy stores) as the canonical scope key.
+
+    Multi-tenant adopters compose the tenant scope INTO ``Account.id``
+    here, so every downstream store sees a globally-unique identifier
+    and never has to know about tenants::
+
+        class MyAccountStore:
+            resolution = "explicit"
+
+            async def resolve(self, ref, auth_info=None):
+                tenant_id = self._tenant_from(auth_info)
+                buyer_ref = (ref or {}).get("account_id", "default")
+                return Account(
+                    id=f"{tenant_id}:{buyer_ref}",   # globally unique
+                    metadata={"tenant_id": tenant_id},
+                )
+
+    Pushing tenant scope DOWN into a downstream store (parsing
+    ``account_id`` back out inside ``ProposalStore.put_draft``, or
+    threading a separate ``tenant_id`` argument through every
+    Protocol method) is the wrong layer: it forces every store to
+    re-derive what ``resolve()`` already knows, and adopter
+    encoding-convention changes silently break every downstream
+    Protocol call site.
+
+    :func:`~adcp.decisioning.create_tenant_store` ships this pattern as
+    a typed factory with a baked-in per-entry tenant-isolation gate —
+    use it directly unless you have a reason to write your own.
     """
 
     resolution: ClassVar[str]

--- a/src/adcp/decisioning/pg/proposal_store.py
+++ b/src/adcp/decisioning/pg/proposal_store.py
@@ -66,12 +66,31 @@ tenant scope INTO ``Account.id`` at the
 :class:`~adcp.decisioning.AccountStore` layer (see the AccountStore
 docstring's "Multi-tenant deployments" section, or use
 :func:`~adcp.decisioning.create_tenant_store`) — this store treats
-``account_id`` as opaque and does not parse it. Adopters who want a
-foreign key to their tenants table can add a generated column on top
-of the schema this store ships (e.g.
-``ALTER TABLE adcp_proposal_drafts ADD COLUMN tenant_id TEXT GENERATED
-ALWAYS AS (split_part(account_id, ':', 1)) STORED``) and reference it
-from their own migration; this store does not need to know.
+``account_id`` as opaque and does not parse it.
+
+Adopters who want a foreign key to their tenants table own the schema
+on top of what this store ships. The recommended path is to add a
+plain ``tenant_id`` column to ``adcp_proposal_drafts`` in your own
+migration and populate it at write time alongside the framework's
+``put_draft`` call (your adopter ProposalStore wrapper has the typed
+:attr:`~adcp.decisioning.RequestContext.account` in scope):
+
+.. code-block:: sql
+
+    ALTER TABLE adcp_proposal_drafts ADD COLUMN tenant_id TEXT;
+    ALTER TABLE adcp_proposal_drafts
+        ADD CONSTRAINT adcp_proposal_drafts_tenant_fk
+        FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+        ON DELETE CASCADE;
+    CREATE INDEX adcp_proposal_drafts_tenant_idx
+        ON adcp_proposal_drafts (tenant_id);
+
+A Postgres ``GENERATED ALWAYS AS (...) STORED`` column derived by
+parsing ``account_id`` is tempting but bakes the encoding delimiter
+into adopter schema permanently — a later change to your AccountStore
+encoding (adding a region prefix, swapping the separator) silently
+corrupts the generated value. Mint ``tenant_id`` from application
+code where the encoding is owned in one place.
 
 Concurrency
 -----------

--- a/src/adcp/decisioning/pg/proposal_store.py
+++ b/src/adcp/decisioning/pg/proposal_store.py
@@ -59,6 +59,20 @@ Cross-tenant safety
 tenant isolation at the SQL level — ``WHERE account_id = %s`` is part
 of every query predicate, not a Python-level filter after fetch.
 
+The schema's primary key is ``(account_id, proposal_id)``. That is
+collision-safe **only** when ``account_id`` is globally unique across
+your deployment. Multi-tenant seller adopters are expected to compose
+tenant scope INTO ``Account.id`` at the
+:class:`~adcp.decisioning.AccountStore` layer (see the AccountStore
+docstring's "Multi-tenant deployments" section, or use
+:func:`~adcp.decisioning.create_tenant_store`) — this store treats
+``account_id`` as opaque and does not parse it. Adopters who want a
+foreign key to their tenants table can add a generated column on top
+of the schema this store ships (e.g.
+``ALTER TABLE adcp_proposal_drafts ADD COLUMN tenant_id TEXT GENERATED
+ALWAYS AS (split_part(account_id, ':', 1)) STORED``) and reference it
+from their own migration; this store does not need to know.
+
 Concurrency
 -----------
 

--- a/src/adcp/decisioning/proposal_store.py
+++ b/src/adcp/decisioning/proposal_store.py
@@ -145,6 +145,20 @@ class ProposalStore(Protocol):
     finalize_consumption-from-DRAFT, etc.) raise :class:`AdcpError`
     with ``code='INTERNAL_ERROR'`` — those are framework / adopter
     bugs, not buyer-facing rejections.
+
+    **``account_id`` is opaque.** The framework threads
+    ``ctx.account.id`` (whatever the adopter's
+    :class:`~adcp.decisioning.AccountStore.resolve` returned) into
+    every method. The store MUST NOT parse it, split it, or re-derive
+    tenant scope from it. Multi-tenant adopters encode their tenant
+    scope into ``Account.id`` at the
+    :class:`~adcp.decisioning.AccountStore` layer once, and the
+    composite ``(account_id, proposal_id)`` then carries unique
+    identity across the entire deployment without needing a separate
+    ``tenant_id`` parameter on this Protocol. See the AccountStore
+    docstring's "Multi-tenant deployments" section for the canonical
+    encoding pattern, and :func:`~adcp.decisioning.create_tenant_store`
+    for the typed helper.
     """
 
     is_durable: ClassVar[bool]

--- a/src/adcp/decisioning/task_registry.py
+++ b/src/adcp/decisioning/task_registry.py
@@ -188,6 +188,18 @@ class TaskRegistry(Protocol):
     task_id guessing. See
     ``tests/test_decisioning_task_registry_cross_tenant.py`` for
     the regression suite.
+
+    **``account_id`` is opaque.** The framework threads
+    ``ctx.account.id`` (whatever the adopter's
+    :class:`~adcp.decisioning.AccountStore.resolve` returned) into
+    every method. The registry MUST NOT parse it or re-derive tenant
+    scope from it. Multi-tenant adopters encode their tenant scope
+    into ``Account.id`` once at the
+    :class:`~adcp.decisioning.AccountStore` layer; the registry then
+    gets a globally-unique scope key and the cross-tenant probe
+    check above degenerates to a simple equality. See the
+    AccountStore docstring's "Multi-tenant deployments" section for
+    the canonical encoding pattern.
     """
 
     #: Whether this registry persists tasks across process restarts.

--- a/src/adcp/decisioning/tenant_store.py
+++ b/src/adcp/decisioning/tenant_store.py
@@ -518,6 +518,15 @@ def create_tenant_store(
     """Build an :class:`AccountStore` whose ``resolve`` / ``upsert`` /
     ``list`` / ``sync_governance`` methods enforce tenant isolation.
 
+    Canonical helper for the multi-tenant pattern described in
+    :class:`~adcp.decisioning.AccountStore` — composes tenant scope
+    into the returned ``Account.id`` so every downstream store
+    (:class:`~adcp.decisioning.ProposalStore`,
+    :class:`~adcp.decisioning.TaskRegistry`, framework idempotency
+    cache) sees globally-unique identifiers and treats tenancy as
+    opaque. Adopters writing a hand-rolled multi-tenant
+    :class:`AccountStore` should reach for this factory first.
+
     :param resolve_by_ref: ``(ref, ctx) -> Account | None``. Resolves a
         wire :class:`AccountReference` to the framework Account it
         points at — independent of who the caller is. Return ``None``


### PR DESCRIPTION
## Summary

Closes #738. Adopters reading Protocol docstrings in isolation could mistake `account_id` for a wire-level buyer reference and either push tenant context down into downstream Protocol methods (the #737 anti-pattern) or parse it back out inside individual stores. Documents the actual seam: buyers send a per-tenant `account_ref`, transport sets `tenant_id` from the host header, and `AccountStore.resolve()` is the single layer that mints `Account.id`. Multi-tenant adopters compose tenant scope INTO the returned id; every downstream store then treats it as opaque.

## What changed

- **`AccountStore`** — new "Multi-tenant deployments" section in the Protocol class docstring with a 4-line example showing the `f"{tenant_id}:{buyer_ref}"` composition, and a pointer at `create_tenant_store` as the typed helper.
- **`create_tenant_store`** — function docstring now calls itself out as the canonical helper for the pattern, with a back-reference to `AccountStore`.
- **`ProposalStore` / `TaskRegistry`** — one paragraph each stating `account_id` is opaque and pointing back to the AccountStore encoding seam. Makes the wrong-layer pull (parsing `account_id` inside the store) visibly wrong from the Protocol surface.
- **`PgProposalStore` module docstring** — explains the `(account_id, proposal_id)` PK uniqueness contract that the schema actually relies on, and shows the Postgres generated-column pattern adopters can use today for a tenant FK without any library schema change.

Pure docstring changes — no behaviour, no Protocol surface, no schema. Closes the #737 follow-up cleanly.

## Test plan

- [x] `ruff check` — passes
- [x] `mypy src/adcp/decisioning/{accounts,tenant_store,proposal_store,task_registry,pg/proposal_store}.py` — passes
- [x] `pytest tests/test_proposal_store.py tests/test_decisioning_pg_proposal_store.py tests/test_decisioning_task_registry_cross_tenant.py tests/test_tenant_store.py tests/test_account_mode_gate.py` — 105 passed, 1 skipped
- [x] Pre-commit hooks (black/ruff/mypy/bandit) — all green

## salesagent follow-ups (not blocking this PR)

Mentioned in #738 for tracking, restated here for visibility:
- Fix `SalesAgentProposalStore._resolve_tenant_id_for_account` to read `account.metadata["tenant_id"]` instead of parsing `account.id`.
- Adopt `PgProposalStore` (closes the seller-side compliance work entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)