### PR TITLE
fix(decisioning): signal-owned specialism requires only get_signals

### DIFF
--- a/src/adcp/decisioning/dispatch.py
+++ b/src/adcp/decisioning/dispatch.py
@@ -206,8 +206,13 @@ REQUIRED_METHODS_PER_SPECIALISM: dict[str, frozenset[str]] = {
             "sync_catalogs",
         }
     ),
-    # Signals specialisms — third-party data brokers and first-party
-    # data providers share the same SignalsPlatform Protocol surface.
+    # Signals specialisms — two distinct wire surfaces:
+    # * signal-marketplace: third-party data brokers (LiveRamp, Oracle
+    #   Data Cloud, etc.) that provision signals onto buyer destinations.
+    #   Requires both get_signals (catalog) + activate_signal (provisioning).
+    # * signal-owned: first-party/publisher data already active on the
+    #   seller's own inventory. No buyer-triggered activation step —
+    #   get_signals alone is sufficient for the discovery/catalog use case.
     "signal-marketplace": frozenset(
         {
             "get_signals",
@@ -217,7 +222,6 @@ REQUIRED_METHODS_PER_SPECIALISM: dict[str, frozenset[str]] = {
     "signal-owned": frozenset(
         {
             "get_signals",
-            "activate_signal",
         }
     ),
     # Audience-sync — first-party CRM audience push with delta upsert.

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -265,6 +265,11 @@ _SIGNALS_ADVERTISED_TOOLS: frozenset[str] = frozenset(
         "activate_signal",
     }
 )
+#: Narrower tool set for ``signal-owned`` (first-party/publisher signals).
+#: Owned signals are already active on the seller's inventory — there is no
+#: buyer-triggered destination provisioning step, so ``activate_signal`` is
+#: not part of the wire surface for this specialism.
+_SIGNALS_OWNED_ADVERTISED_TOOLS: frozenset[str] = frozenset({"get_signals"})
 _AUDIENCE_ADVERTISED_TOOLS: frozenset[str] = frozenset(
     {
         "sync_audiences",
@@ -373,9 +378,10 @@ SPECIALISM_TO_ADVERTISED_TOOLS: dict[str, frozenset[str]] = {
     "creative-generative": _CREATIVE_ADVERTISED_TOOLS,
     "creative-template": _CREATIVE_ADVERTISED_TOOLS,
     "creative-ad-server": _CREATIVE_ADVERTISED_TOOLS,
-    # Signals — marketplace + owned share the same wire surface.
+    # Signals — marketplace exposes get_signals + activate_signal;
+    # owned exposes get_signals only (no buyer-triggered provisioning).
     "signal-marketplace": _SIGNALS_ADVERTISED_TOOLS,
-    "signal-owned": _SIGNALS_ADVERTISED_TOOLS,
+    "signal-owned": _SIGNALS_OWNED_ADVERTISED_TOOLS,
     # Audience.
     "audience-sync": _AUDIENCE_ADVERTISED_TOOLS,
     # Governance — spend-authority + delivery-monitor share the

--- a/src/adcp/decisioning/specialisms/__init__.py
+++ b/src/adcp/decisioning/specialisms/__init__.py
@@ -13,8 +13,11 @@ Public surface re-exported from :mod:`adcp.decisioning.specialisms`:
   (non-guaranteed, guaranteed, broadcast-tv, social, proposal-mode,
   catalog-driven) under one unified hybrid shape.
 * :class:`SignalsPlatform` — covers ``signal-marketplace`` +
-  ``signal-owned``. Two methods: ``get_signals`` (catalog discovery)
-  and ``activate_signal`` (provisioning onto destination platforms).
+  ``signal-owned``. ``get_signals`` (catalog discovery) is required
+  for both. ``activate_signal`` (provisioning onto destination
+  platforms) is required for ``signal-marketplace`` only —
+  ``signal-owned`` platforms expose first-party signals already active
+  on their inventory and do not expose buyer-triggered activation.
 * :class:`AudiencePlatform` — covers ``audience-sync``. Two methods:
   ``sync_audiences`` (push first-party CRM audiences with delta
   upsert) and ``poll_audience_statuses`` (batch state read).

--- a/src/adcp/decisioning/specialisms/signals.py
+++ b/src/adcp/decisioning/specialisms/signals.py
@@ -6,10 +6,15 @@ brokers — LiveRamp, Oracle Data Cloud, third-party DMPs) or
 data, retailer customer-graph) implements the methods on this Protocol.
 The slugs mirror ``schemas/cache/enums/specialism.json``.
 
-Two methods:
+**Required methods by specialism:**
 
-* :meth:`get_signals` — sync catalog discovery
-* :meth:`activate_signal` — sync provisioning onto destination platforms
+* ``signal-marketplace`` — ``get_signals`` + ``activate_signal``:
+  third-party data brokers must expose both catalog discovery and
+  buyer-triggered destination provisioning.
+* ``signal-owned`` — ``get_signals`` only: first-party/publisher
+  signals are already active on the seller's inventory; there is no
+  buyer-triggered provisioning step. ``activate_signal`` MUST NOT be
+  required or advertised for this specialism.
 
 Async story: ``activate_signal`` is sync at the wire level — its
 response union has no ``Submitted`` arm. Long-running activation
@@ -18,6 +23,15 @@ hours) return :class:`ActivateSignalSuccessResponse` immediately with
 ``deployments`` rows in ``pending`` state, then emit
 ``ctx.publish_status_change(resource_type='signal', ...)`` events as
 each deployment reaches ``activating`` / ``deployed`` / ``failed``.
+
+**Runtime isinstance note:** Because this Protocol defines both
+``get_signals`` and ``activate_signal``, ``isinstance(platform,
+SignalsPlatform)`` requires both methods. A ``signal-owned`` platform
+that correctly omits ``activate_signal`` will fail the ``isinstance``
+check. Use :func:`adcp.decisioning.dispatch.validate_platform` (not
+``isinstance``) as the conformance check at server boot — it reads
+``REQUIRED_METHODS_PER_SPECIALISM``, which correctly requires only
+``get_signals`` for ``signal-owned``.
 
 Mirrors the JS-side ``SignalsPlatform`` interface at
 ``src/lib/server/decisioning/specialisms/signals.ts``.

--- a/tests/test_decisioning_advertised_per_specialism.py
+++ b/tests/test_decisioning_advertised_per_specialism.py
@@ -101,6 +101,14 @@ class _SignalsOnlyPlatform(DecisioningPlatform):
         return {}
 
 
+class _SignalsOwnedPlatform(DecisioningPlatform):
+    capabilities = DecisioningCapabilities(specialisms=["signal-owned"])
+    accounts = SingletonAccounts(account_id="signals-owned")
+
+    def get_signals(self, req, ctx):
+        return {"signals": []}
+
+
 class _CreativeOnlyPlatform(DecisioningPlatform):
     capabilities = DecisioningCapabilities(specialisms=["creative-generative"])
     accounts = SingletonAccounts(account_id="creative-only")
@@ -166,6 +174,23 @@ def test_signals_only_does_not_advertise_sales_tools(executor) -> None:
     }
     leaked = forbidden & tools
     assert not leaked, f"signals-only leaked: {sorted(leaked)}"
+
+
+def test_signal_owned_advertises_get_signals_not_activate_signal(executor) -> None:
+    """signal-owned platforms expose get_signals only — no activate_signal.
+    Owned/first-party signals are already active on the seller's inventory."""
+    handler = PlatformHandler(
+        _SignalsOwnedPlatform(),
+        executor=executor,
+        registry=InMemoryTaskRegistry(),
+    )
+    tools = {tool["name"] for tool in get_tools_for_handler(handler)}
+
+    assert "get_signals" in tools
+    assert "activate_signal" not in tools, (
+        "signal-owned must not advertise activate_signal — owned signals "
+        "have no buyer-triggered provisioning step"
+    )
 
 
 def test_creative_only_does_not_advertise_sales_or_signals_tools(executor) -> None:

--- a/tests/test_decisioning_specialisms.py
+++ b/tests/test_decisioning_specialisms.py
@@ -129,8 +129,9 @@ def test_validate_platform_enforces_signal_marketplace_methods() -> None:
 
 
 def test_validate_platform_enforces_signal_owned_methods() -> None:
-    """``signal-owned`` shares the SignalsPlatform Protocol surface —
-    same required-method enforcement."""
+    """``signal-owned`` requires only ``get_signals`` — no ``activate_signal``.
+    Owned/first-party signals are already active on the seller's inventory;
+    there is no buyer-triggered provisioning step."""
 
     class _PartialSignalOwnedPlatform(DecisioningPlatform):
         capabilities = DecisioningCapabilities(specialisms=["signal-owned"])
@@ -142,7 +143,21 @@ def test_validate_platform_enforces_signal_owned_methods() -> None:
     assert exc_info.value.code == "INVALID_REQUEST"
     missing_methods = {m["method"] for m in exc_info.value.details["missing"]}
     assert "get_signals" in missing_methods
-    assert "activate_signal" in missing_methods
+    assert "activate_signal" not in missing_methods
+
+
+def test_validate_platform_passes_signal_owned_without_activate_signal() -> None:
+    """A ``signal-owned`` platform implementing only ``get_signals`` passes
+    validation — ``activate_signal`` must NOT be required."""
+
+    class _OwnedSignalsPlatform(DecisioningPlatform):
+        capabilities = DecisioningCapabilities(specialisms=["signal-owned"])
+        accounts = SingletonAccounts(account_id="hello")
+
+        def get_signals(self, req, ctx):
+            return {"signals": []}
+
+    validate_platform(_OwnedSignalsPlatform())
 
 
 def test_validate_platform_passes_for_complete_signals_platform() -> None:
@@ -161,13 +176,20 @@ def test_validate_platform_passes_for_complete_signals_platform() -> None:
     validate_platform(_CompleteSignalsPlatform())
 
 
-def test_signal_marketplace_and_signal_owned_share_method_set() -> None:
-    """Both signal specialisms gate on the same two methods. Drift in
-    REQUIRED_METHODS_PER_SPECIALISM here surfaces as a visible test
-    failure since they should track together."""
-    expected = {"get_signals", "activate_signal"}
-    assert REQUIRED_METHODS_PER_SPECIALISM["signal-marketplace"] == expected
-    assert REQUIRED_METHODS_PER_SPECIALISM["signal-owned"] == expected
+def test_signal_marketplace_requires_both_methods() -> None:
+    """signal-marketplace (third-party brokers) requires both get_signals
+    and activate_signal — catalog discovery + destination provisioning."""
+    assert REQUIRED_METHODS_PER_SPECIALISM["signal-marketplace"] == {
+        "get_signals",
+        "activate_signal",
+    }
+
+
+def test_signal_owned_requires_only_get_signals() -> None:
+    """signal-owned (first-party/publisher signals) requires only get_signals.
+    Owned signals are already active on the seller's inventory — no
+    buyer-triggered activation step exists."""
+    assert REQUIRED_METHODS_PER_SPECIALISM["signal-owned"] == {"get_signals"}
 
 
 # ---- AudiencePlatform ----


### PR DESCRIPTION
Closes #787

`signal-owned` (first-party/publisher signals) previously required and advertised both `get_signals` and `activate_signal`, identical to `signal-marketplace`. This forced owned-signal sellers to either expose a no-op activation API or avoid the specialism entirely.

This PR implements Option 1 from the issue: make `signal-owned` discovery-only. Owned signals are already active on the seller's inventory — no buyer-triggered destination provisioning step exists.

## What changed

- `REQUIRED_METHODS_PER_SPECIALISM["signal-owned"]` → `{"get_signals"}` only (removed `activate_signal`). `validate_platform` no longer fails at boot for `signal-owned` platforms that don't implement `activate_signal`.
- `SPECIALISM_TO_ADVERTISED_TOOLS["signal-owned"]` → new `_SIGNALS_OWNED_ADVERTISED_TOOLS = frozenset({"get_signals"})`. `tools/list` for `signal-owned` platforms now exposes only `get_signals`.
- `SignalsPlatform` docstring updated to document the per-specialism split and the `@runtime_checkable` gap: a `signal-owned` platform correctly omitting `activate_signal` fails `isinstance(platform, SignalsPlatform)`; `validate_platform` is the correct conformance check.
- `specialisms/__init__.py` updated to document the divergence.

## What tested

- `pytest tests/test_decisioning_specialisms.py tests/test_decisioning_advertised_per_specialism.py` — 56 passed
- `pytest tests/ --ignore=tests/conformance --ignore=tests/integration -k "not test_real_tls"` — **4314 passed, 18 skipped, 1 xfailed**
- `mypy src/adcp/decisioning/dispatch.py src/adcp/decisioning/handler.py src/adcp/decisioning/specialisms/` — clean
- `ruff check` on all modified files — clean

## Pre-PR review

- **code-reviewer**: approved — no blockers. Nits: `_SIGNALS_ADVERTISED_TOOLS` could be renamed `_SIGNALS_MARKETPLACE_ADVERTISED_TOOLS` for symmetry with the new `_SIGNALS_OWNED_ADVERTISED_TOOLS`; `test_signals_platform_runtime_check_fails_when_methods_missing` could add a comment clarifying the gap is a Protocol structural limitation, not a bug. Schema manifest conflict documented in PR body (see below).
- **ad-tech-protocol-expert**: approved — the manifest discrepancy is spec errata; `exercised_tools` describes what a buyer *may encounter*, not what a seller *must implement*. Semantically correct as Option 1.

## Open question for reviewer: spec manifest discrepancy

`schemas/cache/3.0/manifest.json` lists `activate_signal` in both `tools.activate_signal.specialisms` and `signal_owned.exercised_tools`. This PR diverges from that. Two positions:

- **Option A (this PR):** `exercised_tools` is spec errata — it describes storyboard coverage, not conformance requirements. Keeping `activate_signal` advertised for `signal-owned` surfaces it in `tools/list` even for platforms that can't implement it (misleading buyers). File errata against adcontextprotocol.org.
- **Option B (alternative):** Keep `activate_signal` in `SPECIALISM_TO_ADVERTISED_TOOLS["signal-owned"]` per the manifest. Drop it from `REQUIRED_METHODS_PER_SPECIALISM["signal-owned"]`. Add `self._require_platform_method("activate_signal")` to the handler shim so unimplemented platforms return `UNSUPPORTED_FEATURE` instead of `INTERNAL_ERROR`. One-line revert: `handler.py:383 "signal-owned": _SIGNALS_ADVERTISED_TOOLS`.

The issue author's explicit ask is Option A. If Option B is preferred, only `handler.py` line 383 needs reverting plus the `_require_platform_method` call addition in the `activate_signal` shim.

**Follow-up (not in this PR):** The `SignalsPlatform` Protocol should eventually be split into `SignalsMarketplacePlatform` / `SignalsOwnedPlatform` to resolve the `@runtime_checkable` structural gap.

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Wj8hJ62PeTgk6J3aKn4PXp