### PR TITLE
fix(decisioning): project malformed-JSON 2xx responses to AdcpError

### DIFF
--- a/src/adcp/decisioning/upstream.py
+++ b/src/adcp/decisioning/upstream.py
@@ -282,7 +282,20 @@ class UpstreamHttpClient:
             )
         if response.status_code == 204 or not response.content:
             return {}
-        parsed: Any = response.json()
+        try:
+            parsed: Any = response.json()
+        except ValueError as exc:
+            # Server returned a successful status with a non-JSON body (e.g.
+            # a proxy/CDN HTML error page). Project to SERVICE_UNAVAILABLE so
+            # adopters get a typed AdcpError rather than a raw JSONDecodeError.
+            raise AdcpError(
+                "SERVICE_UNAVAILABLE",
+                message=(
+                    f"upstream {method} {path} returned non-JSON body "
+                    f"(status {response.status_code}): {exc}"
+                ),
+                recovery="transient",
+            ) from exc
         return parsed
 
     async def get(

--- a/tests/test_upstream_helpers.py
+++ b/tests/test_upstream_helpers.py
@@ -428,6 +428,22 @@ async def test_async_context_manager_closes_client() -> None:
 
 
 @respx.mock
+async def test_200_with_malformed_json_raises_service_unavailable() -> None:
+    """A 2xx response with non-JSON body (e.g. CDN/proxy HTML page) must
+    surface as SERVICE_UNAVAILABLE, not a raw JSONDecodeError."""
+    respx.get(f"{BASE}/items").mock(
+        return_value=httpx.Response(200, content=b"<html>bad gateway</html>")
+    )
+    client = create_upstream_http_client(BASE)
+    with pytest.raises(AdcpError) as exc_info:
+        await client.get("/items")
+    assert exc_info.value.code == "SERVICE_UNAVAILABLE"
+    assert exc_info.value.recovery == "transient"
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+    await client.aclose()
+
+
+@respx.mock
 async def test_pool_reused_across_calls() -> None:
     respx.get(f"{BASE}/a").mock(return_value=httpx.Response(200, json={}))
     respx.get(f"{BASE}/b").mock(return_value=httpx.Response(200, json={}))


### PR DESCRIPTION
Refs #453

When an upstream returns a successful (2xx) status with a non-JSON body (e.g. a CDN or proxy returning an HTML error page), `UpstreamHttpClient._request` previously propagated a raw `json.JSONDecodeError` from `response.json()`. Adopters catch `AdcpError` throughout; an unhandled `ValueError` subclass breaks that contract and is invisible in typed code. This PR wraps the call in `except ValueError` and re-raises as `AdcpError(SERVICE_UNAVAILABLE, recovery="transient")` — the same code used for 5xx responses, since an upstream returning HTML for a JSON endpoint is indistinguishable from a transient infrastructure failure.

This is a re-cut of the original branch from #767 (`claude/issue-453-json-decode-error-handling`), which was behind main and had maintainer edits disabled. The diff is identical to #767 but rebased cleanly on current main.

## What changed

- `src/adcp/decisioning/upstream.py`: wrap `response.json()` in `try/except ValueError`; raise `AdcpError(SERVICE_UNAVAILABLE)` with `recovery="transient"` and `from exc` chain.
- `tests/test_upstream_helpers.py`: add `test_200_with_malformed_json_raises_service_unavailable` — mocks a 200 with an HTML body and asserts code, recovery, and `__cause__`.

## What tested

- `pytest tests/test_upstream_helpers.py -q` — **35 passed, 0 failed**
- `mypy src/adcp/decisioning/upstream.py` — clean
- `ruff check src/adcp/decisioning/upstream.py tests/test_upstream_helpers.py` — clean

## Pre-PR review

- **code-reviewer**: approved — flagged missing `@pytest.mark.asyncio` (false positive: `asyncio_mode = "auto"` in pyproject.toml); one nit on truncating `exc` in message (low severity, `AdcpError` is internal)
- **dx-expert**: approved — `SERVICE_UNAVAILABLE / transient` is correct for CDN/proxy interception; nit on adding bounded `response.text[:200]` snippet to message; no blockers

**Nits (not fixed):**
- Error message embeds raw `exc` text rather than a body-length hint; useful for debugging, acceptable for an internal error type
- `recovery="transient"` is correct per the spec but can't distinguish "CDN blip" from "permanently misconfigured upstream" — no better enum value exists

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018wq8sxhkG9c2WW4vgpYgS8

---
_Generated by [Claude Code](https://claude.ai/code/session_018wq8sxhkG9c2WW4vgpYgS8)_