### PR TITLE
ci(storyboard): extract reusable harness script for seller_agent.py storyboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,78 +381,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
-      - name: Pre-install @adcp/sdk (once, then call binary directly)
-        # Single install step at the top of the job; subsequent runner
-        # calls invoke the already-installed binary instead of paying
-        # the ``npx -y -p ...`` per-invocation extract+link tax.
-        # ``@adcp/sdk@latest`` is intentionally unpinned: this is AdCP's
-        # own CI running AdCP's own canonical runner — tracking latest
-        # surfaces protocol drift as soon as it ships, which is the
-        # point of this job.
-        run: |
-          npm install -g @adcp/sdk@latest
-          adcp --version
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Start seller agent
-        run: |
-          ADCP_PORT=3001 python examples/seller_agent.py &
-          AGENT_PID=$!
-          for i in $(seq 1 60); do
-            # Any HTTP response (including 405 on GET to a POST-only endpoint)
-            # means the server is up and accepting connections.
-            # ``||`` runs on the assignment so curl's "000" stdout and the
-            # fallback don't concatenate when the connection is refused.
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
-              http://127.0.0.1:3001/mcp 2>/dev/null) || HTTP_CODE="000"
-            if [ "$HTTP_CODE" != "000" ]; then
-              echo "Seller agent ready (HTTP ${HTTP_CODE}, pid ${AGENT_PID})"
-              break
-            fi
-            if ! kill -0 "$AGENT_PID" 2>/dev/null; then
-              echo "Seller agent process died during startup"
-              exit 1
-            fi
-            if [ "$i" -eq 60 ]; then
-              echo "Seller agent failed to start within 30s"
-              kill "$AGENT_PID" 2>/dev/null || true
-              exit 1
-            fi
-            sleep 0.5
-          done
-
-      - name: Run storyboard suite
-        timeout-minutes: 5
-        # ``adcp`` was installed once at job start (see "Pre-install"
-        # step) — call the binary directly to skip per-invocation
-        # ``npx`` extract+link overhead.
-        run: |
-          adcp storyboard run \
-            http://127.0.0.1:3001/mcp media_buy_seller \
-            --json --allow-http \
-            > storyboard-result.json
-
-      - name: Assert pass
-        run: |
-          python -c "
-          import json, sys, pathlib
-          p = pathlib.Path('storyboard-result.json')
-          if not p.exists() or p.stat().st_size == 0:
-              print('storyboard-result.json missing or empty — runner produced no output')
-              sys.exit(1)
-          with p.open() as f:
-              d = json.load(f)
-          if d.get('overall_status') != 'passing':
-              print(json.dumps(d, indent=2))
-              sys.exit(1)
-          if not d.get('controller_detected'):
-              print('controller_detected was false; check DemoStore overrides (see #304)')
-              sys.exit(1)
-          "
+      - name: Run storyboard reference seller
+        timeout-minutes: 10
+        # scripts/ci/run_storyboard_reference_seller.sh owns the full
+        # recipe: SDK install + isolated venv + agent boot + storyboard
+        # run + assertions. See #815.
+        env:
+          ADCP_SDK_VERSION: latest
+          STORYBOARD_RESULT_PATH: storyboard-result.json
+        run: ./scripts/ci/run_storyboard_reference_seller.sh
 
       - if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.ci-venv/
 
 # Spyder project settings
 .spyderproject

--- a/scripts/ci/run_storyboard_reference_seller.sh
+++ b/scripts/ci/run_storyboard_reference_seller.sh
@@ -14,10 +14,17 @@
 #   ADCP_PORT              Port for the seller agent (default: 3001)
 #   STORYBOARD_RESULT_PATH  Path for JSON result output; omit to write to stdout
 #
-# Run from the root of an adcp-client-python checkout.
+# Works from any working directory: the script resolves the repo root from
+# its own location (scripts/ci/) and changes into it before running.
 # Node.js (npm + adcp binary) and Python must be on PATH.
 
 set -euo pipefail
+
+# Resolve repo root and change into it so all relative paths work regardless
+# of the caller's working directory.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_SCRIPT_DIR}/../.." && pwd)"
+cd "${_REPO_ROOT}"
 
 # --- Validate inputs ---
 
@@ -62,7 +69,7 @@ adcp --version
 # --- Install Python deps in an isolated venv ---
 # Uses the base package only — seller_agent.py does not need dev extras.
 
-VENV_DIR=".ci-venv"
+VENV_DIR="${_REPO_ROOT}/.ci-venv"
 python -m venv "${VENV_DIR}"
 "${VENV_DIR}/bin/pip" install --quiet --upgrade pip
 "${VENV_DIR}/bin/pip" install --quiet -e .
@@ -70,8 +77,10 @@ python -m venv "${VENV_DIR}"
 # --- Boot seller agent with guaranteed cleanup on exit ---
 
 AGENT_PID=""
+_TMPFILE=""
 _cleanup() {
   [[ -n "${AGENT_PID}" ]] && kill "${AGENT_PID}" 2>/dev/null || true
+  [[ -n "${_TMPFILE}" ]] && rm -f "${_TMPFILE}" || true
 }
 trap _cleanup EXIT
 
