### PR TITLE
fix: reference seller storyboard compat with TS 3.1 runner

### DIFF
--- a/examples/seller_agent.py
+++ b/examples/seller_agent.py
@@ -345,7 +345,7 @@ class DemoSeller(ADCPHandler):
                     }
                 ]
             return {
-                **products_response(PRODUCTS),
+                **products_response(PRODUCTS, cache_scope="public"),
                 "proposals": [
                     {
                         "proposal_id": proposal_id,
@@ -355,7 +355,7 @@ class DemoSeller(ADCPHandler):
                     }
                 ],
             }
-        return products_response(PRODUCTS)
+        return products_response(PRODUCTS, cache_scope="public")
 
     async def create_media_buy(self, params: dict[str, Any], context: Any = None) -> dict[str, Any]:
         account_id = (params.get("account") or {}).get("account_id") or _DEFAULT_ACCOUNT_ID

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -354,6 +354,7 @@ def media_buy_response(
     Auto-sets revision to 1 and confirmed_at to now if not provided.
     """
     resp: dict[str, Any] = {
+        "status": "completed",
         "media_buy_id": media_buy_id,
         "packages": _serialize(packages),
         "revision": revision if revision is not None else 1,
@@ -364,7 +365,6 @@ def media_buy_response(
         resp["buyer_ref"] = buyer_ref
     if status is not None:
         resp["media_buy_status"] = status
-        resp["status"] = status
         if valid_actions is None:
             resp["valid_actions"] = valid_actions_for_status(status)
         else:

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -405,7 +405,6 @@ def update_media_buy_response(
         resp["affected_packages"] = _serialize(affected_packages)
     if status is not None:
         resp["media_buy_status"] = status
-        resp["status"] = status
         if valid_actions is None:
             resp["valid_actions"] = valid_actions_for_status(status)
         else:

--- a/tests/test_server_dx.py
+++ b/tests/test_server_dx.py
@@ -152,7 +152,8 @@ class TestUpdateMediaBuyResponse:
     def test_basic(self):
         result = update_media_buy_response("mb-123", status="active", revision=2)
         assert result["media_buy_id"] == "mb-123"
-        assert result["status"] == "active"
+        assert result["media_buy_status"] == "active"
+        assert "status" not in result
         assert result["revision"] == 2
 
 

--- a/tests/test_server_dx.py
+++ b/tests/test_server_dx.py
@@ -138,7 +138,8 @@ class TestMediaBuyResponse:
     def test_with_buyer_ref_and_status(self):
         result = media_buy_response("mb-123", [], buyer_ref="b1", status="active")
         assert result["buyer_ref"] == "b1"
-        assert result["status"] == "active"
+        assert result["status"] == "completed"
+        assert result["media_buy_status"] == "active"
 
 
 class TestMediaBuyErrorResponse:


### PR DESCRIPTION
Closes #825

## Summary

Two schema validation failures caused the reference seller storyboard to go red against `@adcp/sdk` 3.1.0-beta.3:

1. **`get_products` missing `cache_scope`** — the `products_response()` dict helper only emits `cache_scope` when explicitly passed; `examples/seller_agent.py` wasn't passing it. AdCP 3.1 requires the field. Fix: pass `cache_scope="public"` at both call sites in `seller_agent.py`.

2. **`create_media_buy` response `status` field contaminated with lifecycle value** — `media_buy_response()` was writing the media-buy lifecycle status (e.g. `"active"`) into `resp["status"]`, which AdCP 3.1 strictly validates as a 9-value task-envelope enum (`submitted/working/completed/…`). Fix: hardcode `status: "completed"` (task envelope) and keep `media_buy_status` for the lifecycle value.

`update_media_buy_response()` had the identical `resp["status"] = status` bug; fixed in the same pass (code-reviewer flagged it as a blocker).

## Changes

| File | Change |
|---|---|
| `examples/seller_agent.py` | Add `cache_scope="public"` to both `products_response()` calls |
| `src/adcp/server/responses.py` | `media_buy_response()`: hardcode `status="completed"`, remove lifecycle bleed. `update_media_buy_response()`: remove `resp["status"] = status` |
| `tests/test_server_dx.py` | Update `TestMediaBuyResponse.test_with_buyer_ref_and_status` and `TestUpdateMediaBuyResponse.test_basic` to assert corrected shape |

## Test plan

- [x] `pytest tests/test_server_dx.py::TestMediaBuyResponse` — 2 passed
- [x] `pytest tests/test_server_dx.py::TestUpdateMediaBuyResponse` — 1 passed
- [x] Full suite: 4991 passed, 38 skipped, 1 xfailed (pre-existing `test_real_tls_handshake_still_validates_hostname` failure unrelated to this change)

## Pre-PR expert review

**code-reviewer**: Flagged `update_media_buy_response()` as blocker (same `resp["status"] = status` bug) — fixed in commit `3c9ff70`. Noted three other example files (`a2a_db_tasks.py`, `a2a_sqlalchemy_tasks.py`, `mcp_with_auth_middleware.py`) missing `cache_scope` — those examples are not exercised by the storyboard CI harness and are left as a follow-up.

**ad-tech-protocol-expert**: Confirmed `cache_scope: "public"` correct semantics (universal rate card, no per-account overlays). Confirmed hardcoded `"completed"` is the right task-envelope status for a synchronous seller. Assessed `update_media_buy_response()` fix as "acceptable before GA"; no blocking protocol concerns.

---
*Triage-managed PR — opened automatically by the issue triage routine for issue #825.*

https://claude.ai/code/session_01N1M8Y3pfbkJzTD9wYYqwe4

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1M8Y3pfbkJzTD9wYYqwe4)_