### PR TITLE
feat(decisioning): add request-scoped capabilities hook

### DIFF
--- a/docs/decisioning-capabilities.md
+++ b/docs/decisioning-capabilities.md
@@ -100,6 +100,83 @@ alongside the spec; they line up.
 - **`compliance_testing`** — declare when you support
   `comply_test_controller`-driven scenarios.
 
+## Request-scoped capability blocks
+
+Most capability declarations are static. Multi-tenant agents sometimes
+need values that depend on the current request context: for example,
+`media_buy.portfolio.publisher_domains` from the tenant's publisher
+partner table, or `webhook_signing` only when that tenant has an active
+locally usable signing credential.
+
+Override `DecisioningPlatform.get_adcp_capabilities_for_request()` for
+those cases. Return `None` to use the class-level declaration unchanged,
+or return a complete `DecisioningCapabilities` instance for this
+request. The SDK still owns the canonical `get_adcp_capabilities`
+response shape.
+
+The hook may enrich request-specific capability blocks, but it must not
+change `specialisms` or the effective `supported_protocols`. Those fields
+drive boot-time method validation and `tools/list`, so they stay static
+for the handler instance.
+
+```python
+from dataclasses import replace
+
+from adcp.decisioning import DecisioningCapabilities, DecisioningPlatform
+from adcp.decisioning.capabilities import (
+    Account,
+    MediaBuy,
+    Portfolio,
+    Specialism,
+    SupportedProtocol,
+    WebhookSigning,
+)
+
+
+class MultiTenantSeller(DecisioningPlatform):
+    capabilities = DecisioningCapabilities(
+        # Static defaults that are valid without tenant context.
+        specialisms=[Specialism.sales_non_guaranteed],
+        supported_protocols=[SupportedProtocol.media_buy],
+        account=Account(supported_billing=["operator"]),
+        media_buy=MediaBuy(supported_pricing_models=["cpm"]),
+    )
+
+    def get_adcp_capabilities_for_request(self, params=None, context=None):
+        if context is None or context.tenant_id is None:
+            return None
+
+        tenant = self.lookup_tenant(context.tenant_id)
+        base = self.capabilities
+        media_buy = base.media_buy.model_copy(
+            update={
+                "portfolio": Portfolio(
+                    publisher_domains=tenant.publisher_domains,
+                )
+            }
+        )
+        webhook_signing = (
+            WebhookSigning(
+                supported=True,
+                profile="adcp/webhook-signing/v1",
+                algorithms=[tenant.signing_algorithm],
+            )
+            if tenant.has_active_signing_credential
+            else None
+        )
+        return replace(
+            base,
+            media_buy=media_buy,
+            webhook_signing=webhook_signing,
+        )
+```
+
+The hook may be synchronous or asynchronous. It receives the typed
+`get_adcp_capabilities` request (or dict, for custom dispatch paths) and
+the current `ToolContext`, so tenant identity can come from
+`context.tenant_id`, auth middleware metadata, or a custom context
+subclass.
+
 ## What you don't declare directly
 
 The framework auto-derives a few things:
@@ -213,11 +290,11 @@ declaration.
 - **Server boot** — `validate_capabilities_response_shape` runs the
   full projection synchronously and validates the output against
   `protocol/get-adcp-capabilities-response.json`. Boot-time errors here
-  are the cleanest possible — fix the declaration or override the
-  projection on a `PlatformHandler` subclass.
+  are the cleanest possible — fix the static declaration, the
+  request-scoped capabilities hook, or a custom handler override.
 - **Discovery time** — every `get_adcp_capabilities` call reads the
-  declaration once and projects. There's no per-call I/O; the projection
-  is pure.
+  declaration, gives `get_adcp_capabilities_for_request()` a chance to
+  return a request-scoped override, then projects the result to the wire.
 
 ## Custom blocks
 

--- a/src/adcp/decisioning/handler.py
+++ b/src/adcp/decisioning/handler.py
@@ -52,6 +52,7 @@ from adcp.decisioning.dispatch import (
 )
 from adcp.decisioning.implementation_config import ProductConfigStore
 from adcp.decisioning.pagination import _query_hash, apply_framework_pagination
