### PR TITLE
fix(adagents): raise AdagentsBotMitigationError on HTTP 403 + cf-mitigated: challenge

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -49,6 +49,7 @@ from adcp.capabilities import (  # noqa: F401
 )
 from adcp.client import ADCPClient, ADCPMultiAgentClient, Checkpoint
 from adcp.exceptions import (  # noqa: F401
+    AdagentsBotMitigationError,
     AdagentsNotFoundError,
     AdagentsTimeoutError,
     AdagentsValidationError,
@@ -925,6 +926,7 @@ __all__ = [
     "AdagentsValidationError",
     "AdagentsNotFoundError",
     "AdagentsTimeoutError",
+    "AdagentsBotMitigationError",
     "ConfigurationError",
     "RegistryError",
     # Validation utilities

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -22,7 +22,12 @@ from urllib.parse import quote, urlparse
 import httpx
 from pydantic import Field
 
-from adcp.exceptions import AdagentsNotFoundError, AdagentsTimeoutError, AdagentsValidationError
+from adcp.exceptions import (
+    AdagentsBotMitigationError,
+    AdagentsNotFoundError,
+    AdagentsTimeoutError,
+    AdagentsValidationError,
+)
 from adcp.types.base import AdCPBaseModel
 from adcp.validation import ValidationError, validate_adagents
 
@@ -1076,6 +1081,10 @@ async def _fetch_adagents_url(
     if status_code == 404:
         parsed = urlparse(url)
         raise AdagentsNotFoundError(parsed.netloc)
+
+    if status_code == 403 and response_headers.get("cf-mitigated", "").lower() == "challenge":
+        parsed = urlparse(url)
+        raise AdagentsBotMitigationError(parsed.netloc)
 
     if status_code != 200:
         raise AdagentsValidationError(f"Failed to fetch adagents.json: HTTP {status_code}")

--- a/src/adcp/exceptions.py
+++ b/src/adcp/exceptions.py
@@ -285,6 +285,32 @@ class AdagentsTimeoutError(AdagentsValidationError):
         super().__init__(message, None, None, suggestion)
 
 
+class AdagentsBotMitigationError(AdagentsValidationError):
+    """adagents.json fetch was blocked by bot mitigation (e.g. Cloudflare challenge).
+
+    Raised when the server returns HTTP 403 with a ``cf-mitigated: challenge``
+    response header, indicating the request was scored as automated traffic at
+    the network edge rather than rejected for authorization reasons.
+
+    Callers that catch :class:`AdagentsValidationError` continue to work
+    unchanged; callers that need to distinguish bot-blocked fetches from other
+    validation failures can catch this subclass specifically.
+    """
+
+    def __init__(self, publisher_domain: str):
+        """Initialize bot mitigation error."""
+        message = (
+            f"adagents.json fetch blocked by bot mitigation for domain: {publisher_domain}"
+        )
+        suggestion = (
+            "The publisher's CDN or WAF is blocking programmatic fetches of "
+            "/.well-known/adagents.json as automated traffic.\n"
+            "     Ask the publisher to add an allowlist rule for AAO crawlers, "
+            "or contact adops@raptive.com if the domain is Raptive/CafeMedia-managed."
+        )
+        super().__init__(message, None, None, suggestion)
+
+
 class ADCPTaskError(ADCPError):
     """A task returned an ADCP error response.
 

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -925,6 +925,76 @@ class TestSSRFProtection:
             result = await fetch_adagents("example.com", client=mock_client)
         assert "authorized_agents" in result
 
+    @pytest.mark.asyncio
+    async def test_403_cf_mitigated_challenge_raises_bot_mitigation_error(self):
+        """HTTP 403 with cf-mitigated: challenge raises AdagentsBotMitigationError."""
+        from adcp.adagents import fetch_adagents
+        from adcp.exceptions import AdagentsBotMitigationError
+
+        mock_client = make_url_dispatching_client(
+            {
+                "https://cafemedia.com/.well-known/adagents.json": (
+                    None,
+                    403,
+                    {"cf-mitigated": "challenge"},
+                )
+            }
+        )
+        with pytest.raises(AdagentsBotMitigationError, match="cafemedia.com"):
+            await fetch_adagents("cafemedia.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_bot_mitigation_error_is_subclass_of_validation_error(self):
+        """AdagentsBotMitigationError is caught by existing AdagentsValidationError handlers."""
+        from adcp.adagents import fetch_adagents
+        from adcp.exceptions import AdagentsBotMitigationError, AdagentsValidationError
+
+        mock_client = make_url_dispatching_client(
+            {
+                "https://cafemedia.com/.well-known/adagents.json": (
+                    None,
+                    403,
+                    {"cf-mitigated": "challenge"},
+                )
+            }
+        )
+        with pytest.raises(AdagentsValidationError):
+            await fetch_adagents("cafemedia.com", client=mock_client)
+
+        assert issubclass(AdagentsBotMitigationError, AdagentsValidationError)
+
+    @pytest.mark.asyncio
+    async def test_403_without_cf_mitigated_raises_generic_validation_error(self):
+        """Plain HTTP 403 (no cf-mitigated header) raises AdagentsValidationError, not bot error."""
+        from adcp.adagents import fetch_adagents
+        from adcp.exceptions import AdagentsBotMitigationError, AdagentsValidationError
+
+        mock_client = make_url_dispatching_client(
+            {"https://example.com/.well-known/adagents.json": (None, 403, {})}
+        )
+        with pytest.raises(AdagentsValidationError, match="HTTP 403") as exc_info:
+            await fetch_adagents("example.com", client=mock_client)
+        assert not isinstance(exc_info.value, AdagentsBotMitigationError)
+
+    @pytest.mark.asyncio
+    async def test_403_cf_mitigated_non_challenge_raises_generic_validation_error(self):
+        """HTTP 403 with cf-mitigated: other-value does not raise bot mitigation error."""
+        from adcp.adagents import fetch_adagents
+        from adcp.exceptions import AdagentsBotMitigationError, AdagentsValidationError
+
+        mock_client = make_url_dispatching_client(
+            {
+                "https://example.com/.well-known/adagents.json": (
+                    None,
+                    403,
+                    {"cf-mitigated": "other"},
+                )
+            }
+        )
+        with pytest.raises(AdagentsValidationError, match="HTTP 403") as exc_info:
+            await fetch_adagents("example.com", client=mock_client)
+        assert not isinstance(exc_info.value, AdagentsBotMitigationError)
+
 
 class TestVerifyAgentForProperty:
     """Test convenience wrapper for fetching and verifying in one call."""


### PR DESCRIPTION
Closes #801

## Summary

When Cloudflare's bot-management layer blocks an `adagents.json` fetch with HTTP 403 + `cf-mitigated: challenge`, the SDK now raises `AdagentsBotMitigationError` (a subclass of `AdagentsValidationError`) instead of the generic `"Failed to fetch adagents.json: HTTP 403"`. The new exception carries an actionable suggestion pointing adopters to request a publisher allowlist rule, with a direct contact hint for Raptive/CafeMedia-managed domains.

Existing callers that catch `AdagentsValidationError` continue working unchanged. Callers that need to distinguish bot-blocked fetches (e.g. to surface "ask publisher to allowlist AAO crawlers" in a UI) can now catch `AdagentsBotMitigationError` specifically.

The detection is narrow: only `status_code == 403` **and** `cf-mitigated: challenge` (case-insensitive) triggers the new path. Plain 403s and other `cf-mitigated` values fall through to the existing generic error.

## What was tested

- `pytest tests/test_adagents.py -k "test_403 or test_bot_miti"` — 4 new tests pass
- `pytest tests/test_adagents.py` — 191/191 pass
- `mypy src/adcp/exceptions.py src/adcp/adagents.py` — clean
- `ruff check src/adcp/exceptions.py src/adcp/adagents.py src/adcp/__init__.py` — clean

New tests cover:
- `test_403_cf_mitigated_challenge_raises_bot_mitigation_error` — exact exception type
- `test_bot_mitigation_error_is_subclass_of_validation_error` — backward-compat catch
- `test_403_without_cf_mitigated_raises_generic_validation_error` — plain 403 falls through
- `test_403_cf_mitigated_non_challenge_raises_generic_validation_error` — other cf-mitigated values fall through

## Pre-PR review

- **code-reviewer**: approved — no blockers. Nits: (1) `parsed = urlparse(url)` re-parses an already-parsed URL (pre-existing pattern from the 404 block; not new debt); (2) real brand names in suggestion text (`adops@raptive.com` — taken from the publisher's own adagents.json `contact` field per the issue; retained as actionable remediation).
- **dx-expert**: approved — no blockers. Nits: (1) `publisher_domain` not stored as `self.publisher_domain` (consistent with sibling exceptions `AdagentsNotFoundError` / `AdagentsTimeoutError`; worth a follow-up to fix all three); (2) `contact` param was dead at callsite — **fixed pre-merge** (removed the optional parameter entirely; can be re-added when contact-block parsing is wired up).

**Nits surfaced (not fixed in this PR):**
- `parsed = urlparse(url)` re-parse pre-existing pattern (lines 1082–1083 and 1085–1086 both parse `url`; the top-level `parsed` binding at line 1045 could be reused for both)
- `self.publisher_domain` not set as instance attribute (follow-up to make `AdagentsNotFoundError`, `AdagentsTimeoutError`, and `AdagentsBotMitigationError` consistent)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 802` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01FJT7xY1j8uAVinQ9gWRR12

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJT7xY1j8uAVinQ9gWRR12)_