### PR TITLE
ci(adcp-sdk): pin @adcp/sdk to 7.9.0 (last known-green), salt cache key (closes #779 Track B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Pinned @adcp/sdk version. Bump deliberately; cache invalidates when this moves.
+# Background: adcontextprotocol/adcp-client-python#779 (Track B), adcontextprotocol/adcp#4907.
+env:
+  ADCP_SDK_VERSION: "7.9.0"
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -369,17 +374,13 @@ jobs:
 
       # Cache the npm tarball + extracted package directory so the
       # storyboard runner install isn't a cold network fetch every run.
-      # Key by OS only (not by version) so the cache survives across
-      # ``@adcp/sdk`` releases — npm install reuses tarballs that are
-      # already in the cache and only fetches the delta. ``@latest`` is
-      # intentional for drift detection (see "Run storyboard suite"
-      # below); the cache amortizes the 5-15 s of fetch+extract that
-      # would otherwise repeat on every CI run.
+      # Cache key is salted with the pinned ``@adcp/sdk`` version so
+      # bumping ADCP_SDK_VERSION invalidates the cache deterministically.
       - name: Cache ~/.npm
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-adcp-sdk
+          key: ${{ runner.os }}-npm-adcp-sdk-${{ env.ADCP_SDK_VERSION }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
@@ -387,12 +388,11 @@ jobs:
         # Single install step at the top of the job; subsequent runner
         # calls invoke the already-installed binary instead of paying
         # the ``npx -y -p ...`` per-invocation extract+link tax.
-        # ``@adcp/sdk@latest`` is intentionally unpinned: this is AdCP's
-        # own CI running AdCP's own canonical runner — tracking latest
-        # surfaces protocol drift as soon as it ships, which is the
-        # point of this job.
+        # Pinned to ADCP_SDK_VERSION (see workflow header) — bump via PR
+        # so reference-impl breakage from a new SDK release shows up as
+        # a labelled change set, not silent CI flake.
         run: |
-          npm install -g @adcp/sdk@latest
+          npm install -g @adcp/sdk@${ADCP_SDK_VERSION}
           adcp --version
 
       - name: Install dependencies
@@ -525,15 +525,13 @@ jobs:
         with:
           node-version: "22"
 
-      # Cache ~/.npm by OS only so subsequent runs hit the tarball
-      # cache; npm install reuses what's there and only fetches the
-      # delta on a new ``@latest`` release. See the storyboard job
-      # above for the same pattern + rationale.
+      # Same cache pattern as the storyboard job: keyed by
+      # ADCP_SDK_VERSION so a bump invalidates deterministically.
       - name: Cache ~/.npm
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-adcp-sdk
+          key: ${{ runner.os }}-npm-adcp-sdk-${{ env.ADCP_SDK_VERSION }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
@@ -549,7 +547,7 @@ jobs:
 
       - name: Pre-install @adcp/sdk (once, then call binary directly)
         run: |
-          npm install -g @adcp/sdk@latest
+          npm install -g @adcp/sdk@${ADCP_SDK_VERSION}
           adcp --version
 
       - name: Start JS mock-server upstream
@@ -752,13 +750,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-adcp-sdk
+          key: ${{ runner.os }}-npm-adcp-sdk-${{ env.ADCP_SDK_VERSION }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
       - name: Pre-install @adcp/sdk
         run: |
-          npm install -g @adcp/sdk@latest
+          npm install -g @adcp/sdk@${ADCP_SDK_VERSION}
           adcp --version
 
       - name: Install dependencies
@@ -853,13 +851,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-adcp-sdk
+          key: ${{ runner.os }}-npm-adcp-sdk-${{ env.ADCP_SDK_VERSION }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
       - name: Pre-install @adcp/sdk
         run: |
-          npm install -g @adcp/sdk@latest
+          npm install -g @adcp/sdk@${ADCP_SDK_VERSION}
           adcp --version
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Pins `@adcp/sdk` from floating `@latest` to **7.9.0** in `.github/workflows/ci.yml`, and salts the npm cache key with the pinned version.

**Why 7.9.0 and not 7.10.x:** `@adcp/sdk@7.10.0` was published 2026-05-21T14:29Z. The first storyboard failure on main appeared at 14:42Z (on PR #774's merge). Last known-green CI on main was `1c4e57d4` at 13:55Z — that ran against 7.9.0. 7.10.x ships new scenarios (`measurement_terms_rejected/create_media_buy_aggressive_terms`, `invalid_transitions/update_unknown_package`, etc.) that this repo's `examples/seller_agent.py` doesn't yet satisfy.

This PR fixes the **silent-upgrade footgun** that let 7.10.0 land on every CI run without anyone noticing. The example-side gap to 7.10.x is tracked separately (filed as a follow-up issue, link below).

## Background

The npm cache key was `${{ runner.os }}-npm-adcp-sdk` — OS-only, no version salt. With `@adcp/sdk@latest` floating, a new SDK release silently coexists with old-cached copies; same commit goes red/green depending on which runner picks it up. Bumping the SDK is now a labelled PR diff instead of an invisible registry-publish event.

See:
- adcontextprotocol/adcp#4907 §Concrete trigger for the forensic walkthrough.
- adcontextprotocol/adcp-client-python#779 Track B for the scope here.

## Changes

- Workflow-level `env.ADCP_SDK_VERSION = "7.9.0"`.
- All 4 `npm install -g @adcp/sdk@latest` sites use `@adcp/sdk@${ADCP_SDK_VERSION}`.
- All 4 cache keys salted with `${{ env.ADCP_SDK_VERSION }}`.
- Stale comments that justified `@latest` ("intentional for drift detection", etc.) replaced with the pin's rationale.

## What this does NOT fix

- The **example seller_agent.py gap** versus `@adcp/sdk@7.10.x` — filed as a follow-up.
- The **bidirectional contract test** — adcontextprotocol/adcp#4907 Phase 1 / adcontextprotocol/adcp-client#1916.
- The reference-target-stability question — adcp#4907 Open Q #1 / #779 Track A.

## Bumping the SDK version going forward

Edit `ADCP_SDK_VERSION` in `.github/workflows/ci.yml`. The salted cache key auto-invalidates. SDK breakage surfaces in a PR diff, not a flaky main.

## Closes

- #779 Track B (`@adcp/sdk` version pin + cache hygiene)

## Refs

- adcontextprotocol/adcp#4907 (primary RFC)
- adcontextprotocol/adcp-client#1916 (companion: TS-side interop workflow)
- #782 (seller_agent.py 7.10.x compatibility — example-side catch-up to 7.10.x scenarios)

## Test plan

- [ ] CI green on this PR pinned to 7.9.0
- [ ] Once merged, PRs #750 and #752 rebase + auto-merge cleanly off the now-green main