### PR TITLE
fix(adagents): disable follow_redirects on ads.txt MANAGERDOMAIN fetch

### DIFF
--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -625,18 +625,26 @@ async def _fetch_ads_txt_managerdomains(
     or oversized body) — the fallback is best-effort and absence is not
     an error. Bodies larger than :data:`MAX_ADS_TXT_BYTES` are discarded
     so a hostile publisher can't force the SDK to buffer arbitrary data.
+
+    ``follow_redirects=False`` matches the adagents.json streaming path:
+    HTTP 30x is not a sanctioned cross-host delegation mechanism for
+    ads.txt either, and following one transparently would bypass the
+    SSRF gate on the resolved Location host. Publishers who serve
+    ads.txt behind a redirect will fall through to "no MANAGERDOMAIN
+    found" — the SDK then surfaces the publisher's original 404,
+    which is the correct outcome for a best-effort fallback.
     """
     url = f"https://{publisher_domain}/ads.txt"
     headers = {"User-Agent": user_agent, "Accept": "text/plain"}
     try:
         if client is not None:
             response = await client.get(
-                url, headers=headers, timeout=timeout, follow_redirects=True
+                url, headers=headers, timeout=timeout, follow_redirects=False
             )
         else:
             async with httpx.AsyncClient() as new_client:
                 response = await new_client.get(
-                    url, headers=headers, timeout=timeout, follow_redirects=True
+                    url, headers=headers, timeout=timeout, follow_redirects=False
                 )
         if response.status_code != 200:
             return []

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -2301,6 +2301,36 @@ class TestValidateAdagentsDomain:
         assert result.manager_domain is None
 
     @pytest.mark.asyncio
+    async def test_ads_txt_30x_is_not_followed(self):
+        # ads.txt fetch uses follow_redirects=False to match adagents.json;
+        # a 30x response from the publisher therefore falls through to
+        # "no MANAGERDOMAIN parsed" rather than transparently chasing the
+        # Location header (which would bypass the SSRF gate).
+        from adcp.adagents import validate_adagents_domain
+
+        def handler(url):
+            if url == "https://publisher.example/.well-known/adagents.json":
+                return self._not_found()
+            if url == "https://publisher.example/ads.txt":
+                response = MagicMock()
+                response.status_code = 302
+                response.headers = httpx.Headers({"location": "https://127.0.0.1/ads.txt"})
+                response.text = ""
+                response.content = b""
+                response.json.return_value = {}
+                return response
+            raise AssertionError(f"unexpected url {url}")
+
+        result = await validate_adagents_domain(
+            "publisher.example", client=self._build_mock_client(handler)
+        )
+
+        # A 30x ads.txt is treated as "no managerdomain", so the result
+        # is the publisher's original 404 with no manager fallback.
+        assert result.valid is False
+        assert result.manager_domain is None
+
+    @pytest.mark.asyncio
     async def test_redirect_target_404_does_not_trigger_managerdomain_fallback(self):
         # A 404 on a publisher-named authoritative_location target is a
         # broken redirect chain, not a missing publisher manifest, and


### PR DESCRIPTION
## Summary

Mirrors the adagents.json streaming-fetch posture (`_stream_capped` uses `follow_redirects=False`): ads.txt is a publisher-controlled URL and a transparent 30x by httpx would bypass `_check_safe_host` on the resolved Location, re-opening the same SSRF surface PR #753 already closed for the main path.

Surfaced by the **round-2 security review** on PR #753 as a defense-in-depth follow-up — pre-existing behavior, not regressed by that PR, but worth closing.

## Why this is safe

ads.txt fetch is **best-effort by construction**: any non-200 already returns an empty MANAGERDOMAIN list. Publishers who 30x their ads.txt now fall through to "no managerdomain found", and the SDK surfaces the publisher's original 404 — same outcome as if the publisher had no ads.txt at all. Acceptable for a fallback path.

## What changed

- `_fetch_ads_txt_managerdomains` passes `follow_redirects=False` on both branches (caller-supplied client and fresh client).
- Expanded docstring documents the rationale alongside the existing size-cap rationale.
- New test `test_ads_txt_30x_is_not_followed` asserts the 30x → fall-through behavior with a Location pointing at `127.0.0.1` (the attack we're closing).

## Test plan

- [x] `ruff check src/` — passes
- [x] `mypy src/adcp/` — passes
- [x] `pytest tests/test_adagents.py` — 151 passed
- [ ] CI green across Python 3.10–3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)