@@ -100,22 +109,23 @@ for i in $(seq 1 60); do
 done
 
 # --- Run storyboard ---
+# Always write to a file so the assertion step can read it regardless of
+# whether STORYBOARD_RESULT_PATH is set. When unset, print to stdout after.
 
 _RESULT_DEST="${STORYBOARD_RESULT_PATH:-}"
 if [[ -n "${_RESULT_DEST}" ]]; then
-  adcp storyboard run \
-    "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
-    --json --allow-http \
-    > "${_RESULT_DEST}"
   _ASSERT_FILE="${_RESULT_DEST}"
 else
   _TMPFILE="$(mktemp)"
-  adcp storyboard run \
-    "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
-    --json --allow-http \
-    | tee "${_TMPFILE}"
   _ASSERT_FILE="${_TMPFILE}"
 fi
+
+adcp storyboard run \
+  "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
+  --json --allow-http \
+  > "${_ASSERT_FILE}"
+
+[[ -z "${_RESULT_DEST}" ]] && cat "${_ASSERT_FILE}"
 
 # --- Assert result ---
 

--- a/scripts/ci/run_storyboard_reference_seller.sh
+++ b/scripts/ci/run_storyboard_reference_seller.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# scripts/ci/run_storyboard_reference_seller.sh
+#
+# Boot examples/seller_agent.py and run the media_buy_seller storyboard
+# against it. Callable from Python CI and from cross-repo release-gating
+# (adcp-client#1916) without duplicating the recipe.
+#
+# Required — set exactly one of:
+#   ADCP_SDK_VERSION   @adcp/sdk version to install from npm ("latest" or
+#                      a specific version such as "7.10.2")
+#   ADCP_SDK_TARBALL   Absolute path to a candidate @adcp/sdk .tgz/.tar.gz
+#
+# Optional:
+#   ADCP_PORT              Port for the seller agent (default: 3001)
+#   STORYBOARD_RESULT_PATH  Path for JSON result output; omit to write to stdout
+#
+# Run from the root of an adcp-client-python checkout.
+# Node.js (npm + adcp binary) and Python must be on PATH.
+
+set -euo pipefail
+
+# --- Validate inputs ---
+
+if [[ -z "${ADCP_SDK_VERSION:-}" && -z "${ADCP_SDK_TARBALL:-}" ]]; then
+  echo "Error: set exactly one of ADCP_SDK_VERSION or ADCP_SDK_TARBALL" >&2
+  echo "  ADCP_SDK_VERSION=latest ${0}" >&2
+  echo "  ADCP_SDK_VERSION=7.10.2 ${0}" >&2
+  echo "  ADCP_SDK_TARBALL=/absolute/path/adcp-sdk.tgz ${0}" >&2
+  exit 1
+fi
+if [[ -n "${ADCP_SDK_VERSION:-}" && -n "${ADCP_SDK_TARBALL:-}" ]]; then
+  echo "Error: set only one of ADCP_SDK_VERSION or ADCP_SDK_TARBALL, not both" >&2
+  exit 1
+fi
+
+ADCP_PORT="${ADCP_PORT:-3001}"
+
+if [[ -n "${ADCP_SDK_TARBALL:-}" ]]; then
+  if [[ "${ADCP_SDK_TARBALL}" != /* ]]; then
+    echo "Error: ADCP_SDK_TARBALL must be an absolute path (got: ${ADCP_SDK_TARBALL})" >&2
+    exit 1
+  fi
+  if [[ ! -f "${ADCP_SDK_TARBALL}" ]]; then
+    echo "Error: ADCP_SDK_TARBALL not found: ${ADCP_SDK_TARBALL}" >&2
+    exit 1
+  fi
+  case "${ADCP_SDK_TARBALL}" in
+    *.tgz|*.tar.gz) ;;
+    *) echo "Error: ADCP_SDK_TARBALL must be a .tgz or .tar.gz file" >&2; exit 1 ;;
+  esac
+fi
+
+# --- Install @adcp/sdk ---
+
+if [[ -n "${ADCP_SDK_VERSION:-}" ]]; then
+  npm install -g "@adcp/sdk@${ADCP_SDK_VERSION}"
+else
+  npm install -g "${ADCP_SDK_TARBALL}"
+fi
+adcp --version
+
+# --- Install Python deps in an isolated venv ---
+# Uses the base package only — seller_agent.py does not need dev extras.
+
+VENV_DIR=".ci-venv"
+python -m venv "${VENV_DIR}"
+"${VENV_DIR}/bin/pip" install --quiet --upgrade pip
+"${VENV_DIR}/bin/pip" install --quiet -e .
+
+# --- Boot seller agent with guaranteed cleanup on exit ---
+
+AGENT_PID=""
+_cleanup() {
+  [[ -n "${AGENT_PID}" ]] && kill "${AGENT_PID}" 2>/dev/null || true
+}
+trap _cleanup EXIT
+
+ADCP_PORT="${ADCP_PORT}" "${VENV_DIR}/bin/python" examples/seller_agent.py &
+AGENT_PID=$!
+
+echo "Waiting for seller agent (pid ${AGENT_PID}) on port ${ADCP_PORT}..."
+for i in $(seq 1 60); do
+  # Any HTTP response (including 405 on GET to a POST-only endpoint) means
+  # the server is up and accepting connections.
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
+    "http://127.0.0.1:${ADCP_PORT}/mcp" 2>/dev/null) || HTTP_CODE="000"
+  if [[ "${HTTP_CODE}" != "000" ]]; then
+    echo "Seller agent ready (HTTP ${HTTP_CODE}, pid ${AGENT_PID})"
+    break
+  fi
+  if ! kill -0 "${AGENT_PID}" 2>/dev/null; then
+    echo "Seller agent process died during startup" >&2
+    exit 1
+  fi
+  if [[ "${i}" -eq 60 ]]; then
+    echo "Seller agent failed to start within 30s" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+
+# --- Run storyboard ---
+
+_RESULT_DEST="${STORYBOARD_RESULT_PATH:-}"
+if [[ -n "${_RESULT_DEST}" ]]; then
+  adcp storyboard run \
+    "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
+    --json --allow-http \
+    > "${_RESULT_DEST}"
+  _ASSERT_FILE="${_RESULT_DEST}"
+else
+  _TMPFILE="$(mktemp)"
+  adcp storyboard run \
+    "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
+    --json --allow-http \
+    | tee "${_TMPFILE}"
+  _ASSERT_FILE="${_TMPFILE}"
+fi
+
+# --- Assert result ---
+
+"${VENV_DIR}/bin/python" - "${_ASSERT_FILE}" <<'PYEOF'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+if not p.exists() or p.stat().st_size == 0:
+    print("storyboard result missing or empty — runner produced no output")
+    sys.exit(1)
+with p.open() as f:
+    d = json.load(f)
+if d.get("overall_status") != "passing":
+    print(json.dumps(d, indent=2))
+    sys.exit(1)
+if not d.get("controller_detected"):
+    print("controller_detected was false; check DemoStore overrides (see #304)")
+    sys.exit(1)
+print("Storyboard passed.")
+PYEOF


### PR DESCRIPTION
Closes #815

## Summary

Moves the inline storyboard CI recipe for `examples/seller_agent.py` out of `.github/workflows/ci.yml` and into a reusable script `scripts/ci/run_storyboard_reference_seller.sh`. The script can be called from Python CI as-is and from cross-repo release-gating (`adcp-client#1916`) without duplicating any shell steps.

The CI job now sets `ADCP_SDK_VERSION: latest` (preserving existing drift-detection behavior) and calls `./scripts/ci/run_storyboard_reference_seller.sh`.

## What changed

- **`scripts/ci/run_storyboard_reference_seller.sh`** (new, 147 lines) — portable harness with:
  - Resolves repo root from `BASH_SOURCE[0]` so it works from any caller directory
  - `ADCP_SDK_VERSION` / `ADCP_SDK_TARBALL` as mutually exclusive inputs with input validation (absolute path, file existence, extension guard)
  - Isolated venv (`.ci-venv/`) using base package only — avoids polluting the caller's environment with dev extras
  - `trap _cleanup EXIT` covering both the agent PID and any tmpfile
  - `ADCP_PORT` defaulting to 3001; `STORYBOARD_RESULT_PATH` optional (omit to write JSON to stdout for local dev)
- **`.github/workflows/ci.yml`** — replaces 5 inline steps with one step calling the script
- **`.gitignore`** — adds `.ci-venv/`

## Interface

```bash
# Python CI (pinned latest, result to file):
ADCP_SDK_VERSION=latest STORYBOARD_RESULT_PATH=storyboard-result.json \
  ./scripts/ci/run_storyboard_reference_seller.sh

# Cross-repo release-gating with candidate SDK tarball:
ADCP_SDK_TARBALL=/abs/path/adcp-sdk.tgz \
  ./scripts/ci/run_storyboard_reference_seller.sh

# Local dev (stdout):
ADCP_SDK_VERSION=7.10.2 ./scripts/ci/run_storyboard_reference_seller.sh
```

## What was tested

- `ruff check src/` — passed
- `pytest tests/` — 4320 passed, 21 skipped, 1 xfailed (no regressions; no Python source changed)
- `bash -n scripts/ci/run_storyboard_reference_seller.sh` — syntax OK

## Pre-PR review

- code-reviewer: approved — both blockers (relative venv path, tmpfile leak) resolved; no remaining blockers
- dx-expert: approved — cross-repo interface complete; `_BASH_SOURCE[0]` resolution and `_cleanup` trap confirmed correct

## Known nits (not blocking)

- `[[ ... ]] && kill ... || true` idiom in `_cleanup` is a common bash footgun; functionally correct here
- Startup wait hard-coded at 30 s; a `SELLER_STARTUP_TIMEOUT_SECS` var would be a nice follow-up

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01BdEqT6X8riNXLLCZUxUTMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdEqT6X8riNXLLCZUxUTMx)_