### PR TITLE
ci: fix release-please manifest tag handling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,10 +34,20 @@ jobs:
 
       - name: Normalize release PR pyproject prerelease version
         if: ${{ steps.release.outputs.prs_created == 'true' }}
-        env:
-          RELEASE_PR_BRANCH: release-please--branches--${{ github.ref_name }}
         run: |
           set -euo pipefail
+
+          BASE_RELEASE_PR_BRANCH="release-please--branches--${{ github.ref_name }}"
+          COMPONENT_RELEASE_PR_BRANCH="${BASE_RELEASE_PR_BRANCH}--components--adcp"
+
+          if git ls-remote --exit-code --heads origin "${COMPONENT_RELEASE_PR_BRANCH}" >/dev/null 2>&1; then
+            RELEASE_PR_BRANCH="${COMPONENT_RELEASE_PR_BRANCH}"
+          elif git ls-remote --exit-code --heads origin "${BASE_RELEASE_PR_BRANCH}" >/dev/null 2>&1; then
+            RELEASE_PR_BRANCH="${BASE_RELEASE_PR_BRANCH}"
+          else
+            echo "No release PR branch found to normalize"
+            exit 0
+          fi
 
           git fetch origin "${RELEASE_PR_BRANCH}:${RELEASE_PR_BRANCH}"
           git switch "${RELEASE_PR_BRANCH}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
+      "include-component-in-tag": false,
       "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta"


### PR DESCRIPTION
## Summary

- Set `include-component-in-tag: false` so manifest-mode Release Please looks for the existing `vX.Y.Z` tags instead of `adcp-vX.Y.Z`.
- Make the pyproject prerelease-normalization step skip cleanly when Release Please reports a PR update but no release PR branch exists.

## Why

After #877 switched to manifest mode, Release Please treated `package-name: adcp` as the component for tag lookup and opened a bogus historical release PR for `adcp 6.0.0-beta.1`. The repo's existing release tags are componentless (`v6.3.0-beta.4`), so manifest mode needs to keep component names out of tags.

## Validation

- `python3 -c 'import json; json.load(open("release-please-config.json"))'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml")'`
- `git diff --check`
- pre-commit hooks from `git commit`
