### PR TITLE
feat(validation): validate_publisher_properties_item accepts Pydantic models

### DIFF
--- a/src/adcp/validation/legacy.py
+++ b/src/adcp/validation/legacy.py
@@ -27,8 +27,13 @@ class ValidationError(ValueError):
     pass
 
 
-def validate_publisher_properties_item(item: dict[str, Any]) -> None:
+def validate_publisher_properties_item(item: Any) -> None:
     """Validate a single ``publisher_properties[]`` entry.
+
+    Accepts either a raw ``dict`` (the wire form) or a parsed Pydantic
+    model instance (``PublisherPropertySelector1`` / ``…2`` / ``…3``).
+    For Pydantic instances the model is coerced via
+    ``.model_dump(exclude_none=False)`` and the same checks apply.
 
     Two XORs are enforced per the publisher-property-selector JSON Schema
     (adcp#4504):
@@ -42,12 +47,28 @@ def validate_publisher_properties_item(item: dict[str, Any]) -> None:
       callers wanting per-publisher ID sets must use one entry per
       publisher.
 
+    Why the Pydantic input form matters: ``datamodel-code-generator``
+    cannot translate the JSON Schema's
+    ``allOf[not[required[both]]] + anyOf[required[either]]`` construct
+    into Pydantic field constraints, so the typed surface (selector 1/3
+    direct instantiation) is laxer than the schema. Consumers parsing
+    via Pydantic should call this helper post-construction to close the
+    gap.
+
     Args:
-        item: A single item from publisher_properties array
+        item: A single item from publisher_properties array — either a
+            ``dict`` or a Pydantic ``BaseModel`` instance.
 
     Raises:
         ValidationError: If discriminator or field constraints are violated
     """
+    if hasattr(item, "model_dump"):
+        item = item.model_dump(exclude_none=False)
+    if not isinstance(item, dict):
+        raise ValidationError(
+            "publisher_properties item must be a dict or a Pydantic model "
+            f"instance, got {type(item).__name__}"
+        )
     selection_type = item.get("selection_type")
     has_property_ids = "property_ids" in item and item["property_ids"] is not None
     has_property_tags = "property_tags" in item and item["property_tags"] is not None

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -2842,6 +2842,43 @@ class TestPublisherDomainsCompactForm:
         assert all(s["selection_type"] == "by_tag" for s in resolved)
         assert all(s["property_tags"] == ["ctv"] for s in resolved)
 
+    def test_validate_accepts_pydantic_model_instance(self):
+        # datamodel-codegen can't emit allOf[not[required[both]]] +
+        # anyOf[required[either]] as Pydantic field constraints, so the
+        # typed surface accepts {} or {selection_type: "all"} with no
+        # publisher_domain* set. Pydantic consumers can close that gap by
+        # calling this helper on the parsed selector.
+        from adcp.types.generated_poc.core.publisher_property_selector import (
+            PublisherPropertySelector1,
+        )
+        from adcp.validation import (
+            ValidationError,
+            validate_publisher_properties_item,
+        )
+
+        # Pydantic-instantiated without a publisher_domain — silently
+        # legal at the type layer, but the runtime check raises.
+        bad = PublisherPropertySelector1(selection_type="all")
+        with pytest.raises(ValidationError, match="exactly one"):
+            validate_publisher_properties_item(bad)
+
+        # Same shape via dict for parity.
+        with pytest.raises(ValidationError, match="exactly one"):
+            validate_publisher_properties_item({"selection_type": "all"})
+
+        # Valid Pydantic instance passes.
+        good = PublisherPropertySelector1(selection_type="all", publisher_domain="cnn.com")
+        validate_publisher_properties_item(good)
+
+    def test_validate_rejects_non_dict_non_model(self):
+        from adcp.validation import (
+            ValidationError,
+            validate_publisher_properties_item,
+        )
+
+        with pytest.raises(ValidationError, match="dict or a Pydantic model"):
+            validate_publisher_properties_item("not-an-object")
+
     def test_xor_violation_both_publisher_fields(self):
         from adcp.validation import (
             ValidationError,


### PR DESCRIPTION
## Summary

Closes the documented **Pydantic-XOR gap** surfaced by the round-1 protocol review on PR #753.

datamodel-codegen cannot translate the publisher-property-selector JSON Schema's `allOf[not[required[both]]] + anyOf[required[either]]` construct into Pydantic field constraints, so direct instantiation of `PublisherPropertySelector1` / `…3` silently accepts payloads the schema rejects (notably `{selection_type: "all"}` with neither `publisher_domain` nor `publisher_domains` set).

This change lets Pydantic consumers close the gap with a single call:

```python
selector = PublisherPropertySelector1.model_validate(payload)
validate_publisher_properties_item(selector)  # raises if XOR fails
```

The helper now accepts either a `dict` (existing wire-form path) or any object with a `.model_dump()` method (i.e. a Pydantic model). For anything else it raises a clear error.

## Why not auto-enforce at parse time?

A `model_validator(mode='after')` attached post-class to the generated selectors would require either:

1. **Hand-patching `generated_poc/`** — forbidden by the codebase's strict layering rule (CLAUDE.md → "Import Architecture for Generated Types"), and would be overwritten on the next regen.
2. **Hooking Pydantic core-schema internals** (`__pydantic_validator__`, `core_schema` overrides) — fragile across Pydantic minor versions.

A follow-up issue tracks the auto-enforcement path so this surfaces in spec discussion rather than getting silently lost.

## What changed

- `validate_publisher_properties_item` signature accepts `Any`; coerces Pydantic instances via `.model_dump(exclude_none=False)` then runs the existing dict-level checks.
- Clear error when input is neither dict nor Pydantic model.
- Docstring documents the schema/codegen gap and the consumer pattern.
- Two new tests: Pydantic-model input (positive + negative case) and the non-dict-non-model error path.

## Test plan

- [x] `ruff check src/ tests/test_adagents.py` — passes
- [x] `mypy src/adcp/` — passes
- [x] `pytest tests/test_adagents.py` — 152 passed
- [ ] CI green across Python 3.10–3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)