+from adcp.decisioning.platform import DecisioningCapabilities
 from adcp.decisioning.property_list import (
     maybe_apply_property_list_filter,
     property_list_capability_enabled,
@@ -117,6 +118,7 @@ from adcp.types import (
     DeleteCollectionListResponse,
     DeletePropertyListRequest,
     DeletePropertyListResponse,
+    GetAdcpCapabilitiesRequest,
     GetBrandIdentityRequest,
     GetBrandIdentitySuccessResponse,
     GetCollectionListRequest,
@@ -954,6 +956,74 @@ def _method_accepts_configs(platform: Any, method_name: str) -> bool:
         return False
 
 
+def _specialism_slugs(caps: DecisioningCapabilities) -> tuple[str, ...]:
+    return tuple(
+        entry.value if hasattr(entry, "value") else str(entry) for entry in caps.specialisms
+    )
+
+
+def _effective_supported_protocols(caps: DecisioningCapabilities) -> tuple[str, ...]:
+    if caps.supported_protocols is not None:
+        return tuple(
+            sorted(p.value if hasattr(p, "value") else str(p) for p in caps.supported_protocols)
+        )
+    protocols: set[str] = set()
+    for slug in _specialism_slugs(caps):
+        protocols.update(SPECIALISM_TO_PROTOCOLS.get(slug, frozenset()))
+    return tuple(sorted(protocols))
+
+
+def _validate_scoped_capabilities_static_contract(
+    *,
+    static_caps: DecisioningCapabilities,
+    scoped_caps: DecisioningCapabilities,
+) -> None:
+    """Reject scoped overrides that would desynchronize discovery from dispatch."""
+    static_specialisms = _specialism_slugs(static_caps)
+    scoped_specialisms = _specialism_slugs(scoped_caps)
+    if scoped_specialisms != static_specialisms:
+        from adcp.decisioning.types import AdcpError
+
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message=(
+                "DecisioningPlatform.get_adcp_capabilities_for_request() may "
+                "enrich request-scoped capability blocks, but it must not "
+                "change specialisms. Tool advertisement and platform method "
+                "validation are derived from the static capabilities "
+                "declaration at server boot."
+            ),
+            recovery="terminal",
+            details={
+                "field": "specialisms",
+                "static_specialisms": list(static_specialisms),
+                "scoped_specialisms": list(scoped_specialisms),
+            },
+        )
+
+    static_protocols = _effective_supported_protocols(static_caps)
+    scoped_protocols = _effective_supported_protocols(scoped_caps)
+    if scoped_protocols != static_protocols:
+        from adcp.decisioning.types import AdcpError
+
+        raise AdcpError(
+            "INVALID_REQUEST",
+            message=(
+                "DecisioningPlatform.get_adcp_capabilities_for_request() may "
+                "enrich request-scoped capability blocks, but it must not "
+                "change supported_protocols. Discovery must stay aligned with "
+                "the handler's advertised tools and boot-time method "
+                "validation."
+            ),
+            recovery="terminal",
+            details={
+                "field": "supported_protocols",
+                "static_supported_protocols": list(static_protocols),
+                "scoped_supported_protocols": list(scoped_protocols),
+            },
+        )
+
+
 def _extract_media_buy_id(result: Any) -> str | None:
     """Pull ``media_buy_id`` off a ``create_media_buy`` return — handles
     Pydantic models, plain dicts, and the ``Submitted`` envelope shape.
@@ -1449,7 +1519,7 @@ class PlatformHandler(ADCPHandler[ToolContext]):
 
     async def get_adcp_capabilities(
         self,
-        params: Any = None,
+        params: GetAdcpCapabilitiesRequest | dict[str, Any] | None = None,
         context: ToolContext | None = None,
     ) -> dict[str, Any]:
         """Project the platform's :class:`DecisioningCapabilities` into a
@@ -1491,13 +1561,71 @@ class PlatformHandler(ADCPHandler[ToolContext]):
           get a ``DeprecationWarning`` pointing at
           ``media_buy.portfolio``.
 
-        Adopters who need a custom projection (vendor-specific feature
-        flags, hand-shaped sub-blocks) override
-        ``get_adcp_capabilities`` on a :class:`PlatformHandler`
-        subclass.
+        Adopters who need request-scoped capability blocks (for
+        example tenant-specific publisher domains or webhook-signing
+        support) override
+        :meth:`DecisioningPlatform.get_adcp_capabilities_for_request`.
+        That hook returns a typed :class:`DecisioningCapabilities`
+        override; this method remains responsible for the canonical
+        wire projection.
         """
-        del params, context  # Discovery; no auth or input required.
+        from adcp.decisioning.types import AdcpError
+
         caps = self._platform.capabilities
+        try:
+            scoped_caps = self._platform.get_adcp_capabilities_for_request(params, context)
+            if inspect.isawaitable(scoped_caps):
+                scoped_caps = await scoped_caps
+        except AdcpError:
+            raise
+        except Exception as exc:
+            logger.exception(
+                "Unhandled exception in platform.get_adcp_capabilities_for_request — "
+                "wrapping to INTERNAL_ERROR"
+            )
+            raise AdcpError(
+                "INTERNAL_ERROR",
+                message=(
+                    "Unhandled exception in platform.get_adcp_capabilities_for_request: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                recovery="terminal",
+                details={
+                    "caused_by": {
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                },
+            ) from exc
+        has_scoped_caps = scoped_caps is not None
+        if scoped_caps is not None:
+            caps = scoped_caps
+        if not isinstance(caps, DecisioningCapabilities):
+            raise AdcpError(
+                "INVALID_REQUEST",
+                message=(
+                    "DecisioningPlatform.get_adcp_capabilities_for_request() "
+                    "must return DecisioningCapabilities or None; got "
+                    f"{type(caps).__name__}"
+                ),
+                recovery="terminal",
+            )
+        if has_scoped_caps:
+            _validate_scoped_capabilities_static_contract(
+                static_caps=self._platform.capabilities,
+                scoped_caps=caps,
+            )
+            from adcp.decisioning.validate_idempotency import (
+                validate_idempotency_wiring_for_capabilities,
+            )
+            from adcp.decisioning.webhook_emit import validate_webhook_signing_for_capabilities
+
+            validate_idempotency_wiring_for_capabilities(self._platform, caps)
+            validate_webhook_signing_for_capabilities(
+                capabilities=caps,
+                sender=self._webhook_sender,
+                supervisor=self._webhook_supervisor,
+            )
 
         # ----- supported_protocols: explicit override > derive from specialisms -----
         supported_protocols: list[str]
@@ -1601,6 +1729,11 @@ class PlatformHandler(ADCPHandler[ToolContext]):
             response["media_buy"] = {
                 "supported_pricing_models": list(dict.fromkeys(caps.pricing_models)),
             }
+
+        if has_scoped_caps:
+            from adcp.decisioning.validate_capabilities import _validate_response_dict
+
+            _validate_response_dict(response)
 
         return response
 

--- a/src/adcp/decisioning/platform.py
+++ b/src/adcp/decisioning/platform.py
@@ -12,6 +12,7 @@ existing transport machinery.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,8 @@ from adcp.types.capabilities import (
 if TYPE_CHECKING:
     from adcp.decisioning.accounts import AccountStore
     from adcp.decisioning.context import RequestContext
+    from adcp.server.base import ToolContext
+    from adcp.types import GetAdcpCapabilitiesRequest
 
 
 @dataclass
@@ -398,6 +401,28 @@ class DecisioningPlatform:
     #: ``account.metadata['mock_upstream_url']`` and never consult
     #: this attribute.
     upstream_url: str | None = None
+
+    def get_adcp_capabilities_for_request(
+        self,
+        params: GetAdcpCapabilitiesRequest | dict[str, Any] | None = None,
+        context: ToolContext | None = None,
+    ) -> DecisioningCapabilities | None | Awaitable[DecisioningCapabilities | None]:
+        """Optionally override capabilities for the current discovery request.
+
+        The class-level :attr:`capabilities` declaration remains the default
+        source of truth. Multi-tenant adopters can override this hook when a
+        valid capability block depends on request context, such as tenant
+        publisher domains or whether the tenant has an active webhook-signing
+        credential.
+
+        Return ``None`` to use :attr:`capabilities` unchanged, or return a
+        complete :class:`DecisioningCapabilities` instance for this request.
+        The framework still performs the canonical
+        ``get_adcp_capabilities`` response projection; this hook is not a raw
+        wire-response override. The hook may be synchronous or asynchronous.
+        """
+        del params, context
+        return None
 
     def upstream_for(
         self,

--- a/src/adcp/decisioning/validate_capabilities.py
+++ b/src/adcp/decisioning/validate_capabilities.py
@@ -3,8 +3,10 @@
 The framework auto-projects :class:`DecisioningCapabilities` into a
 spec-shaped ``get_adcp_capabilities`` response (see
 :meth:`adcp.decisioning.handler.PlatformHandler.get_adcp_capabilities`).
-Adopters may also override the projection on a subclass. Either way,
-the response that ships on the wire must satisfy the
+Adopters may also override capabilities per request via
+``DecisioningPlatform.get_adcp_capabilities_for_request`` or override the
+projection on a handler subclass. Either way, the response that ships on
+the wire must satisfy the
 ``protocol/get-adcp-capabilities-response.json`` schema **and** the
 spec invariants the schema cannot fully express on its own (e.g.
 "``account.supported_billing`` must exist and be non-empty whenever the
@@ -52,9 +54,9 @@ def _running_loop_error(cause: RuntimeError) -> RuntimeError:
 def _invoke_capabilities(handler: PlatformHandler) -> dict[str, Any]:
     """Call ``handler.get_adcp_capabilities()`` synchronously.
 
-    The handler method is async but never blocks (no I/O — pure
-    projection over ``platform.capabilities``). We drive it via
-    :func:`asyncio.run` so this validator stays callable from the
+    The handler method is async because request-scoped capability hooks may
+    be async. We drive it via :func:`asyncio.run` so this validator stays
+    callable from the
     synchronous server-boot path. **Cannot be called from inside a
     running event loop** — see #700; the stdlib's ``RuntimeError`` is
     re-raised with an SDK-specific message pointing at the opt-out.

--- a/src/adcp/decisioning/validate_idempotency.py
+++ b/src/adcp/decisioning/validate_idempotency.py
@@ -34,22 +34,26 @@ from typing import Any
 from adcp.server.idempotency import is_wrapped
 
 
-def idempotency_capability_supported(platform: Any) -> bool:
-    """Return True if ``platform.capabilities.adcp.idempotency.supported`` is True.
-
-    Walks the three-level attribute chain defensively — adopters may set
-    capabilities to ``None`` or omit nested fields entirely.
-    """
-    caps = getattr(platform, "capabilities", None)
-    if caps is None:
+def _idempotency_capability_supported(capabilities: Any) -> bool:
+    """Return True if ``capabilities.adcp.idempotency.supported`` is True."""
+    if capabilities is None:
         return False
-    adcp = getattr(caps, "adcp", None)
+    adcp = getattr(capabilities, "adcp", None)
     if adcp is None:
         return False
     idempotency = getattr(adcp, "idempotency", None)
     if idempotency is None:
         return False
     return getattr(idempotency, "supported", None) is True
+
+
+def idempotency_capability_supported(platform: Any) -> bool:
+    """Return True if ``platform.capabilities.adcp.idempotency.supported`` is True.
+
+    Walks the three-level attribute chain defensively — adopters may set
+    capabilities to ``None`` or omit nested fields entirely.
+    """
+    return _idempotency_capability_supported(getattr(platform, "capabilities", None))
 
 
 def _candidate_method_names(platform: Any) -> list[str]:
@@ -94,8 +98,8 @@ def _platform_has_wrapped_method(platform: Any) -> bool:
     return False
 
 
-def validate_idempotency_wiring(platform: Any) -> None:
-    """Boot-time fail-fast: idempotency advertised but no method wrapped.
+def validate_idempotency_wiring_for_capabilities(platform: Any, capabilities: Any) -> None:
+    """Fail fast: these capabilities advertise idempotency without wiring.
 
     Honors the ``_adcp_idempotency_external = True`` opt-out for
     adopters with upstream gateway dedup or a BYO decorator the SDK
@@ -107,7 +111,7 @@ def validate_idempotency_wiring(platform: Any) -> None:
         :meth:`adcp.server.idempotency.IdempotencyStore.wrap` AND the
         external opt-out is not set.
     """
-    if not idempotency_capability_supported(platform):
+    if not _idempotency_capability_supported(capabilities):
         return
     if getattr(platform, "_adcp_idempotency_external", False):
         return
@@ -148,7 +152,16 @@ def validate_idempotency_wiring(platform: Any) -> None:
     )
 
 
+def validate_idempotency_wiring(platform: Any) -> None:
+    """Boot-time fail-fast: idempotency advertised but no method wrapped."""
+    validate_idempotency_wiring_for_capabilities(
+        platform,
+        getattr(platform, "capabilities", None),
+    )
+
+
 __all__ = [
     "idempotency_capability_supported",
     "validate_idempotency_wiring",
+    "validate_idempotency_wiring_for_capabilities",
 ]

--- a/tests/test_decisioning_capabilities_projection.py
+++ b/tests/test_decisioning_capabilities_projection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 
 import pytest
 
@@ -27,11 +28,16 @@ from adcp.decisioning import (
 from adcp.decisioning.capabilities import (
     Account,
     Adcp,
+    IdempotencySupported,
     IdempotencyUnsupported,
     MediaBuy,
+    Portfolio,
     SupportedProtocol,
+    WebhookSigning,
 )
 from adcp.decisioning.handler import SPECIALISM_TO_PROTOCOLS, PlatformHandler
+from adcp.decisioning.types import AdcpError
+from adcp.server.base import ToolContext
 from adcp.validation.schema_validator import validate_response
 
 
@@ -42,11 +48,26 @@ def executor():
     pool.shutdown(wait=True)
 
 
-def _build_handler(platform: DecisioningPlatform, executor: ThreadPoolExecutor) -> PlatformHandler:
+class _WebhookSenderAuth:
+    alg = "ed25519"
+
+
+class _Rfc9421WebhookSender:
+    signs_with_rfc9421 = True
+    _auth = _WebhookSenderAuth()
+
+
+def _build_handler(
+    platform: DecisioningPlatform,
+    executor: ThreadPoolExecutor,
+    *,
+    webhook_sender=None,
+) -> PlatformHandler:
     return PlatformHandler(
         platform,
         executor=executor,
         registry=InMemoryTaskRegistry(),
+        webhook_sender=webhook_sender,
     )
 
 
@@ -238,3 +259,212 @@ def test_mixed_major_custom_adcp_block_does_not_invent_exact_versions(
 
     assert response["adcp"]["major_versions"] == [2, 3]
     assert "supported_versions" not in response["adcp"]
+
+
+def test_request_scoped_capabilities_hook_projects_tenant_blocks(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _TenantCapabilitiesPlatform(_SalesPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params
+            if context is None or context.tenant_id is None:
+                return None
+
+            base = self.capabilities
+            assert base.media_buy is not None
+            media_buy = base.media_buy.model_copy(
+                update={
+                    "portfolio": Portfolio(
+                        publisher_domains=[f"{context.tenant_id}.example"],
+                    )
+                }
+            )
+            webhook_signing = (
+                WebhookSigning(
+                    supported=True,
+                    profile="adcp/webhook-signing/v1",
+                    algorithms=["ed25519"],
+                )
+                if context.tenant_id == "signed"
+                else None
+            )
+            return replace(
+                base,
+                media_buy=media_buy,
+                webhook_signing=webhook_signing,
+            )
+
+    handler = _build_handler(
+        _TenantCapabilitiesPlatform(),
+        executor,
+        webhook_sender=_Rfc9421WebhookSender(),
+    )
+
+    unsigned = asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="tenant-a")))
+    signed = asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="signed")))
+    default = asyncio.run(handler.get_adcp_capabilities())
+
+    assert unsigned["media_buy"]["portfolio"]["publisher_domains"] == ["tenant-a.example"]
+    assert "webhook_signing" not in unsigned
+    assert signed["media_buy"]["portfolio"]["publisher_domains"] == ["signed.example"]
+    assert signed["webhook_signing"]["supported"] is True
+    assert signed["webhook_signing"]["algorithms"] == ["ed25519"]
+    assert "portfolio" not in default["media_buy"]
+
+
+def test_request_scoped_webhook_signing_reuses_sender_invariant(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _TenantCapabilitiesPlatform(_SalesPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params, context
+            return replace(
+                self.capabilities,
+                webhook_signing=WebhookSigning(
+                    supported=True,
+                    profile="adcp/webhook-signing/v1",
+                    algorithms=["ed25519"],
+                ),
+            )
+
+    handler = _build_handler(_TenantCapabilitiesPlatform(), executor)
+
+    with pytest.raises(AdcpError) as exc_info:
+        asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="signed")))
+
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.details["missing"] == "webhook_sender_with_rfc9421_key"
+
+
+def test_request_scoped_capabilities_are_schema_validated(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _InvalidTenantCapabilitiesPlatform(_SalesPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params, context
+            return replace(
+                self.capabilities,
+                account=None,
+            )
+
+    handler = _build_handler(_InvalidTenantCapabilitiesPlatform(), executor)
+
+    with pytest.raises(AdcpError) as exc_info:
+        asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="tenant-a")))
+
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert "account" in str(exc_info.value) or "supported_billing" in str(exc_info.value)
+
+
+def test_request_scoped_capabilities_cannot_change_supported_protocols(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _ProtocolChangingPlatform(_SignalsPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params, context
+            return replace(
+                self.capabilities,
+                supported_protocols=[SupportedProtocol.media_buy],
+            )
+
+    handler = _build_handler(_ProtocolChangingPlatform(), executor)
+
+    with pytest.raises(AdcpError) as exc_info:
+        asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="tenant-a")))
+
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.details["field"] == "supported_protocols"
+
+
+def test_request_scoped_capabilities_cannot_change_specialisms(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _SpecialismChangingPlatform(_SignalsPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params, context
+            return replace(
+                self.capabilities,
+                specialisms=["sales-non-guaranteed"],
+            )
+
+    handler = _build_handler(_SpecialismChangingPlatform(), executor)
+
+    with pytest.raises(AdcpError) as exc_info:
+        asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="tenant-a")))
+
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.details["field"] == "specialisms"
+
+
+def test_request_scoped_idempotency_reuses_wiring_invariant(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _TenantCapabilitiesPlatform(_SalesPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params, context
+            return replace(
+                self.capabilities,
+                adcp=Adcp(
+                    major_versions=[3],
+                    idempotency=IdempotencySupported(
+                        supported=True,
+                        replay_ttl_seconds=86400,
+                    ),
+                ),
+            )
+
+    handler = _build_handler(_TenantCapabilitiesPlatform(), executor)
+
+    with pytest.raises(AdcpError) as exc_info:
+        asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="tenant-a")))
+
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert exc_info.value.details["missing"] == "@IdempotencyStore.wrap"
+
+
+def test_request_scoped_capabilities_hook_exceptions_are_structured(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _FailingTenantCapabilitiesPlatform(_SalesPlatform):
+        def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params, context
+            raise RuntimeError("tenant lookup failed")
+
+    handler = _build_handler(_FailingTenantCapabilitiesPlatform(), executor)
+
+    with pytest.raises(AdcpError) as exc_info:
+        asyncio.run(handler.get_adcp_capabilities(context=ToolContext(tenant_id="tenant-a")))
+
+    assert exc_info.value.code == "INTERNAL_ERROR"
+    assert exc_info.value.details["caused_by"]["type"] == "RuntimeError"
+
+
+def test_request_scoped_capabilities_hook_may_be_async(
+    executor: ThreadPoolExecutor,
+) -> None:
+    class _AsyncTenantCapabilitiesPlatform(_SalesPlatform):
+        async def get_adcp_capabilities_for_request(self, params=None, context=None):
+            del params
+            if context is None or context.tenant_id is None:
+                return None
+
+            base = self.capabilities
+            assert base.media_buy is not None
+            return replace(
+                base,
+                media_buy=base.media_buy.model_copy(
+                    update={
+                        "portfolio": Portfolio(
+                            publisher_domains=[f"{context.tenant_id}.example"],
+                        )
+                    }
+                ),
+            )
+
+    handler = _build_handler(_AsyncTenantCapabilitiesPlatform(), executor)
+
+    response = asyncio.run(
+        handler.get_adcp_capabilities(context=ToolContext(tenant_id="async-tenant"))
+    )
+
+    assert response["media_buy"]["portfolio"]["publisher_domains"] == ["async-tenant.example"]


### PR DESCRIPTION
## Summary
- add DecisioningPlatform.get_adcp_capabilities_for_request for tenant/request-scoped capability blocks
- keep PlatformHandler responsible for canonical get_adcp_capabilities projection and typed request dispatch
- validate scoped overrides against schema/invariants, webhook-signing wiring, idempotency wiring, and static protocol/tool contract
- document the multi-tenant portfolio/webhook_signing pattern

## Expert review
- protocol review found scoped webhook_signing and schema validation gaps; fixed with scoped webhook-signing validation and scoped response validation
- code review found idempotency, protocol/tool desync, and hook exception handling gaps; fixed with scoped idempotency validation, static specialisms/protocol guards, and structured INTERNAL_ERROR wrapping

## Validation
- ruff check src/adcp/decisioning/platform.py src/adcp/decisioning/handler.py src/adcp/decisioning/validate_capabilities.py src/adcp/decisioning/validate_idempotency.py tests/test_decisioning_capabilities_projection.py
- PYTHONPATH=src pytest tests/test_decisioning_capabilities_projection.py tests/test_capabilities_response_shape_validation.py tests/test_decisioning_capabilities_submodule.py tests/test_webhook_signing_capabilities.py tests/test_validate_idempotency_wiring.py -q
- PYTHONPATH=src python3 typed-dispatch smoke
- pre-commit: black, ruff, mypy, bandit, trailing whitespace, EOF, YAML/JSON, large files, merge conflicts, case conflicts, private key checks