### PR TITLE
fix(adagents): raise AdagentsAccessBlockedError on 403 + cf-mitigated: challenge

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -49,6 +49,7 @@ from adcp.capabilities import (  # noqa: F401
 )
 from adcp.client import ADCPClient, ADCPMultiAgentClient, Checkpoint
 from adcp.exceptions import (  # noqa: F401
+    AdagentsAccessBlockedError,
     AdagentsNotFoundError,
     AdagentsTimeoutError,
     AdagentsValidationError,
@@ -928,6 +929,7 @@ __all__ = [
     "ADCPSigningRequiredError",
     "ADCPWebhookError",
     "ADCPWebhookSignatureError",
+    "AdagentsAccessBlockedError",
     "AdagentsValidationError",
     "AdagentsNotFoundError",
     "AdagentsTimeoutError",

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -1943,7 +1943,10 @@ async def fetch_agent_authorizations(
             return (domain, AuthorizationContext(properties))
 
         except (AdagentsNotFoundError, AdagentsValidationError, AdagentsTimeoutError):
-            # Silently skip domains with missing or invalid adagents.json
+            # Silently skip domains with missing or invalid adagents.json.
+            # AdagentsAccessBlockedError (AdagentsValidationError subclass) is
+            # intentionally swallowed: a bot-blocked domain is treated as
+            # authorization-unavailable, same as a missing file.
             return (domain, None)
 
     # Fetch all domains in parallel

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -22,7 +22,12 @@ from urllib.parse import quote, urlparse
 import httpx
 from pydantic import Field
 
-from adcp.exceptions import AdagentsNotFoundError, AdagentsTimeoutError, AdagentsValidationError
+from adcp.exceptions import (
+    AdagentsAccessBlockedError,
+    AdagentsNotFoundError,
+    AdagentsTimeoutError,
+    AdagentsValidationError,
+)
 from adcp.types.base import AdCPBaseModel
 from adcp.validation import ValidationError, validate_adagents
 
@@ -779,6 +784,9 @@ async def fetch_adagents(
     Raises:
         AdagentsNotFoundError: If adagents.json was not found via any
             discovery path.
+        AdagentsAccessBlockedError: If the publisher's CDN returns HTTP
+            403 with ``cf-mitigated: challenge`` (Cloudflare bot-management
+            block). Subclass of ``AdagentsValidationError``.
         AdagentsValidationError: If JSON is invalid, malformed, or
             redirects exceed maximum depth or form a loop.
         AdagentsTimeoutError: If request times out.
@@ -885,6 +893,10 @@ async def _try_managerdomain_fallback(
         )
         return data
     except (AdagentsNotFoundError, AdagentsValidationError, AdagentsTimeoutError):
+        # AdagentsAccessBlockedError (a AdagentsValidationError subclass) is
+        # intentionally swallowed here: a bot-blocked manager domain is treated
+        # as "not available", and fetch_adagents re-raises the original
+        # AdagentsNotFoundError for the primary domain.
         return None
 
 
@@ -1076,6 +1088,12 @@ async def _fetch_adagents_url(
     if status_code == 404:
         parsed = urlparse(url)
         raise AdagentsNotFoundError(parsed.netloc)
+
+    if status_code == 403 and (
+        response_headers.get("cf-mitigated", "").strip().lower() == "challenge"
+    ):
+        parsed = urlparse(url)
+        raise AdagentsAccessBlockedError(parsed.netloc)
 
     if status_code != 200:
         raise AdagentsValidationError(f"Failed to fetch adagents.json: HTTP {status_code}")

--- a/src/adcp/exceptions.py
+++ b/src/adcp/exceptions.py
@@ -285,6 +285,38 @@ class AdagentsTimeoutError(AdagentsValidationError):
         super().__init__(message, None, None, suggestion)
 
 
+class AdagentsAccessBlockedError(AdagentsValidationError):
+    """adagents.json fetch blocked by publisher-side bot management (403, cf-mitigated: challenge).
+
+    Only surfaces in direct-fetch workflows (``fetch_adagents``). SDK callers that
+    use ``fetch_agent_authorizations`` avoid this entirely — the AAO directory crawler
+    handles publisher fetches and serves cached results without exposing the SDK to
+    publisher-side bot management.
+
+    If you need to catch this specifically without catching all
+    ``AdagentsValidationError``s, use ``except AdagentsAccessBlockedError``.
+    """
+
+    def __init__(self, publisher_domain: str):
+        """Initialize bot-management blocked error."""
+        self.publisher_domain = publisher_domain
+        message = (
+            f"adagents.json blocked by bot management for {publisher_domain} "
+            f"(HTTP 403, cf-mitigated: challenge)"
+        )
+        suggestion = (
+            "The publisher's origin blocked this request with a Cloudflare bot management\n"
+            "     challenge. This only affects direct adagents.json fetches (fetch_adagents).\n"
+            "\n"
+            "     To unblock local debugging:\n"
+            "     - Retry with a browser-like User-Agent via the user_agent= parameter, e.g.\n"
+            '       user_agent="Mozilla/5.0"\n'
+            "     - Or call fetch_agent_authorizations() to query the AAO directory instead,\n"
+            "       which bypasses publisher-side bot management entirely."
+        )
+        super().__init__(message, None, None, suggestion)
+
+
 class ADCPTaskError(ADCPError):
     """A task returned an ADCP error response.
 

--- a/tests/fixtures/public_api_snapshot.json
+++ b/tests/fixtures/public_api_snapshot.json
@@ -30,6 +30,7 @@
     "ActivateSignalResponse1",
     "ActivateSignalSuccessResponse",
     "AdAgentsValidationResult",
+    "AdagentsAccessBlockedError",
     "AdagentsCacheEntry",
     "AdagentsEntryError",
     "AdagentsFetchResult",

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -23,6 +23,7 @@ from adcp.adagents import (
     verify_agent_authorization,
 )
 from adcp.exceptions import (
+    AdagentsAccessBlockedError,
     AdagentsValidationError,
 )
 
@@ -673,6 +674,44 @@ class TestFetchAdagents:
 
         # Should stop after reasonable number of redirects (not go forever)
         assert call_count[0] <= 10
+
+    @pytest.mark.asyncio
+    async def test_fetch_403_cf_mitigated_raises_access_blocked(self):
+        """403 + cf-mitigated: challenge raises AdagentsAccessBlockedError."""
+        from adcp.adagents import fetch_adagents
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = httpx.Headers({"cf-mitigated": "challenge"})
+        mock_response.json.return_value = None
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsAccessBlockedError, match="cf-mitigated: challenge"):
+            await fetch_adagents("cafemedia.com", client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_fetch_403_no_cf_header_raises_generic_validation_error(self):
+        """Plain 403 without cf-mitigated header raises generic AdagentsValidationError."""
+        from adcp.adagents import fetch_adagents
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = httpx.Headers({})
+        mock_response.json.return_value = None
+
+        mock_client = create_mock_httpx_client(mock_response)
+
+        with pytest.raises(AdagentsValidationError, match="HTTP 403") as exc_info:
+            await fetch_adagents("example.com", client=mock_client)
+        assert not isinstance(exc_info.value, AdagentsAccessBlockedError)
+
+    def test_access_blocked_is_subclass_of_validation_error(self):
+        """AdagentsAccessBlockedError is catchable as AdagentsValidationError."""
+        err = AdagentsAccessBlockedError("cafemedia.com")
+        assert isinstance(err, AdagentsValidationError)
+        assert "cf-mitigated: challenge" in str(err)
+        assert "cafemedia.com" in str(err)
 
 
 class TestSSRFProtection:

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -676,13 +676,14 @@ class TestFetchAdagents:
         assert call_count[0] <= 10
 
     @pytest.mark.asyncio
-    async def test_fetch_403_cf_mitigated_raises_access_blocked(self):
-        """403 + cf-mitigated: challenge raises AdagentsAccessBlockedError."""
+    @pytest.mark.parametrize("cf_value", ["challenge", "Challenge"])
+    async def test_fetch_403_cf_mitigated_raises_access_blocked(self, cf_value):
+        """403 + cf-mitigated: challenge raises AdagentsAccessBlockedError (case-insensitive)."""
         from adcp.adagents import fetch_adagents
 
         mock_response = MagicMock()
         mock_response.status_code = 403
-        mock_response.headers = httpx.Headers({"cf-mitigated": "challenge"})
+        mock_response.headers = httpx.Headers({"cf-mitigated": cf_value})
         mock_response.json.return_value = None
 
         mock_client = create_mock_httpx_client(mock_response)

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -712,7 +712,7 @@ class TestFetchAdagents:
         err = AdagentsAccessBlockedError("cafemedia.com")
         assert isinstance(err, AdagentsValidationError)
         assert "cf-mitigated: challenge" in str(err)
-        assert "cafemedia.com" in str(err)
+        assert err.publisher_domain == "cafemedia.com"
 
 
 class TestSSRFProtection:


### PR DESCRIPTION
Closes #801.

When `_fetch_adagents_url` receives HTTP 403 with `cf-mitigated: challenge`, it now raises `AdagentsAccessBlockedError` (an `AdagentsValidationError` subclass) instead of the generic `AdagentsValidationError`. This makes the Cloudflare bot-challenge case distinguishable in application code without breaking existing `except AdagentsValidationError` handlers.

## Changes

- **`src/adcp/exceptions.py`** — new `AdagentsAccessBlockedError(AdagentsValidationError)` with `publisher_domain` attribute and actionable suggestion text
- **`src/adcp/adagents.py`** — 403 + `cf-mitigated: challenge` guard inserted in `_fetch_adagents_url` between the 404 and generic non-200 checks; `fetch_adagents` docstring `Raises` section updated; explanatory comments added at swallow sites
- **`src/adcp/__init__.py`** — `AdagentsAccessBlockedError` added to exports and `__all__`
- **`tests/test_adagents.py`** — four new tests: CF-mitigated 403 raises the subclass (parametrized for `challenge`/`Challenge` casing), plain 403 does not, subclass is catchable as `AdagentsValidationError`
- **`tests/fixtures/public_api_snapshot.json`** — `AdagentsAccessBlockedError` added alphabetically

## Design notes

- Inherits from `AdagentsValidationError` (not `ADCPError` directly) — existing `except AdagentsValidationError` call sites catch it automatically; no call-site patches required
- Only fires when **both** conditions hold: status 403 **and** `cf-mitigated: challenge` header present (case-insensitive, OWS-stripped); plain 403s still raise the generic error
- Non-breaking: all existing exception handling continues to work
- `AdagentsAccessBlockedError` is intentionally swallowed in `_try_managerdomain_fallback` and `fetch_agent_authorizations` (treated as authorization-unavailable, same as a missing file); comments added to each site
- `validate_adagents_domain` surfaces the error via `str(e)` in `AdAgentsValidationResult.errors` — the actionable message reaches callers

## What was tested

- `pytest tests/test_adagents.py -v` — 192 passed
- `pytest tests/` (excluding pre-existing TLS network test) — 5021 passed, 35 skipped
- `mypy src/adcp/adagents.py src/adcp/exceptions.py src/adcp/__init__.py` — no issues
- `ruff check` — no issues

## Pre-PR review

- **code-reviewer:** approved — guard condition and exception hierarchy correct; blocker (missing `Challenge`-casing test) fixed; intentional-swallow sites commented
- **dx-expert:** approved — inheritance hierarchy is correct for back-compat; guard condition is tight; error message and suggestion text are actionable; `publisher_domain` attribute is a DX improvement

**Known nit (not fixed in this PR):** `AdagentsNotFoundError` and `AdagentsTimeoutError` do not store `publisher_domain` as an instance attribute; `AdagentsAccessBlockedError` does. Backfilling those siblings is a separate, additive change.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/cse_01HBuAdZK8P2nCiEGqAeJ2wj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBuAdZK8P2nCiEGqAeJ2wj)_