### PR TITLE
ci: skip mypy plugin in API docs

### DIFF
--- a/src/adcp/types/__init__.py
+++ b/src/adcp/types/__init__.py
@@ -27,7 +27,10 @@ Type Coercion:
 
 from __future__ import annotations
 
-__pdoc__ = {"generated_poc": False}
+__pdoc__ = {
+    "generated_poc": False,
+    "mypy_plugin": False,
+}
 
 # Apply type coercion to generated types (must be imported before other types)
 # Note: the deprecation shim for the removed ``format_category`` submodule


### PR DESCRIPTION
## Summary
- skip `adcp.types.mypy_plugin` in pdoc output alongside regenerated schema internals

## Root cause
After generated schema internals were excluded, the GitHub Pages docs job reached `adcp.types.mypy_plugin`. That module is intentionally only usable when `mypy` is installed, but the docs workflow installs docs extras only, so pdoc failed importing it.

## Validation
- `uv run --no-dev --extra docs pdoc --html --output-dir .context/docs-api-nodev adcp`
- verified generated internals and `mypy_plugin.html` are not emitted
- `git diff --check`
- pre-commit hooks during commit, including `mypy` and `bandit`
