### PR TITLE
test(codegen): lock deprecation-decorator generation on deprecated JSON Schema properties

### DIFF
--- a/tests/test_codegen_deprecation_contract.py
+++ b/tests/test_codegen_deprecation_contract.py
@@ -18,7 +18,7 @@ Regression classes this test prevents:
 
 Anchor cases (AdCP 3.0.7 — the current schema bundle):
   * ``TargetingOverlay.axe_include_segment`` / ``.axe_exclude_segment``
-    across the create/update media-buy request and response bundles.
+    (core schema class; bundled variants are separate generated classes).
   * ``GetSignalsRequest.max_results``
   * ``ProductFilters.required_axe_integrations``
 
@@ -64,10 +64,10 @@ def _assert_field_deprecated(model_cls: type, field_name: str) -> None:
 # ---------------------------------------------------------------------------
 # TargetingOverlay.axe_include_segment / axe_exclude_segment
 #
-# Source schema: bundled/media-buy/{create,update}-media-buy-{request,response}.json
+# Source schema: core/targeting.json (the core class; the bundled
+# media-buy schemas generate structurally identical but separate classes).
 # These are the canonical deprecated fields in the 3.0 schema bundle.
-# The public TargetingOverlay re-exports the same generated class so
-# one assertion here covers all four bundled schema occurrences.
+# ``adcp.types.TargetingOverlay`` resolves to the core schema class.
 # ---------------------------------------------------------------------------
 
 
@@ -106,7 +106,7 @@ def test_product_filters_required_axe_integrations_is_deprecated() -> None:
 # uncomment the block below and remove this comment.  Both fields will
 # carry ``deprecated: true`` in the 3.1 schema after adcp#4904 merges.
 #
-# from adcp.types.aliases import (
+# from adcp.types import (
 #     CreateMediaBuySuccessResponse,
 #     UpdateMediaBuySuccessResponse,
 # )

--- a/tests/test_codegen_deprecation_contract.py
+++ b/tests/test_codegen_deprecation_contract.py
@@ -1,0 +1,120 @@
+"""Lock that JSON Schema ``deprecated: true`` propagates through the
+codegen pipeline to ``deprecated=True`` on Pydantic v2 field metadata.
+
+The pinned ``datamodel-code-generator==0.56.1`` in ``pyproject.toml``
+must emit ``deprecated=True`` on ``pydantic.Field(...)`` for every
+JSON Schema property that carries ``"deprecated": true``.  This test
+locks that contract so regressions are caught in CI rather than in
+production.
+
+Regression classes this test prevents:
+  * An unreviewed bump to the ``datamodel-code-generator`` pin that
+    silently drops deprecation semantics (the issue that prompted
+    adcontextprotocol/adcp#4904's expert review flag).
+  * A schema refresh that adds ``deprecated: true`` on a field whose
+    generated Pydantic type misses the marker.
+  * A toolchain swap that changes how the ``deprecated`` keyword
+    surfaces in generated output.
+
+Anchor cases (AdCP 3.0.7 — the current schema bundle):
+  * ``TargetingOverlay.axe_include_segment`` / ``.axe_exclude_segment``
+    across the create/update media-buy request and response bundles.
+  * ``GetSignalsRequest.max_results``
+  * ``ProductFilters.required_axe_integrations``
+
+Pending anchor cases (active once AdCP 3.1 schema sync lands, #778):
+  ``CreateMediaBuySuccessResponse.status`` and
+  ``UpdateMediaBuySuccessResponse.status`` will carry ``deprecated: true``
+  after adcontextprotocol/adcp#4904 is merged and the schema cache is
+  refreshed.  See the commented-out block at the bottom of this file.
+"""
+
+from __future__ import annotations
+
+from adcp.types import (
+    GetSignalsRequest,
+    ProductFilters,
+    TargetingOverlay,
+)
+
+
+def _assert_field_deprecated(model_cls: type, field_name: str) -> None:
+    """Assert that *field_name* on *model_cls* carries ``deprecated=True``.
+
+    Pydantic v2 stores the ``deprecated`` marker directly on ``FieldInfo``
+    as a bool or string (truthy when the field is deprecated).  This
+    helper normalises the check and provides a consistent failure message
+    that points back to the codegen pipeline.
+    """
+    assert field_name in model_cls.model_fields, (
+        f"{model_cls.__name__} has no field {field_name!r} — "
+        f"was the field removed or renamed in the schema?"
+    )
+    fi = model_cls.model_fields[field_name]
+    assert fi.deprecated, (
+        f"{model_cls.__name__}.{field_name} must carry deprecated=True.\n"
+        f"  Got: deprecated={fi.deprecated!r}\n"
+        f"  If datamodel-code-generator was bumped, verify that the new "
+        f"version still emits 'deprecated=True' on Pydantic fields whose "
+        f"JSON Schema property sets 'deprecated: true'.  "
+        f"See pyproject.toml for the pinned version."
+    )
+
+
+# ---------------------------------------------------------------------------
+# TargetingOverlay.axe_include_segment / axe_exclude_segment
+#
+# Source schema: bundled/media-buy/{create,update}-media-buy-{request,response}.json
+# These are the canonical deprecated fields in the 3.0 schema bundle.
+# The public TargetingOverlay re-exports the same generated class so
+# one assertion here covers all four bundled schema occurrences.
+# ---------------------------------------------------------------------------
+
+
+def test_targeting_overlay_axe_include_segment_is_deprecated() -> None:
+    _assert_field_deprecated(TargetingOverlay, "axe_include_segment")
+
+
+def test_targeting_overlay_axe_exclude_segment_is_deprecated() -> None:
+    _assert_field_deprecated(TargetingOverlay, "axe_exclude_segment")
+
+
+# ---------------------------------------------------------------------------
+# GetSignalsRequest.max_results
+# Source schema: bundled/signals/get-signals-request.json
+# ---------------------------------------------------------------------------
+
+
+def test_get_signals_request_max_results_is_deprecated() -> None:
+    _assert_field_deprecated(GetSignalsRequest, "max_results")
+
+
+# ---------------------------------------------------------------------------
+# ProductFilters.required_axe_integrations
+# Source schema: bundled/media-buy/get-products-request.json
+# ---------------------------------------------------------------------------
+
+
+def test_product_filters_required_axe_integrations_is_deprecated() -> None:
+    _assert_field_deprecated(ProductFilters, "required_axe_integrations")
+
+
+# ---------------------------------------------------------------------------
+# Pending anchor cases — AdCP 3.1 (issue #778 / adcp#4904)
+# ---------------------------------------------------------------------------
+# When the AdCP 3.1 schema bundle is synced and types are regenerated,
+# uncomment the block below and remove this comment.  Both fields will
+# carry ``deprecated: true`` in the 3.1 schema after adcp#4904 merges.
+#
+# from adcp.types.aliases import (
+#     CreateMediaBuySuccessResponse,
+#     UpdateMediaBuySuccessResponse,
+# )
+#
+# def test_create_media_buy_success_status_is_deprecated_adcp_3_1() -> None:
+#     """CreateMediaBuySuccess.status deprecated in AdCP 3.1 (adcp#4904)."""
+#     _assert_field_deprecated(CreateMediaBuySuccessResponse, "status")
+#
+# def test_update_media_buy_success_status_is_deprecated_adcp_3_1() -> None:
+#     """UpdateMediaBuySuccess.status deprecated in AdCP 3.1 (adcp#4904)."""
+#     _assert_field_deprecated(UpdateMediaBuySuccessResponse, "status")


