### PR TITLE
feat(adagents): add permissive property resolver

### DIFF
--- a/src/adcp/__init__.py
+++ b/src/adcp/__init__.py
@@ -36,6 +36,7 @@ from adcp.adagents import (
     get_all_tags,
     get_properties_by_agent,
     identifiers_match,
+    resolve_properties_for_agent,
     validate_adagents_domain,
     validate_adagents_structure,
     verify_agent_authorization,
@@ -923,6 +924,7 @@ __all__ = [
     "get_all_properties",
     "get_all_tags",
     "get_properties_by_agent",
+    "resolve_properties_for_agent",
     # Test helpers
     "test_agent",
     "test_agent_a2a",

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 DiscoveryMethod = Literal["direct", "authoritative_location", "ads_txt_managerdomain"]
 PropertyResolutionMode = Literal["strict", "permissive"]
+_BARE_AUTHORIZED_AGENT_KEYS = {"url", "authorized_for"}
 
 
 # authorization_type discriminator -> required selector field, per the AdCP
@@ -1298,10 +1299,14 @@ def _resolve_agent_properties(
 
 
 def _is_bare_authorized_agent_entry(agent: dict[str, Any]) -> bool:
-    """Return True for entries that list an agent but no property selector."""
-    if "authorization_type" in agent:
-        return False
-    return not any(selector in agent for selector in _AUTHORIZATION_TYPE_TO_SELECTOR.values())
+    """Return True only for the exact legacy bare-entry shape."""
+    return (
+        set(agent).issubset(_BARE_AUTHORIZED_AGENT_KEYS)
+        and isinstance(agent.get("url"), str)
+        and bool(agent["url"])
+        and isinstance(agent.get("authorized_for"), str)
+        and bool(agent["authorized_for"])
+    )
 
 
 def _build_domain_index(
@@ -1634,12 +1639,13 @@ def resolve_properties_for_agent(
     inline ``properties`` legacy shape.
 
     ``mode="permissive"`` keeps every strict selector behavior unchanged, but
-    treats a matching bare ``authorized_agents`` entry as authorizing the
-    file's top-level ``properties[]``. This is for operational binding of
+    treats one exact matching bare ``authorized_agents`` entry
+    (``{"url": ..., "authorized_for": ...}``) as authorizing the file's
+    top-level ``properties[]``. This is for operational binding of
     non-conformant publisher files that list an agent URL without an
-    ``authorization_type`` or selector. If the agent is not listed, or the
-    matching entry has any explicit selector, the resolver still returns the
-    strict result.
+    ``authorization_type`` or selector. If the agent is not listed, has any
+    explicit or unknown selector field, or has multiple same-URL entries, the
+    resolver still returns the strict result.
 
     Args:
         adagents_data: Parsed adagents.json data
@@ -1702,6 +1708,7 @@ def _resolve_properties_for_agent(
 
     domain_index = _build_domain_index(revoked_top_level)
 
+    matches: list[dict[str, Any]] = []
     for agent in authorized_agents:
         if not isinstance(agent, dict):
             continue
@@ -1712,17 +1719,25 @@ def _resolve_properties_for_agent(
 
         if normalize_url(agent_url_from_json) != normalized_agent_url:
             continue
+        matches.append(agent)
 
+    resolved: list[dict[str, Any]] = []
+    for agent in matches:
         # revoked_top_level pre-filters revoked domains from the per-domain
         # index, so inline resolution honors revocation transparently.
-        resolved = _resolve_agent_properties(agent, revoked_top_level, domain_index)
-        if (
-            permissive_bare_top_level
-            and not resolved
-            and _is_bare_authorized_agent_entry(agent)
-        ):
-            return [p for p in revoked_top_level if isinstance(p, dict)]
+        for prop in _resolve_agent_properties(agent, revoked_top_level, domain_index):
+            if prop not in resolved:
+                resolved.append(prop)
+
+    if resolved:
         return resolved
+
+    if (
+        permissive_bare_top_level
+        and len(matches) == 1
+        and _is_bare_authorized_agent_entry(matches[0])
+    ):
+        return [p for p in revoked_top_level if isinstance(p, dict)]
 
     return []
 

--- a/src/adcp/adagents.py
+++ b/src/adcp/adagents.py
@@ -34,6 +34,7 @@ from adcp.validation import ValidationError, validate_adagents
 logger = logging.getLogger(__name__)
 
 DiscoveryMethod = Literal["direct", "authoritative_location", "ads_txt_managerdomain"]
+PropertyResolutionMode = Literal["strict", "permissive"]
 
 
 # authorization_type discriminator -> required selector field, per the AdCP
@@ -1296,6 +1297,13 @@ def _resolve_agent_properties(
     return []
 
 
+def _is_bare_authorized_agent_entry(agent: dict[str, Any]) -> bool:
+    """Return True for entries that list an agent but no property selector."""
+    if "authorization_type" in agent:
+        return False
+    return not any(selector in agent for selector in _AUTHORIZATION_TYPE_TO_SELECTOR.values())
+
+
 def _build_domain_index(
     properties: list[dict[str, Any]],
 ) -> dict[str, list[dict[str, Any]]]:
@@ -1610,6 +1618,64 @@ def get_properties_by_agent(adagents_data: dict[str, Any], agent_url: str) -> li
     Raises:
         AdagentsValidationError: If adagents_data is malformed
     """
+    return _resolve_properties_for_agent(adagents_data, agent_url, permissive_bare_top_level=False)
+
+
+def resolve_properties_for_agent(
+    adagents_data: dict[str, Any],
+    agent_url: str,
+    *,
+    mode: PropertyResolutionMode = "strict",
+) -> list[dict[str, Any]]:
+    """Resolve properties for an agent with an explicit strict/permissive mode.
+
+    ``mode="strict"`` is identical to :func:`get_properties_by_agent` and
+    only honors schema-conformant authorization selectors plus the historical
+    inline ``properties`` legacy shape.
+
+    ``mode="permissive"`` keeps every strict selector behavior unchanged, but
+    treats a matching bare ``authorized_agents`` entry as authorizing the
+    file's top-level ``properties[]``. This is for operational binding of
+    non-conformant publisher files that list an agent URL without an
+    ``authorization_type`` or selector. If the agent is not listed, or the
+    matching entry has any explicit selector, the resolver still returns the
+    strict result.
+
+    Args:
+        adagents_data: Parsed adagents.json data
+        agent_url: URL of the agent to filter by
+        mode: ``"strict"`` for spec-conformant resolution, ``"permissive"``
+            to opt into bare-entry top-level property fallback.
+
+    Returns:
+        List of properties for the specified agent.
+
+    Raises:
+        AdagentsValidationError: If adagents_data is malformed
+        ValueError: If mode is not ``"strict"`` or ``"permissive"``
+    """
+    if mode == "strict":
+        return _resolve_properties_for_agent(
+            adagents_data,
+            agent_url,
+            permissive_bare_top_level=False,
+        )
+    if mode == "permissive":
+        return _resolve_properties_for_agent(
+            adagents_data,
+            agent_url,
+            permissive_bare_top_level=True,
+        )
+    raise ValueError("mode must be 'strict' or 'permissive'")
+
+
+def _resolve_properties_for_agent(
+    adagents_data: dict[str, Any],
+    agent_url: str,
+    *,
+    permissive_bare_top_level: bool,
+) -> list[dict[str, Any]]:
+    """Implementation shared by strict and opt-in permissive property resolution."""
     if not isinstance(adagents_data, dict):
         raise AdagentsValidationError("adagents_data must be a dictionary")
 
@@ -1650,6 +1716,12 @@ def get_properties_by_agent(adagents_data: dict[str, Any], agent_url: str) -> li
         # revoked_top_level pre-filters revoked domains from the per-domain
         # index, so inline resolution honors revocation transparently.
         resolved = _resolve_agent_properties(agent, revoked_top_level, domain_index)
+        if (
+            permissive_bare_top_level
+            and not resolved
+            and _is_bare_authorized_agent_entry(agent)
+        ):
+            return [p for p in revoked_top_level if isinstance(p, dict)]
         return resolved
 
     return []

--- a/tests/fixtures/public_api_snapshot.json
+++ b/tests/fixtures/public_api_snapshot.json
@@ -424,6 +424,7 @@
     "has_assets",
     "identifiers_match",
     "normalize_assets_required",
+    "resolve_properties_for_agent",
     "sign_legacy_webhook",
     "sign_webhook",
     "test_agent",

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -20,6 +20,7 @@ from adcp.adagents import (
     get_all_tags,
     get_properties_by_agent,
     identifiers_match,
+    resolve_properties_for_agent,
     verify_agent_authorization,
 )
 from adcp.exceptions import (
@@ -2061,6 +2062,157 @@ class TestGetPropertiesByAgent:
 
         properties = get_properties_by_agent(adagents_data, "https://agent1.example.com")
         assert len(properties) == 0
+
+    def test_resolve_properties_for_agent_strict_keeps_bare_entries_empty(self):
+        """Strict resolution preserves get_properties_by_agent behavior for bare entries."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "All listed properties",
+                },
+            ],
+        }
+
+        assert get_properties_by_agent(adagents_data, "https://agent1.example.com") == []
+        assert resolve_properties_for_agent(adagents_data, "https://agent1.example.com") == []
+
+    def test_resolve_properties_for_agent_permissive_bare_entry_uses_top_level_properties(self):
+        """Permissive mode treats a matching bare entry as authorizing top-level properties."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+                {
+                    "property_id": "app1",
+                    "property_type": "mobile_app",
+                    "name": "App 1",
+                    "identifiers": [{"type": "bundle_id", "value": "com.example.app"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "All listed properties",
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://agent1.example.com",
+            mode="permissive",
+        )
+        assert [p["property_id"] for p in properties] == ["site1", "app1"]
+
+    def test_resolve_properties_for_agent_permissive_still_requires_matching_agent(self):
+        """Permissive mode does not expose properties when the agent is not listed."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "All listed properties",
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://other-agent.example.com",
+            mode="permissive",
+        )
+        assert properties == []
+
+    def test_resolve_properties_for_agent_permissive_does_not_override_selectors(self):
+        """Permissive fallback applies only to bare entries, not broken explicit selectors."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "Explicit but broken selector",
+                    "property_ids": ["site1"],
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://agent1.example.com",
+            mode="permissive",
+        )
+        assert properties == []
+
+    def test_resolve_properties_for_agent_permissive_honors_revoked_domains(self):
+        """Bare-entry fallback still excludes top-level properties revoked by the file."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "publisher_domain": "active.example",
+                    "property_type": "website",
+                    "name": "Active",
+                    "identifiers": [{"type": "domain", "value": "active.example"}],
+                },
+                {
+                    "property_id": "site2",
+                    "publisher_domain": "revoked.example",
+                    "property_type": "website",
+                    "name": "Revoked",
+                    "identifiers": [{"type": "domain", "value": "revoked.example"}],
+                },
+            ],
+            "revoked_publisher_domains": [{"publisher_domain": "revoked.example"}],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "All listed properties",
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://agent1.example.com",
+            mode="permissive",
+        )
+        assert [p["property_id"] for p in properties] == ["site1"]
+
+    def test_resolve_properties_for_agent_rejects_unknown_mode(self):
+        """Unknown resolver modes fail loudly instead of silently broadening access."""
+        with pytest.raises(ValueError, match="mode"):
+            resolve_properties_for_agent(
+                {"authorized_agents": []},
+                "https://agent1.example.com",
+                mode="loose",
+            )
 
 
 class TestAuthorizationContext:

--- a/tests/test_adagents.py
+++ b/tests/test_adagents.py
@@ -2170,6 +2170,96 @@ class TestGetPropertiesByAgent:
         )
         assert properties == []
 
