### PR TITLE
ci: tolerate generated docs import errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build docs
         run: |
-          pdoc --html --output-dir docs/api adcp
+          pdoc --html --skip-errors --output-dir docs/api adcp
 
       - name: Configure Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Summary
- add `--skip-errors` to the pdoc docs build so beta3 generated modules with import-time schema collisions warn instead of failing the docs deploy

## Validation
- `uv run --extra docs pdoc --html --skip-errors --output-dir .context/docs-api-test adcp`
- `python3` YAML parse for all `.github/workflows/*.yml`
- `git diff --check`
- pre-commit YAML/file checks during commit

## Context
The new GitHub-native Pages workflow starts correctly now that Pages is in workflow mode and the `github-pages` environment allows `main`. The remaining failure was in the pre-existing pdoc build step before upload/deploy.