### PR DESCRIPTION
Closes #778

Adds a CI gate that asserts `"deprecated": true` in the JSON Schema source propagates to `deprecated=True` on Pydantic v2 `FieldInfo` through the pinned `datamodel-code-generator==0.56.1` codegen pipeline.

**Motivation:** The expert review on adcontextprotocol/adcp#4904 (AdCP 3.1 additive-deprecate of `CreateMediaBuySuccess.status` / `UpdateMediaBuySuccess.status`) flagged that `datamodel-code-generator` has historically had uneven `deprecated` keyword support across versions — older pinned versions silently drop it. This test locks the contract so regressions are caught in CI rather than in production.

**What changed:**
- New `tests/test_codegen_deprecation_contract.py` with 4 assertions covering existing deprecated fields in the 3.0.7 schema bundle:
  - `TargetingOverlay.axe_include_segment` / `.axe_exclude_segment` (core schema class)
  - `GetSignalsRequest.max_results`
  - `ProductFilters.required_axe_integrations`
- Shared `_assert_field_deprecated()` helper with a failure message that points back to the codegen pin
- Commented-out block documenting the pending AdCP 3.1 anchor cases (`CreateMediaBuySuccessResponse.status`, `UpdateMediaBuySuccessResponse.status`) for easy activation after adcp#4904 schema sync

**What tested:**
- `pytest tests/test_codegen_deprecation_contract.py` — 4 passed
- `pytest tests/` — 4734 passed, 1 pre-existing network test skipped (`test_real_tls_handshake_still_validates_hostname` in the signing conformance suite, unrelated to this change)
- `ruff check` — clean
- `python -m mypy src/adcp/` — success, 805 source files, no issues

**Pre-PR review:**
- code-reviewer: approved — 2 nits fixed (duplicate docstring bullet removed, pending import updated from `adcp.types.aliases` to `adcp.types`)
- ad-tech-protocol-expert: approved after blocker fixed — corrected inaccurate comment claiming one assertion covers all four bundled schema occurrences (public `TargetingOverlay` resolves to the core schema class, not the structurally identical bundled variants)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0169cPJV4qE4hxoLvkJsm2mg

---
_Generated by [Claude Code](https://claude.ai/code/session_0169cPJV4qE4hxoLvkJsm2mg)_