### PR TITLE
ci: limit release-please releasable sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,12 +17,6 @@
     {"type": "fix", "section": "Bug Fixes"},
     {"type": "perf", "section": "Performance Improvements"},
     {"type": "revert", "section": "Reverts"},
-    {"type": "docs", "section": "Documentation"},
-    {"type": "style", "section": "Styles"},
-    {"type": "chore", "section": "Miscellaneous Chores"},
-    {"type": "refactor", "section": "Code Refactoring"},
-    {"type": "test", "section": "Tests"},
-    {"type": "build", "section": "Build System"},
-    {"type": "ci", "section": "Continuous Integration"}
+    {"type": "deps", "section": "Dependencies"}
   ]
 }


### PR DESCRIPTION
## Summary

- Keep Release Please changelog sections to package-relevant release types: `feat`, `fix`, `perf`, `revert`, and `deps`.
- Drop `ci`, `build`, `chore`, `docs`, `style`, `refactor`, and `test` from configured release sections so manifest mode does not cut PyPI betas for infrastructure-only commits.

## Why

After manifest mode started honoring the repository config, CI-only commits opened a beta release PR. The beta number was correct, but the trigger was too broad for package publishing.

## Validation

- `python3 -c 'import json; json.load(open("release-please-config.json"))'`
- `git diff --check`
- pre-commit hooks from `git commit`
