### PR TITLE
feat(decisioning): wire create_media_buy_store into PlatformHandler dispatch (closes #462)

### DIFF
--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -186,6 +186,7 @@ from adcp.types import (
 if TYPE_CHECKING:
     from concurrent.futures import ThreadPoolExecutor
 
+    from adcp.decisioning.media_buy_store import MediaBuyStore
     from adcp.decisioning.platform import DecisioningPlatform
     from adcp.decisioning.property_list import PropertyListFetcher
     from adcp.decisioning.registry import BuyerAgent, BuyerAgentRegistry
@@ -806,6 +807,28 @@ def _extract_media_buy_id(result: Any) -> str | None:
     return str(value)
 
 
+def _to_store_dict(value: Any) -> Any:
+    """Normalize a Pydantic model OR plain dict to a JSON-compatible
+    dict for the :class:`MediaBuyStore` adopter contract.
+
+    The store Protocol uses ``Any`` typing, but the reference impl (and
+    the JS-side port) expects dict-shaped payloads — ``.get("packages")``,
+    ``["media_buy_id"]``, etc. Adopters writing against the Protocol
+    benefit from a stable shape regardless of whether their platform
+    method returned a typed Pydantic response or a hand-built dict.
+
+    ``mode='json'`` serializes ``AnyUrl`` to ``str`` and ``datetime``
+    to ISO-8601 ``str`` so the dict matches what would go over the wire
+    — adopters serializing to JSON for persistence don't have to
+    re-normalize. ``exclude_none=False`` preserves explicit nulls (the
+    merge contract treats ``None`` as "clear this field"; dropping them
+    would silently change semantics).
+    """
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json", exclude_none=False, by_alias=False)
+    return value
+
+
 class PlatformHandler(ADCPHandler[ToolContext]):
     """ADCPHandler subclass that routes wire requests to a
     :class:`DecisioningPlatform` via :func:`_invoke_platform_method`.
@@ -998,6 +1021,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         buyer_agent_registry: BuyerAgentRegistry | None = None,
         config_store: ProductConfigStore | None = None,
         property_list_fetcher: PropertyListFetcher | None = None,
+        media_buy_store: MediaBuyStore | None = None,
         advertise_all: bool = False,
     ) -> None:
         super().__init__()
@@ -1012,6 +1036,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         self._buyer_agent_registry = buyer_agent_registry
         self._config_store = config_store
         self._property_list_fetcher = property_list_fetcher
+        self._media_buy_store = media_buy_store
         self._advertise_all = advertise_all
 
         # Cache whether the platform's create_media_buy accepts 'configs'
@@ -1643,6 +1668,26 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             on_complete = _finalize_consumption_hook
             on_failure = _release_reservation_hook
 
+        # MediaBuyStore persist hook — fires on the same on_complete seam
+        # so both sync and HITL completions persist the per-package
+        # ``targeting_overlay`` for later echo on ``get_media_buys``.
+        # Chains with the proposal hook (if any) so both side effects run.
+        if self._media_buy_store is not None:
+            prior_on_complete = on_complete
+            captured_store = self._media_buy_store
+            captured_account_id = account.id
+
+            async def _persist_overlay_hook(create_result: Any) -> None:
+                if prior_on_complete is not None:
+                    await prior_on_complete(create_result)
+                await captured_store.persist_from_create(
+                    captured_account_id,
+                    _to_store_dict(params),
+                    _to_store_dict(create_result),
+                )
+
+            on_complete = _persist_overlay_hook
+
         result = await _invoke_platform_method(
             self._platform,
             "create_media_buy",
@@ -1679,6 +1724,27 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             ctx,
             packages=list(getattr(params, "packages", None) or []),
         )
+
+        # MediaBuyStore merge hook — fires on the on_complete seam so the
+        # patch is recorded for both sync and HITL completions. Spec:
+        # ``targeting_overlay`` is echoed from the most recent
+        # ``create_media_buy`` OR ``update_media_buy`` per the
+        # ``get-media-buys-response`` schema.
+        on_complete: Callable[[Any], Awaitable[None]] | None = None
+        if self._media_buy_store is not None:
+            captured_store = self._media_buy_store
+            captured_account_id = account.id
+            captured_media_buy_id = params.media_buy_id
+
+            async def _merge_overlay_hook(_update_result: Any) -> None:
+                await captured_store.merge_from_update(
+                    captured_account_id,
+                    captured_media_buy_id,
+                    _to_store_dict(params),
+                )
+
+            on_complete = _merge_overlay_hook
+
         result = await _invoke_platform_method(
             self._platform,
             "update_media_buy",
@@ -1687,6 +1753,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             executor=self._executor,
             registry=self._registry,
             arg_projector={"media_buy_id": params.media_buy_id, "patch": params},
+            on_complete=on_complete,
         )
         self._maybe_auto_emit_sync_completion("update_media_buy", params, result)
         return cast("UpdateMediaBuySuccessResponse", result)
@@ -1748,17 +1815,25 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         tool_ctx = context or ToolContext()
         account = await self._resolve_account(params.account, tool_ctx)
         ctx = self._build_ctx(tool_ctx, account)
-        return cast(
-            "GetMediaBuysResponse",
-            await _invoke_platform_method(
-                self._platform,
-                "get_media_buys",
-                params,
-                ctx,
-                executor=self._executor,
-                registry=self._registry,
-            ),
+        result = await _invoke_platform_method(
+            self._platform,
+            "get_media_buys",
+            params,
+            ctx,
+            executor=self._executor,
+            registry=self._registry,
         )
+        # MediaBuyStore backfill — fill in ``packages[].targeting_overlay``
+        # from the persisted store for sellers claiming
+        # ``property-lists`` / ``collection-lists``. Packages the
+        # platform already echoed are left untouched (the in-memory
+        # reference impl checks ``pkg.get("targeting_overlay") is not None``
+        # before injecting). Normalize to dict before the store sees it
+        # so the adopter contract is consistent regardless of whether the
+        # platform returned a typed Pydantic response or a dict.
+        if self._media_buy_store is not None:
+            result = await self._media_buy_store.backfill(account.id, _to_store_dict(result))
+        return cast("GetMediaBuysResponse", result)
 
     async def provide_performance_feedback(  # type: ignore[override]
         self,

--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -41,6 +41,7 @@ from adcp.decisioning.types import AdcpError
 
 if TYPE_CHECKING:
     from adcp.decisioning.implementation_config import ProductConfigStore
+    from adcp.decisioning.media_buy_store import MediaBuyStore
     from adcp.decisioning.platform import DecisioningPlatform
     from adcp.decisioning.property_list import PropertyListFetcher
     from adcp.decisioning.registry import BuyerAgentRegistry
@@ -87,6 +88,7 @@ def create_adcp_server_from_platform(
     buyer_agent_registry: BuyerAgentRegistry | None = None,
     config_store: ProductConfigStore | None = None,
     property_list_fetcher: PropertyListFetcher | None = None,
+    media_buy_store: MediaBuyStore | None = None,
     advertise_all: bool = False,
     validate_at_init: bool = True,
 ) -> tuple[PlatformHandler, ThreadPoolExecutor, TaskRegistry]:
@@ -179,6 +181,20 @@ def create_adcp_server_from_platform(
         (avoid duplicate delivery; idempotency-key dedup at the
         receiver would handle it but explicit suppression matches the
         v5 manual-emit posture for adopters mid-migration).
+    :param media_buy_store: Opt-in :class:`adcp.decisioning.MediaBuyStore`
+        wrapper that gates ``targeting_overlay`` echo on the seller's
+        declared specialisms. Typically built via
+        :func:`adcp.decisioning.create_media_buy_store` with the seller's
+        ``capabilities`` so the persistence layer only fires for sellers
+        claiming ``property-lists`` or ``collection-lists``. When wired,
+        the framework calls ``persist_from_create`` on successful
+        ``create_media_buy`` (via the same on-complete hook the proposal
+        flow uses, so HITL completions also persist), calls
+        ``merge_from_update`` on successful ``update_media_buy``, and
+        calls ``backfill`` before returning from ``get_media_buys``.
+        Default ``None`` — sellers who don't claim the relevant
+        specialisms or who echo ``targeting_overlay`` themselves omit
+        this and pay no overhead.
     :param advertise_all: Mirror of the same flag on :func:`serve` —
         controls how :meth:`PlatformHandler.get_advertised_tools` and
         the eventual ``tools/list`` response filter the handler's tool
@@ -319,6 +335,7 @@ def create_adcp_server_from_platform(
         buyer_agent_registry=buyer_agent_registry,
         config_store=config_store,
         property_list_fetcher=property_list_fetcher,
+        media_buy_store=media_buy_store,
         advertise_all=advertise_all,
     )
 

--- a/tests/test_media_buy_store_integration.py
+++ b/tests/test_media_buy_store_integration.py
@@ -1,0 +1,462 @@
+"""Integration tests for the :class:`MediaBuyStore` wired through
+:class:`PlatformHandler`.
+
+The unit tests in ``test_media_buy_store.py`` exercise the standalone
+wrapper (specialism gating + sync/async dispatch + reference impl
+behavior). These tests verify the framework integration: a store wired
+via ``media_buy_store=`` on :class:`PlatformHandler` is invoked from the
+``create_media_buy`` / ``update_media_buy`` / ``get_media_buys`` shims
+with the correct call shape so adopters never persist + echo by hand.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    InMemoryTaskRegistry,
+    SingletonAccounts,
+    create_media_buy_store,
+)
+from adcp.decisioning.handler import PlatformHandler
+from adcp.server.base import ToolContext
+
+PROPERTY_LIST = {
+    "list_id": "acme_outdoor_allowlist_v1",
+    "agent_url": "https://lists.example.com",
+}
+
+
+@pytest.fixture
+def executor():
+    pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="test-store-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+class _RecordingMediaBuyStore:
+    """Adopter-side reference store that records every call shape.
+
+    Records dict-shaped payloads so tests can assert the framework
+    normalized Pydantic → dict before crossing the adopter boundary.
+    """
+
+    def __init__(self) -> None:
+        self.records: dict[str, dict[str, dict[str, dict[str, Any]]]] = {}
+        self.persist_calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+        self.merge_calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.backfill_calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def persist_from_create(
+        self,
+        account_id: str,
+        request: dict[str, Any],
+        result: dict[str, Any],
+    ) -> None:
+        self.persist_calls.append((account_id, request, result))
+        media_buy_id = result.get("media_buy_id")
+        if not media_buy_id:
+            return
+        request_packages = request.get("packages") or []
+        response_packages = result.get("packages") or []
+        persisted: dict[str, dict[str, Any]] = {}
+        for i, req_pkg in enumerate(request_packages):
+            overlay = req_pkg.get("targeting_overlay")
+            if not overlay:
+                continue
+            if i < len(response_packages):
+                package_id = response_packages[i].get("package_id")
+                if package_id:
+                    persisted[package_id] = overlay
+        if persisted:
+            self.records.setdefault(account_id, {})[media_buy_id] = persisted
+
+    async def merge_from_update(
+        self,
+        account_id: str,
+        media_buy_id: str,
+        patch: dict[str, Any],
+    ) -> None:
+        self.merge_calls.append((account_id, media_buy_id, patch))
+        prior = self.records.setdefault(account_id, {}).setdefault(media_buy_id, {})
+        for pkg in patch.get("packages") or []:
+            package_id = pkg.get("package_id")
+            overlay = pkg.get("targeting_overlay")
+            if not package_id or not overlay:
+                continue
+            existing = dict(prior.get(package_id, {}))
+            existing.update(overlay)
+            prior[package_id] = existing
+
+    async def backfill(self, account_id: str, result: dict[str, Any]) -> dict[str, Any]:
+        self.backfill_calls.append((account_id, result))
+        for buy in result.get("media_buys") or []:
+            media_buy_id = buy.get("media_buy_id")
+            record = self.records.get(account_id, {}).get(media_buy_id or "", {})
+            for pkg in buy.get("packages") or []:
+                package_id = pkg.get("package_id")
+                if not package_id or pkg.get("targeting_overlay") is not None:
+                    continue
+                persisted = record.get(package_id)
+                if persisted:
+                    pkg["targeting_overlay"] = persisted
+        return result
+
+
+def _make_handler(
+    platform: DecisioningPlatform,
+    executor: ThreadPoolExecutor,
+    *,
+    media_buy_store: Any = None,
+) -> PlatformHandler:
+    return PlatformHandler(
+        platform,
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        media_buy_store=media_buy_store,
+    )
+
+
+# -----------------------------
+# create_media_buy → persist_from_create
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_persists_overlay_through_handler(executor) -> None:
+    """A successful ``create_media_buy`` invokes
+    ``store.persist_from_create`` with the request and response
+    normalized to dict shape, scoped to the resolved ``account.id``.
+    """
+    from adcp.types import (
+        CreateMediaBuyRequest,
+        CreateMediaBuySuccessResponse,
+    )
+    from adcp.types.generated_poc.core.package import Package
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["property-lists"])
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def create_media_buy(self, req, ctx):
+            return CreateMediaBuySuccessResponse(
+                media_buy_id="mb_1",
+                packages=[Package(package_id="seller_pkg_001")],
+                status="active",
+            )
+
+    backing = _RecordingMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_Platform.capabilities)
+    handler = _make_handler(_Platform(), executor, media_buy_store=store)
+
+    req = CreateMediaBuyRequest(
+        account={"account_id": "acct_a"},
+        brand={"domain": "example.com"},
+        idempotency_key="idem_aaaa1234567890",
+        start_time="2026-05-01T00:00:00Z",
+        end_time="2026-05-31T23:59:59Z",
+        packages=[
+            {
+                "product_id": "prod_a",
+                "buyer_ref": "pkg_a",
+                "budget": 1000.0,
+                "pricing_option_id": "po_a",
+                "targeting_overlay": {"property_list": PROPERTY_LIST},
+            }
+        ],
+    )
+    await handler.create_media_buy(req, ToolContext())
+
+    assert len(backing.persist_calls) == 1
+    account_id, request_dict, result_dict = backing.persist_calls[0]
+    assert account_id == "acme:anonymous"
+    # Framework normalized Pydantic → dict before crossing the adopter
+    # boundary so the store contract is shape-stable. Pydantic's
+    # ``mode='json'`` dump preserves explicit nulls and normalizes
+    # ``AnyUrl`` to its string form — adopters see the same shape that
+    # would go on the wire.
+    assert isinstance(request_dict, dict)
+    assert isinstance(result_dict, dict)
+    persisted_property_list = request_dict["packages"][0]["targeting_overlay"]["property_list"]
+    assert persisted_property_list["list_id"] == PROPERTY_LIST["list_id"]
+    assert result_dict["media_buy_id"] == "mb_1"
+    # Reference store actually persisted under the seller package_id.
+    assert (
+        backing.records["acme:anonymous"]["mb_1"]["seller_pkg_001"]["property_list"]["list_id"]
+        == PROPERTY_LIST["list_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_with_no_store_skips_persist(executor) -> None:
+    """When no store is wired, the handler doesn't pay the
+    ``on_complete`` hook cost — the create path is unchanged."""
+    from adcp.types import (
+        CreateMediaBuyRequest,
+        CreateMediaBuySuccessResponse,
+    )
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def create_media_buy(self, req, ctx):
+            return CreateMediaBuySuccessResponse(media_buy_id="mb_1", packages=[], status="active")
+
+    handler = _make_handler(_Platform(), executor, media_buy_store=None)
+
+    resp = await handler.create_media_buy(
+        CreateMediaBuyRequest(
+            account={"account_id": "acct_a"},
+            brand={"domain": "example.com"},
+            idempotency_key="idem_aaaa1234567890",
+            start_time="2026-05-01T00:00:00Z",
+            end_time="2026-05-31T23:59:59Z",
+        ),
+        ToolContext(),
+    )
+    assert resp.media_buy_id == "mb_1"
+
+
+@pytest.mark.asyncio
+async def test_create_media_buy_noop_path_when_seller_lacks_specialism(executor) -> None:
+    """Adopter wires a store but seller doesn't claim
+    ``property-lists`` / ``collection-lists`` — the wrapper's no-op
+    path short-circuits and the backing store is never touched."""
+    from adcp.types import (
+        CreateMediaBuyRequest,
+        CreateMediaBuySuccessResponse,
+    )
+    from adcp.types.generated_poc.core.package import Package
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["sales-non-guaranteed"])
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def create_media_buy(self, req, ctx):
+            return CreateMediaBuySuccessResponse(
+                media_buy_id="mb_1",
+                packages=[Package(package_id="p1")],
+                status="active",
+            )
+
+    backing = _RecordingMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_Platform.capabilities)
+    handler = _make_handler(_Platform(), executor, media_buy_store=store)
+
+    await handler.create_media_buy(
+        CreateMediaBuyRequest(
+            account={"account_id": "acct_a"},
+            brand={"domain": "example.com"},
+            idempotency_key="idem_aaaa1234567890",
+            start_time="2026-05-01T00:00:00Z",
+            end_time="2026-05-31T23:59:59Z",
+            packages=[
+                {
+                    "product_id": "p",
+                    "budget": 100.0,
+                    "pricing_option_id": "po",
+                    "targeting_overlay": {"property_list": PROPERTY_LIST},
+                }
+            ],
+        ),
+        ToolContext(),
+    )
+    assert backing.persist_calls == []
+    assert backing.records == {}
+
+
+# -----------------------------
+# update_media_buy → merge_from_update
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_media_buy_merges_overlay_through_handler(executor) -> None:
+    """A successful ``update_media_buy`` invokes
+    ``store.merge_from_update`` with the dict-normalized patch and the
+    media_buy_id pulled off the request."""
+    from adcp.types import UpdateMediaBuyRequest, UpdateMediaBuySuccessResponse
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["property-lists"])
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def update_media_buy(self, media_buy_id, patch, ctx):
+            return UpdateMediaBuySuccessResponse(
+                media_buy_id=media_buy_id, status="active", packages=[]
+            )
+
+    backing = _RecordingMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_Platform.capabilities)
+    handler = _make_handler(_Platform(), executor, media_buy_store=store)
+
+    req = UpdateMediaBuyRequest(
+        account={"account_id": "acct_a"},
+        media_buy_id="mb_1",
+        idempotency_key="idem_bbbb1234567890",
+        packages=[
+            {
+                "package_id": "seller_pkg_001",
+                "targeting_overlay": {"property_list": PROPERTY_LIST},
+            }
+        ],
+    )
+    await handler.update_media_buy(req, ToolContext())
+
+    assert len(backing.merge_calls) == 1
+    account_id, media_buy_id, patch_dict = backing.merge_calls[0]
+    assert account_id == "acme:anonymous"
+    assert media_buy_id == "mb_1"
+    assert isinstance(patch_dict, dict)
+    merged_property_list = patch_dict["packages"][0]["targeting_overlay"]["property_list"]
+    assert merged_property_list["list_id"] == PROPERTY_LIST["list_id"]
+    assert (
+        backing.records["acme:anonymous"]["mb_1"]["seller_pkg_001"]["property_list"]["list_id"]
+        == PROPERTY_LIST["list_id"]
+    )
+
+
+# -----------------------------
+# get_media_buys → backfill
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_media_buys_backfills_overlay_through_handler(executor) -> None:
+    """``get_media_buys`` calls ``store.backfill`` before returning; the
+    persisted overlay is injected into packages the platform didn't
+    echo itself."""
+    from adcp.types import GetMediaBuysRequest
+
+    backing = _RecordingMediaBuyStore()
+    # Pre-populate the store as if a prior create_media_buy persisted.
+    backing.records["acme:anonymous"] = {
+        "mb_1": {"seller_pkg_001": {"property_list": PROPERTY_LIST}}
+    }
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["property-lists"])
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def get_media_buys(self, req, ctx):
+            # Adopter returns dict-shaped response (valid per the wire
+            # contract — handler.py allows dict OR Pydantic). Packages
+            # carry no ``targeting_overlay`` so the store has work to
+            # do.
+            return {
+                "media_buys": [
+                    {
+                        "media_buy_id": "mb_1",
+                        "packages": [{"package_id": "seller_pkg_001"}],
+                    }
+                ]
+            }
+
+    store = create_media_buy_store(backing, capabilities=_Platform.capabilities)
+    handler = _make_handler(_Platform(), executor, media_buy_store=store)
+
+    resp = await handler.get_media_buys(
+        GetMediaBuysRequest(account={"account_id": "acct_a"}), ToolContext()
+    )
+
+    assert len(backing.backfill_calls) == 1
+    backfill_account, _ = backing.backfill_calls[0]
+    assert backfill_account == "acme:anonymous"
+    # Response now carries the echoed overlay.
+    assert resp["media_buys"][0]["packages"][0]["targeting_overlay"] == {
+        "property_list": PROPERTY_LIST,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_media_buys_with_no_store_returns_response_untouched(executor) -> None:
+    """No store wired → response passes through verbatim."""
+    from adcp.types import GetMediaBuysRequest
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def get_media_buys(self, req, ctx):
+            return {"media_buys": [{"media_buy_id": "mb_1", "packages": [{"package_id": "p1"}]}]}
+
+    handler = _make_handler(_Platform(), executor, media_buy_store=None)
+    resp = await handler.get_media_buys(
+        GetMediaBuysRequest(account={"account_id": "acct_a"}), ToolContext()
+    )
+    assert "targeting_overlay" not in resp["media_buys"][0]["packages"][0]
+
+
+# -----------------------------
+# End-to-end persist → backfill round-trip
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_persist_then_backfill_round_trip(executor) -> None:
+    """The full spec flow: ``create_media_buy`` persists the overlay,
+    a subsequent ``get_media_buys`` echoes it. Exercises both shims via
+    the same handler with one wired store, like a real adopter."""
+    from adcp.types import (
+        CreateMediaBuyRequest,
+        CreateMediaBuySuccessResponse,
+        GetMediaBuysRequest,
+    )
+    from adcp.types.generated_poc.core.package import Package
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["property-lists"])
+        accounts = SingletonAccounts(account_id="acme")
+
+        async def create_media_buy(self, req, ctx):
+            return CreateMediaBuySuccessResponse(
+                media_buy_id="mb_42",
+                packages=[Package(package_id="seller_pkg_42")],
+                status="active",
+            )
+
+        async def get_media_buys(self, req, ctx):
+            return {
+                "media_buys": [
+                    {
+                        "media_buy_id": "mb_42",
+                        "packages": [{"package_id": "seller_pkg_42"}],
+                    }
+                ]
+            }
+
+    backing = _RecordingMediaBuyStore()
+    store = create_media_buy_store(backing, capabilities=_Platform.capabilities)
+    handler = _make_handler(_Platform(), executor, media_buy_store=store)
+
+    await handler.create_media_buy(
+        CreateMediaBuyRequest(
+            account={"account_id": "acct_a"},
+            brand={"domain": "example.com"},
+            idempotency_key="idem_cccc1234567890",
+            start_time="2026-05-01T00:00:00Z",
+            end_time="2026-05-31T23:59:59Z",
+            packages=[
+                {
+                    "product_id": "p",
+                    "buyer_ref": "pkg",
+                    "budget": 1000.0,
+                    "pricing_option_id": "po",
+                    "targeting_overlay": {"property_list": PROPERTY_LIST},
+                }
+            ],
+        ),
+        ToolContext(),
+    )
+
+    resp = await handler.get_media_buys(
+        GetMediaBuysRequest(account={"account_id": "acct_a"}), ToolContext()
+    )
+    echoed = resp["media_buys"][0]["packages"][0]["targeting_overlay"]
+    assert echoed["property_list"]["list_id"] == PROPERTY_LIST["list_id"]


