### PR TITLE
ci: skip generated internals in API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build docs
         run: |
-          pdoc --html --skip-errors --output-dir docs/api adcp
+          pdoc --html --output-dir docs/api adcp
 
       - name: Configure Pages
         uses: actions/configure-pages@v6

--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -27,6 +27,8 @@ Type Coercion:
 
 from __future__ import annotations
 
+__pdoc__ = {"generated_poc": False}
+
 # Apply type coercion to generated types (must be imported before other types)
 # Note: the deprecation shim for the removed ``format_category`` submodule
 # lives as a real file at ``generated_poc/enums/format_category.py`` — no


### PR DESCRIPTION
## Summary
- mark `adcp.types.generated_poc` as internal for pdoc so API docs skip regenerated schema modules
- remove the temporary `--skip-errors` docs workaround now that the generated tree is excluded intentionally

## Root cause
The GitHub-native Pages replacement exposed an existing pdoc issue: the docs build crawled `adcp.types.generated_poc`, a large regenerated schema tree with discriminator definitions that can fail import under pdoc. Crawling that internal tree also made the docs job much slower than needed.

## Validation
- `uv run --extra docs pdoc --html --output-dir .context/docs-api-noskip adcp`
- verified `.context/docs-api-noskip/adcp/types/generated_poc` is not generated
- workflow YAML parse
- `git diff --check`
- pre-commit hooks during commit, including `mypy` and `bandit`
