### PR TITLE
fix: seller SDK version compatibility

### DIFF
--- a/src/adcp/_version.py
+++ b/src/adcp/_version.py
@@ -113,11 +113,29 @@ def _read_packaged_version() -> str:
     return (files("adcp") / "ADCP_VERSION").read_text().strip()
 
 
+def get_supported_adcp_versions() -> tuple[str, ...]:
+    """Release-precision versions to advertise in capabilities.
+
+    ``COMPATIBLE_ADCP_VERSIONS`` keeps the stable release lines the SDK
+    can speak. When the packaged spec is a prerelease for one of those
+    lines, advertise the exact prerelease instead of the future stable alias
+    so buyers can select the schema contract that actually ships with this
+    wheel.
+    """
+    packaged = normalize_to_release_precision(_read_packaged_version())
+    packaged_base = packaged.split("-", 1)[0]
+    versions = [v for v in COMPATIBLE_ADCP_VERSIONS if v != packaged_base or "-" not in packaged]
+    if packaged not in versions:
+        versions.append(packaged)
+    return tuple(versions)
+
+
 def resolve_adcp_version(pin: str | None) -> str:
     """Validate and resolve a constructor-supplied ``adcp_version`` pin.
 
     - ``None`` → reads the packaged ``ADCP_VERSION`` file (SDK default).
-    - Same-major pin → accepted.
+    - Explicit same-major pin → accepted only when the normalized release
+      is advertised by this SDK.
     - Cross-major pin → raises :class:`ConfigurationError`.
     - Unparseable string → raises :class:`ConfigurationError`.
 
@@ -146,4 +164,13 @@ def resolve_adcp_version(pin: str | None) -> str:
             f"AdCP {major}.x — cross-major pinning is not supported."
         )
 
-    return normalize_to_release_precision(raw)
+    normalized = normalize_to_release_precision(raw)
+    supported = get_supported_adcp_versions()
+    if pin is not None and normalized not in supported:
+        raise ConfigurationError(
+            f"adcp_version={raw!r} is not advertised by this SDK "
+            f"(supported_versions={list(supported)}). Use one of those exact "
+            "values, or omit adcp_version to use the packaged default."
+        )
+
+    return normalized

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -1498,21 +1498,20 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             supported_protocols = sorted(protocols)
 
         # ----- adcp block: structured > default -----
-        # When the adopter declares a full :class:`Adcp` block, take it
-        # in its entirety so ``major_versions`` and any future fields
-        # (``supported_versions``, ``build_version``) get carried
-        # through to the wire. When unset, the envelope helper's default
-        # of ``major_versions=[3]`` plus ``idempotency={"supported": False}``
-        # keeps the response spec-valid (though buyers will treat the
-        # seller as retry-unsafe).
+        # Route structured overrides through the response helper so its
+        # supported_versions defaults stay aligned with major_versions.
+        # A custom Adcp(major_versions=[2, 3]) without exact
+        # supported_versions must not inherit the SDK's 3.x exact list.
         from adcp.server.responses import capabilities_response
 
+        adcp = caps.adcp.model_dump(mode="json", exclude_none=True) if caps.adcp is not None else {}
         response = capabilities_response(
             supported_protocols,
-            idempotency={"supported": False},
+            major_versions=adcp.get("major_versions"),
+            supported_versions=adcp.get("supported_versions"),
+            build_version=adcp.get("build_version"),
+            idempotency=adcp.get("idempotency") or {"supported": False},
         )
-        if caps.adcp is not None:
-            response["adcp"] = caps.adcp.model_dump(mode="json", exclude_none=True)
 
         # ----- structured capability blocks (model_dump for each) -----
         # Each block emits only when the adopter has declared a value.

--- a/src/adcp/decisioning/validate_capabilities.py
+++ b/src/adcp/decisioning/validate_capabilities.py
@@ -33,6 +33,22 @@ if TYPE_CHECKING:
     from adcp.decisioning.handler import PlatformHandler
 
 
+def _running_loop_error(cause: RuntimeError) -> RuntimeError:
+    return RuntimeError(
+        "validate_capabilities_response_shape() was called from "
+        "inside a running event loop, which is incompatible with "
+        "the sync validator's internal asyncio.run(). Two fixes:\n"
+        "  1. In an async context (test fixture, Starlette "
+        "lifespan, in-process A2A client): construct the server "
+        "with create_adcp_server_from_platform(..., "
+        "validate_at_init=False) and `await "
+        "validate_capabilities_response_shape_async(handler)`.\n"
+        "  2. In a sync boot path that is not yet inside a loop: "
+        "no change needed — the validator runs as before.\n"
+        "See https://github.com/adcontextprotocol/adcp-client-python/issues/700."
+    )
+
+
 def _invoke_capabilities(handler: PlatformHandler) -> dict[str, Any]:
     """Call ``handler.get_adcp_capabilities()`` synchronously.
 
@@ -44,28 +60,12 @@ def _invoke_capabilities(handler: PlatformHandler) -> dict[str, Any]:
     re-raised with an SDK-specific message pointing at the opt-out.
     """
     try:
+        asyncio.get_running_loop()
+    except RuntimeError:
         return asyncio.run(handler.get_adcp_capabilities())
-    except RuntimeError as exc:
-        # Stdlib's ``asyncio.run`` raises ``RuntimeError("asyncio.run()
-        # cannot be called from a running event loop")``. That message
-        # is opaque to adopters — they have to find the issue / PR to
-        # learn the opt-out. Re-raise with the fix inline so the
-        # diagnostic answers the question "what do I do?".
-        if "running event loop" not in str(exc):
-            raise
-        raise RuntimeError(
-            "validate_capabilities_response_shape() was called from "
-            "inside a running event loop, which is incompatible with "
-            "the sync validator's internal asyncio.run(). Two fixes:\n"
-            "  1. In an async context (test fixture, Starlette "
-            "lifespan, in-process A2A client): construct the server "
-            "with create_adcp_server_from_platform(..., "
-            "validate_at_init=False) and `await "
-            "validate_capabilities_response_shape_async(handler)`.\n"
-            "  2. In a sync boot path that is not yet inside a loop: "
-            "no change needed — the validator runs as before.\n"
-            "See https://github.com/adcontextprotocol/adcp-client-python/issues/700."
-        ) from exc
+
+    cause = RuntimeError("asyncio.run() cannot be called from a running event loop")
+    raise _running_loop_error(cause) from cause
 
 
 def _violation(reason: str, *, details: dict[str, Any]) -> AdcpError:

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -33,6 +33,7 @@ from adcp.types import (
 )
 from adcp.types.error_narrowing import narrow_union_errors
 from adcp.validation.client_hooks import ValidationHookConfig
+from adcp.validation.envelope import DEFAULT_UNNEGOTIATED_ADCP_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -46,20 +47,26 @@ def _looks_like_sync_media_buy_success(method_name: str, result: dict[str, Any])
     )
 
 
-def _normalize_response_envelope(
-    method_name: str, result: dict[str, Any], raw_params: dict[str, Any]
-) -> None:
-    """Populate beta 3 envelope defaults before serialization/validation.
+def _is_adcp_31_or_newer(version: str | None) -> bool:
+    if version is None:
+        return True
+    try:
+        major_text, rest = version.split(".", 1)
+        release_text = rest.split("-", 1)[0].split(".", 1)[0]
+        return int(major_text) > 3 or (int(major_text) == 3 and int(release_text) >= 1)
+    except (AttributeError, TypeError, ValueError):
+        return True
 
