### PR TITLE
ci: extract reference seller storyboard harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,9 +355,8 @@ jobs:
   storyboard:
     name: AdCP storyboard runner — examples/seller_agent.py
     runs-on: ubuntu-latest
-    # Non-blocking until seller-agent content gaps in #304 are resolved.
-    # Promote to required once overall_status: passing and controller_detected: true.
-    continue-on-error: true
+    # Blocking gate: examples/seller_agent.py is the Python-owned
+    # reference target for bidirectional storyboard interop.
 
     steps:
       - uses: actions/checkout@v6
@@ -384,93 +383,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
-      - name: Pre-install @adcp/sdk (once, then call binary directly)
-        # Single install step at the top of the job; subsequent runner
-        # calls invoke the already-installed binary instead of paying
-        # the ``npx -y -p ...`` per-invocation extract+link tax.
-        # Pinned to ADCP_SDK_VERSION (see workflow header) — bump via PR
-        # so reference-impl breakage from a new SDK release shows up as
-        # a labelled change set, not silent CI flake.
-        #
-        # Vendor missing fixtures into the SDK install:
-        # ``@adcp/sdk`` does not ship two fixtures its storyboard runner
-        # needs — ``aao-reference-formats.json`` (AAO format catalog,
-        # upstream adcontextprotocol/adcp#3307) and
-        # ``v1-canonical-mapping.json`` (v1→v2 format mapping registry
-        # at schemas/cache/3.1.0-beta.2/registries/). The SDK's own
-        # error messages recommend vendoring both at the exact paths
-        # below. We keep copies under ``tests/fixtures/`` and drop them
-        # into the SDK's expected locations post-install; idempotent if
-        # upstream later ships them in the npm tarball.
+      - name: Run reference seller storyboard harness
+        timeout-minutes: 15
+        env:
+          PYTHON: python
         run: |
-          npm install -g @adcp/sdk@${ADCP_SDK_VERSION}
-          adcp --version
-          SDK_ROOT="$(npm root -g)/@adcp/sdk"
-          mkdir -p "${SDK_ROOT}/test/lib/v2-projection-fixtures"
-          cp tests/fixtures/aao-reference-formats.json "${SDK_ROOT}/test/lib/v2-projection-fixtures/aao-reference-formats.json"
-          mkdir -p "${SDK_ROOT}/schemas/cache/3.1.0-beta.2/registries"
-          cp tests/fixtures/v1-canonical-mapping.json "${SDK_ROOT}/schemas/cache/3.1.0-beta.2/registries/v1-canonical-mapping.json"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Start seller agent
-        run: |
-          ADCP_PORT=3001 python examples/seller_agent.py &
-          AGENT_PID=$!
-          for i in $(seq 1 60); do
-            # Any HTTP response (including 405 on GET to a POST-only endpoint)
-            # means the server is up and accepting connections.
-            # ``||`` runs on the assignment so curl's "000" stdout and the
-            # fallback don't concatenate when the connection is refused.
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
-              http://127.0.0.1:3001/mcp 2>/dev/null) || HTTP_CODE="000"
-            if [ "$HTTP_CODE" != "000" ]; then
-              echo "Seller agent ready (HTTP ${HTTP_CODE}, pid ${AGENT_PID})"
-              break
-            fi
-            if ! kill -0 "$AGENT_PID" 2>/dev/null; then
-              echo "Seller agent process died during startup"
-              exit 1
-            fi
-            if [ "$i" -eq 60 ]; then
-              echo "Seller agent failed to start within 30s"
-              kill "$AGENT_PID" 2>/dev/null || true
-              exit 1
-            fi
-            sleep 0.5
-          done
-
-      - name: Run storyboard suite
-        timeout-minutes: 5
-        # ``adcp`` was installed once at job start (see "Pre-install"
-        # step) — call the binary directly to skip per-invocation
-        # ``npx`` extract+link overhead.
-        run: |
-          adcp storyboard run \
-            http://127.0.0.1:3001/mcp media_buy_seller \
-            --json --allow-http \
-            > storyboard-result.json
-
-      - name: Assert pass
-        run: |
-          python -c "
-          import json, sys, pathlib
-          p = pathlib.Path('storyboard-result.json')
-          if not p.exists() or p.stat().st_size == 0:
-              print('storyboard-result.json missing or empty — runner produced no output')
-              sys.exit(1)
-          with p.open() as f:
-              d = json.load(f)
-          if d.get('overall_status') != 'passing':
-              print(json.dumps(d, indent=2))
-              sys.exit(1)
-          if not d.get('controller_detected'):
-              print('controller_detected was false; check DemoStore overrides (see #304)')
-              sys.exit(1)
-          "
+          scripts/ci/run_storyboard_reference_seller.sh
 
       - if: always()
         uses: actions/upload-artifact@v7

