### PR TITLE
docs: add MIGRATION_v5_to_v6 stub + trigger 6.0.0-beta.1 release-please bump (refs #802)

### DIFF
--- a/MIGRATION_v5_to_v6.md
+++ b/MIGRATION_v5_to_v6.md
@@ -1,0 +1,42 @@
+# Migration v5 → v6
+
+> Beta line. Surfaces here MAY change between beta increments. Track this
+> file as features land; sections will be added per-release rather than
+> upfront.
+
+## Why a major version
+
+v6 carries the type-surface changes that come with AdCP 3.1 — most
+notably the canonical-formats projection layer (#741), which alters
+the `ProductFormatDeclaration` discriminator and adds the
+`adcp.canonical_formats` public module. Adopters pinning `adcp~=5.7`
+will keep getting the v5 surface; opt into the beta with
+`pip install --pre adcp` or `pip install adcp==6.0.0b1`.
+
+## Installing the beta
+
+```bash
+pip install --pre adcp
+# or pin explicitly
+pip install adcp==6.0.0b1
+```
+
+PyPI's default resolver excludes prereleases unless `--pre` is set, so
+existing `pip install adcp` calls in production continue resolving to
+5.7.x.
+
+## What's NOT changing
+
+- `ADCP_VERSION` is the upstream protocol version (currently
+  `3.1.0-beta.3`) and is independent of the SDK package version. v6 of
+  the SDK can run against multiple `ADCP_VERSION` values; the schema
+  cache and generated types are pinned via that file, not via the
+  package version.
+- The CI schema-sync drift gate remains gated on stable upstream
+  versions (`.github/workflows/ci.yml`).
+
+## Per-release entries
+
+(Add sections here as breaking changes land. Format: heading per
+released beta increment, bullet list of breaking surfaces with
+migration recipe.)


### PR DESCRIPTION
## Summary

Two things in one tiny PR:

1. **`MIGRATION_v5_to_v6.md` stub** — mirrors the precedent set by the existing `MIGRATION_*.md` files. Will accrete per-release sections as breaking surfaces (canonical-formats #741, etc.) land on the beta line. The aao-ipr-bot flagged this as a non-blocking follow-up on #804.

2. **`Release-As: 6.0.0-beta.1` trailer at the very end of the commit message.** The original trailer on #804 was buried mid-message by the squash-merge (between the original commit body and the fix-up commit's body), so release-please's parser didn't pick it up — the release-please run on `fc5ee16b` reported "PR #817 remained the same" and kept proposing 5.7.1. This commit's clean trailer at end-of-message triggers the bump.

## Verify after merge

- [ ] Release-please run on this PR's merge commit produces an UPDATE to PR #817 (or closes it and opens a new one) proposing **v6.0.0-beta.1**, not 5.7.x.
- [ ] The proposed `pyproject.toml` version is **`6.0.0b1`** (PEP 440 form). The previous PR (#804) dropped the `extra-files` JSON writer so the Python release-type's native updater should now apply the SemVer → PEP 440 conversion correctly.

If the release PR still shows 5.7.x: release-please ran but didn't see the trailer. Try closing PR #817 manually to force re-creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)