### PR TITLE
feat(decisioning): Tier 3 brand-authz dispatch gate (#350 stage 5, closes #350)

### DIFF
--- a/src/adcp/decisioning/brand_authz_gate.py
+++ b/src/adcp/decisioning/brand_authz_gate.py
@@ -35,11 +35,19 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
+
+# ``BuyerAgent`` and ``Account`` are referenced at runtime by the
+# :data:`BrandIdentityResolver` ``Callable`` alias below — that
+# subscription happens at module load (not under
+# ``from __future__ import annotations``, which defers annotations
+# only), so the names must be importable then. Both modules are
+# foundational with no path back to this one, so promoting them out
+# of ``TYPE_CHECKING`` carries no circular-import risk.
+from adcp.decisioning.registry import BuyerAgent
+from adcp.decisioning.types import Account
 
 if TYPE_CHECKING:
-    from adcp.decisioning.registry import BuyerAgent
-    from adcp.decisioning.types import Account
     from adcp.signing.brand_authz import BrandAuthorizationResolver
 
 
@@ -82,7 +90,7 @@ class BrandIdentity:
 #: by their :meth:`AccountStore.resolve`. Either path is fine — the
 #: framework does not constrain the source, only the return shape.
 BrandIdentityResolver = Callable[
-    ["Account[object]", Union["BuyerAgent", None]],
+    [Account[object], BuyerAgent | None],
     BrandIdentity | None | Awaitable[BrandIdentity | None],
 ]
 

--- a/src/adcp/decisioning/brand_authz_gate.py
+++ b/src/adcp/decisioning/brand_authz_gate.py
@@ -1,0 +1,102 @@
+"""Tier 3 brand-authorization dispatch gate.
+
+Composes the :class:`adcp.signing.BrandAuthorizationResolver` Protocol
+(landed in v3-identity stages 1-3, issue #350 PR #770) with the
+framework's dispatch path so adopters can opt into per-brand
+authorization the same way they opt into Tier 2 commercial-identity
+gating today (via ``serve(buyer_agent_registry=...)``).
+
+The gate runs **after** Tier 2 buyer-agent resolution and
+:meth:`AccountStore.resolve`, and **before** the platform method
+executes. By that point the framework has:
+
+* a verified, registry-recognized :class:`BuyerAgent` with an active
+  status (else Tier 2 already raised), and
+* a resolved :class:`Account` the request operates on.
+
+What the gate is *not*: it is not the verifier-side
+``request_signature_*`` rejection path (that lives in
+:mod:`adcp.signing.key_origins` for the JWKS-origin check and in the
+forthcoming verifier integration for the brand_json chain checks —
+issue #776). This dispatch-layer gate emits the cross-cutting
+``PERMISSION_DENIED`` auth-denial code regardless of credential kind,
+matching the Tier 2 unrecognized-agent rejection surface. Per-purpose
+spec-shape codes are reserved for the verifier path.
+
+The gate is opt-in. Adopters wire it by passing **both**
+``brand_authz_resolver`` and ``brand_identity_resolver`` to
+:func:`adcp.decisioning.serve`. Wiring one without the other raises
+at boot — partial wiring is almost always a misconfiguration: a
+resolver without an extractor never has a brand to check, an extractor
+without a resolver never has anything to do.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from adcp.decisioning.registry import BuyerAgent
+    from adcp.decisioning.types import Account
+    from adcp.signing.brand_authz import BrandAuthorizationResolver
+
+
+@dataclass(frozen=True)
+class BrandIdentity:
+    """The brand a request operates against — the input to the Tier 3
+    binding check.
+
+    Mirrors the brand identifier shape carried on wire :class:`AccountReference`
+    natural-key references (``account.brand.domain``) and the
+    spec-defined ``brand_id`` field on
+    ``brand.json/authorized_operators[].brands[]``.
+
+    :param domain: The brand's domain (e.g. ``"nike.com"``). Required —
+        eTLD+1 binding cannot proceed without it.
+    :param id: Optional brand identifier from the seller's portfolio.
+        When set, the operator-delegation check is scoped to this brand
+        (``authorized_operators[i].brands[]`` must contain this ``id``
+        or ``"*"``). When ``None``, only ``"*"``-scoped operators
+        satisfy the delegation check — fail-closed on unscoped
+        delegation per :class:`BrandJsonAuthorizationResolver`.
+    """
+
+    domain: str
+    id: str | None = None
+
+
+#: Adopter-provided callable that extracts the brand identity from a
+#: resolved :class:`Account` (+ the resolved :class:`BuyerAgent`).
+#:
+#: Returns ``None`` when the request has no brand to bind against — the
+#: gate skips on ``None`` (the adopter is telling the framework "this
+#: request isn't brand-scoped, no Tier 3 check applies"). Returns a
+#: :class:`BrandIdentity` when the request operates on behalf of a
+#: brand — the framework runs the binding check.
+#:
+#: Adopters in ``'derived'`` resolution mode typically derive the brand
+#: from ``buyer_agent.allowed_brands`` or the agent's onboarding record;
+#: adopters in ``'explicit'`` mode read ``account.metadata`` populated
+#: by their :meth:`AccountStore.resolve`. Either path is fine — the
+#: framework does not constrain the source, only the return shape.
+BrandIdentityResolver = Callable[
+    ["Account[object]", Union["BuyerAgent", None]],
+    BrandIdentity | None | Awaitable[BrandIdentity | None],
+]
+
+
+@dataclass(frozen=True)
+class BrandAuthorizationGate:
+    """Bundle of the Tier 3 dependencies — the authorization resolver
+    plus the brand-identity extractor.
+
+    Passed to the dispatch path as a single immutable bundle so the
+    pairing rule (both wired or neither) holds by construction:
+    constructing the bundle requires both, so the framework only ever
+    sees a complete configuration or no configuration at all.
+    """
+
+    resolver: BrandAuthorizationResolver
+    extract_identity: BrandIdentityResolver

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -186,6 +186,7 @@ from adcp.types import (
 if TYPE_CHECKING:
     from concurrent.futures import ThreadPoolExecutor
 
+    from adcp.decisioning.brand_authz_gate import BrandAuthorizationGate
     from adcp.decisioning.media_buy_store import MediaBuyStore
     from adcp.decisioning.platform import DecisioningPlatform
     from adcp.decisioning.property_list import PropertyListFetcher
@@ -590,6 +591,107 @@ async def _resolve_buyer_agent(
     # but the framework cannot interpret it, which is operationally
     # equivalent to "not authorized" without a defensible status
     # claim to project on the wire).
+    await budget.enforce()
+    raise AdcpError(
+        "PERMISSION_DENIED",
+        message=_denied_message,
+        recovery="correctable",
+    )
+
+
+async def _enforce_brand_authorization(
+    gate: BrandAuthorizationGate,
+    account: Account[Any],
+    buyer_agent: BuyerAgent | None,
+) -> None:
+    """Tier 3 per-brand authorization gate.
+
+    Runs after Tier 2 (:func:`_resolve_buyer_agent`) and
+    :meth:`AccountStore.resolve` — by this point the framework has a
+    verified, active buyer-agent and a resolved account. The gate asks
+    the adopter's :class:`BrandAuthorizationResolver`: is this agent
+    authorized to act *for this brand*?
+
+    Sourcing the brand identity is the adopter's call — the framework
+    delegates via :attr:`BrandAuthorizationGate.extract_identity`. The
+    extractor reads whatever signal the seller's account model carries
+    (``account.metadata['brand_domain']``, the natural-key reference's
+    ``brand.domain``, an internal mapping, etc.) and returns a
+    :class:`BrandIdentity` or ``None``. ``None`` means "this request
+    isn't brand-scoped" — the gate skips, the platform method runs.
+
+    The extractor MAY be async. Both sync (``-> BrandIdentity | None``)
+    and async (``-> Awaitable[BrandIdentity | None]``) shapes are
+    supported so adopters can fetch from a remote registry without
+    wrapping in :func:`asyncio.to_thread`.
+
+    **No buyer-agent → no gate.** When Tier 2 isn't wired (the
+    framework has no ``buyer_agent``), the gate skips: brand
+    authorization without a buyer-agent identity has no subject to
+    authorize. Adopters wiring Tier 3 without Tier 2 see the gate
+    silently pass — the boot validation in :func:`serve` doesn't
+    enforce the Tier-2-before-Tier-3 pairing because some adopters
+    legitimately want brand identity flowing through dispatch as a
+    capability without commercial-identity gating (read-only audit
+    paths, etc.). They get a no-op gate, not a rejection.
+
+    **Denial surface.** Rejection emits the generic
+    ``PERMISSION_DENIED`` (``recovery="correctable"``) with the same
+    cross-tenant-safe message as Tier 2's unrecognized-agent rejection.
+    Spec-shape ``request_signature_brand_origin_mismatch`` /
+    ``request_signature_agent_not_in_brand_json`` codes belong to the
+    verifier-side wire path (issue #776 will plumb the
+    ``BrandJsonJwksResolver`` source discriminant through to the
+    verifier — this dispatch-layer gate emits the
+    framework-cross-cutting denial code).
+
+    Timing-oracle defense: same :class:`PermissionDeniedBudget` shape
+    as Tier 2. The brand.json fetch path's natural variance (cache hit
+    vs miss vs stale-on-error) is larger than the registry-lookup
+    variance Tier 2 absorbs, so the budget here is a floor, not a
+    ceiling — it prevents the cache-hit-authorized vs
+    cache-hit-rejected paths from leaking timing-distinguishable
+    decisions on the happy-cache path, which is the common case.
+
+    :raises AdcpError: ``PERMISSION_DENIED`` when the resolver denies
+        authorization. ``recovery="correctable"`` per the spec's
+        ``enumMetadata`` for ``PERMISSION_DENIED``.
+    """
+    import inspect
+
+    from adcp.decisioning._permission_denied_budget import PermissionDeniedBudget
+    from adcp.decisioning.types import AdcpError
+
+    if buyer_agent is None:
+        return
+
+    maybe_identity = gate.extract_identity(account, buyer_agent)
+    if inspect.isawaitable(maybe_identity):
+        identity = await maybe_identity
+    else:
+        identity = maybe_identity
+    if identity is None:
+        return
+
+    budget = PermissionDeniedBudget()
+    authorized = await gate.resolver.is_authorized(
+        agent_url=buyer_agent.agent_url,
+        brand_domain=identity.domain,
+        brand_id=identity.id,
+    )
+    if authorized:
+        return
+
+    # Same generic message as the Tier 2 unrecognized-agent rejection.
+    # Identical wire-level error.message across both gates so the
+    # message itself is not a side channel discriminating
+    # commercial-identity rejection from brand-authorization rejection.
+    _denied_message = (
+        "Buyer agent is not authorized for this seller. The seller's "
+        "commercial allowlist did not authorize this credential. "
+        "Resolve out-of-band via the seller's onboarding contact; this "
+        "is not a request-side error the buyer can correct."
+    )
     await budget.enforce()
     raise AdcpError(
         "PERMISSION_DENIED",
@@ -1028,6 +1130,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         webhook_supervisor: WebhookDeliverySupervisor | None = None,
         auto_emit_completion_webhooks: bool = True,
         buyer_agent_registry: BuyerAgentRegistry | None = None,
+        brand_authorization_gate: BrandAuthorizationGate | None = None,
         config_store: ProductConfigStore | None = None,
         property_list_fetcher: PropertyListFetcher | None = None,
         media_buy_store: MediaBuyStore | None = None,
@@ -1043,6 +1146,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         self._webhook_supervisor = webhook_supervisor
         self._auto_emit_completion_webhooks = auto_emit_completion_webhooks
         self._buyer_agent_registry = buyer_agent_registry
+        self._brand_authorization_gate = brand_authorization_gate
         self._config_store = config_store
         self._property_list_fetcher = property_list_fetcher
         self._media_buy_store = media_buy_store
@@ -1153,6 +1257,26 @@ class PlatformHandler(ADCPHandler[ToolContext]):
         from adcp.decisioning.observed_modes import record_resolved_account_mode
 
         record_resolved_account_mode(resolved)
+
+        # Tier 3 brand-authorization gate (issue #350 stage 5). Opt-in
+        # via ``serve(brand_authz_resolver=..., brand_identity_resolver=...)``.
+        # Runs AFTER ``accounts.resolve`` so the gate has the resolved
+        # :class:`Account` available — adopters source the brand identity
+        # from whatever signal their account model carries (the wire
+        # :class:`AccountReference` natural-key shape, ``account.metadata``,
+        # an internal mapping, etc.). The gate is a no-op when no buyer
+        # agent has been resolved (Tier 2 not wired) — see
+        # :func:`_enforce_brand_authorization` for the rationale.
+        if self._brand_authorization_gate is not None:
+            buyer_agent_for_gate = cast(
+                "BuyerAgent | None",
+                ctx.metadata.get(_BUYER_AGENT_METADATA_KEY) if ctx.metadata else None,
+            )
+            await _enforce_brand_authorization(
+                self._brand_authorization_gate,
+                resolved,
+                buyer_agent_for_gate,
+            )
         return resolved
 
     @staticmethod

--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -40,10 +40,7 @@ from adcp.decisioning.task_registry import InMemoryTaskRegistry
 from adcp.decisioning.types import AdcpError
 
 if TYPE_CHECKING:
-    from adcp.decisioning.brand_authz_gate import (
-        BrandAuthorizationGate,
-        BrandIdentityResolver,
-    )
+    from adcp.decisioning.brand_authz_gate import BrandIdentityResolver
     from adcp.decisioning.implementation_config import ProductConfigStore
     from adcp.decisioning.media_buy_store import MediaBuyStore
     from adcp.decisioning.platform import DecisioningPlatform

--- a/src/adcp/decisioning/serve.py
+++ b/src/adcp/decisioning/serve.py
@@ -40,6 +40,10 @@ from adcp.decisioning.task_registry import InMemoryTaskRegistry
 from adcp.decisioning.types import AdcpError
 
 if TYPE_CHECKING:
+    from adcp.decisioning.brand_authz_gate import (
+        BrandAuthorizationGate,
+        BrandIdentityResolver,
+    )
     from adcp.decisioning.implementation_config import ProductConfigStore
     from adcp.decisioning.media_buy_store import MediaBuyStore
     from adcp.decisioning.platform import DecisioningPlatform
@@ -48,6 +52,7 @@ if TYPE_CHECKING:
     from adcp.decisioning.resolve import ResourceResolver
     from adcp.decisioning.state import StateReader
     from adcp.decisioning.task_registry import TaskRegistry
+    from adcp.signing.brand_authz import BrandAuthorizationResolver
     from adcp.webhook_sender import WebhookSender
     from adcp.webhook_supervisor import WebhookDeliverySupervisor
 
@@ -86,6 +91,8 @@ def create_adcp_server_from_platform(
     webhook_supervisor: WebhookDeliverySupervisor | None = None,
     auto_emit_completion_webhooks: bool = True,
     buyer_agent_registry: BuyerAgentRegistry | None = None,
+    brand_authz_resolver: BrandAuthorizationResolver | None = None,
+    brand_identity_resolver: BrandIdentityResolver | None = None,
     config_store: ProductConfigStore | None = None,
     property_list_fetcher: PropertyListFetcher | None = None,
     media_buy_store: MediaBuyStore | None = None,
@@ -323,6 +330,32 @@ def create_adcp_server_from_platform(
     # propagates to the caller.
     validate_platform(platform)
 
+    # Tier 3 brand-authorization gate (issue #350 stage 5). The pair is
+    # bundled here so the dispatch path sees an atomic configuration:
+    # both wired or neither. Passing one without the other is almost
+    # always a misconfiguration (a resolver without an extractor never
+    # has a brand to check; an extractor without a resolver never has
+    # anything to do) — fail closed at boot with a specific diagnostic
+    # rather than a silent never-fires gate at request time.
+    if (brand_authz_resolver is None) != (brand_identity_resolver is None):
+        raise ValueError(
+            "brand_authz_resolver and brand_identity_resolver must be wired "
+            "together. Pass both (to enable Tier 3 brand-authorization gating) "
+            "or neither (to skip the gate). A resolver without an extractor "
+            "has no brand identity to check; an extractor without a resolver "
+            "has nothing to do."
+        )
+    brand_authorization_gate: BrandAuthorizationGate | None
+    if brand_authz_resolver is not None and brand_identity_resolver is not None:
+        from adcp.decisioning.brand_authz_gate import BrandAuthorizationGate
+
+        brand_authorization_gate = BrandAuthorizationGate(
+            resolver=brand_authz_resolver,
+            extract_identity=brand_identity_resolver,
+        )
+    else:
+        brand_authorization_gate = None
+
     handler = PlatformHandler(
         platform,
         executor=executor,
@@ -333,6 +366,7 @@ def create_adcp_server_from_platform(
         webhook_supervisor=webhook_supervisor,
         auto_emit_completion_webhooks=auto_emit_completion_webhooks,
         buyer_agent_registry=buyer_agent_registry,
+        brand_authorization_gate=brand_authorization_gate,
         config_store=config_store,
         property_list_fetcher=property_list_fetcher,
         media_buy_store=media_buy_store,
@@ -428,6 +462,8 @@ def serve(
     webhook_supervisor: WebhookDeliverySupervisor | None = None,
     auto_emit_completion_webhooks: bool = True,
     buyer_agent_registry: BuyerAgentRegistry | None = None,
+    brand_authz_resolver: BrandAuthorizationResolver | None = None,
+    brand_identity_resolver: BrandIdentityResolver | None = None,
     config_store: ProductConfigStore | None = None,
     property_list_fetcher: PropertyListFetcher | None = None,
     advertise_all: bool = False,
@@ -539,6 +575,8 @@ def serve(
         webhook_supervisor=webhook_supervisor,
         auto_emit_completion_webhooks=auto_emit_completion_webhooks,
         buyer_agent_registry=buyer_agent_registry,
+        brand_authz_resolver=brand_authz_resolver,
+        brand_identity_resolver=brand_identity_resolver,
         config_store=config_store,
         property_list_fetcher=property_list_fetcher,
         advertise_all=advertise_all,

--- a/tests/test_decisioning_brand_authz_dispatch.py
+++ b/tests/test_decisioning_brand_authz_dispatch.py
@@ -1,0 +1,560 @@
+"""Tier 3 — brand-authorization dispatch gate.
+
+Tests the dispatch-layer composition between
+:class:`adcp.signing.BrandAuthorizationResolver` (v3-identity stages
+1-3, PR #770) and the framework's ``serve()`` wire-up:
+
+* Boot validation: ``brand_authz_resolver`` and
+  ``brand_identity_resolver`` MUST be wired together. Partial wiring
+  is a misconfiguration (a resolver without an extractor never has a
+  brand to check; an extractor without a resolver never has anything
+  to do) → ``ValueError`` at boot.
+* Authorized path: the gate runs after Tier 2 + ``accounts.resolve``;
+  on success the platform method runs unchanged.
+* Denied path: rejection emits ``PERMISSION_DENIED`` with the same
+  cross-tenant-safe message as Tier 2's unrecognized-agent rejection.
+* No-buyer-agent skip: Tier 3 is a no-op when Tier 2 is not wired
+  (no subject to authorize).
+* Extractor-returns-None skip: the adopter signals "no brand to
+  bind against" and the gate skips.
+* Async extractor: the framework awaits when the extractor returns
+  an awaitable.
+* ``brand_id`` propagation: when the extractor surfaces a ``brand_id``,
+  the resolver sees it (for scoped operator-delegation checks).
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from adcp.decisioning import (
+    AdcpError,
+    BuyerAgent,
+    DecisioningCapabilities,
+    DecisioningPlatform,
+    HttpSigCredential,
+    InMemoryTaskRegistry,
+    SingletonAccounts,
+    signing_only_registry,
+)
+from adcp.decisioning.brand_authz_gate import BrandAuthorizationGate, BrandIdentity
+from adcp.decisioning.context import AuthInfo
+from adcp.decisioning.handler import PlatformHandler
+from adcp.decisioning.serve import create_adcp_server_from_platform
+from adcp.server.base import ToolContext
+
+
+@pytest.fixture
+def executor():
+    pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="test-brand-authz-")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeBrandAuthzResolver:
+    """Records every ``is_authorized`` call; returns a configured bool.
+
+    Adopters in production wire :class:`BrandJsonAuthorizationResolver`
+    from :mod:`adcp.signing.brand_authz`. The dispatch path only sees
+    the Protocol surface, so the test fake matches that surface
+    exactly without spinning up real brand.json fixtures (those are
+    covered in ``tests/test_brand_authz.py``).
+    """
+
+    def __init__(self, *, authorized: bool) -> None:
+        self._authorized = authorized
+        self.calls: list[dict[str, Any]] = []
+
+    async def is_authorized(
+        self,
+        *,
+        agent_url: str,
+        brand_domain: str,
+        agent_type: str | None = None,
+        brand_id: str | None = None,
+    ) -> bool:
+        self.calls.append(
+            {
+                "agent_url": agent_url,
+                "brand_domain": brand_domain,
+                "agent_type": agent_type,
+                "brand_id": brand_id,
+            }
+        )
+        return self._authorized
+
+
+def _signed_auth(agent_url: str) -> AuthInfo:
+    return AuthInfo(
+        kind="http_sig",
+        credential=HttpSigCredential(
+            kind="http_sig",
+            keyid="kid-1",
+            agent_url=agent_url,
+            verified_at=1700000000.0,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Boot validation
+# ---------------------------------------------------------------------------
+
+
+def test_serve_requires_both_brand_resolver_and_identity_resolver_resolver_only() -> None:
+    """``brand_authz_resolver`` without ``brand_identity_resolver`` is
+    a misconfiguration. The resolver has no brand to check; would
+    silently never gate. Fail fast at boot."""
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+    with pytest.raises(ValueError, match="brand_authz_resolver and brand_identity_resolver"):
+        create_adcp_server_from_platform(
+            _Platform(),
+            brand_authz_resolver=_FakeBrandAuthzResolver(authorized=True),
+        )
+
+
+def test_serve_requires_both_brand_resolver_and_identity_resolver_extractor_only() -> None:
+    """``brand_identity_resolver`` without ``brand_authz_resolver`` is
+    a misconfiguration. The extractor would never fire. Fail fast at
+    boot."""
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+    with pytest.raises(ValueError, match="brand_authz_resolver and brand_identity_resolver"):
+        create_adcp_server_from_platform(
+            _Platform(),
+            brand_identity_resolver=lambda _account, _agent: BrandIdentity(domain="brand.com"),
+        )
+
+
+def test_serve_neither_wired_is_back_compat() -> None:
+    """Pre-Tier-3 adopters omit both kwargs entirely; dispatch
+    continues to work unchanged. No ValueError, no warning."""
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+    handler, _executor, _registry = create_adcp_server_from_platform(
+        _Platform(),
+        validate_at_init=False,
+    )
+    assert handler is not None
+    _executor.shutdown(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# Authorized path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authorized_request_runs_platform_method(executor) -> None:
+    """Happy path: registry → buyer_agent → accounts.resolve →
+    brand_authz.is_authorized returns True → platform method runs."""
+    from adcp.types import GetProductsRequest, GetProductsResponse
+
+    buyer = BuyerAgent(
+        agent_url="https://ads.brand.com/agent",
+        display_name="Ads-on-brand.com",
+        status="active",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return buyer if agent_url == buyer.agent_url else None
+
+    resolver = _FakeBrandAuthzResolver(authorized=True)
+    seen: list[Any] = []
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            seen.append(ctx.buyer_agent)
+            return GetProductsResponse(products=[])
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=resolver,
+            extract_identity=lambda _account, _agent: BrandIdentity(domain="brand.com"),
+        ),
+    )
+
+    await handler.get_products(
+        GetProductsRequest(buying_mode="brief", brief="any"),
+        ToolContext(metadata={"adcp.auth_info": _signed_auth(buyer.agent_url)}),
+    )
+
+    assert seen == [buyer]
+    assert len(resolver.calls) == 1
+    assert resolver.calls[0]["agent_url"] == buyer.agent_url
+    assert resolver.calls[0]["brand_domain"] == "brand.com"
+    assert resolver.calls[0]["brand_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_authorized_propagates_brand_id_when_extractor_returns_it(executor) -> None:
+    """When the extractor returns a ``BrandIdentity`` with an ``id``
+    set, the resolver sees it via the ``brand_id=`` keyword — required
+    for spec-conformant scoped operator-delegation checks."""
+    from adcp.types import GetProductsRequest, GetProductsResponse
+
+    buyer = BuyerAgent(
+        agent_url="https://ads.brand.com/agent",
+        display_name="X",
+        status="active",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return buyer
+
+    resolver = _FakeBrandAuthzResolver(authorized=True)
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            return GetProductsResponse(products=[])
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=resolver,
+            extract_identity=lambda _account, _agent: BrandIdentity(domain="brand.com", id="nike"),
+        ),
+    )
+
+    await handler.get_products(
+        GetProductsRequest(buying_mode="brief", brief="any"),
+        ToolContext(metadata={"adcp.auth_info": _signed_auth(buyer.agent_url)}),
+    )
+
+    assert resolver.calls[0]["brand_id"] == "nike"
+
+
+# ---------------------------------------------------------------------------
+# Denied path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_denied_request_raises_permission_denied(executor) -> None:
+    """Rejection: ``is_authorized`` returns False → ``PERMISSION_DENIED``
+    with the cross-tenant-safe denial message, ``recovery="correctable"``,
+    no ``details``. Platform method does NOT run."""
+    from adcp.types import GetProductsRequest, GetProductsResponse
+
+    buyer = BuyerAgent(
+        agent_url="https://attacker.example/agent",
+        display_name="Attacker",
+        status="active",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return buyer
+
+    method_ran = False
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            nonlocal method_ran
+            method_ran = True
+            return GetProductsResponse(products=[])
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=_FakeBrandAuthzResolver(authorized=False),
+            extract_identity=lambda _account, _agent: BrandIdentity(domain="brand.com"),
+        ),
+    )
+
+    with pytest.raises(AdcpError) as exc_info:
+        await handler.get_products(
+            GetProductsRequest(buying_mode="brief", brief="any"),
+            ToolContext(metadata={"adcp.auth_info": _signed_auth(buyer.agent_url)}),
+        )
+
+    assert exc_info.value.code == "PERMISSION_DENIED"
+    assert exc_info.value.recovery == "correctable"
+    # Cross-tenant onboarding-oracle clamp: the wire-level message MUST
+    # be the SAME bytes as the Tier 2 unrecognized-agent rejection so
+    # the message itself is not a discriminator between the two gates.
+    assert "Buyer agent is not authorized for this seller" in str(exc_info.value)
+    assert method_ran is False
+
+
+@pytest.mark.asyncio
+async def test_denied_omits_details_payload(executor) -> None:
+    """The denial MUST NOT carry a ``details`` payload — same posture
+    as Tier 2's unrecognized-agent rejection (omit-on-unestablished-
+    identity rule)."""
+    from adcp.types import GetProductsRequest
+
+    buyer = BuyerAgent(
+        agent_url="https://ads.brand.com/agent",
+        display_name="X",
+        status="active",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return buyer
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            raise AssertionError("should not reach platform method")
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=_FakeBrandAuthzResolver(authorized=False),
+            extract_identity=lambda _account, _agent: BrandIdentity(domain="brand.com"),
+        ),
+    )
+
+    with pytest.raises(AdcpError) as exc_info:
+        await handler.get_products(
+            GetProductsRequest(buying_mode="brief", brief="any"),
+            ToolContext(metadata={"adcp.auth_info": _signed_auth(buyer.agent_url)}),
+        )
+
+    # AdcpError.details defaults to ``{}`` — matches the Tier 2
+    # unrecognized-agent rejection shape (no enumerated discriminator).
+    assert exc_info.value.details == {}
+
+
+# ---------------------------------------------------------------------------
+# Skip paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_buyer_agent_skips_gate(executor) -> None:
+    """Tier 3 wired without Tier 2 → no buyer_agent to authorize → gate
+    is a silent no-op. The framework does not synthesize a fake
+    buyer-agent identity from the AuthInfo credential."""
+    from adcp.types import GetProductsRequest, GetProductsResponse
+
+    resolver = _FakeBrandAuthzResolver(authorized=False)
+    method_ran = False
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            nonlocal method_ran
+            method_ran = True
+            return GetProductsResponse(products=[])
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        # No buyer_agent_registry wired.
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=resolver,
+            extract_identity=lambda _account, _agent: BrandIdentity(domain="brand.com"),
+        ),
+    )
+
+    await handler.get_products(
+        GetProductsRequest(buying_mode="brief", brief="any"),
+        ToolContext(metadata={}),
+    )
+
+    assert method_ran is True
+    assert resolver.calls == []  # Gate did not fire.
+
+
+@pytest.mark.asyncio
+async def test_extractor_returns_none_skips_gate(executor) -> None:
+    """When the extractor returns ``None`` (adopter says "this request
+    has no brand to bind against"), the gate skips. The platform method
+    runs without consulting the resolver."""
+    from adcp.types import GetProductsRequest, GetProductsResponse
+
+    buyer = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="X",
+        status="active",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return buyer
+
+    resolver = _FakeBrandAuthzResolver(authorized=False)
+    method_ran = False
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            nonlocal method_ran
+            method_ran = True
+            return GetProductsResponse(products=[])
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=resolver,
+            # Adopter signals "no brand" — gate skips.
+            extract_identity=lambda _account, _agent: None,
+        ),
+    )
+
+    await handler.get_products(
+        GetProductsRequest(buying_mode="brief", brief="any"),
+        ToolContext(metadata={"adcp.auth_info": _signed_auth(buyer.agent_url)}),
+    )
+
+    assert method_ran is True
+    assert resolver.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Async extractor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_extractor_is_awaited(executor) -> None:
+    """The extractor MAY be async — adopters fetching brand identity
+    from a remote registry shouldn't have to wrap in
+    :func:`asyncio.to_thread`. The framework awaits when the return
+    value is an awaitable."""
+    from adcp.types import GetProductsRequest, GetProductsResponse
+
+    buyer = BuyerAgent(
+        agent_url="https://ads.brand.com/agent",
+        display_name="X",
+        status="active",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return buyer
+
+    resolver = _FakeBrandAuthzResolver(authorized=True)
+
+    async def async_extract(_account: Any, _agent: Any) -> BrandIdentity:
+        return BrandIdentity(domain="brand.com", id="nike")
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            return GetProductsResponse(products=[])
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=resolver,
+            extract_identity=async_extract,
+        ),
+    )
+
+    await handler.get_products(
+        GetProductsRequest(buying_mode="brief", brief="any"),
+        ToolContext(metadata={"adcp.auth_info": _signed_auth(buyer.agent_url)}),
+    )
+
+    assert resolver.calls[0]["brand_id"] == "nike"
+
+
+# ---------------------------------------------------------------------------
+# Three-tier conformance chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_three_tier_chain_orders_tier2_before_tier3(executor) -> None:
+    """End-to-end conformance: Tier 2 (BuyerAgentRegistry) MUST run
+    before Tier 3 (brand-authz). A suspended buyer agent rejects at
+    Tier 2 with ``AGENT_SUSPENDED`` — the brand-authz resolver is
+    never consulted. This pins the ordering so a future refactor
+    can't accidentally invert it and leak a Tier 3 binding decision
+    for a suspended agent."""
+    from adcp.types import GetProductsRequest
+
+    suspended = BuyerAgent(
+        agent_url="https://agent.example/",
+        display_name="X",
+        status="suspended",
+    )
+
+    async def lookup(agent_url: str) -> BuyerAgent | None:
+        return suspended
+
+    resolver = _FakeBrandAuthzResolver(authorized=True)
+
+    class _Platform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities()
+        accounts = SingletonAccounts(account_id="hello")
+
+        async def get_products(self, req, ctx):
+            raise AssertionError("should not reach platform method")
+
+    handler = PlatformHandler(
+        _Platform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+        buyer_agent_registry=signing_only_registry(lookup),
+        brand_authorization_gate=BrandAuthorizationGate(
+            resolver=resolver,
+            extract_identity=lambda _account, _agent: BrandIdentity(domain="brand.com"),
+        ),
+    )
+
+    with pytest.raises(AdcpError) as exc_info:
+        await handler.get_products(
+            GetProductsRequest(buying_mode="brief", brief="any"),
+            ToolContext(metadata={"adcp.auth_info": _signed_auth(suspended.agent_url)}),
+        )
+
+    assert exc_info.value.code == "AGENT_SUSPENDED"
+    # Tier 3 resolver was NOT consulted — the chain short-circuited at
+    # Tier 2 per the spec ordering.
+    assert resolver.calls == []