-    AdCP 3.1 requires ``status`` on every response and requires
-    ``cache_scope`` on products/signals cacheable reads. The SDK can safely
-    infer the public cache only when the request has no account. Account-scoped
-    wholesale reads must be explicit so a seller doesn't accidentally label
-    account-specific inventory as globally cacheable.
-    """
-    if _looks_like_sync_media_buy_success(method_name, result):
-        raw_status = unwrap_enum_value(result.get("status"))
-        media_buy_status = unwrap_enum_value(result.get("media_buy_status"))
+
+def _normalize_sync_media_buy_response(
+    result: dict[str, Any],
+    *,
+    adcp_version: str | None,
+) -> None:
+    raw_status = unwrap_enum_value(result.get("status"))
+    media_buy_status = unwrap_enum_value(result.get("media_buy_status"))
+
+    if _is_adcp_31_or_newer(adcp_version):
         if raw_status is not None:
             result["status"] = raw_status
         if media_buy_status is not None:
@@ -69,9 +76,41 @@ def _normalize_response_envelope(
             result["status"] = "completed"
         elif media_buy_status is not None and raw_status in {None, media_buy_status}:
             result["status"] = "completed"
+        return
+
+    # 3.0 buyers expect the media-buy lifecycle status at top-level
+    # ``status``. This branch is intentionally narrow to create/update
+    # success payloads so the normal task envelope can still be applied to
+    # every other 3.1+ response.
+    if media_buy_status is not None:
+        result["status"] = media_buy_status
+        result.pop("media_buy_status", None)
+    elif raw_status is not None:
+        result["status"] = raw_status
+
+
+def _normalize_response_envelope(
+    method_name: str,
+    result: dict[str, Any],
+    raw_params: dict[str, Any],
+    *,
+    adcp_version: str | None = None,
+) -> None:
+    """Populate beta 3 envelope defaults before serialization/validation.
+
+    AdCP 3.1 requires ``status`` on every response and requires
+    ``cache_scope`` on products/signals cacheable reads. The SDK can safely
+    infer the public cache only when the request has no account. Account-scoped
+    wholesale reads must be explicit so a seller doesn't accidentally label
+    account-specific inventory as globally cacheable.
+    """
+    is_sync_media_buy_success = _looks_like_sync_media_buy_success(method_name, result)
+    if is_sync_media_buy_success:
+        _normalize_sync_media_buy_response(result, adcp_version=adcp_version)
 
     if "status" not in result and "task_id" not in result:
-        result["status"] = "completed"
+        if not (is_sync_media_buy_success and not _is_adcp_31_or_newer(adcp_version)):
+            result["status"] = "completed"
     if (
         method_name in {"get_products", "get_signals"}
         and "cache_scope" not in result
@@ -2062,8 +2101,10 @@ def create_tool_caller(
         # Wire-version detection: read ``adcp_version`` / ``adcp_major_version``
         # off the post-hook params (legacy buyers may rely on a hook to
         # populate the envelope, so this runs after pre_validation_hook).
-        # ``None`` means the buyer didn't claim a version — fall through
-        # to the SDK pin via ``version=None`` on the validator.
+        # ``None`` initially means the buyer didn't claim a version.
+        # After legacy shape probes run, native unnegotiated traffic is
+        # pinned to 3.0 compatibility because those buyers predate the
+        # release-precision ``adcp_version`` field and the 3.1 status split.
         #
         # Strictness gate: setting ``ADCP_STRICT_VERSION_ENVELOPE=1``
         # raises ``VERSION_UNSUPPORTED`` for unsupported claims (the
@@ -2072,9 +2113,11 @@ def create_tool_caller(
         # fixtures using placeholder version values (``adcp_major_version=4``
         # was a common sentinel before this gate existed) keep working
         # while they migrate. Strict will become the default in 5.3.
+        wire_version_rejected = False
         try:
             wire_version = detect_wire_version(params)
         except UnsupportedVersionError as exc:
+            wire_version_rejected = True
             if os.environ.get("ADCP_STRICT_VERSION_ENVELOPE", "0") == "1":
                 raise ADCPTaskError(
                     operation=method_name,
@@ -2134,6 +2177,9 @@ def create_tool_caller(
                     )
                     wire_version = candidate
                     break
+
+        if wire_version is None and not wire_version_rejected:
+            wire_version = DEFAULT_UNNEGOTIATED_ADCP_VERSION
 
         # Legacy-version routing: if the buyer claims (or shape-detected)
         # a version handled via the adapter path (e.g. ``"2.5"``),
@@ -2306,7 +2352,12 @@ def create_tool_caller(
         # from the raw dict the transport sent, not from the validated
         # model (which won't carry the wire ``context`` field).
         if isinstance(result, dict):
-            _normalize_response_envelope(method_name, result, raw_params)
+            _normalize_response_envelope(
+                method_name,
+                result,
+                raw_params,
+                adcp_version=post_adapter_validator_version,
+            )
             inject_context(raw_params, result)
 
         if response_mode is not None and response_mode != "off" and isinstance(result, dict):

--- a/src/adcp/server/responses.py
+++ b/src/adcp/server/responses.py
@@ -26,6 +26,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from adcp._version import ADCP_MAJOR_VERSION, get_supported_adcp_versions
 from adcp.server.helpers import valid_actions_for_status
 
 
@@ -43,6 +44,51 @@ def _rfc3339_now() -> str:
 
 
 _logger = logging.getLogger("adcp.server")
+
+
+def _is_adcp_31_or_newer(version: str) -> bool:
+    try:
+        major_text, rest = version.split(".", 1)
+        release_text = rest.split("-", 1)[0].split(".", 1)[0]
+        return int(major_text) > 3 or (int(major_text) == 3 and int(release_text) >= 1)
+    except (AttributeError, TypeError, ValueError):
+        return True
+
+
+def _major_version_values(major_versions: list[Any]) -> list[int]:
+    values: list[int] = []
+    for version in major_versions:
+        raw = version.root if hasattr(version, "root") else version
+        if isinstance(raw, int):
+            values.append(raw)
+    return values
+
+
+def _normalize_capabilities_adcp_version(
+    adcp_version: str,
+    supported_versions: list[str] | None,
+) -> str:
+    from adcp._version import normalize_to_release_precision
+    from adcp.exceptions import ConfigurationError
+
+    try:
+        normalized = normalize_to_release_precision(adcp_version)
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+
+    if supported_versions is None:
+        raise ConfigurationError(
+            "capabilities_response(adcp_version=...) requires supported_versions "
+            "when the helper cannot infer exact SDK-supported versions. Pass "
+            "supported_versions with exact release values, or omit adcp_version."
+        )
+    if supported_versions is not None and normalized not in supported_versions:
+        raise ConfigurationError(
+            f"adcp_version={adcp_version!r} is not included in supported_versions "
+            f"({supported_versions}). Pass an adcp_version from supported_versions, "
+            "or omit adcp_version."
+        )
+    return normalized
 
 
 def _strip_none_values(value: Any) -> Any:
@@ -167,15 +213,16 @@ def capabilities_response(
             favor of ``supported_versions`` (release-precision); both are
             emitted through 3.x for backwards compatibility.
         adcp_version: Server's pinned release this response was built
-            for (release-precision string, e.g. ``"3.1"``). When set,
-            included on the response envelope so buyers can read what
+            for. Must match one of ``supported_versions`` exactly. When
+            set, included on the response envelope so buyers can read what
             release the server actually served. Typically passed by
             ``ADCPServerBuilder``'s auto-capabilities handler from its
             per-instance pin.
         supported_versions: Release-precision versions this server speaks
             (e.g. ``["3.0", "3.1"]``). Authoritative for buyer-side
-            release pinning per the version-negotiation RFC. When omitted
-            and ``adcp_version`` is set, defaults to ``[adcp_version]``.
+            release pinning per the version-negotiation RFC. When omitted,
+            defaults to the SDK's stable aliases plus the exact packaged
+            prerelease line when applicable.
         build_version: Optional advisory metadata — full
             VERSION.RELEASE.PATCH of the server's build (e.g.
             ``"3.1.2"``). Useful for incident triage; not part of the
@@ -209,9 +256,12 @@ def capabilities_response(
             "Pass idempotency={'supported': False} to declare non-support, "
             "or idempotency=store.capability() to declare support."
         )
-    adcp_info: dict[str, Any] = {"major_versions": major_versions or [3]}
-    if supported_versions is None and adcp_version is not None:
-        supported_versions = [adcp_version]
+    effective_major_versions = major_versions or [ADCP_MAJOR_VERSION]
+    adcp_info: dict[str, Any] = {"major_versions": effective_major_versions}
+    if supported_versions is None:
+        majors = _major_version_values(effective_major_versions)
+        if majors and all(major == ADCP_MAJOR_VERSION for major in majors):
+            supported_versions = list(get_supported_adcp_versions())
     if supported_versions:
         adcp_info["supported_versions"] = supported_versions
     if build_version is not None:
@@ -225,7 +275,10 @@ def capabilities_response(
         "sandbox": sandbox,
     }
     if adcp_version is not None:
-        resp["adcp_version"] = adcp_version
+        resp["adcp_version"] = _normalize_capabilities_adcp_version(
+            adcp_version,
+            supported_versions,
+        )
     if features:
         resp["features"] = features
     if compliance_testing is not None:
@@ -343,6 +396,7 @@ def media_buy_response(
     valid_actions: list[str] | None = None,
     revision: int | None = None,
     confirmed_at: str | None = None,
+    adcp_version: str | None = None,
     sandbox: bool = True,
 ) -> dict[str, Any]:
     """Build a create_media_buy success response.