### PR DESCRIPTION
## Summary

Wires the already-merged `create_media_buy_store` helper into the framework dispatch path. Adopters now opt in via a kwarg on `create_adcp_server_from_platform` instead of hand-rolling `targeting_overlay` persistence + echo per adapter.

- **`create_media_buy`** — `persist_from_create` rides the existing `on_complete` seam, chained with the proposal v1.5 hook when both are wired, so both sync and HITL completions persist.
- **`update_media_buy`** — `merge_from_update` on `on_complete`, honoring the spec contract that `targeting_overlay` echoes from the most recent `create_media_buy` *or* `update_media_buy`.
- **`get_media_buys`** — `backfill` called inline before return.

New `_to_store_dict` helper normalizes Pydantic → JSON-compatible dict via `model_dump(mode='json', exclude_none=False)`. Adopters see the same shape that would go on the wire (`AnyUrl` → str, datetime → ISO-8601 str), and explicit nulls survive the merge contract (`None` = "clear this field").

## API shape decision

The triage comment surfaced an open question: kwarg on `create_adcp_server_from_platform` vs. post-construction `platform.media_buy_store = ...` (as the issue body proposed). Went with the kwarg — matches `buyer_agent_registry`, `webhook_sender`, `resource_resolver`, and every other framework opt-in.

```python
handler, executor, registry = create_adcp_server_from_platform(
    platform,
    media_buy_store=create_media_buy_store(adopter_store, capabilities=platform.capabilities),
)
```

## Test plan

- [x] 7 new integration tests in `tests/test_media_buy_store_integration.py` covering persist / merge / backfill through `PlatformHandler`, the no-op paths (store missing, seller lacks specialism), and a full create→get round-trip
- [x] 10 existing `tests/test_media_buy_store.py` unit tests still pass
- [x] Full test suite: 4881 passed, 0 regressions
- [x] `ruff check` + `mypy` clean on changed files
- [ ] Manual smoke through an adopter platform (defer to follow-up if needed)

Closes #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)