+    def test_resolve_properties_for_agent_permissive_rejects_missing_authorized_for(self):
+        """Permissive fallback requires the exact legacy bare entry shape."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://agent1.example.com",
+            mode="permissive",
+        )
+        assert properties == []
+
+    def test_resolve_properties_for_agent_permissive_rejects_unknown_selector_fields(self):
+        """Permissive fallback does not treat typoed selectors as all-property auth."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "Typoed selector",
+                    "property_idz": ["site1"],
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://agent1.example.com",
+            mode="permissive",
+        )
+        assert properties == []
+
+    def test_resolve_properties_for_agent_permissive_prefers_explicit_duplicate_match(self):
+        """A stale bare row cannot broaden a later explicit same-agent selector."""
+        adagents_data = {
+            "properties": [
+                {
+                    "property_id": "site1",
+                    "property_type": "website",
+                    "name": "Site 1",
+                    "identifiers": [{"type": "domain", "value": "site1.com"}],
+                },
+                {
+                    "property_id": "site2",
+                    "property_type": "website",
+                    "name": "Site 2",
+                    "identifiers": [{"type": "domain", "value": "site2.com"}],
+                },
+            ],
+            "authorized_agents": [
+                {
+                    "url": "https://agent1.example.com",
+                    "authorized_for": "Legacy broad row",
+                },
+                {
+                    "url": "https://agent1.example.com",
+                    "authorization_type": "property_ids",
+                    "authorized_for": "Restricted row",
+                    "property_ids": ["site1"],
+                },
+            ],
+        }
+
+        properties = resolve_properties_for_agent(
+            adagents_data,
+            "https://agent1.example.com",
+            mode="permissive",
+        )
+        assert [p["property_id"] for p in properties] == ["site1"]
+
     def test_resolve_properties_for_agent_permissive_honors_revoked_domains(self):
         """Bare-entry fallback still excludes top-level properties revoked by the file."""
         adagents_data = {


### PR DESCRIPTION
## Summary

Replaces #827 on a repo-owned branch so required base-repo checks can run normally, with the authorization hardening requested by expert review.

Refs #711.

This adds an explicit opt-in resolver for operational adagents.json files that list a sales agent in `authorized_agents[]` but omit the schema-conformant `authorization_type` selector.

The existing `get_properties_by_agent()` behavior stays strict and unchanged. New callers can use:

```python
resolve_properties_for_agent(adagents_data, agent_url, mode="permissive")
```

In permissive mode, a matching exact bare `authorized_agents` entry (`url` + `authorized_for` only) resolves to the file's top-level `properties[]`. The fallback fails closed when the entry has unknown/typoed selector fields, lacks `authorized_for`, or there are multiple same-URL rows with an explicit selector.

## What changed

- Added `resolve_properties_for_agent(..., mode="strict" | "permissive")`.
- Kept `get_properties_by_agent()` as the strict path.
- Exported the new helper from `adcp.__all__` and updated the public API snapshot.
- Hardened permissive fallback to the exact legacy bare-entry shape.
- Aggregated same-URL explicit matches before considering permissive fallback, so a stale bare row cannot broaden a restrictive row.
- Added regression tests for missing `authorized_for`, unknown/typoed selector fields, and duplicate same-URL rows.

## Local validation

- `PYTHONPATH=src pytest tests/test_adagents.py -q -k "resolve_properties_for_agent or get_properties_by_agent"`
- `PYTHONPATH=src pytest tests/test_adagents.py tests/test_public_api.py -q`
- `PYTHONPATH=src ruff check src/adcp/adagents.py src/adcp/__init__.py tests/test_adagents.py tests/fixtures/public_api_snapshot.json`
- `git diff --check`