--- a/scripts/ci/run_storyboard_reference_seller.sh
+++ b/scripts/ci/run_storyboard_reference_seller.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Run the Python reference seller through the AdCP media_buy_seller storyboard.
+#
+# Required runner input: set exactly one of these modes.
+#   ADCP_SDK_VERSION=7.10.2       Install published @adcp/sdk from npm.
+#   ADCP_SDK_TARBALL=/tmp/sdk.tgz Install a candidate @adcp/sdk tarball.
+#   ADCP_RUNNER_BIN=/path/to/adcp Use a preinstalled storyboard runner binary.
+#
+# Optional inputs:
+#   ADCP_PORT=3001
+#   STORYBOARD_RESULT_PATH=storyboard-result.json
+#   PYTHON=python3
+#   ADCP_PYTHON_VENV=.context/storyboard-reference-seller-venv
+#   ADCP_SDK_ROOT=/path/to/@adcp/sdk
+#
+# The script assumes it is running from an adcp-client-python checkout,
+# installs the Python dependencies needed by examples/seller_agent.py,
+# boots the seller, writes the storyboard JSON result, and exits non-zero
+# unless overall_status is "passing" and controller_detected is true.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+ADCP_PORT="${ADCP_PORT:-3001}"
+STORYBOARD_RESULT_PATH="${STORYBOARD_RESULT_PATH:-storyboard-result.json}"
+PYTHON="${PYTHON:-python3}"
+ADCP_PYTHON_VENV="${ADCP_PYTHON_VENV:-$ROOT/.context/storyboard-reference-seller-venv}"
+SELLER_LOG_PATH="${SELLER_LOG_PATH:-/tmp/adcp-reference-seller.log}"
+
+ADCP_RUNNER_BIN="${ADCP_RUNNER_BIN:-}"
+ADCP_SDK_VERSION="${ADCP_SDK_VERSION:-}"
+ADCP_SDK_TARBALL="${ADCP_SDK_TARBALL:-}"
+ADCP_SDK_ROOT="${ADCP_SDK_ROOT:-}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+runner_modes=0
+[[ -n "$ADCP_RUNNER_BIN" ]] && runner_modes=$((runner_modes + 1))
+[[ -n "$ADCP_SDK_TARBALL" ]] && runner_modes=$((runner_modes + 1))
+[[ -n "$ADCP_SDK_VERSION" ]] && runner_modes=$((runner_modes + 1))
+[[ "$runner_modes" -eq 1 ]] || fail "set exactly one of ADCP_RUNNER_BIN, ADCP_SDK_TARBALL, or ADCP_SDK_VERSION"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+vendor_sdk_fixtures() {
+  local sdk_root="$1"
+
+  if [[ -z "$sdk_root" ]]; then
+    echo "No @adcp/sdk root detected; skipping SDK fixture vendoring."
+    return 0
+  fi
+  if [[ ! -d "$sdk_root" ]]; then
+    echo "@adcp/sdk root not found at $sdk_root; skipping SDK fixture vendoring."
+    return 0
+  fi
+
+  echo "Vendoring storyboard fixtures into $sdk_root"
+  mkdir -p "$sdk_root/test/lib/v2-projection-fixtures"
+  cp tests/fixtures/aao-reference-formats.json \
+    "$sdk_root/test/lib/v2-projection-fixtures/aao-reference-formats.json"
+  mkdir -p "$sdk_root/schemas/cache/3.1.0-beta.2/registries"
+  cp tests/fixtures/v1-canonical-mapping.json \
+    "$sdk_root/schemas/cache/3.1.0-beta.2/registries/v1-canonical-mapping.json"
+}
+
+detect_global_sdk_root() {
+  require_command npm
+  local npm_root
+  npm_root="$(npm root -g)"
+  local sdk_root="$npm_root/@adcp/sdk"
+  [[ -d "$sdk_root" ]] && printf '%s\n' "$sdk_root"
+}
+
+install_or_select_runner() {
+  if [[ -n "$ADCP_RUNNER_BIN" ]]; then
+    command -v "$ADCP_RUNNER_BIN" >/dev/null 2>&1 || [[ -x "$ADCP_RUNNER_BIN" ]] || \
+      fail "ADCP_RUNNER_BIN is not executable or on PATH: $ADCP_RUNNER_BIN"
+    echo "Using preinstalled storyboard runner: $ADCP_RUNNER_BIN"
+    if [[ -z "$ADCP_SDK_ROOT" ]] && command -v npm >/dev/null 2>&1; then
+      ADCP_SDK_ROOT="$(detect_global_sdk_root || true)"
+    fi
+  elif [[ -n "$ADCP_SDK_TARBALL" ]]; then
+    require_command npm
+    [[ -f "$ADCP_SDK_TARBALL" ]] || fail "ADCP_SDK_TARBALL not found: $ADCP_SDK_TARBALL"
+    echo "Installing candidate @adcp/sdk tarball: $ADCP_SDK_TARBALL"
+    npm install -g "$ADCP_SDK_TARBALL"
+    ADCP_RUNNER_BIN="adcp"
+    ADCP_SDK_ROOT="${ADCP_SDK_ROOT:-$(detect_global_sdk_root || true)}"
+  else
+    require_command npm
+    echo "Installing published @adcp/sdk@$ADCP_SDK_VERSION"
+    npm install -g "@adcp/sdk@$ADCP_SDK_VERSION"
+    ADCP_RUNNER_BIN="adcp"
+    ADCP_SDK_ROOT="${ADCP_SDK_ROOT:-$(detect_global_sdk_root || true)}"
+  fi
+
+  "$ADCP_RUNNER_BIN" --version
+  vendor_sdk_fixtures "$ADCP_SDK_ROOT"
+}
+
+install_python_dependencies() {
+  if "$PYTHON" - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.prefix != sys.base_prefix else 1)
+PY
+  then
+    echo "Using active Python virtual environment: $PYTHON"
+  else
+    if [[ ! -x "$ADCP_PYTHON_VENV/bin/python" ]]; then
+      echo "Creating Python virtual environment: $ADCP_PYTHON_VENV"
+      "$PYTHON" -m venv "$ADCP_PYTHON_VENV"
+    else
+      echo "Using Python virtual environment: $ADCP_PYTHON_VENV"
+    fi
+    PYTHON="$ADCP_PYTHON_VENV/bin/python"
+  fi
+
+  echo "Installing Python dependencies"
+  "$PYTHON" -m pip install --upgrade pip
+  "$PYTHON" -m pip install -e ".[dev]"
+}
+
+wait_for_seller() {
+  local pid="$1"
+  local url="http://127.0.0.1:${ADCP_PORT}/mcp"
+
+  for i in $(seq 1 60); do
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 "$url" 2>/dev/null) || http_code="000"
+    if [[ "$http_code" != "000" ]]; then
+      echo "Seller agent ready (HTTP ${http_code}, pid ${pid})"
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "Seller agent process died during startup"
+      tail -n 80 "$SELLER_LOG_PATH" 2>/dev/null || true
+      return 1
+    fi
+    if [[ "$i" -eq 60 ]]; then
+      echo "Seller agent failed to start within 30s"
+      tail -n 80 "$SELLER_LOG_PATH" 2>/dev/null || true
+      return 1
+    fi
+    sleep 0.5
+  done
+}
+
+assert_storyboard_passed() {
+  "$PYTHON" - "$STORYBOARD_RESULT_PATH" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.exists() or path.stat().st_size == 0:
+    print(f"{path} missing or empty; runner produced no output")
+    sys.exit(1)
+
+with path.open() as f:
+    doc = json.load(f)
+
+if doc.get("overall_status") != "passing":
+    print(json.dumps(doc, indent=2))
+    sys.exit(1)
+
+if not doc.get("controller_detected"):
+    print("controller_detected was false; check DemoStore overrides (see #304)")
+    sys.exit(1)
+
+summary = doc.get("summary") or {}
+print("Storyboard passing.")
+if summary:
+    print("summary:", json.dumps(summary, sort_keys=True))
+PY
+}
+
+cleanup() {
+  if [[ -n "${SELLER_PID:-}" ]]; then
+    kill "$SELLER_PID" 2>/dev/null || true
+    wait "$SELLER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+install_or_select_runner
+install_python_dependencies
+
+mkdir -p "$(dirname "$STORYBOARD_RESULT_PATH")"
+echo "Starting examples/seller_agent.py on port $ADCP_PORT"
+ADCP_PORT="$ADCP_PORT" "$PYTHON" examples/seller_agent.py >"$SELLER_LOG_PATH" 2>&1 &
+SELLER_PID=$!
+wait_for_seller "$SELLER_PID"
+
+echo "Running media_buy_seller storyboard"
+set +e
+"$ADCP_RUNNER_BIN" storyboard run \
+  "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
+  --json --allow-http \
+  >"$STORYBOARD_RESULT_PATH"
+RUNNER_STATUS=$?
+set -e
+
+if [[ "$RUNNER_STATUS" -ne 0 ]]; then
+  echo "Storyboard runner exited with status $RUNNER_STATUS"
+  [[ -s "$STORYBOARD_RESULT_PATH" ]] && cat "$STORYBOARD_RESULT_PATH"
+  exit "$RUNNER_STATUS"
+fi
+
+assert_storyboard_passed


### PR DESCRIPTION
## Summary
- make the examples/seller_agent.py storyboard job blocking by removing continue-on-error
- extract the reference seller storyboard flow into scripts/ci/run_storyboard_reference_seller.sh
- support published SDK, candidate tarball, and preinstalled adcp runner modes for cross-repo release gating

## Notes
- The harness still fails non-zero unless overall_status is passing and controller_detected is true.
- Branch protection is not currently enabled on main; this PR makes the job blocking when Actions runs, but merge enforcement still needs repo protection/ruleset configuration.

## Validation
- bash -n scripts/ci/run_storyboard_reference_seller.sh
- git diff --check
- parsed .github/workflows/ci.yml as YAML
- ADCP_SDK_VERSION=7.10.2 ADCP_PORT=3001 STORYBOARD_RESULT_PATH=.context/storyboard-result.json scripts/ci/run_storyboard_reference_seller.sh
- ADCP_RUNNER_BIN=adcp ADCP_PORT=3003 STORYBOARD_RESULT_PATH=.context/storyboard-preinstalled-result-2.json scripts/ci/run_storyboard_reference_seller.sh
- ADCP_SDK_TARBALL=.context/adcp-sdk-7.10.2.tgz ADCP_PORT=3004 STORYBOARD_RESULT_PATH=.context/storyboard-tarball-result.json scripts/ci/run_storyboard_reference_seller.sh

Closes #814
Closes #815