### PR TITLE
ci: run Argus review from trusted PR target

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,7 +18,7 @@ name: AI PR Review (Argus)
 # Ported from adcontextprotocol/adcp's Argus workflow.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled
@@ -38,9 +38,14 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # pull_request_target runs with base-repo secrets, so keep the
+      # workspace on trusted base code. Argus reads the untrusted PR via
+      # GitHub APIs (`gh pr diff/view`) and never checks out or executes it.
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       # ─────────────────────────────────────────────────────────────────────
       # Mint an installation token from the AAO release/triage GitHub App.
@@ -81,6 +86,9 @@ jobs:
             echo "No prior bot APPROVED review — running full review."
             exit 0
           fi
+          # Fetch PR objects for diff-only comparisons. Do not checkout or run
+          # PR code in this privileged pull_request_target workflow.
+          git fetch --quiet origin "pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head" || true
           if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
             git fetch --quiet origin "$PRIOR_SHA" 2>/dev/null || true
           fi

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -59,87 +59,7 @@ jobs:
           app-id: ${{ secrets.IPR_APP_ID }}
           private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
 
-      # ─────────────────────────────────────────────────────────────────────
-      # Skip re-runs on `synchronize` when the last bot review on this PR
-      # was APPROVED and the new commits only touch trivial paths (docs,
-      # tests, generated files). Cuts thrash on rebases and docs/test
-      # follow-up pushes. Force-pushes fall back to full review because
-      # the prior SHA may be unreachable.
-      # ─────────────────────────────────────────────────────────────────────
-      - name: Check for skippable re-run
-        id: skip-check
-        if: github.event.action == 'synchronize'
-        continue-on-error: true
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          LATEST_APPROVED="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            --jq '[.[] | select(.user.type == "Bot" and .state == "APPROVED")] | sort_by(.submitted_at) | last // {}')"
-          PRIOR_SHA="$(echo "$LATEST_APPROVED" | jq -r '.commit_id // ""')"
-          if [ -z "$PRIOR_SHA" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "No prior bot APPROVED review — running full review."
-            exit 0
-          fi
-          # Fetch PR objects for diff-only comparisons. Do not checkout or run
-          # PR code in this privileged pull_request_target workflow.
-          git fetch --quiet origin "pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head" || true
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            git fetch --quiet origin "$PRIOR_SHA" 2>/dev/null || true
-          fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Prior review SHA $PRIOR_SHA unreachable (likely force-pushed) — running full review."
-            exit 0
-          fi
-          CHANGED="$(git diff --name-only "$PRIOR_SHA" "$HEAD_SHA")"
-          if [ -z "$CHANGED" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No file changes since prior approval at $PRIOR_SHA — skipping."
-            exit 0
-          fi
-          # Trivial paths in adcp-client-python — re-pushes touching only these
-          # skip re-review. Source under src/adcp/ (excluding generated_poc) is
-          # NEVER trivial.
-          is_trivial() {
-            case "$1" in
-              *.md|*.mdx) return 0 ;;
-              docs/*) return 0 ;;
-              examples/*) return 0 ;;
-              src/adcp/types/generated_poc/*) return 0 ;;
-              src/adcp/types/_generated.py) return 0 ;;
-              tests/*) return 0 ;;
-              test_*.py|*_test.py) return 0 ;;
-              CHANGELOG.md) return 0 ;;
-              schemas/*) return 0 ;;
-              llms.txt) return 0 ;;
-            esac
-            return 1
-          }
-          NON_TRIVIAL=""
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            if ! is_trivial "$f"; then
-              NON_TRIVIAL="${NON_TRIVIAL}${f}"$'\n'
-            fi
-          done <<< "$CHANGED"
-          if [ -z "$NON_TRIVIAL" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "All changes since $PRIOR_SHA are trivial — skipping re-review. Changed files:"
-            echo "$CHANGED"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Non-trivial changes since $PRIOR_SHA — running full review:"
-            echo "$NON_TRIVIAL"
-          fi
-
       - name: Build Argus review prompt
-        if: steps.skip-check.outputs.skip != 'true'
         id: build-prompt
         shell: bash
         env:
@@ -165,7 +85,6 @@ jobs:
 
       - name: Run Argus PR Review
         id: ai-review
-        if: steps.skip-check.outputs.skip != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -181,7 +100,7 @@ jobs:
 
       - name: Verify Argus posted a review
         id: verify
-        if: always() && steps.app-token.outcome == 'success' && steps.skip-check.outputs.skip != 'true'
+        if: always() && steps.app-token.outcome == 'success'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -211,7 +130,7 @@ jobs:
           echo "review_state=$STATE" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR if Argus review failed
-        if: steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
+        if: steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true'
         uses: actions/github-script@v8
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary

Allow Argus to review fork PRs without mirroring contributor branches into this repository.

The previous `pull_request` workflow could not access `IPR_APP_ID`, `IPR_APP_PRIVATE_KEY`, or `ANTHROPIC_API_KEY` for forked PRs, so Argus failed before review execution. This moves the workflow to `pull_request_target`, where base-repo secrets are available, while keeping the privileged workspace pinned to trusted base code.

## Safety posture

- Checkout is explicitly pinned to `github.event.pull_request.base.sha`.
- `persist-credentials` is disabled for checkout.
- PR code is not checked out or executed in the privileged workflow.
- The synchronize skip logic fetches `refs/pull/<number>/head` only for git object diffing.
- Argus continues to inspect the untrusted PR via `gh pr diff/view`.

## Validation

- `check yaml` pre-commit hook passed.
- Parsed `.github/workflows/ai-review.yml` with PyYAML.
