### PR TITLE
fix(adagents): raise AdagentsBotMitigationError on HTTP 403 + cf-mitigated challenge/managed

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -49,6 +49,7 @@ from adcp.capabilities import (  # noqa: F401
 )
 from adcp.client import ADCPClient, ADCPMultiAgentClient, Checkpoint
 from adcp.exceptions import (  # noqa: F401
+    AdagentsBotMitigationError,
     AdagentsNotFoundError,
     AdagentsTimeoutError,
     AdagentsValidationError,
@@ -922,6 +923,7 @@ __all__ = [
     "ADCPSigningRequiredError",
     "ADCPWebhookError",
     "ADCPWebhookSignatureError",
+    "AdagentsBotMitigationError",
     "AdagentsValidationError",
     "AdagentsNotFoundError",
     "AdagentsTimeoutError",

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -1087,12 +1087,10 @@ async def _fetch_adagents_url(
         parsed = urlparse(url)
         raise AdagentsNotFoundError(parsed.netloc)
 
-    if status_code == 403 and response_headers.get("cf-mitigated", "").lower() in {
-        "challenge",
-        "managed",
-    }:
+    cf_mitigated = response_headers.get("cf-mitigated", "").lower()
+    if status_code == 403 and cf_mitigated in {"challenge", "managed"}:
         parsed = urlparse(url)
-        raise AdagentsBotMitigationError(parsed.netloc)
+        raise AdagentsBotMitigationError(parsed.netloc, mitigation_type=cf_mitigated)
 
     if status_code != 200:
         raise AdagentsValidationError(f"Failed to fetch adagents.json: HTTP {status_code}")

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -22,7 +22,12 @@ from urllib.parse import quote, urlparse
 import httpx
 from pydantic import Field
 
-from adcp.exceptions import AdagentsNotFoundError, AdagentsTimeoutError, AdagentsValidationError
+from adcp.exceptions import (
+    AdagentsBotMitigationError,
+    AdagentsNotFoundError,
+    AdagentsTimeoutError,
+    AdagentsValidationError,
+)
 from adcp.types.base import AdCPBaseModel
 from adcp.validation import ValidationError, validate_adagents
 
@@ -884,7 +889,12 @@ async def _try_managerdomain_fallback(
             manager_domain_normalized, timeout, user_agent, client=None
         )
         return data
-    except (AdagentsNotFoundError, AdagentsValidationError, AdagentsTimeoutError):
+    except (
+        AdagentsNotFoundError,
+        AdagentsValidationError,
+        AdagentsTimeoutError,
+        AdagentsBotMitigationError,
+    ):
         return None
 
 
@@ -939,7 +949,7 @@ async def validate_adagents_domain(
         )
     except AdagentsNotFoundError as direct_error:
         direct_error_msg = str(direct_error)
-    except (AdagentsValidationError, AdagentsTimeoutError) as e:
+    except (AdagentsValidationError, AdagentsTimeoutError, AdagentsBotMitigationError) as e:
         return AdAgentsValidationResult(
             domain=normalized,
             url=url,
@@ -993,7 +1003,7 @@ async def validate_adagents_domain(
                 f"manager domain {manager_normalized} did not serve adagents.json",
             ],
         )
-    except (AdagentsValidationError, AdagentsTimeoutError) as e:
+    except (AdagentsValidationError, AdagentsTimeoutError, AdagentsBotMitigationError) as e:
         return AdAgentsValidationResult(
             domain=normalized,
             url=url,
@@ -1076,6 +1086,13 @@ async def _fetch_adagents_url(
     if status_code == 404:
         parsed = urlparse(url)
         raise AdagentsNotFoundError(parsed.netloc)
+
+    if status_code == 403 and response_headers.get("cf-mitigated", "").lower() in {
+        "challenge",
+        "managed",
+    }:
+        parsed = urlparse(url)
+        raise AdagentsBotMitigationError(parsed.netloc)
 
     if status_code != 200:
         raise AdagentsValidationError(f"Failed to fetch adagents.json: HTTP {status_code}")
@@ -1924,6 +1941,9 @@ async def fetch_agent_authorizations(
             # Create authorization context
             return (domain, AuthorizationContext(properties))
 
+        except AdagentsBotMitigationError as e:
+            logger.warning("Bot mitigation blocked adagents.json fetch for %s: %s", domain, e)
+            return (domain, None)
         except (AdagentsNotFoundError, AdagentsValidationError, AdagentsTimeoutError):
             # Silently skip domains with missing or invalid adagents.json
             return (domain, None)

--- a/src/adcp/exceptions.py
+++ b/src/adcp/exceptions.py
@@ -289,8 +289,9 @@ class AdagentsBotMitigationError(ADCPError):
     """adagents.json fetch blocked by WAF bot mitigation (HTTP 403 with mitigation challenge).
 
     Raised when a publisher's CDN (commonly Cloudflare) returns HTTP 403 with a
-    ``cf-mitigated: challenge`` response header, indicating the SDK's HTTP client
-    fingerprint (TLS ClientHello, HTTP/2 SETTINGS) was scored as automated traffic.
+    ``cf-mitigated`` response header (values: ``challenge`` or ``managed``),
+    indicating the SDK's HTTP client fingerprint (TLS ClientHello, HTTP/2 SETTINGS)
+    was scored as automated traffic.
     This is a transport-layer refusal — the file was never fetched. Changing the
     User-Agent does not help.
 

--- a/src/adcp/exceptions.py
+++ b/src/adcp/exceptions.py
@@ -299,11 +299,11 @@ class AdagentsBotMitigationError(ADCPError):
     instead of fetching directly from the publisher.
     """
 
-    def __init__(self, publisher_domain: str):
+    def __init__(self, publisher_domain: str, mitigation_type: str = "challenge"):
         """Initialize bot mitigation error."""
         message = (
             f"adagents.json fetch blocked by bot mitigation on {publisher_domain} "
-            f"(HTTP 403, cf-mitigated: challenge)"
+            f"(HTTP 403, cf-mitigated: {mitigation_type})"
         )
         suggestion = (
             "The publisher's CDN is blocking programmatic HTTP clients at the "
@@ -315,6 +315,7 @@ class AdagentsBotMitigationError(ADCPError):
         )
         super().__init__(message, None, None, suggestion)
         self.publisher_domain = publisher_domain
+        self.mitigation_type = mitigation_type
 
 
 class ADCPTaskError(ADCPError):

--- a/src/adcp/exceptions.py
+++ b/src/adcp/exceptions.py
@@ -285,6 +285,38 @@ class AdagentsTimeoutError(AdagentsValidationError):
         super().__init__(message, None, None, suggestion)
 
 
+class AdagentsBotMitigationError(ADCPError):
+    """adagents.json fetch blocked by WAF bot mitigation (HTTP 403 with mitigation challenge).
+
+    Raised when a publisher's CDN (commonly Cloudflare) returns HTTP 403 with a
+    ``cf-mitigated: challenge`` response header, indicating the SDK's HTTP client
+    fingerprint (TLS ClientHello, HTTP/2 SETTINGS) was scored as automated traffic.
+    This is a transport-layer refusal — the file was never fetched. Changing the
+    User-Agent does not help.
+
+    The recommended recovery path for most callers post-5.7.0 is to use
+    ``fetch_agent_authorizations_from_directory()`` to query the AAO directory
+    instead of fetching directly from the publisher.
+    """
+
+    def __init__(self, publisher_domain: str):
+        """Initialize bot mitigation error."""
+        message = (
+            f"adagents.json fetch blocked by bot mitigation on {publisher_domain} "
+            f"(HTTP 403, cf-mitigated: challenge)"
+        )
+        suggestion = (
+            "The publisher's CDN is blocking programmatic HTTP clients at the "
+            "TLS/HTTP fingerprint level (not UA-based — curl succeeds). Recovery options:\n"
+            "     1. Contact the publisher to allowlist AAO crawler egress IPs.\n"
+            "     2. Use fetch_agent_authorizations_from_directory() to query the AAO "
+            "directory instead of fetching the publisher URL directly — the directory "
+            "bypasses publisher-side WAF entirely."
+        )
+        super().__init__(message, None, None, suggestion)
+        self.publisher_domain = publisher_domain
+
+
 class ADCPTaskError(ADCPError):
     """A task returned an ADCP error response.
 

--- a/tests/fixtures/public_api_snapshot.json
+++ b/tests/fixtures/public_api_snapshot.json
@@ -30,6 +30,7 @@
     "ActivateSignalResponse1",
     "ActivateSignalSuccessResponse",
     "AdAgentsValidationResult",
+    "AdagentsBotMitigationError",
     "AdagentsCacheEntry",
     "AdagentsEntryError",
     "AdagentsFetchResult",

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -692,6 +692,7 @@ class TestFetchAdagents:
         with pytest.raises(AdagentsBotMitigationError) as exc_info:
             await fetch_adagents("cafemedia.com", client=client)
         assert exc_info.value.publisher_domain == "cafemedia.com"
+        assert exc_info.value.mitigation_type == "challenge"
 
     @pytest.mark.asyncio
     async def test_cloudflare_managed_challenge_raises_bot_mitigation_error(self):
@@ -708,8 +709,9 @@ class TestFetchAdagents:
                 )
             }
         )
-        with pytest.raises(AdagentsBotMitigationError):
+        with pytest.raises(AdagentsBotMitigationError) as exc_info:
             await fetch_adagents("pub.example.com", client=client)
+        assert exc_info.value.mitigation_type == "managed"
 
     @pytest.mark.asyncio
     async def test_plain_403_does_not_raise_bot_mitigation_error(self):

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -674,6 +674,54 @@ class TestFetchAdagents:
         # Should stop after reasonable number of redirects (not go forever)
         assert call_count[0] <= 10
 
+    @pytest.mark.asyncio
+    async def test_cloudflare_challenge_raises_bot_mitigation_error(self):
+        """HTTP 403 + cf-mitigated: challenge raises AdagentsBotMitigationError."""
+        from adcp.adagents import fetch_adagents
+        from adcp.exceptions import AdagentsBotMitigationError
+
+        client = make_url_dispatching_client(
+            {
+                "https://cafemedia.com/.well-known/adagents.json": (
+                    None,
+                    403,
+                    {"cf-mitigated": "challenge"},
+                )
+            }
+        )
+        with pytest.raises(AdagentsBotMitigationError) as exc_info:
+            await fetch_adagents("cafemedia.com", client=client)
+        assert exc_info.value.publisher_domain == "cafemedia.com"
+
+    @pytest.mark.asyncio
+    async def test_cloudflare_managed_challenge_raises_bot_mitigation_error(self):
+        """HTTP 403 + cf-mitigated: managed also raises AdagentsBotMitigationError."""
+        from adcp.adagents import fetch_adagents
+        from adcp.exceptions import AdagentsBotMitigationError
+
+        client = make_url_dispatching_client(
+            {
+                "https://pub.example.com/.well-known/adagents.json": (
+                    None,
+                    403,
+                    {"cf-mitigated": "managed"},
+                )
+            }
+        )
+        with pytest.raises(AdagentsBotMitigationError):
+            await fetch_adagents("pub.example.com", client=client)
+
+    @pytest.mark.asyncio
+    async def test_plain_403_does_not_raise_bot_mitigation_error(self):
+        """HTTP 403 without cf-mitigated header raises generic AdagentsValidationError."""
+        from adcp.adagents import fetch_adagents
+
+        client = make_url_dispatching_client(
+            {"https://example.com/.well-known/adagents.json": (None, 403, {})}
+        )
+        with pytest.raises(AdagentsValidationError, match="HTTP 403"):
+            await fetch_adagents("example.com", client=client)
+
 
 class TestSSRFProtection:
     """Test SSRF protections on authoritative_location redirects."""
@@ -2900,6 +2948,26 @@ class TestValidateAdagentsDomain:
         # No fallback hop is attempted, so discovery_method remains default.
         assert result.manager_domain is None
         assert any("points back" in err for err in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_bot_mitigation_captured_in_result_errors(self):
+        """Bot mitigation 403 is reported in result.errors, not raised."""
+        from adcp.adagents import validate_adagents_domain
+
+        def _stream(method, url, **kwargs):
+            response = _make_stream_response(
+                status_code=403, body=b"", headers={"cf-mitigated": "challenge"}
+            )
+            return _stream_cm(response)
+
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(side_effect=_stream)
+        mock_client.get = AsyncMock(return_value=self._not_found())
+
+        result = await validate_adagents_domain("cafemedia.com", client=mock_client)
+
+        assert result.valid is False
+        assert any("bot mitigation" in err.lower() for err in result.errors)
 
 
 class TestValidateAdagentsStructure:

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -2496,6 +2496,45 @@ class TestFetchAgentAuthorizations:
             call_kwargs = mock_fetch.call_args[1]
             assert call_kwargs.get("client") == mock_client
 
+    @pytest.mark.asyncio
+    async def test_bot_mitigation_domain_excluded_with_warning(self, caplog):
+        """WAF-blocked domain is absent from result and a warning is logged."""
+        import logging
+
+        from adcp.adagents import fetch_agent_authorizations
+        from adcp.exceptions import AdagentsBotMitigationError
+
+        client = make_url_dispatching_client(
+            {
+                "https://open.example.com/.well-known/adagents.json": {
+                    "authorized_agents": [
+                        {
+                            "url": "https://our-agent.com",
+                            "authorized_for": "All",
+                            "authorization_type": "property_ids",
+                            "property_ids": ["p1"],
+                        }
+                    ]
+                },
+                "https://blocked.example.com/.well-known/adagents.json": (
+                    None,
+                    403,
+                    {"cf-mitigated": "challenge"},
+                ),
+            }
+        )
+
+        with caplog.at_level(logging.WARNING, logger="adcp.adagents"):
+            result = await fetch_agent_authorizations(
+                "https://our-agent.com",
+                ["open.example.com", "blocked.example.com"],
+                client=client,
+            )
+
+        assert "open.example.com" in result
+        assert "blocked.example.com" not in result
+        assert any("blocked.example.com" in r.message for r in caplog.records)
+
 
 class TestParseManagerdomains:
     """Test ads.txt MANAGERDOMAIN directive parsing."""


### PR DESCRIPTION
Closes #801

## Summary

`_fetch_adagents_url` currently raises a generic `AdagentsValidationError: Failed to fetch adagents.json: HTTP 403` when a publisher's Cloudflare WAF returns `cf-mitigated: challenge` or `cf-mitigated: managed`. This gives callers no way to distinguish a WAF bot-mitigation block from an auth error or other 403.

This PR adds `AdagentsBotMitigationError` — raised when HTTP 403 + `cf-mitigated` header is detected — with:
- `publisher_domain` attribute
- `mitigation_type` attribute (the actual cf-mitigated value: `"challenge"` or `"managed"`)
- Actionable suggestion text directing callers to `fetch_agent_authorizations_from_directory()` or publisher allowlist coordination

Per the reframing in #801's comment thread, post-5.7.0 the impacted callers are: (1) the AAO directory crawler, (2) real-time re-verification callers, (3) dev/debug. `fetch_agent_authorizations_from_directory()` is the recommended path for everyone else.

## What changed

- `src/adcp/exceptions.py`: New `AdagentsBotMitigationError(ADCPError)` — typed exception with `publisher_domain` and `mitigation_type` attributes
- `src/adcp/adagents.py`:
  - `_fetch_adagents_url`: detect `status_code == 403` + `cf-mitigated: challenge|managed` before generic non-200 handler
  - `_try_managerdomain_fallback`: added to silent-return except tuple
  - `validate_adagents_domain` (2 sites): added to "report on result" except tuples
  - `fetch_agent_authorizations`: explicit `logger.warning` + return `(domain, None)` before generic swallow
- `src/adcp/__init__.py`: exported in import block and `__all__`
- `tests/fixtures/public_api_snapshot.json`: regenerated
- `tests/test_adagents.py`: 4 new tests (challenge, managed, plain-403 negative case, validate_adagents_domain capture)

## What tested

- `pytest tests/test_adagents.py tests/test_public_api.py` — 210 passed
- `ruff check src/adcp/` — clean
- Import verified: `from adcp import AdagentsBotMitigationError` ✓

## Open design question — flagged for human review

**Pre-PR experts disagreed on the inheritance of `AdagentsBotMitigationError`:**

- **ad-tech-protocol-expert**: inheriting from `ADCPError` directly (current impl) is a breaking inconsistency — `AdagentsNotFoundError` and `AdagentsTimeoutError` both inherit from `AdagentsValidationError`, and callers that catch `AdagentsValidationError` as a cluster (e.g. `verify_agent_for_property`, `fetch_adagents_with_cache`) will not catch this error. Recommends `AdagentsBotMitigationError(AdagentsValidationError)` for consistency.

- **dx-expert**: `AdagentsValidationError` is wrong conceptually — a WAF block is a transport-layer refusal, not a validation error. Callers that catch `AdagentsValidationError` generically would silently swallow it; the new error should propagate to force explicit handling.

Both positions have merit. The current PR uses `ADCPError` directly (dx-expert position) and explicitly adds the new class to the four call-site except tuples that need it. Changing to `AdagentsValidationError` would remove those four explicit catches but alter the error hierarchy semantics.

**Please resolve before merge.**

## Pre-PR review

- ad-tech-protocol-expert: approved with 1 blocker fixed (error message now uses actual `mitigation_type`), 1 design question flagged above
- code-reviewer: see initial review findings (inheritance, mitigation_type, snapshot); all addressed except inheritance (flagged)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01CmYfKqiv5eePuh9xR8PuxB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmYfKqiv5eePuh9xR8PuxB)_