### PR DESCRIPTION
## Summary

Final stage of issue #350 — closes the v3-identity roadmap by wiring the `BrandAuthorizationResolver` from PR #770 into the framework's dispatch path. Adopters can now opt into per-brand authorization via two new `serve()` kwargs, matching the opt-in shape of Tier 2's `buyer_agent_registry`.

After this lands, all three v3 identity tiers are framework-enforced when the adopter wires them:

| Tier | What | Surface |
|---|---|---|
| 1 | Cryptographic identity (signed request → JWKS via brand.json) | `verify_starlette_request` + `BrandJsonJwksResolver` (PR #770) |
| 2 | Commercial recognition (BuyerAgent registry) | `serve(buyer_agent_registry=...)` (shipped earlier) |
| 3 | **Per-brand authorization (agent ↔ brand binding)** | `serve(brand_authz_resolver=..., brand_identity_resolver=...)` (**this PR**) |

## Surface

```python
serve(
    ...,
    brand_authz_resolver: BrandAuthorizationResolver | None = None,
    brand_identity_resolver: Callable[
        [Account, BuyerAgent | None],
        BrandIdentity | None | Awaitable[BrandIdentity | None],
    ] | None = None,
)
```

**Both must be wired together.** Partial wiring raises `ValueError` at boot — a resolver without an extractor has no brand to check; an extractor without a resolver has nothing to do.

## Dispatch sequence

```
inbound request
  → Tier 2: registry.resolve_by_(agent_url|credential) → BuyerAgent | None
       ── suspended/blocked → AGENT_SUSPENDED / AGENT_BLOCKED (short-circuit)
  → AccountStore.resolve(ref, auth_info) → Account
  → NEW: Tier 3 brand-authz gate
       ── extract_identity(account, buyer_agent) → BrandIdentity | None
       ── (if None: skip — adopter says no brand to bind against)
       ── resolver.is_authorized(agent_url, brand_domain, brand_id?) → bool
       ── (if False: PERMISSION_DENIED, identical message bytes to Tier 2)
  → platform method runs
```

The gate is a no-op when no `BuyerAgent` has been resolved (Tier 2 not wired) — brand authorization without a subject identity has nothing to authorize.

## Denial surface

`PERMISSION_DENIED` with `recovery="correctable"`, identical message bytes to the Tier 2 unrecognized-agent rejection so the wire-level `error.message` is not a side channel discriminating the two gates. `details` defaults to `{}` (omit-on-unestablished-identity rule, same as Tier 2).

The spec-shape codes (`request_signature_brand_origin_mismatch` / `_agent_not_in_brand_json`) belong to the verifier-side wire path — issue #776 will plumb the `BrandJsonJwksResolver` source discriminant through to the verifier so `check_key_origin_consistency` (landed in PR #775) can be invoked with the publisher-pin carve-out per spec #3690 step 7. That's verifier-side integration, separate concern from this dispatch-layer gate.

## Timing-oracle defense

Reuses the `PermissionDeniedBudget` from Tier 2. The brand.json fetch path's natural variance (cache hit vs miss vs stale-on-error) is larger than the registry-lookup variance Tier 2 absorbs, so the budget here is a floor — it prevents the cache-hit-authorized vs cache-hit-rejected paths from leaking timing-distinguishable decisions on the happy-cache path (the common case).

## What's in this PR

| File | Change |
|---|---|
| `src/adcp/decisioning/brand_authz_gate.py` (new) | `BrandIdentity` dataclass (domain + optional id), `BrandIdentityResolver` callable type (sync OR async), `BrandAuthorizationGate` frozen bundle pairing (resolver, extractor) atomically |
| `src/adcp/decisioning/handler.py` | `_enforce_brand_authorization` helper next to `_resolve_buyer_agent`; PlatformHandler accepts `brand_authorization_gate`; `_resolve_account` invokes the gate after `accounts.resolve` |
| `src/adcp/decisioning/serve.py` | New kwargs on both `create_adcp_server_from_platform` and `serve`. Bundles into `BrandAuthorizationGate`. Boot validation raises `ValueError` on partial wiring |
| `tests/test_decisioning_brand_authz_dispatch.py` (new) | 11 tests |

## Tests

11 new tests covering:
- Boot validation: resolver-only and extractor-only both raise `ValueError`; neither wired is back-compat.
- Authorized path: extractor runs → resolver runs → platform method runs.
- Authorized with `brand_id`: propagation through to resolver.
- Denied path: rejection emits `PERMISSION_DENIED` with the cross-tenant-safe message; platform method does NOT run.
- Denied `details == {}`: omit-on-unestablished-identity per Tier 2 parity.
- No-buyer-agent skip: Tier 3 silently passes when Tier 2 isn't wired.
- Extractor-returns-None skip: adopter signals "no brand to bind against".
- Async extractor: framework awaits when the return is an awaitable.
- **Three-tier conformance**: Tier 2 rejects a suspended agent BEFORE the Tier 3 resolver is consulted. Pins the ordering against future refactor.

Full impacted surface (1244 tests across `decision/buyer_agent/brand/registry/dispatch` keyword grep) remains green. ruff + mypy clean.

## What's deferred (not blocking)

- **Issue #776** — plumbing the JWKS-source discriminant (brand.json walk vs publisher pin) through `BrandJsonJwksResolver` so the verifier path can invoke `check_key_origin_consistency` with the publisher-pin carve-out per spec #3690 step 7. Verifier-side integration, separate concern from this dispatch-layer gate.
- **Issue #777** — package-wide IDNA 2003 → IDNA 2008 migration across the four `host.encode("idna")` callsites. Separate spec-conformance pass.

Closes #350.

## Test plan

- [ ] CI green on Python 3.10–3.13
- [ ] Argus AI reviewer pass on the timing-oracle posture and the message-byte-identity property
- [ ] Downstream import smoke (new symbols not re-exported from `adcp.decisioning` — by design, they're framework-internal until adopters need them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)