### PR TITLE
feat(server): add unknown-field policy and hook composition

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -476,6 +476,7 @@ from adcp.utils import (
 )
 from adcp.validation import (
     SchemaValidationError,
+    UnknownFieldPolicy,
     ValidationError,
     ValidationHookConfig,
     ValidationIssue,
@@ -953,6 +954,7 @@ __all__ = [
     "RegistryError",
     # Validation utilities
     "SchemaValidationError",
+    "UnknownFieldPolicy",
     "ValidationError",
     "ValidationHookConfig",
     "ValidationIssue",

--- a/src/adcp/server/__init__.py
+++ b/src/adcp/server/__init__.py
@@ -151,7 +151,10 @@ from adcp.server.serve import (
 )
 from adcp.server.spec_compat import (
     CANONICAL_CREATIVE_AGENT_URL,
+    PreValidationHook,
+    PreValidationHookChain,
     PreValidationHooks,
+    compose_pre_validation_hooks,
     spec_compat_hooks,
 )
 from adcp.server.sponsored_intelligence import SponsoredIntelligenceHandler
@@ -263,7 +266,10 @@ __all__ = [
     "register_test_controller",
     # Spec compatibility
     "CANONICAL_CREATIVE_AGENT_URL",
+    "PreValidationHook",
+    "PreValidationHookChain",
     "PreValidationHooks",
+    "compose_pre_validation_hooks",
     "spec_compat_hooks",
     # DX helpers
     "AccountError",

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -37,6 +37,7 @@ from starlette.applications import Starlette
 
 from adcp.exceptions import ADCPError
 from adcp.server.base import ADCPHandler, ToolContext
+from adcp.server.spec_compat import PreValidationHooks
 
 # Decisioning-layer ``AdcpError`` (from ``adcp.decisioning.types``) is the
 # wire-shaped structured error platform methods raise. It is NOT a subclass
@@ -181,7 +182,7 @@ class ADCPAgentExecutor(AgentExecutor):
         message_parser: MessageParser | None = None,
         advertise_all: bool = False,
         validation: ValidationHookConfig | None = SERVER_DEFAULT_VALIDATION,
-        pre_validation_hooks: dict[str, Any] | None = None,
+        pre_validation_hooks: PreValidationHooks | None = None,
         test_controller_account_resolver: Any | None = None,
     ) -> None:
         self._handler = handler
@@ -915,7 +916,7 @@ def create_a2a_server(
     message_parser: MessageParser | None = None,
     advertise_all: bool = False,
     validation: ValidationHookConfig | None = SERVER_DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Any] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     context_builder: Any | None = None,
     auth: BearerTokenAuth | None = None,
     public_url: str | PublicUrlResolver | None = None,

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -26,14 +26,16 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 from adcp.server.base import ADCPHandler, ToolContext
+from adcp.server.spec_compat import PreValidationHook, PreValidationHookChain
 from adcp.server.test_controller import SCENARIOS as _CONTROLLER_SCENARIOS
 from adcp.types import (
     MEDIA_BUY_LEGACY_STATUS_VALUES,
     unwrap_enum_value,
 )
 from adcp.types.error_narrowing import narrow_union_errors
-from adcp.validation.client_hooks import ValidationHookConfig
+from adcp.validation.client_hooks import UnknownFieldPolicy, ValidationHookConfig
 from adcp.validation.envelope import DEFAULT_UNNEGOTIATED_ADCP_VERSION
+from adcp.validation.schema_loader import get_validator
 
 logger = logging.getLogger(__name__)
 
@@ -1981,12 +1983,118 @@ def _resolve_params_pydantic_model(method: Any) -> type[Any] | None:
     return None
 
 
+def _flatten_pre_validation_hooks(
+    hooks: PreValidationHookChain | None,
+) -> tuple[PreValidationHook, ...]:
+    if hooks is None:
+        return ()
+    if callable(hooks):
+        return (hooks,)
+    flattened = tuple(hooks)
+    for hook in flattened:
+        if not callable(hook):
+            raise TypeError("pre-validation hook chains must contain callables")
+    return flattened
+
+
+def _apply_pre_validation_hooks(
+    hooks: tuple[PreValidationHook, ...],
+    method_name: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    next_params = params
+    for hook in hooks:
+        next_params = hook(method_name, dict(next_params))
+        if not isinstance(next_params, dict):
+            raise TypeError("pre-validation hooks must return dict arguments")
+    return next_params
+
+
+def _normalize_unknown_field_policy(
+    policy: UnknownFieldPolicy | str | None,
+) -> UnknownFieldPolicy:
+    if policy is None:
+        return UnknownFieldPolicy.IGNORE
+    if isinstance(policy, UnknownFieldPolicy):
+        return policy
+    return UnknownFieldPolicy(policy)
+
+
+def _allowed_top_level_fields(
+    method_name: str,
+    *,
+    version: str | None,
+    params_model: type[Any] | None,
+) -> set[str] | None:
+    validator = get_validator(method_name, "request", version=version)
+    if validator is not None:
+        schema = getattr(validator, "schema", None)
+        if isinstance(schema, dict):
+            properties = schema.get("properties")
+            if isinstance(properties, dict):
+                return {str(name) for name in properties}
+
+    if params_model is None:
+        return None
+
+    model_fields = getattr(params_model, "model_fields", None)
+    if not isinstance(model_fields, dict):
+        return None
+
+    allowed: set[str] = set()
+    for name, field in model_fields.items():
+        allowed.add(str(name))
+        alias = getattr(field, "alias", None)
+        if isinstance(alias, str):
+            allowed.add(alias)
+    return allowed
+
+
+def _apply_unknown_field_policy(
+    method_name: str,
+    params: dict[str, Any],
+    *,
+    policy: UnknownFieldPolicy,
+    version: str | None,
+    params_model: type[Any] | None,
+) -> dict[str, Any]:
+    if policy == UnknownFieldPolicy.IGNORE:
+        return params
+
+    allowed = _allowed_top_level_fields(method_name, version=version, params_model=params_model)
+    if allowed is None:
+        return params
+
+    unknown = [key for key in params if key not in allowed]
+    if not unknown:
+        return params
+
+    if policy == UnknownFieldPolicy.STRIP:
+        return {key: value for key, value in params.items() if key in allowed}
+
+    first = unknown[0]
+    from adcp.exceptions import ADCPTaskError
+    from adcp.types import Error
+
+    raise ADCPTaskError(
+        operation=method_name,
+        errors=[
+            Error(
+                code="INVALID_REQUEST",
+                field=first,
+                message=f"Unexpected top-level field {first!r} for {method_name}",
+                details={"unknown_fields": unknown, "policy": policy.value},
+            )
+        ],
+    )
+
+
 def create_tool_caller(
     handler: ADCPHandler[Any],
     method_name: str,
     *,
     validation: ValidationHookConfig | None = None,
-    pre_validation_hook: Callable[[str, dict[str, Any]], dict[str, Any]] | None = None,
+    pre_validation_hook: PreValidationHookChain | None = None,
 ) -> Callable[..., Any]:
     """Create a tool caller function for an ADCP handler method.
 
@@ -2016,11 +2124,13 @@ def create_tool_caller(
     server validation is a deliberate opt-in for authors who want
     dispatcher-level enforcement.
 
-    **Pre-validation hook (issue #614).** When ``pre_validation_hook`` is
-    supplied, it is called with ``(tool_name, shallow_copy_of_args)`` and
-    must return a ``dict`` that replaces the wire args before schema
-    validation and Pydantic ``model_validate`` run. The framework passes
-    a shallow copy of the incoming params dict, so the hook may mutate
+    **Pre-validation hooks (issues #614, #859).** When
+    ``pre_validation_hook`` is supplied, each hook is called with
+    ``(tool_name, shallow_copy_of_args)`` and must return a ``dict`` that
+    replaces the wire args before schema validation and Pydantic
+    ``model_validate`` run. Pass either one hook or an ordered sequence of
+    hooks; sequences run left-to-right. The framework passes a shallow
+    copy of the incoming params dict to each hook, so a hook may mutate
     its argument freely or return a brand-new dict — either style is safe.
     The original wire params are captured before the copy is made, so
     context echo always reflects what the buyer sent. Use this to apply
@@ -2029,6 +2139,14 @@ def create_tool_caller(
     inference). The hook runs on every call; keep it fast.
     Exceptions from the hook surface as ``INVALID_REQUEST`` — do not raise
     for missing-but-defaultable fields, only for structurally unusable args.
+
+    **Unknown-field policy (issue #858).** When
+    ``validation=ValidationHookConfig(unknown_fields=...)`` is supplied,
+    unsupported top-level tool arguments are handled after pre-validation
+    hooks and legacy adapters, but before request schema validation and
+    Pydantic coercion. ``"reject"`` raises ``INVALID_REQUEST``,
+    ``"strip"`` removes unsupported keys, and ``"ignore"`` preserves the
+    current permissive behavior.
 
     .. note::
         For the specific case of buyers omitting ``account``, see issue
@@ -2043,9 +2161,10 @@ def create_tool_caller(
         validation: Optional :class:`ValidationHookConfig` with
             per-side modes (``strict`` / ``warn`` / ``off``). Omitting
             it disables server-side schema validation entirely.
-        pre_validation_hook: Optional callable ``(tool_name, args) -> args``
-            invoked on the raw wire dict before schema + Pydantic validation.
-            See the **Pre-validation hook** section above.
+        pre_validation_hook: Optional callable or ordered sequence of
+            callables ``(tool_name, args) -> args`` invoked on the raw wire
+            dict before schema + Pydantic validation. See the
+            **Pre-validation hooks** section above.
 
     Returns:
         Async callable ``call_tool(params, context=None)``. The ``context``
@@ -2078,15 +2197,21 @@ def create_tool_caller(
     # ``createAdcpServer`` is the same: validation is an explicit opt-in.
     request_mode = validation.requests if validation is not None else None
     response_mode = validation.responses if validation is not None else None
+    unknown_field_policy = _normalize_unknown_field_policy(
+        validation.unknown_fields if validation is not None else None
+    )
+    pre_validation_hooks = _flatten_pre_validation_hooks(pre_validation_hook)
 
     async def call_tool(params: dict[str, Any], context: ToolContext | None = None) -> Any:
         ctx = context if context is not None else ToolContext()
 
         raw_params = params  # Preserve original wire params for context echo.
 
-        if pre_validation_hook is not None:
+        if pre_validation_hooks:
             try:
-                params = pre_validation_hook(method_name, dict(params))
+                params = _apply_pre_validation_hooks(
+                    pre_validation_hooks, method_name, dict(params)
+                )
             except Exception as exc:
                 raise ADCPTaskError(
                     operation=method_name,
@@ -2265,6 +2390,15 @@ def create_tool_caller(
         else:
             post_adapter_validator_version = wire_version
 
+        if isinstance(params, dict):
+            params = _apply_unknown_field_policy(
+                method_name,
+                params,
+                policy=unknown_field_policy,
+                version=post_adapter_validator_version,
+                params_model=params_model,
+            )
+
         if request_mode is not None and request_mode != "off":
             outcome = validate_request(method_name, params, version=post_adapter_validator_version)
             if not outcome.valid:
@@ -2434,9 +2568,7 @@ class MCPToolSet:
         *,
         advertise_all: bool = False,
         validation: ValidationHookConfig | None = None,
-        pre_validation_hooks: (
-            dict[str, Callable[[str, dict[str, Any]], dict[str, Any]]] | None
-        ) = None,
+        pre_validation_hooks: dict[str, PreValidationHookChain] | None = None,
     ):
         """Create tool set from handler.
 
@@ -2450,8 +2582,9 @@ class MCPToolSet:
             validation: Opt-in schema validation config applied to every
                 tool caller. See :func:`create_tool_caller`.
             pre_validation_hooks: Optional dict mapping tool name to a
-                ``(tool_name, args) -> args`` callable. Applied before
-                schema + Pydantic validation. See :func:`create_tool_caller`.
+                ``(tool_name, args) -> args`` callable or ordered sequence.
+                Applied before schema + Pydantic validation. See
+                :func:`create_tool_caller`.
         """
         self.handler = handler
         self._filtered_definitions = get_tools_for_handler(handler, advertise_all=advertise_all)
@@ -2497,7 +2630,7 @@ def create_mcp_tools(
     *,
     advertise_all: bool = False,
     validation: ValidationHookConfig | None = None,
-    pre_validation_hooks: dict[str, Callable[[str, dict[str, Any]], dict[str, Any]]] | None = None,
+    pre_validation_hooks: dict[str, PreValidationHookChain] | None = None,
 ) -> MCPToolSet:
     """Create MCP tools from an ADCP handler.
 
@@ -2533,8 +2666,9 @@ def create_mcp_tools(
             the bundled AdCP JSON schemas. See
             :func:`create_tool_caller` for mode semantics.
         pre_validation_hooks: Optional dict mapping tool name to a
-            ``(tool_name, args) -> args`` callable. Applied before schema
-            + Pydantic validation. See :func:`create_tool_caller`.
+            ``(tool_name, args) -> args`` callable or ordered sequence.
+            Applied before schema + Pydantic validation. See
+            :func:`create_tool_caller`.
 
     Returns:
         MCPToolSet with tool definitions and handlers.

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -36,6 +36,7 @@ from adcp.server.mcp_tools import (
     create_tool_caller,
     get_tools_for_handler,
 )
+from adcp.server.spec_compat import PreValidationHooks
 from adcp.validation.client_hooks import (
     SERVER_DEFAULT_VALIDATION as DEFAULT_VALIDATION,
 )
@@ -166,7 +167,7 @@ class ServeConfig:
     advertise_all: bool = False
     max_request_size: int | None = None
     validation: ValidationHookConfig | None = None
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None
+    pre_validation_hooks: PreValidationHooks | None = None
 
     # --- Discovery manifest ---
     base_url: str | None = None
@@ -598,7 +599,7 @@ def serve(
     stateless_http: bool = False,
     session_idle_timeout: float | None = 1800.0,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     enable_debug_endpoints: bool = False,
     debug_traffic_source: Callable[[], dict[str, int]] | None = None,
     base_url: str | None = None,
@@ -1421,7 +1422,7 @@ def _serve_mcp(
     stateless_http: bool = False,
     session_idle_timeout: float | None = 1800.0,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     base_url: str | None = None,
     specialisms: list[str] | None = None,
     description: str | None = None,
@@ -1585,7 +1586,7 @@ def _serve_a2a(
     advertise_all: bool = False,
     max_request_size: int | None = None,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     base_url: str | None = None,
     specialisms: list[str] | None = None,
     description: str | None = None,
@@ -1671,7 +1672,7 @@ def _build_mcp_and_a2a_app(
     stateless_http: bool = False,
     session_idle_timeout: float | None = 1800.0,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     base_url: str | None = None,
     specialisms: list[str] | None = None,
     description: str | None = None,
@@ -1922,7 +1923,7 @@ def _serve_mcp_and_a2a(
     stateless_http: bool = False,
     session_idle_timeout: float | None = 1800.0,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     base_url: str | None = None,
     specialisms: list[str] | None = None,
     description: str | None = None,
@@ -2060,7 +2061,7 @@ def create_mcp_server(
     stateless_http: bool = False,
     session_idle_timeout: float | None = 1800.0,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     allowed_hosts: Sequence[str] | None = None,
     allowed_origins: Sequence[str] | None = None,
     enable_dns_rebinding_protection: bool | None = None,
@@ -2294,7 +2295,7 @@ def _register_handler_tools(
     middleware: Sequence[SkillMiddleware] | None = None,
     advertise_all: bool = False,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
 ) -> None:
     """Register all ADCP tools from a handler onto a FastMCP server."""
     # Freeze middleware ordering at registration time. Tuple both guards

--- a/src/adcp/server/spec_compat.py
+++ b/src/adcp/server/spec_compat.py
@@ -14,10 +14,10 @@ framework dependencies so they compose cleanly with adopter-specific hooks::
     serve(handler, pre_validation_hooks=spec_compat_hooks())
 
     # Combined with adopter-specific hooks:
-    serve(handler, pre_validation_hooks={
-        **spec_compat_hooks(),
-        "create_media_buy": my_custom_hook,
-    })
+    serve(handler, pre_validation_hooks=compose_pre_validation_hooks(
+        spec_compat_hooks(),
+        {"create_media_buy": my_custom_hook},
+    ))
 
     # Selective opt-out (skip sync_creatives coercions entirely):
     serve(handler, pre_validation_hooks=spec_compat_hooks(exclude={"sync_creatives"}))
@@ -31,10 +31,16 @@ framework dependencies so they compose cleanly with adopter-specific hooks::
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Mapping, Sequence
 from typing import Any, TypeAlias
 
-PreValidationHooks: TypeAlias = dict[str, Callable[[str, dict[str, Any]], dict[str, Any]]]
+PreValidationHook: TypeAlias = Callable[[str, dict[str, Any]], dict[str, Any]]
+"""Callable shape for a pre-validation hook."""
+
+PreValidationHookChain: TypeAlias = PreValidationHook | Sequence[PreValidationHook]
+"""One hook or an ordered sequence of hooks for a single tool."""
+
+PreValidationHooks: TypeAlias = dict[str, PreValidationHookChain]
 """Type alias for the ``pre_validation_hooks`` parameter of ``serve()``."""
 
 CANONICAL_CREATIVE_AGENT_URL = "https://creative.adcontextprotocol.org"
@@ -72,6 +78,35 @@ _KNOWN_ASSET_TYPES: frozenset[str] = frozenset(
         "catalog",
     }
 )
+
+
+def _flatten_hook_chain(chain: PreValidationHookChain) -> tuple[PreValidationHook, ...]:
+    if callable(chain):
+        return (chain,)
+    hooks = tuple(chain)
+    for hook in hooks:
+        if not callable(hook):
+            raise TypeError("pre-validation hook chains must contain callables")
+    return hooks
+
+
+def compose_pre_validation_hooks(
+    *hook_maps: Mapping[str, PreValidationHookChain] | None,
+) -> dict[str, tuple[PreValidationHook, ...]]:
+    """Compose ordered pre-validation hook maps.
+
+    Later maps append to earlier maps for overlapping tool names. Each
+    tool's hooks run left-to-right, feeding the returned args from one hook
+    into the next.
+    """
+
+    composed: dict[str, list[PreValidationHook]] = {}
+    for hook_map in hook_maps:
+        if hook_map is None:
+            continue
+        for tool_name, chain in hook_map.items():
+            composed.setdefault(tool_name, []).extend(_flatten_hook_chain(chain))
+    return {tool_name: tuple(hooks) for tool_name, hooks in composed.items()}
 
 
 def _hook_get_products(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001

--- a/src/adcp/testing/decisioning.py
+++ b/src/adcp/testing/decisioning.py
@@ -35,7 +35,7 @@ from adcp.validation.client_hooks import SERVER_DEFAULT_VALIDATION as DEFAULT_VA
 from adcp.validation.client_hooks import ValidationHookConfig
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+    from collections.abc import AsyncIterator, Mapping, Sequence
     from datetime import datetime
 
     import httpx
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     )
     from adcp.server.auth import BearerTokenAuth
     from adcp.server.serve import ASGIMiddlewareEntry, ContextFactory, SkillMiddleware
+    from adcp.server.spec_compat import PreValidationHooks
 
 
 def make_request_context(
@@ -149,7 +150,7 @@ def build_asgi_app(
     max_request_size: int | None = None,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
     discovery_base_url: str | None = None,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     **factory_kwargs: Any,
 ) -> Any:
     """Build a Starlette ASGI app for in-process integration tests.
@@ -222,8 +223,8 @@ def build_asgi_app(
         as the advertised base URL (e.g. ``"http://test"``). ``None`` →
         discovery endpoint not mounted.
     :param pre_validation_hooks: Optional dict mapping AdCP tool name to
-        a ``(tool_name, raw_args) -> raw_args`` callable. Forwarded to
-        :func:`create_mcp_server`, identical semantics to
+        a ``(tool_name, raw_args) -> raw_args`` callable or ordered
+        sequence. Forwarded to :func:`create_mcp_server`, identical semantics to
         :func:`adcp.decisioning.serve`'s ``pre_validation_hooks`` param.
         Use to install the same coercion hooks your production
         :func:`serve` call uses so in-process tests see the same
@@ -308,7 +309,7 @@ async def build_test_client(
     max_request_size: int | None = None,
     validation: ValidationHookConfig | None = DEFAULT_VALIDATION,
     discovery_base_url: str | None = None,
-    pre_validation_hooks: dict[str, Callable[..., Any]] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     **factory_kwargs: Any,
 ) -> AsyncIterator[httpx.AsyncClient]:
     """Async context manager yielding an ``httpx.AsyncClient`` wired against

--- a/src/adcp/validation/__init__.py
+++ b/src/adcp/validation/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from adcp.validation.client_hooks import (
     SERVER_DEFAULT_VALIDATION,
     DebugLogEntry,
+    UnknownFieldPolicy,
     ValidationHookConfig,
     ValidationMode,
     resolve_validation_modes,
@@ -80,6 +81,7 @@ __all__ = [
     # Client hooks
     "DebugLogEntry",
     "SERVER_DEFAULT_VALIDATION",
+    "UnknownFieldPolicy",
     "ValidationHookConfig",
     "ValidationMode",
     "resolve_validation_modes",

--- a/src/adcp/validation/client_hooks.py
+++ b/src/adcp/validation/client_hooks.py
@@ -8,6 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Literal, TypedDict
 
 from adcp.validation.schema_errors import build_validation_error
@@ -21,6 +22,18 @@ from adcp.validation.schema_validator import (
 logger = logging.getLogger(__name__)
 
 ValidationMode = Literal["strict", "warn", "off"]
+
+
+class UnknownFieldPolicy(str, Enum):
+    """Server-side policy for unknown top-level tool arguments.
+
+    Runs at the transport boundary before Pydantic request-model coercion
+    can silently accept or drop extra fields.
+    """
+
+    REJECT = "reject"
+    STRIP = "strip"
+    IGNORE = "ignore"
 
 
 @dataclass(frozen=True)
@@ -56,6 +69,9 @@ class ValidationHookConfig:
 
     requests: ValidationMode | None = None
     responses: ValidationMode | None = None
+    #: Server-side policy for unsupported top-level tool arguments.
+    #: ``None`` preserves existing permissive behavior.
+    unknown_fields: UnknownFieldPolicy | Literal["reject", "strip", "ignore"] | None = None
 
 
 #: Server-side default — strict on both request and response sides.

--- a/tests/fixtures/public_api_snapshot.json
+++ b/tests/fixtures/public_api_snapshot.json
@@ -343,6 +343,7 @@
     "TimeBasedPricingOption",
     "TimeUnit",
     "Transform",
+    "UnknownFieldPolicy",
     "UpdateContentStandardsErrorResponse",
     "UpdateContentStandardsResponse1",
     "UpdateContentStandardsSuccessResponse",

--- a/tests/test_pre_validation_hooks.py
+++ b/tests/test_pre_validation_hooks.py
@@ -13,11 +13,11 @@ Tests that:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
 from adcp.exceptions import ADCPTaskError
+from adcp.server import compose_pre_validation_hooks
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.mcp_tools import create_tool_caller
 
@@ -110,6 +110,59 @@ async def test_hook_supplies_missing_required_field() -> None:
     result = await caller({})
     assert called_with == [{}]
     assert result["params_received"]["buying_mode"] == "brief"
+
+
+@pytest.mark.asyncio
+async def test_multiple_hooks_for_one_tool_run_in_order() -> None:
+    """A tool can receive an ordered hook chain; each hook sees the previous output."""
+    order: list[str] = []
+
+    def first(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        order.append(f"first:{tool_name}")
+        return {**args, "a": 1}
+
+    def second(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        order.append(f"second:{tool_name}:{args['a']}")
+        return {**args, "b": 2}
+
+    handler = _MinimalHandler()
+    caller = create_tool_caller(handler, "get_products", pre_validation_hook=[first, second])
+
+    result = await caller({"buying_mode": "brief"})
+    assert order == ["first:get_products", "second:get_products:1"]
+    assert result["params_received"]["a"] == 1
+    assert result["params_received"]["b"] == 2
+
+
+def test_compose_pre_validation_hooks_appends_overlapping_tools() -> None:
+    """The public helper preserves map order and appends overlaps."""
+    calls: list[str] = []
+
+    def sdk(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"sdk:{tool_name}")
+        return {**args, "sdk": True}
+
+    def local(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"local:{tool_name}")
+        return {**args, "local": True}
+
+    def creative(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"creative:{tool_name}")
+        return args
+
+    hooks = compose_pre_validation_hooks(
+        {"get_products": sdk, "sync_creatives": creative},
+        {"get_products": [local]},
+    )
+
+    get_products_hooks = hooks["get_products"]
+    out = {"brief": "test"}
+    for hook in get_products_hooks:
+        out = hook("get_products", out)
+
+    assert calls == ["sdk:get_products", "local:get_products"]
+    assert out == {"brief": "test", "sdk": True, "local": True}
+    assert hooks["sync_creatives"] == (creative,)
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +280,6 @@ def test_mcp_tool_set_threads_hook_to_tool_caller() -> None:
 
         MCPToolSet(handler, pre_validation_hooks=hooks)
 
-    assert any(h is my_hook for h in captured_hooks), (
-        "my_hook was not forwarded to create_tool_caller for get_products"
-    )
+    assert any(
+        h is my_hook for h in captured_hooks
+    ), "my_hook was not forwarded to create_tool_caller for get_products"

--- a/tests/test_unknown_field_policy_server.py
+++ b/tests/test_unknown_field_policy_server.py
@@ -1,0 +1,110 @@
+"""Server unknown-field policy before tool argument coercion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adcp.exceptions import ADCPTaskError
+from adcp.server.a2a_server import ADCPAgentExecutor
+from adcp.server.base import ADCPHandler, ToolContext
+from adcp.server.mcp_tools import create_tool_caller
+from adcp.validation import UnknownFieldPolicy, ValidationHookConfig
+
+
+class _RecorderHandler(ADCPHandler[Any]):
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    async def get_products(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
+        self.received.append(dict(params))
+        return {"products": []}
+
+    async def create_media_buy(self, params: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
+        self.received.append(dict(params))
+        return {"media_buy_id": "mb_1", "packages": []}
+
+
+@pytest.mark.asyncio
+async def test_reject_unknown_top_level_field_before_dispatch() -> None:
+    handler = _RecorderHandler()
+    caller = create_tool_caller(
+        handler,
+        "get_products",
+        validation=ValidationHookConfig(unknown_fields=UnknownFieldPolicy.REJECT),
+    )
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"buying_mode": "brief", "brief": "ads", "nonsense_field": "bar"})
+
+    assert handler.received == []
+    err = exc_info.value.errors[0]
+    assert err.code == "INVALID_REQUEST"
+    assert err.field == "nonsense_field"
+    assert err.details is not None
+    assert err.details["unknown_fields"] == ["nonsense_field"]
+
+
+@pytest.mark.asyncio
+async def test_strip_unknown_top_level_field_for_mutating_tool() -> None:
+    handler = _RecorderHandler()
+    caller = create_tool_caller(
+        handler,
+        "create_media_buy",
+        validation=ValidationHookConfig(unknown_fields=UnknownFieldPolicy.STRIP),
+    )
+
+    await caller({"proposal_id": "prop_1", "nonsense_field": "bar"})
+
+    assert handler.received == [{"proposal_id": "prop_1"}]
+
+
+@pytest.mark.asyncio
+async def test_ignore_preserves_current_permissive_behavior() -> None:
+    handler = _RecorderHandler()
+    caller = create_tool_caller(
+        handler,
+        "get_products",
+        validation=ValidationHookConfig(unknown_fields=UnknownFieldPolicy.IGNORE),
+    )
+
+    await caller({"buying_mode": "brief", "brief": "ads", "nonsense_field": "bar"})
+
+    assert handler.received[0]["nonsense_field"] == "bar"
+
+
+@pytest.mark.asyncio
+async def test_unknown_field_policy_runs_after_pre_validation_hooks() -> None:
+    def normalize(_tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        legacy_brief = args.pop("legacy_brief")
+        return {**args, "buying_mode": "brief", "brief": legacy_brief}
+
+    handler = _RecorderHandler()
+    caller = create_tool_caller(
+        handler,
+        "get_products",
+        validation=ValidationHookConfig(unknown_fields="reject"),
+        pre_validation_hook=normalize,
+    )
+
+    await caller({"legacy_brief": "ads"})
+
+    assert handler.received == [{"buying_mode": "brief", "brief": "ads"}]
+
+
+@pytest.mark.asyncio
+async def test_a2a_executor_uses_same_unknown_field_policy() -> None:
+    handler = _RecorderHandler()
+    executor = ADCPAgentExecutor(
+        handler,
+        validation=ValidationHookConfig(unknown_fields=UnknownFieldPolicy.REJECT),
+    )
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await executor._tool_callers["create_media_buy"](
+            {"proposal_id": "prop_1", "nonsense_field": "bar"}
+        )
+
+    assert handler.received == []
+    assert exc_info.value.errors[0].field == "nonsense_field"


### PR DESCRIPTION
## Summary

- Add `UnknownFieldPolicy` on `ValidationHookConfig` for server-side top-level argument handling: `reject`, `strip`, or `ignore`.
- Apply the unknown-field policy after pre-validation hooks and legacy adapters, before JSON schema validation and Pydantic request coercion.
- Support ordered pre-validation hook chains per tool and add `compose_pre_validation_hooks(...)` for deterministic SDK/adopter hook composition.
- Cover MCP and A2A dispatch paths, including mutating `create_media_buy` behavior.

## Motivation

Fixes #858 and #859. This moves unknown top-level field handling into the SDK transport boundary and removes the need for adopters to manually wrap SDK compatibility hooks with local pre-validation logic.

## Validation

- `ruff check src/`
- `PYTHONPATH=src mypy src/adcp/`
- `PYTHONPATH=src mypy --strict tests/type_checks/`
- `PYTHONPATH=src pytest tests/test_pre_validation_hooks.py tests/test_unknown_field_policy_server.py tests/test_schema_validation_server.py tests/test_serve_validation_passthrough.py tests/test_dispatcher_pre_adapter_validation.py tests/test_dispatcher_version_routing.py tests/test_testing_decisioning.py tests/test_public_api.py tests/test_validation_modes.py tests/test_spec_compat_hooks.py -q`
- `PYTHONPATH=src pytest tests/ -q` hit one local timing outlier in `tests/test_permission_denied_budget.py::test_branch_parity_absorbs_registry_variance`; rerunning that test in isolation passed.
- Commit hooks: black, ruff, mypy, bandit, and file checks passed.