@@ -352,6 +406,10 @@ def media_buy_response(
 
     Auto-populates valid_actions from status if not provided.
     Auto-sets revision to 1 and confirmed_at to now if not provided.
+    Pass ``adcp_version="3.0"`` for the 3.0 top-level lifecycle status
+    shape, or an exact 3.1+ supported version for the task-envelope shape
+    (``status="completed"`` plus ``media_buy_status``). When omitted, the
+    dispatcher projects by the buyer's requested version.
     """
     resp: dict[str, Any] = {
         "media_buy_id": media_buy_id,
@@ -363,13 +421,18 @@ def media_buy_response(
     if buyer_ref is not None:
         resp["buyer_ref"] = buyer_ref
     if status is not None:
-        resp["media_buy_status"] = status
+        if adcp_version is None or _is_adcp_31_or_newer(adcp_version):
+            resp["media_buy_status"] = status
+        else:
+            resp["status"] = status
         if valid_actions is None:
             resp["valid_actions"] = valid_actions_for_status(status)
         else:
             resp["valid_actions"] = valid_actions
     elif valid_actions is not None:
         resp["valid_actions"] = valid_actions
+    if adcp_version is not None and _is_adcp_31_or_newer(adcp_version):
+        resp["status"] = "completed"
     return resp
 
 
@@ -389,12 +452,17 @@ def update_media_buy_response(
     status: str | None = None,
     valid_actions: list[str] | None = None,
     revision: int | None = None,
+    adcp_version: str | None = None,
     sandbox: bool = True,
 ) -> dict[str, Any]:
     """Build an update_media_buy success response.
 
     Matches UpdateMediaBuyResponse1 (success) schema.
     Auto-populates valid_actions from status if not provided.
+    Pass ``adcp_version="3.0"`` for the 3.0 top-level lifecycle status
+    shape, or an exact 3.1+ supported version for the task-envelope shape
+    (``status="completed"`` plus ``media_buy_status``). When omitted, the
+    dispatcher projects by the buyer's requested version.
     """
     resp: dict[str, Any] = {
         "media_buy_id": media_buy_id,
@@ -403,7 +471,10 @@ def update_media_buy_response(
     if affected_packages is not None:
         resp["affected_packages"] = _serialize(affected_packages)
     if status is not None:
-        resp["media_buy_status"] = status
+        if adcp_version is None or _is_adcp_31_or_newer(adcp_version):
+            resp["media_buy_status"] = status
+        else:
+            resp["status"] = status
         if valid_actions is None:
             resp["valid_actions"] = valid_actions_for_status(status)
         else:
@@ -412,6 +483,8 @@ def update_media_buy_response(
         resp["valid_actions"] = valid_actions
     if revision is not None:
         resp["revision"] = revision
+    if adcp_version is not None and _is_adcp_31_or_newer(adcp_version):
+        resp["status"] = "completed"
     return resp
 
 

--- a/src/adcp/validation/envelope.py
+++ b/src/adcp/validation/envelope.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from adcp._version import COMPATIBLE_ADCP_VERSIONS, normalize_to_release_precision
+from adcp._version import get_supported_adcp_versions, normalize_to_release_precision
 from adcp.compat.legacy import LEGACY_ADAPTER_VERSIONS
 
 #: Every version the server speaks — natively-validated majors plus
@@ -31,9 +31,18 @@ from adcp.compat.legacy import LEGACY_ADAPTER_VERSIONS
 #: ``supported`` set for :func:`detect_wire_version` so the dispatcher
 #: accepts both shapes.
 SUPPORTED_WIRE_VERSIONS: tuple[str, ...] = (
-    *COMPATIBLE_ADCP_VERSIONS,
-    *LEGACY_ADAPTER_VERSIONS,
+    *dict.fromkeys(
+        (
+            *get_supported_adcp_versions(),
+            *LEGACY_ADAPTER_VERSIONS,
+        )
+    ),
 )
+
+# Buyers that omit the release-precision ``adcp_version`` predate the 3.1
+# status-envelope split, so native unnegotiated traffic stays on the 3.0
+# contract. The dispatcher applies this only after legacy shape probes run.
+DEFAULT_UNNEGOTIATED_ADCP_VERSION = "3.0"
 
 
 class UnsupportedVersionError(ValueError):
@@ -64,11 +73,15 @@ def detect_wire_version(
     1. ``payload['adcp_version']`` — string, normalized to release
        precision (``"3.0.7"`` → ``"3.0"``). Must be in ``supported`` or
        raises :class:`UnsupportedVersionError`.
-    2. ``payload['adcp_major_version']`` — int. Maps to the highest minor
-       in ``supported`` for that major. No supported minor for the major
-       raises :class:`UnsupportedVersionError`.
-    3. Neither field set — returns ``None`` so the caller falls back to
-       the SDK's compile-time pin.
+    2. ``payload['adcp_major_version']`` — int. Prefer ``MAJOR.0`` when
+       supported because this legacy field predates release-precision
+       negotiation and the 3.1 response envelope split. If ``MAJOR.0`` is
+       unavailable, maps to the highest minor in ``supported`` for that
+       major. No supported minor for the major raises
+       :class:`UnsupportedVersionError`.
+    3. Neither field set — returns ``None`` so the caller can apply its
+       unnegotiated default (the server dispatcher currently applies
+       ``3.0`` after legacy-shape probes).
 
     Non-dict payloads return ``None`` (validation skipped — the schema
     layer rejects non-dict requests via its own type check).
@@ -106,7 +119,13 @@ def detect_wire_version(
         candidates = [v for v in supported if v.startswith(f"{major_value}.")]
         if not candidates:
             raise UnsupportedVersionError(major_value, supported)
-        # Highest supported minor for this major.
+        # Major-only buyers predate release-precision negotiation. Keep
+        # them on the base minor when possible so they do not accidentally
+        # opt into newer response-envelope semantics.
+        base_minor = f"{major_value}.0"
+        if base_minor in candidates:
+            return base_minor
+        # Otherwise fall back to the highest supported minor for this major.
         return max(candidates, key=lambda v: int(v.split(".")[1].split("-")[0]))
 
     return None

--- a/tests/test_adcp_version_option.py
+++ b/tests/test_adcp_version_option.py
@@ -1,10 +1,11 @@
 """Tests for the per-instance ``adcp_version`` constructor option (Stage 2).
 
-Validates the plumbing only — Stage 3 (per-instance schema/validator
-selection, wire emission) is deferred. These tests assert that:
+Validates the per-instance pinning and wire-emission plumbing. These
+tests assert that:
 
 - Default resolution reads the packaged ``ADCP_VERSION`` file.
-- Same-major release- and patch-precision pins are accepted as-is.
+- Same-major pins are accepted only when they normalize to an exact
+  advertised ``supported_versions`` entry.
 - Cross-major pins raise ``ConfigurationError`` at construction.
 - Unparseable strings raise ``ConfigurationError``.
 - All four constructor surfaces (``ADCPClient``,
@@ -20,6 +21,7 @@ from adcp import ADCPClient, ADCPMultiAgentClient, get_adcp_spec_version
 from adcp._version import (
     ADCP_MAJOR_VERSION,
     COMPATIBLE_ADCP_VERSIONS,
+    get_supported_adcp_versions,
     normalize_to_release_precision,
     parse_adcp_major_version,
     resolve_adcp_version,
@@ -27,6 +29,8 @@ from adcp._version import (
 from adcp.exceptions import ConfigurationError
 from adcp.server.builder import ADCPServerBuilder, adcp_server
 from adcp.types import AgentConfig, Protocol
+
+_PACKAGED_ADCP_VERSION = normalize_to_release_precision(get_adcp_spec_version())
 
 # ---------------------------------------------------------------------------
 # parse_adcp_major_version
@@ -80,16 +84,22 @@ def test_resolve_default_returns_normalized_packaged_version() -> None:
     "version,expected",
     [
         ("3.0", "3.0"),
-        ("3.1", "3.1"),
         ("3.0.0", "3.0"),  # normalized — patch stripped
         ("3.0.1", "3.0"),  # normalized — patch stripped
-        ("3.1-beta", "3.1-beta"),
-        ("3.1.0-rc.1", "3.1-rc.1"),  # normalized — patch stripped, pre-release kept
+        (_PACKAGED_ADCP_VERSION, _PACKAGED_ADCP_VERSION),
     ],
 )
 def test_resolve_same_major_normalized(version: str, expected: str) -> None:
-    """All same-major pins resolve to release-precision per the spec wire rule."""
+    """Advertised same-major pins resolve to release-precision per the wire rule."""
     assert resolve_adcp_version(version) == expected
+
+
+@pytest.mark.parametrize("version", ["3.1", "3.1-beta", "3.1.0-rc.1"])
+def test_resolve_unadvertised_same_major_rejected(version: str) -> None:
+    if normalize_to_release_precision(version) in get_supported_adcp_versions():
+        pytest.skip("Version is advertised by this SDK")
+    with pytest.raises(ConfigurationError, match="Use one of those exact values"):
+        resolve_adcp_version(version)
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +155,10 @@ def test_compatible_versions_constant_matches_major() -> None:
         assert parse_adcp_major_version(v) == ADCP_MAJOR_VERSION
 
 
+def test_supported_versions_include_packaged_spec_line() -> None:
+    assert _PACKAGED_ADCP_VERSION in get_supported_adcp_versions()
+
+
 # ---------------------------------------------------------------------------
 # ADCPClient
 # ---------------------------------------------------------------------------
@@ -160,15 +174,14 @@ def _agent_config() -> AgentConfig:
 
 def test_adcp_client_default_uses_normalized_packaged_version() -> None:
     client = ADCPClient(_agent_config())
-    assert client.get_adcp_version() == normalize_to_release_precision(get_adcp_spec_version())
+    assert client.get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 @pytest.mark.parametrize(
     "version,expected",
     [
         ("3.0", "3.0"),
-        ("3.1", "3.1"),
-        ("3.1-beta", "3.1-beta"),
+        (_PACKAGED_ADCP_VERSION, _PACKAGED_ADCP_VERSION),
         ("3.0.0", "3.0"),  # patch input → release stored
         ("3.0.1", "3.0"),
     ],
@@ -195,13 +208,13 @@ def test_adcp_client_unparseable_rejected() -> None:
 
 def test_multi_agent_default_uses_packaged_version() -> None:
     multi = ADCPMultiAgentClient(agents=[_agent_config()])
-    assert multi.get_adcp_version() == normalize_to_release_precision(get_adcp_spec_version())
+    assert multi.get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 def test_multi_agent_pin_forwards_to_per_agent() -> None:
-    multi = ADCPMultiAgentClient(agents=[_agent_config()], adcp_version="3.1")
-    assert multi.get_adcp_version() == "3.1"
-    assert multi.agent("test").get_adcp_version() == "3.1"
+    multi = ADCPMultiAgentClient(agents=[_agent_config()], adcp_version=_PACKAGED_ADCP_VERSION)
+    assert multi.get_adcp_version() == _PACKAGED_ADCP_VERSION
+    assert multi.agent("test").get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 def test_multi_agent_cross_major_rejected() -> None:
@@ -220,28 +233,26 @@ def test_multi_agent_per_agent_map_pins_each_agent_independently() -> None:
     """Per-agent dict form lets a holdco pin each seller separately."""
     multi = ADCPMultiAgentClient(
         agents=_two_agents(),
-        adcp_version={"seller_a": "3.0", "seller_b": "3.1"},
+        adcp_version={"seller_a": "3.0", "seller_b": _PACKAGED_ADCP_VERSION},
     )
     assert multi.agent("seller_a").get_adcp_version() == "3.0"
-    assert multi.agent("seller_b").get_adcp_version() == "3.1"
+    assert multi.agent("seller_b").get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 def test_multi_agent_per_agent_map_falls_back_to_default_for_missing_keys() -> None:
     multi = ADCPMultiAgentClient(
         agents=_two_agents(),
-        adcp_version={"seller_a": "3.1"},
+        adcp_version={"seller_a": _PACKAGED_ADCP_VERSION},
     )
-    assert multi.agent("seller_a").get_adcp_version() == "3.1"
+    assert multi.agent("seller_a").get_adcp_version() == _PACKAGED_ADCP_VERSION
     # seller_b missing from map → SDK default.
-    assert multi.agent("seller_b").get_adcp_version() == normalize_to_release_precision(
-        get_adcp_spec_version()
-    )
+    assert multi.agent("seller_b").get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 def test_multi_agent_get_version_raises_on_heterogeneous_pins() -> None:
     multi = ADCPMultiAgentClient(
         agents=_two_agents(),
-        adcp_version={"seller_a": "3.0", "seller_b": "3.1"},
+        adcp_version={"seller_a": "3.0", "seller_b": _PACKAGED_ADCP_VERSION},
     )
     with pytest.raises(ValueError) as exc:
         multi.get_adcp_version()
@@ -254,9 +265,12 @@ def test_multi_agent_get_version_returns_uniform_when_map_agrees() -> None:
     """Dict form with all agents at the same pin still resolves uniformly."""
     multi = ADCPMultiAgentClient(
         agents=_two_agents(),
-        adcp_version={"seller_a": "3.1", "seller_b": "3.1"},
+        adcp_version={
+            "seller_a": _PACKAGED_ADCP_VERSION,
+            "seller_b": _PACKAGED_ADCP_VERSION,
+        },
     )
-    assert multi.get_adcp_version() == "3.1"
+    assert multi.get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 def test_multi_agent_per_agent_map_cross_major_rejected() -> None:
@@ -274,10 +288,10 @@ def test_multi_agent_per_agent_map_cross_major_rejected() -> None:
 
 def test_server_builder_default_uses_packaged_version() -> None:
     builder = ADCPServerBuilder("my-seller")
-    assert builder.get_adcp_version() == normalize_to_release_precision(get_adcp_spec_version())
+    assert builder.get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
-@pytest.mark.parametrize("version", ["3.0", "3.1"])
+@pytest.mark.parametrize("version", ["3.0", _PACKAGED_ADCP_VERSION])
 def test_server_builder_explicit_pin_accepted(version: str) -> None:
     builder = ADCPServerBuilder("my-seller", adcp_version=version)
     assert builder.get_adcp_version() == version
@@ -289,8 +303,8 @@ def test_server_builder_cross_major_rejected() -> None:
 
 
 def test_adcp_server_factory_passes_adcp_version_through() -> None:
-    builder = adcp_server("my-seller", adcp_version="3.1")
-    assert builder.get_adcp_version() == "3.1"
+    builder = adcp_server("my-seller", adcp_version=_PACKAGED_ADCP_VERSION)
+    assert builder.get_adcp_version() == _PACKAGED_ADCP_VERSION
 
 
 def test_adcp_server_factory_cross_major_rejected() -> None:

--- a/tests/test_adcp_version_wire.py
+++ b/tests/test_adcp_version_wire.py
@@ -5,9 +5,8 @@ Validates:
 - Outbound request params get ``adcp_version`` injected from the
   client's per-instance pin (via ``ProtocolAdapter.envelope_enricher``).
 - Caller-supplied values on the params dict win over the enricher.
-- ``capabilities_response()`` emits ``supported_versions`` /
-  ``build_version`` / top-level ``adcp_version`` when the server
-  builder's pin is threaded through.
+- ``capabilities_response()`` emits exact ``supported_versions`` by default,
+  plus ``build_version`` / top-level ``adcp_version`` when supplied.
 - ``ADCPServerBuilder``'s auto-generated capabilities handler passes
   the pin into ``capabilities_response()``.
 """
@@ -16,10 +15,16 @@ from __future__ import annotations
 
 import asyncio
 
-from adcp import ADCPClient
+import pytest
+
+from adcp import ADCPClient, get_adcp_spec_version
+from adcp._version import get_supported_adcp_versions, normalize_to_release_precision
+from adcp.exceptions import ConfigurationError
 from adcp.server.builder import ADCPServerBuilder, adcp_server
 from adcp.server.responses import capabilities_response
 from adcp.types import AgentConfig, Protocol
+
+_PACKAGED_ADCP_VERSION = normalize_to_release_precision(get_adcp_spec_version())
 
 
 def _agent_config() -> AgentConfig:
@@ -36,33 +41,30 @@ def _agent_config() -> AgentConfig:
 
 
 def test_envelope_enricher_injects_pin() -> None:
-    client = ADCPClient(_agent_config(), adcp_version="3.1")
+    client = ADCPClient(_agent_config(), adcp_version=_PACKAGED_ADCP_VERSION)
     enriched = client.adapter._enrich_outgoing_params({"brief": "hi"})
-    assert enriched == {"adcp_version": "3.1", "brief": "hi"}
+    assert enriched == {"adcp_version": _PACKAGED_ADCP_VERSION, "brief": "hi"}
 
 
 def test_envelope_enricher_does_not_overwrite_caller_value() -> None:
     """Caller-supplied adcp_version on the params dict wins over the pin."""
-    client = ADCPClient(_agent_config(), adcp_version="3.1")
+    client = ADCPClient(_agent_config(), adcp_version=_PACKAGED_ADCP_VERSION)
     enriched = client.adapter._enrich_outgoing_params({"adcp_version": "3.0", "brief": "hi"})
     assert enriched == {"adcp_version": "3.0", "brief": "hi"}
 
 
 def test_envelope_enricher_passes_through_non_dict() -> None:
     """Rare but possible: non-dict params (e.g. None or a list) pass through."""
-    client = ADCPClient(_agent_config(), adcp_version="3.1")
+    client = ADCPClient(_agent_config(), adcp_version=_PACKAGED_ADCP_VERSION)
     assert client.adapter._enrich_outgoing_params(None) is None
     assert client.adapter._enrich_outgoing_params([1, 2, 3]) == [1, 2, 3]
 
 
 def test_envelope_enricher_uses_default_when_pin_omitted() -> None:
     """Default pin = packaged ADCP_VERSION, normalized to release-precision."""
-    from adcp import get_adcp_spec_version
-    from adcp._version import normalize_to_release_precision
-
     client = ADCPClient(_agent_config())
     enriched = client.adapter._enrich_outgoing_params({})
-    assert enriched["adcp_version"] == normalize_to_release_precision(get_adcp_spec_version())
+    assert enriched["adcp_version"] == _PACKAGED_ADCP_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -70,39 +72,53 @@ def test_envelope_enricher_uses_default_when_pin_omitted() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_capabilities_response_omits_new_fields_when_no_pin() -> None:
-    """Backwards compatible: existing callers see no new fields."""
+def test_capabilities_response_emits_supported_versions_when_no_pin() -> None:
     resp = capabilities_response(["media_buy"])
     assert "adcp_version" not in resp
-    assert "supported_versions" not in resp["adcp"]
+    assert resp["adcp"]["supported_versions"] == list(get_supported_adcp_versions())
     assert "build_version" not in resp["adcp"]
     assert resp["adcp"]["major_versions"] == [3]
 
 
 def test_capabilities_response_emits_supported_versions_from_pin() -> None:
-    """Single-pin server: supported_versions defaults to [pin]."""
-    resp = capabilities_response(["media_buy"], adcp_version="3.1")
-    assert resp["adcp_version"] == "3.1"
-    assert resp["adcp"]["supported_versions"] == ["3.1"]
+    """The server pin is advisory; supported_versions lists compatible releases."""
+    resp = capabilities_response(["media_buy"], adcp_version=_PACKAGED_ADCP_VERSION)
+    assert resp["adcp_version"] == _PACKAGED_ADCP_VERSION
+    assert resp["adcp"]["supported_versions"] == list(get_supported_adcp_versions())
     # Legacy field still emitted for back-compat.
     assert resp["adcp"]["major_versions"] == [3]
+
+
+def test_capabilities_response_rejects_pin_not_in_default_supported_versions() -> None:
+    if "3.1" in get_supported_adcp_versions():
+        pytest.skip("SDK now advertises stable 3.1")
+    with pytest.raises(ConfigurationError, match="Pass an adcp_version from supported_versions"):
+        capabilities_response(["media_buy"], adcp_version="3.1")
+
+
+def test_capabilities_response_requires_supported_versions_for_mixed_major_pin() -> None:
+    with pytest.raises(
+        ConfigurationError,
+        match="Pass supported_versions with exact release values",
+    ):
+        capabilities_response(["media_buy"], major_versions=[2, 3], adcp_version="3.0")
 
 
 def test_capabilities_response_explicit_supported_versions_override() -> None:
     """Multi-release server: caller passes explicit list."""
     resp = capabilities_response(
         ["media_buy"],
-        adcp_version="3.1",
-        supported_versions=["3.0", "3.1"],
+        adcp_version=_PACKAGED_ADCP_VERSION,
+        supported_versions=["3.0", _PACKAGED_ADCP_VERSION],
     )
-    assert resp["adcp_version"] == "3.1"
-    assert resp["adcp"]["supported_versions"] == ["3.0", "3.1"]
+    assert resp["adcp_version"] == _PACKAGED_ADCP_VERSION
+    assert resp["adcp"]["supported_versions"] == ["3.0", _PACKAGED_ADCP_VERSION]
 
 
 def test_capabilities_response_emits_build_version() -> None:
     resp = capabilities_response(
         ["media_buy"],
-        adcp_version="3.1",
+        adcp_version=_PACKAGED_ADCP_VERSION,
         build_version="3.1.2",
     )
     assert resp["adcp"]["build_version"] == "3.1.2"
@@ -116,7 +132,7 @@ def test_capabilities_response_emits_build_version() -> None:
 def test_server_builder_auto_capabilities_emits_pin() -> None:
     """The auto-generated get_adcp_capabilities handler threads the pin
     into capabilities_response()."""
-    builder = adcp_server("my-seller", adcp_version="3.1")
+    builder = adcp_server("my-seller", adcp_version=_PACKAGED_ADCP_VERSION)
 
     @builder.get_products
     async def _get_products(params, context=None):
@@ -125,15 +141,12 @@ def test_server_builder_auto_capabilities_emits_pin() -> None:
     handler = builder.build_handler()
 
     response = asyncio.run(handler.get_adcp_capabilities({}, None))
-    assert response["adcp_version"] == "3.1"
-    assert response["adcp"]["supported_versions"] == ["3.1"]
+    assert response["adcp_version"] == _PACKAGED_ADCP_VERSION
+    assert response["adcp"]["supported_versions"] == list(get_supported_adcp_versions())
 
 
 def test_server_builder_auto_capabilities_uses_default_pin() -> None:
     """No explicit pin → packaged ADCP_VERSION (normalized) drives the response."""
-    from adcp import get_adcp_spec_version
-    from adcp._version import normalize_to_release_precision
-
     builder = ADCPServerBuilder("my-seller")
 
     @builder.get_products
@@ -142,4 +155,4 @@ def test_server_builder_auto_capabilities_uses_default_pin() -> None:
 
     handler = builder.build_handler()
     response = asyncio.run(handler.get_adcp_capabilities({}, None))
-    assert response["adcp_version"] == normalize_to_release_precision(get_adcp_spec_version())
+    assert response["adcp_version"] == _PACKAGED_ADCP_VERSION

--- a/tests/test_capabilities_response_shape_validation.py
+++ b/tests/test_capabilities_response_shape_validation.py
@@ -28,6 +28,7 @@ from adcp.decisioning import (
     InMemoryTaskRegistry,
     SingletonAccounts,
 )
+from adcp.decisioning.capabilities import Account, MediaBuy, SupportedProtocol
 from adcp.decisioning.handler import PlatformHandler
 from adcp.decisioning.serve import create_adcp_server_from_platform
 from adcp.decisioning.types import AdcpError
@@ -54,23 +55,7 @@ def _build_handler(platform: DecisioningPlatform, executor: ThreadPoolExecutor) 
 # ---- Conformant platform ----
 
 
-class _ConformantSalesPlatform(DecisioningPlatform):
-    """Sales-non-guaranteed with supported_billing — projects a valid response.
-
-    Stubs the five SalesPlatform-required methods so ``validate_platform``
-    accepts the class when it's wired through
-    :func:`create_adcp_server_from_platform`. The capabilities-shape
-    validator under test runs *after* ``validate_platform``.
-    """
-
-    capabilities = DecisioningCapabilities(
-        specialisms=("sales-non-guaranteed",),
-        channels=("display",),
-        pricing_models=("cpm",),
-        supported_billing=("operator", "agent"),
-    )
-    accounts = SingletonAccounts(account_id="test")
-
+class _SalesPlatformMethods:
     def get_products(self, req, ctx):
         return {"products": []}
 
@@ -86,6 +71,36 @@ class _ConformantSalesPlatform(DecisioningPlatform):
     def get_media_buy_delivery(self, req, ctx):
         return {"media_buy_deliveries": []}
 
+    def get_media_buys(self, req, ctx):
+        return {"media_buys": []}
+
+    def list_creative_formats(self, req, ctx):
+        return {"formats": []}
+
+    def list_creatives(self, req, ctx):
+        return {"creatives": []}
+
+    def provide_performance_feedback(self, req, ctx):
+        return {"status": "completed"}
+
+
+class _ConformantSalesPlatform(_SalesPlatformMethods, DecisioningPlatform):
+    """Sales-non-guaranteed with supported_billing — projects a valid response.
+
+    Stubs the five SalesPlatform-required methods so ``validate_platform``
+    accepts the class when it's wired through
+    :func:`create_adcp_server_from_platform`. The capabilities-shape
+    validator under test runs *after* ``validate_platform``.
+    """
+
+    capabilities = DecisioningCapabilities(
+        specialisms=("sales-non-guaranteed",),
+        supported_protocols=[SupportedProtocol.media_buy],
+        account=Account(supported_billing=["operator", "agent"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+    )
+    accounts = SingletonAccounts(account_id="test")
+
 
 def test_conformant_platform_passes(executor: ThreadPoolExecutor) -> None:
     """A platform whose projection conforms to the spec passes silently."""
@@ -97,7 +112,7 @@ def test_conformant_platform_passes(executor: ThreadPoolExecutor) -> None:
 # ---- media_buy claimer missing supported_billing ----
 
 
-class _MediaBuyMissingBillingPlatform(DecisioningPlatform):
+class _MediaBuyMissingBillingPlatform(_SalesPlatformMethods, DecisioningPlatform):
     """Claims sales-non-guaranteed (→ media_buy) but omits supported_billing.
 
     Recreates the v3 reference seller's pre-#402 misconfiguration: the
@@ -108,8 +123,8 @@ class _MediaBuyMissingBillingPlatform(DecisioningPlatform):
 
     capabilities = DecisioningCapabilities(
         specialisms=("sales-non-guaranteed",),
-        channels=("display",),
-        pricing_models=("cpm",),
+        supported_protocols=[SupportedProtocol.media_buy],
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
         # supported_billing intentionally unset.
     )
     accounts = SingletonAccounts(account_id="test")
@@ -233,7 +248,7 @@ def test_schema_violation_in_override_fails(executor: ThreadPoolExecutor) -> Non
 # ---- Wired into create_adcp_server_from_platform ----
 
 
-class _NonConformantSalesPlatform(DecisioningPlatform):
+class _NonConformantSalesPlatform(_SalesPlatformMethods, DecisioningPlatform):
     """Sales platform with required-method coverage but missing
     ``supported_billing`` — passes ``validate_platform`` so the
     capabilities-shape validator is the gate that fails.
@@ -241,26 +256,11 @@ class _NonConformantSalesPlatform(DecisioningPlatform):
 
     capabilities = DecisioningCapabilities(
         specialisms=("sales-non-guaranteed",),
-        channels=("display",),
-        pricing_models=("cpm",),
+        supported_protocols=[SupportedProtocol.media_buy],
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
         # supported_billing intentionally unset.
     )
     accounts = SingletonAccounts(account_id="test")
-
-    def get_products(self, req, ctx):
-        return {"products": []}
-
-    def create_media_buy(self, req, ctx):
-        return {"media_buy_id": "x", "status": "active"}
-
-    def update_media_buy(self, media_buy_id, patch, ctx):
-        return {"media_buy_id": media_buy_id, "status": "active"}
-
-    def sync_creatives(self, req, ctx):
-        return {"creatives": []}
-
-    def get_media_buy_delivery(self, req, ctx):
-        return {"media_buy_deliveries": []}
 
 
 def test_create_adcp_server_rejects_non_conformant_platform() -> None:
@@ -318,9 +318,9 @@ def test_v3_reference_seller_shape_passes(executor: ThreadPoolExecutor) -> None:
     class _V3RefSellerShape(DecisioningPlatform):
         capabilities = DecisioningCapabilities(
             specialisms=("sales-non-guaranteed",),
-            channels=("display", "ctv"),
-            pricing_models=("cpm",),
-            supported_billing=("operator", "agent"),
+            supported_protocols=[SupportedProtocol.media_buy],
+            account=Account(supported_billing=["operator", "agent"]),
+            media_buy=MediaBuy(supported_pricing_models=["cpm"]),
         )
         accounts = SingletonAccounts(account_id="test")
 

--- a/tests/test_decisioning_capabilities_projection.py
+++ b/tests/test_decisioning_capabilities_projection.py
@@ -17,11 +17,19 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from adcp._version import get_supported_adcp_versions
 from adcp.decisioning import (
     DecisioningCapabilities,
     DecisioningPlatform,
     InMemoryTaskRegistry,
     SingletonAccounts,
+)
+from adcp.decisioning.capabilities import (
+    Account,
+    Adcp,
+    IdempotencyUnsupported,
+    MediaBuy,
+    SupportedProtocol,
 )
 from adcp.decisioning.handler import SPECIALISM_TO_PROTOCOLS, PlatformHandler
 from adcp.validation.schema_validator import validate_response
@@ -47,9 +55,9 @@ class _SalesPlatform(DecisioningPlatform):
 
     capabilities = DecisioningCapabilities(
         specialisms=["sales-non-guaranteed"],
-        channels=["display", "ctv"],
-        pricing_models=["cpm"],
-        supported_billing=["operator", "agent"],
+        supported_protocols=[SupportedProtocol.media_buy],
+        account=Account(supported_billing=["operator", "agent"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
     )
     accounts = SingletonAccounts(account_id="test")
 
@@ -59,7 +67,8 @@ class _SignalsPlatform(DecisioningPlatform):
 
     capabilities = DecisioningCapabilities(
         specialisms=["signal-marketplace"],
-        supported_billing=["agent"],
+        supported_protocols=[SupportedProtocol.signals],
+        account=Account(supported_billing=["agent"]),
     )
     accounts = SingletonAccounts(account_id="test")
 
@@ -69,7 +78,8 @@ class _OwnedSignalsPlatform(DecisioningPlatform):
 
     capabilities = DecisioningCapabilities(
         specialisms=["signal-owned"],
-        supported_billing=["agent"],
+        supported_protocols=[SupportedProtocol.signals],
+        account=Account(supported_billing=["agent"]),
     )
     accounts = SingletonAccounts(account_id="test")
 
@@ -187,3 +197,44 @@ def test_idempotency_defaults_to_unsupported(executor: ThreadPoolExecutor) -> No
     response = asyncio.run(handler.get_adcp_capabilities())
 
     assert response["adcp"]["idempotency"] == {"supported": False}
+
+
+def test_custom_adcp_block_preserves_supported_versions(executor: ThreadPoolExecutor) -> None:
+    class _CustomAdcpSalesPlatform(_SalesPlatform):
+        capabilities = DecisioningCapabilities(
+            specialisms=["sales-non-guaranteed"],
+            supported_protocols=[SupportedProtocol.media_buy],
+            adcp=Adcp(
+                major_versions=[3],
+                idempotency=IdempotencyUnsupported(supported=False),
+            ),
+            account=Account(supported_billing=["operator", "agent"]),
+            media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+        )
+
+    handler = _build_handler(_CustomAdcpSalesPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["adcp"]["supported_versions"] == list(get_supported_adcp_versions())
+
+
+def test_mixed_major_custom_adcp_block_does_not_invent_exact_versions(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _MixedMajorSalesPlatform(_SalesPlatform):
+        capabilities = DecisioningCapabilities(
+            specialisms=["sales-non-guaranteed"],
+            supported_protocols=[SupportedProtocol.media_buy],
+            adcp=Adcp(
+                major_versions=[2, 3],
+                idempotency=IdempotencyUnsupported(supported=False),
+            ),
+            account=Account(supported_billing=["operator", "agent"]),
+            media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+        )
+
+    handler = _build_handler(_MixedMajorSalesPlatform(), executor)
+    response = asyncio.run(handler.get_adcp_capabilities())
+
+    assert response["adcp"]["major_versions"] == [2, 3]
+    assert "supported_versions" not in response["adcp"]

--- a/tests/test_discovery_endpoint.py
+++ b/tests/test_discovery_endpoint.py
@@ -193,6 +193,8 @@ class _DiscoveryTestHandler(ADCPHandler[ToolContext]):
     """Minimal handler — discovery endpoint serves regardless of the
     handler's tool surface, but we need a real one to build the apps."""
 
+    advertised_tools = {"get_adcp_capabilities"}
+
     async def get_adcp_capabilities(self, params, context=None):
         return capabilities_response(["media_buy"])
 

--- a/tests/test_dispatcher_version_routing.py
+++ b/tests/test_dispatcher_version_routing.py
@@ -2,8 +2,8 @@
 
 Exercises ``create_tool_caller``'s version detection. Three scenarios:
 
-1. Buyer omits version fields → validator runs against SDK pin (existing
-   behaviour, regression guard).
+1. Buyer omits version fields → validator runs against 3.0 compatibility
+   after legacy shape probes.
 2. Buyer claims a supported version → validator runs against that
    version's schema (Stage 2 loader receives the matching ``version=``).
 3. Buyer claims an unsupported version → dispatcher raises
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 import pytest
 
+from adcp import get_adcp_spec_version
+from adcp._version import normalize_to_release_precision
 from adcp.exceptions import ADCPTaskError
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.mcp_tools import create_tool_caller
@@ -45,9 +47,9 @@ class _RecorderHandler(ADCPHandler[Any]):
 
 
 @pytest.mark.asyncio
-async def test_no_version_field_validator_uses_sdk_pin() -> None:
+async def test_no_version_field_validator_uses_legacy_30_compat() -> None:
     """Buyer omits ``adcp_version`` and ``adcp_major_version`` — the
-    validator should be invoked with ``version=None`` (SDK pin)."""
+    validator should be invoked with ``version='3.0'``."""
     handler = _RecorderHandler()
 
     with patch("adcp.validation.schema_validator.validate_request") as mock_validate:
@@ -61,8 +63,7 @@ async def test_no_version_field_validator_uses_sdk_pin() -> None:
 
     assert mock_validate.call_count == 1
     _, kwargs = mock_validate.call_args
-    # No wire-version field → SDK pin → ``version=None``.
-    assert kwargs.get("version") is None
+    assert kwargs.get("version") == "3.0"
 
 
 @pytest.mark.asyncio
@@ -107,8 +108,33 @@ async def test_explicit_adcp_version_threads_through_to_validator() -> None:
 
 
 @pytest.mark.asyncio
+async def test_exact_packaged_adcp_version_threads_through_to_validator() -> None:
+    """Capabilities may advertise the packaged beta line; selecting it is supported."""
+    handler = _RecorderHandler()
+    exact_version = normalize_to_release_precision(get_adcp_spec_version())
+
+    with patch("adcp.validation.schema_validator.validate_request") as mock_validate:
+        mock_validate.return_value = type("Outcome", (), {"valid": True, "issues": []})()
+        caller = create_tool_caller(
+            handler,
+            "get_products",
+            validation=ValidationHookConfig(requests="warn"),
+        )
+        await caller(
+            {
+                "adcp_version": exact_version,
+                "buying_mode": "brief",
+                "brief": "Q4",
+            },
+        )
+
+    _, kwargs = mock_validate.call_args
+    assert kwargs.get("version") == exact_version
+
+
+@pytest.mark.asyncio
 async def test_adcp_major_version_int_threads_through_to_validator() -> None:
-    """Pre-3.1 buyer sets only ``adcp_major_version=3`` → highest supported minor."""
+    """Pre-3.1 buyer sets only ``adcp_major_version=3`` → 3.0 compatibility."""
     handler = _RecorderHandler()
 
     with patch("adcp.validation.schema_validator.validate_request") as mock_validate:
@@ -128,8 +154,7 @@ async def test_adcp_major_version_int_threads_through_to_validator() -> None:
 
     assert mock_validate.call_count == 1
     _, kwargs = mock_validate.call_args
-    # 3 → highest supported minor for major 3 in COMPATIBLE_ADCP_VERSIONS = ("3.0","3.1")
-    assert kwargs.get("version") == "3.1"
+    assert kwargs.get("version") == "3.0"
 
 
 @pytest.mark.asyncio
@@ -244,6 +269,7 @@ async def test_response_validation_uses_same_wire_version() -> None:
     request claimed — so a v2.5 buyer's response gets v2.5-schema-checked.
     """
     handler = _RecorderHandler()
+    exact_version = normalize_to_release_precision(get_adcp_spec_version())
 
     with patch("adcp.validation.schema_validator.validate_response") as mock_validate:
         mock_validate.return_value = type("Outcome", (), {"valid": True, "issues": []})()
@@ -254,11 +280,34 @@ async def test_response_validation_uses_same_wire_version() -> None:
         )
         await caller(
             {
-                "adcp_version": "3.1",
+                "adcp_version": exact_version,
                 "buying_mode": "brief",
                 "brief": "Q4",
             },
         )
 
     _, kwargs = mock_validate.call_args
-    assert kwargs.get("version") == "3.1"
+    assert kwargs.get("version") == exact_version
+
+
+@pytest.mark.asyncio
+async def test_stable_31_wire_version_is_not_accepted_while_packaged_line_is_beta(
+    strict_version_envelope: None,
+) -> None:
+    """Only exact advertised versions are accepted for release-precision routing."""
+    exact_version = normalize_to_release_precision(get_adcp_spec_version())
+    if exact_version == "3.1":
+        pytest.skip("Package now advertises stable 3.1")
+
+    handler = _RecorderHandler()
+    caller = create_tool_caller(handler, "get_products")
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"adcp_version": "3.1"})
+
+    err = exc_info.value.errors[0]
+    assert err.code == "VERSION_UNSUPPORTED"
+    assert err.details is not None
+    assert err.details.get("claimed_version") == "3.1"
+    assert exact_version in err.details.get("supported_versions", [])
+    assert handler.received == []

--- a/tests/test_schema_validation_server.py
+++ b/tests/test_schema_validation_server.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+from adcp import get_adcp_spec_version
+from adcp._version import normalize_to_release_precision
 from adcp.exceptions import ADCPTaskError
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.mcp_tools import create_tool_caller
@@ -34,6 +36,11 @@ class _StubHandler(ADCPHandler[Any]):
 class _CreateMediaBuyHandler(ADCPHandler[Any]):
     async def create_media_buy(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
         return media_buy_response("mb_1", [], status="pending_creatives")
+
+
+class _CreateMediaBuyNoStatusHandler(ADCPHandler[Any]):
+    async def create_media_buy(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
+        return media_buy_response("mb_1", [])
 
 
 class _LegacyCreateMediaBuyStatusHandler(ADCPHandler[Any]):
@@ -198,7 +205,7 @@ class TestResponses:
         assert result["cache_scope"] == "public"
 
     @pytest.mark.asyncio
-    async def test_media_buy_status_keeps_task_envelope_status(self) -> None:
+    async def test_omitted_version_uses_30_media_buy_status_shape(self) -> None:
         handler = _CreateMediaBuyHandler()
         caller = create_tool_caller(
             handler,
@@ -217,11 +224,59 @@ class TestResponses:
                 ],
             }
         )
+        assert result["status"] == "pending_creatives"
+        assert "media_buy_status" not in result
+
+    @pytest.mark.asyncio
+    async def test_omitted_version_does_not_invent_30_lifecycle_status(self) -> None:
+        handler = _CreateMediaBuyNoStatusHandler()
+        caller = create_tool_caller(
+            handler,
+            "create_media_buy",
+            validation=ValidationHookConfig(responses="strict"),
+        )
+        result = await caller(
+            {
+                "brand": {"domain": "acme.example"},
+                "packages": [
+                    {
+                        "product_id": "premium-homepage",
+                        "budget": 1000,
+                        "pricing_option_id": "po-cpm-homepage",
+                    }
+                ],
+            }
+        )
+        assert "status" not in result
+        assert "media_buy_status" not in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_31_media_buy_status_keeps_task_envelope_status(self) -> None:
+        handler = _CreateMediaBuyHandler()
+        exact_version = normalize_to_release_precision(get_adcp_spec_version())
+        caller = create_tool_caller(
+            handler,
+            "create_media_buy",
+            validation=ValidationHookConfig(responses="strict"),
+        )
+        result = await caller(
+            {
+                "adcp_version": exact_version,
+                "brand": {"domain": "acme.example"},
+                "packages": [
+                    {
+                        "product_id": "premium-homepage",
+                        "budget": 1000,
+                        "pricing_option_id": "po-cpm-homepage",
+                    }
+                ],
+            }
+        )
         assert result["media_buy_status"] == "pending_creatives"
         assert result["status"] == "completed"
 
     @pytest.mark.asyncio
-    async def test_legacy_media_buy_status_normalizes_to_task_envelope(self) -> None:
+    async def test_omitted_version_preserves_legacy_media_buy_status(self) -> None:
         handler = _LegacyCreateMediaBuyStatusHandler()
         caller = create_tool_caller(
             handler,
@@ -240,11 +295,11 @@ class TestResponses:
                 ],
             }
         )
