### PR TITLE
ci: replace third-party Pages deploy action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,20 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
 
@@ -30,8 +39,16 @@ jobs:
         run: |
           pdoc --html --output-dir docs/api adcp
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/api/adcp
+          path: docs/api/adcp
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+        with:
+          artifact_name: github-pages


### PR DESCRIPTION
## Summary
- replace `peaceiris/actions-gh-pages` with GitHub-native Pages artifact deployment
- use `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`, and `actions/deploy-pages@v5`
- switch docs workflow permissions from broad `contents: write` to `contents: read`, `pages: write`, and `id-token: write`

## Validation
- `python3` YAML parse for all `.github/workflows/*.yml`
- `git diff --check`
- pre-commit YAML/file checks during commit
- verified docs workflow action metadata resolves to Node 24 for JavaScript actions

## Deployment note
The repository Pages source is currently configured as legacy `gh-pages` branch publishing. After this lands, Pages should be switched to GitHub Actions/workflow publishing so `actions/deploy-pages` owns deployments.
