### PR TITLE
fix(webhooks): promote McpWebhookPayload.token from extras shim to typed field

### DIFF
--- a/src/adcp/webhooks.py
+++ b/src/adcp/webhooks.py
@@ -233,16 +233,6 @@ def create_mcp_webhook_payload(
     else:
         result_value = result
 
-    # `token` isn't a typed schema field but is accepted via `extra='allow'`;
-    # it round-trips through `model_dump`. Tracked upstream for promotion to
-    # a typed field on `mcp-webhook-payload.json`.
-    extras: dict[str, Any] = {}
-    if token is not None:
-        # Buyer-supplied token from push_notification_config.token,
-        # echoed back per push-notification-config.json spec text:
-        # "Echoed back in webhook payload to validate request authenticity."
-        extras["token"] = token
-
     payload = McpWebhookPayload.model_validate(
         {
             "idempotency_key": idempotency_key,
@@ -254,7 +244,7 @@ def create_mcp_webhook_payload(
             "operation_id": operation_id,
             "message": message,
             "context_id": context_id,
-            **extras,
+            "token": token,
         }
     )
     # Preserve task result payloads byte-for-byte. Validating through the

--- a/tests/test_webhooks_to_wire_dict.py
+++ b/tests/test_webhooks_to_wire_dict.py
@@ -237,3 +237,57 @@ def test_create_mcp_webhook_payload_protocol_kwarg() -> None:
             protocol="media_buy",
             idempotency_key="whk_01HW9D2T3VXQ5M7K9N1P3R5S7U",
         )
+
+
+def test_token_is_typed_field_not_model_extra() -> None:
+    """``McpWebhookPayload.token`` is now a typed schema field.
+
+    Regression for adcp#4339 promotion: token must appear in
+    ``model_fields``, not in ``model_extra``, and the typed kwarg path
+    must produce a wire dict byte-identical to what the old
+    ``additionalProperties`` shim produced.
+    """
+    token_value = "buyer-supplied-token-abc123456789"
+    ik = "whk_01HW9D2T3VXQ5M7K9N1P3R5S7U"
+
+    payload = create_mcp_webhook_payload(
+        task_id="task_123",
+        status="completed",
+        task_type="create_media_buy",
+        token=token_value,
+        idempotency_key=ik,
+    )
+
+    # token is a typed field, not a stray extra
+    assert "token" in McpWebhookPayload.model_fields
+    assert payload.token == token_value
+    assert "token" not in (payload.model_extra or {})
+
+    wire = to_wire_dict(payload)
+    assert wire["token"] == token_value
+
+    # Wire parity: dict built by hand must match the typed kwarg path
+    hand_built = McpWebhookPayload.model_validate(
+        {
+            "idempotency_key": ik,
+            "task_id": "task_123",
+            "task_type": "create_media_buy",
+            "status": "completed",
+            "timestamp": payload.timestamp,
+            "token": token_value,
+        }
+    )
+    hand_wire = to_wire_dict(hand_built)
+    assert hand_wire["token"] == wire["token"]
+
+
+def test_token_none_omitted_from_wire() -> None:
+    """When no token is supplied the key is absent from the wire dict."""
+    payload = create_mcp_webhook_payload(
+        task_id="task_123",
+        status="completed",
+        task_type="create_media_buy",
+        idempotency_key="whk_01HW9D2T3VXQ5M7K9N1P3R5S7U",
+    )
+    wire = to_wire_dict(payload)
+    assert "token" not in wire


### PR DESCRIPTION
Closes #638

Upstream `adcontextprotocol/adcp#4339` promoted `token` from an undocumented `additionalProperties` round-trip to a typed field in `mcp-webhook-payload.json`. The generated type already has `token: Annotated[str | None, Field(max_length=4096, min_length=16)] = None` (regenerated 2026-05-22). This PR removes the extras shim from `create_mcp_webhook_payload` and wires `token` directly as a typed kwarg.

**Wire shape is unchanged** — adopters reading `to_wire_dict()` output see no difference. Adopters using `payload.token` now get typed attribute access instead of `model_extra["token"]`, and `McpWebhookPayload.model_fields` now includes `token`.

Note: `min_length=16` is now enforced at construction time on the typed field. Under the old extras-bag path no length validation ran, but `push-notification-config.json` already enforces `minLength: 16` on the buyer side — any token shorter than 16 chars was already schema-invalid at registration. This is a correct tightening, not a latent break.

## What changed

- `src/adcp/webhooks.py`: removed the `extras: dict[str, Any]` shim block; `"token": token` is now passed directly in the `model_validate` call like every other typed field.
- `tests/test_webhooks_to_wire_dict.py`: added `test_token_is_typed_field_not_model_extra` (checks `model_fields`, attribute access, wire parity) and `test_token_none_omitted_from_wire`.

## What was tested

- `pytest tests/test_webhooks_to_wire_dict.py` — 13/13 passed (2 new)
- `pytest tests/test_webhook_handling.py tests/test_webhooks_deliver.py` — 140 passed, 15 skipped
- `ruff check src/adcp/webhooks.py tests/test_webhooks_to_wire_dict.py` — all checks passed
- `mypy src/adcp/webhooks.py` — no issues found

**Nits (not fixed, noted for reviewer):**
- `create_mcp_webhook_payload` docstring for the `token` kwarg could mention `payload.token` now provides direct typed attribute access (dx-expert nit).
- `test_webhooks_to_wire_dict.py` already imports `McpWebhookPayload` from the internal generated path (`adcp.types.generated_poc…`) rather than `adcp.types` — pre-existing, not introduced here; layering test still passes.
- Tests don't cover the `min_length=16` rejection path for token; follow-on candidate.

## Pre-PR review

- code-reviewer: approved — no blockers; nits on test coverage boundary and parity assertion strength
- dx-expert: approved — no blockers; mechanical change is correct, wire shape identical, both regression tests substantive

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 835` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_013qBwgszbHTYiy5PZdgCAQm