-        assert result["media_buy_status"] == "active"
-        assert result["status"] == "completed"
+        assert result["status"] == "active"
+        assert "media_buy_status" not in result
 
     @pytest.mark.asyncio
-    async def test_enum_media_buy_status_normalizes_to_task_envelope(self) -> None:
+    async def test_enum_media_buy_status_uses_30_shape_when_unnegotiated(self) -> None:
         handler = _EnumMediaBuyStatusHandler()
         create = create_tool_caller(
             handler,
@@ -263,8 +318,8 @@ class TestResponses:
                 ],
             }
         )
-        assert create_result["media_buy_status"] == "active"
-        assert create_result["status"] == "completed"
+        assert create_result["status"] == "active"
+        assert "media_buy_status" not in create_result
 
         update = create_tool_caller(
             handler,
@@ -272,8 +327,21 @@ class TestResponses:
             validation=ValidationHookConfig(responses="strict"),
         )
         update_result = await update({"media_buy_id": "mb_1"})
-        assert update_result["media_buy_status"] == "paused"
-        assert update_result["status"] == "completed"
+        assert update_result["status"] == "paused"
+        assert "media_buy_status" not in update_result
+
+    @pytest.mark.asyncio
+    async def test_explicit_31_update_media_buy_uses_envelope_status(self) -> None:
+        handler = _EnumMediaBuyStatusHandler()
+        exact_version = normalize_to_release_precision(get_adcp_spec_version())
+        update = create_tool_caller(
+            handler,
+            "update_media_buy",
+            validation=ValidationHookConfig(responses="strict"),
+        )
+        result = await update({"adcp_version": exact_version, "media_buy_id": "mb_1"})
+        assert result["media_buy_status"] == "paused"
+        assert result["status"] == "completed"
 
     @pytest.mark.asyncio
     async def test_invalid_legacy_media_buy_status_is_not_rewritten(self) -> None:
@@ -352,6 +420,7 @@ class TestResponses:
             validation=ValidationHookConfig(responses="strict"),
         )
         request = dict(VALID_GET_PRODUCTS)
+        request["adcp_version"] = normalize_to_release_precision(get_adcp_spec_version())
         request["account"] = {"account_id": "acc_1"}
         with pytest.raises(ADCPTaskError) as info:
             await caller(request)

--- a/tests/test_server_dx.py
+++ b/tests/test_server_dx.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import pytest
 
+from adcp import get_adcp_spec_version
+from adcp._version import get_supported_adcp_versions, normalize_to_release_precision
 from adcp.server.responses import (
     activate_signal_response,
     build_creative_response,
@@ -28,11 +30,15 @@ from adcp.server.responses import (
     update_media_buy_response,
 )
 from adcp.server.test_controller import (
-    TestControllerError,
+    TestControllerError as ControllerError,
+)
+from adcp.server.test_controller import (
     TestControllerStore,
     _handle_test_controller,
     _list_scenarios,
 )
+
+_PACKAGED_ADCP_VERSION = normalize_to_release_precision(get_adcp_spec_version())
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +60,7 @@ class TestCapabilitiesResponse:
         result = capabilities_response(["media_buy"])
         assert result["supported_protocols"] == ["media_buy"]
         assert result["adcp"]["major_versions"] == [3]
+        assert result["adcp"]["supported_versions"] == list(get_supported_adcp_versions())
         assert result["sandbox"] is True
 
     def test_multiple_protocols(self):
@@ -63,6 +70,7 @@ class TestCapabilitiesResponse:
     def test_custom_versions(self):
         result = capabilities_response(["media_buy"], major_versions=[2, 3])
         assert result["adcp"]["major_versions"] == [2, 3]
+        assert "supported_versions" not in result["adcp"]
 
     def test_sandbox_false(self):
         result = capabilities_response(["media_buy"], sandbox=False)
@@ -141,6 +149,21 @@ class TestMediaBuyResponse:
         assert "status" not in result
         assert result["media_buy_status"] == "active"
 
+    def test_explicit_30_status_shape(self):
+        result = media_buy_response("mb-123", [], status="pending_creatives", adcp_version="3.0")
+        assert result["status"] == "pending_creatives"
+        assert "media_buy_status" not in result
+
+    def test_explicit_31_status_shape(self):
+        result = media_buy_response(
+            "mb-123",
+            [],
+            status="pending_creatives",
+            adcp_version=_PACKAGED_ADCP_VERSION,
+        )
+        assert result["status"] == "completed"
+        assert result["media_buy_status"] == "pending_creatives"
+
     def test_typed_success_normalizes_legacy_status(self):
         from adcp.types import CreateMediaBuySuccessResponse
 
@@ -209,6 +232,20 @@ class TestUpdateMediaBuyResponse:
         assert "status" not in result
         assert result["media_buy_status"] == "active"
         assert result["revision"] == 2
+
+    def test_explicit_30_status_shape(self):
+        result = update_media_buy_response("mb-123", status="paused", adcp_version="3.0")
+        assert result["status"] == "paused"
+        assert "media_buy_status" not in result
+
+    def test_explicit_31_status_shape(self):
+        result = update_media_buy_response(
+            "mb-123",
+            status="paused",
+            adcp_version=_PACKAGED_ADCP_VERSION,
+        )
+        assert result["status"] == "completed"
+        assert result["media_buy_status"] == "paused"
 
     def test_typed_success_normalizes_legacy_status(self):
         from adcp.types import UpdateMediaBuySuccessResponse
@@ -668,7 +705,7 @@ class TestTestControllerError:
     async def test_error_is_caught(self):
         class ErrorStore(TestControllerStore):
             async def force_account_status(self, account_id: str, status: str) -> dict[str, Any]:
-                raise TestControllerError("NOT_FOUND", f"Account {account_id} not found")
+                raise ControllerError("NOT_FOUND", f"Account {account_id} not found")
 
         store = ErrorStore()
         result = await _handle_test_controller(
@@ -685,7 +722,7 @@ class TestTestControllerError:
             async def force_media_buy_status(
                 self, media_buy_id: str, status: str, rejection_reason: str | None = None
             ) -> dict[str, Any]:
-                raise TestControllerError(
+                raise ControllerError(
                     "INVALID_TRANSITION", "Cannot transition", current_state="completed"
                 )
 
@@ -833,6 +870,8 @@ class TestCreateMcpServer:
         from adcp.server.serve import create_mcp_server
 
         class TestHandler(ADCPHandler):
+            advertised_tools = {"get_adcp_capabilities"}
+
             async def get_adcp_capabilities(self, params, context=None):
                 return {"adcp": {"major_versions": [3]}}
 
@@ -862,6 +901,8 @@ class TestServeWithTestController:
         from adcp.server.serve import create_mcp_server
 
         class TestHandler(ADCPHandler):
+            advertised_tools = {"get_adcp_capabilities"}
+
             async def get_adcp_capabilities(self, params, context=None):
                 return {}
 

--- a/tests/test_validation_envelope.py
+++ b/tests/test_validation_envelope.py
@@ -29,9 +29,13 @@ def test_explicit_adcp_version_wins_over_major_version() -> None:
     assert detect_wire_version(payload, supported=_SUPPORTED) == "3.1"
 
 
-def test_adcp_major_version_picks_highest_supported_minor() -> None:
-    """Pre-3.1 buyer sends only ``adcp_major_version`` — pick highest minor."""
-    assert detect_wire_version({"adcp_major_version": 3}, supported=_SUPPORTED) == "3.1"
+def test_adcp_major_version_prefers_base_minor_when_supported() -> None:
+    """Pre-3.1 buyer sends only ``adcp_major_version`` — prefer base minor."""
+    assert detect_wire_version({"adcp_major_version": 3}, supported=_SUPPORTED) == "3.0"
+
+
+def test_adcp_major_version_uses_highest_minor_when_base_minor_unavailable() -> None:
+    assert detect_wire_version({"adcp_major_version": 2}, supported=("2.5",)) == "2.5"
 
 
 def test_adcp_major_version_unsupported_major_raises() -> None:
@@ -68,7 +72,7 @@ def test_adcp_version_empty_string_treated_as_missing() -> None:
     """An empty string falls through to ``adcp_major_version`` lookup."""
     assert (
         detect_wire_version({"adcp_version": "", "adcp_major_version": 3}, supported=_SUPPORTED)
-        == "3.1"
+        == "3.0"
     )
 
 

--- a/tests/test_validation_version.py
+++ b/tests/test_validation_version.py
@@ -36,6 +36,7 @@ def test_resolve_bundle_key_accepts_major_minor_pass_through() -> None:
     precision, so the dispatcher can hand it straight to the loader.
     """
     assert resolve_bundle_key("3.0") == "3.0"
+    assert resolve_bundle_key("3.1") == "3.1"
     assert resolve_bundle_key("2.5") == "2.5"
 
 


### PR DESCRIPTION
## Summary
- default omitted buyer versions to 3.0 compatibility after legacy probes
- advertise exact supported AdCP spec versions, including the packaged prerelease line, and reject contradictory pins
- preserve 3.0 vs exact 3.1 response shapes for create/update media-buy helpers and dispatcher normalization
- clean up warning-as-error test issues in capabilities/discovery/server DX coverage

## Verification
- ruff check on touched source/tests
- PYTHONPATH=src pytest -W error tests/test_dispatcher_version_routing.py tests/test_adcp_version_wire.py tests/test_schema_validation_server.py tests/test_server_dx.py tests/test_server_helpers.py tests/test_adcp_version_option.py tests/test_validation_version.py tests/test_validation_envelope.py tests/test_capabilities.py tests/test_capabilities_response_shape_validation.py tests/test_decisioning_capabilities_projection.py tests/test_schema_validation.py tests/test_schema_loader_per_version.py tests/test_discovery_endpoint.py tests/test_server_builder.py
- pre-commit hooks on commit: black, ruff, mypy, bandit, whitespace/eof/yaml/json/large-file/merge-conflict/case/private-key checks

## Expert Review
- code reviewer: no blockers
- protocol reviewer: final pass no blockers after exact-version and mixed-major fixes

Closes #851