### PR TITLE
fix(server): centralize pre-validation hook composition

### DIFF
--- a/src/adcp/server/__init__.py
+++ b/src/adcp/server/__init__.py
@@ -53,6 +53,12 @@ What the framework does automatically:
 from __future__ import annotations
 
 from adcp.capabilities import validate_capabilities
+from adcp.server._hooks import (
+    PreValidationHook,
+    PreValidationHookChain,
+    PreValidationHooks,
+    compose_pre_validation_hooks,
+)
 from adcp.server.a2a_server import (
     ADCPAgentExecutor,
     MessageParser,
@@ -151,10 +157,6 @@ from adcp.server.serve import (
 )
 from adcp.server.spec_compat import (
     CANONICAL_CREATIVE_AGENT_URL,
-    PreValidationHook,
-    PreValidationHookChain,
-    PreValidationHooks,
-    compose_pre_validation_hooks,
     spec_compat_hooks,
 )
 from adcp.server.sponsored_intelligence import SponsoredIntelligenceHandler

--- a/src/adcp/server/_hooks.py
+++ b/src/adcp/server/_hooks.py
@@ -1,0 +1,95 @@
+"""Shared pre-validation hook utilities for server transports."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, TypeAlias
+
+PreValidationHook: TypeAlias = Callable[[str, dict[str, Any]], dict[str, Any]]
+"""Callable shape for a pre-validation hook."""
+
+PreValidationHookChain: TypeAlias = PreValidationHook | Sequence[PreValidationHook]
+"""One hook or an ordered sequence of hooks for a single tool."""
+
+PreValidationHooks: TypeAlias = dict[str, PreValidationHookChain]
+"""Type alias for ``pre_validation_hooks`` parameters."""
+
+
+class PreValidationHookError(Exception):
+    """Raised when one hook in an ordered pre-validation chain fails."""
+
+    def __init__(
+        self,
+        *,
+        index: int,
+        hook_name: str,
+        message: str,
+    ) -> None:
+        self.index = index
+        self.hook_name = hook_name
+        super().__init__(f"pre_validation_hook[{index}] {hook_name} {message}")
+
+
+def _hook_name(hook: PreValidationHook) -> str:
+    name = getattr(hook, "__name__", None)
+    if isinstance(name, str) and name:
+        return name
+    return hook.__class__.__name__
+
+
+def _flatten_pre_validation_hooks(
+    hooks: PreValidationHookChain | None,
+) -> tuple[PreValidationHook, ...]:
+    if hooks is None:
+        return ()
+    if callable(hooks):
+        return (hooks,)
+    flattened = tuple(hooks)
+    for hook in flattened:
+        if not callable(hook):
+            raise TypeError("pre-validation hook chains must contain callables")
+    return flattened
+
+
+def _apply_pre_validation_hooks(
+    hooks: tuple[PreValidationHook, ...],
+    tool_name: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    next_params = params
+    for index, hook in enumerate(hooks):
+        hook_name = _hook_name(hook)
+        try:
+            next_params = hook(tool_name, dict(next_params))
+        except Exception as exc:
+            raise PreValidationHookError(
+                index=index,
+                hook_name=hook_name,
+                message=f"raised {type(exc).__name__}: {exc}",
+            ) from exc
+        if not isinstance(next_params, dict):
+            raise PreValidationHookError(
+                index=index,
+                hook_name=hook_name,
+                message=f"returned {type(next_params).__name__}, expected dict",
+            )
+    return next_params
+
+
+def compose_pre_validation_hooks(
+    *hook_maps: Mapping[str, PreValidationHookChain] | None,
+) -> dict[str, tuple[PreValidationHook, ...]]:
+    """Compose ordered pre-validation hook maps.
+
+    Later maps append to earlier maps for overlapping tool names. Each
+    tool's hooks run left-to-right, feeding the returned args from one hook
+    into the next.
+    """
+
+    composed: dict[str, list[PreValidationHook]] = {}
+    for hook_map in hook_maps:
+        if hook_map is None:
+            continue
+        for tool_name, chain in hook_map.items():
+            composed.setdefault(tool_name, []).extend(_flatten_pre_validation_hooks(chain))
+    return {tool_name: tuple(hooks) for tool_name, hooks in composed.items()}

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -36,8 +36,8 @@ from google.protobuf.struct_pb2 import Value
 from starlette.applications import Starlette
 
 from adcp.exceptions import ADCPError
+from adcp.server._hooks import PreValidationHooks
 from adcp.server.base import ADCPHandler, ToolContext
-from adcp.server.spec_compat import PreValidationHooks
 
 # Decisioning-layer ``AdcpError`` (from ``adcp.decisioning.types``) is the
 # wire-shaped structured error platform methods raise. It is NOT a subclass

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -25,8 +25,14 @@ import os
 from collections.abc import Callable, Iterable
 from typing import Any
 
+from adcp.server._hooks import (
+    PreValidationHookChain,
+    PreValidationHookError,
+    PreValidationHooks,
+    _apply_pre_validation_hooks,
+    _flatten_pre_validation_hooks,
+)
 from adcp.server.base import ADCPHandler, ToolContext
-from adcp.server.spec_compat import PreValidationHook, PreValidationHookChain
 from adcp.server.test_controller import SCENARIOS as _CONTROLLER_SCENARIOS
 from adcp.types import (
     MEDIA_BUY_LEGACY_STATUS_VALUES,
@@ -2032,33 +2038,6 @@ def _resolve_params_pydantic_model(method: Any) -> type[Any] | None:
     return None
 
 
-def _flatten_pre_validation_hooks(
-    hooks: PreValidationHookChain | None,
-) -> tuple[PreValidationHook, ...]:
-    if hooks is None:
-        return ()
-    if callable(hooks):
-        return (hooks,)
-    flattened = tuple(hooks)
-    for hook in flattened:
-        if not callable(hook):
-            raise TypeError("pre-validation hook chains must contain callables")
-    return flattened
-
-
-def _apply_pre_validation_hooks(
-    hooks: tuple[PreValidationHook, ...],
-    method_name: str,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    next_params = params
-    for hook in hooks:
-        next_params = hook(method_name, dict(next_params))
-        if not isinstance(next_params, dict):
-            raise TypeError("pre-validation hooks must return dict arguments")
-    return next_params
-
-
 def _normalize_unknown_field_policy(
     policy: UnknownFieldPolicy | str | None,
 ) -> UnknownFieldPolicy:
@@ -2266,13 +2245,13 @@ def create_tool_caller(
                 params = _apply_pre_validation_hooks(
                     pre_validation_hooks, method_name, dict(params)
                 )
-            except Exception as exc:
+            except PreValidationHookError as exc:
                 raise ADCPTaskError(
                     operation=method_name,
                     errors=[
                         Error(
                             code="INVALID_REQUEST",
-                            message=f"pre_validation_hook raised {type(exc).__name__}: {exc}",
+                            message=str(exc),
                         )
                     ],
                 ) from exc
@@ -2624,7 +2603,7 @@ class MCPToolSet:
         *,
         advertise_all: bool = False,
         validation: ValidationHookConfig | None = None,
-        pre_validation_hooks: dict[str, PreValidationHookChain] | None = None,
+        pre_validation_hooks: PreValidationHooks | None = None,
     ):
         """Create tool set from handler.
 
@@ -2686,7 +2665,7 @@ def create_mcp_tools(
     *,
     advertise_all: bool = False,
     validation: ValidationHookConfig | None = None,
-    pre_validation_hooks: dict[str, PreValidationHookChain] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
 ) -> MCPToolSet:
     """Create MCP tools from an ADCP handler.
 

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -30,13 +30,13 @@ logger = logging.getLogger("adcp.server")
 
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
+from adcp.server._hooks import PreValidationHooks
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.mcp_tools import (
     _HANDLER_TOOLS,
     create_tool_caller,
     get_tools_for_handler,
 )
-from adcp.server.spec_compat import PreValidationHooks
 from adcp.validation.client_hooks import (
     SERVER_DEFAULT_VALIDATION as DEFAULT_VALIDATION,
 )

--- a/src/adcp/server/spec_compat.py
+++ b/src/adcp/server/spec_compat.py
@@ -31,17 +31,24 @@ framework dependencies so they compose cleanly with adopter-specific hooks::
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Collection, Mapping, Sequence
-from typing import Any, TypeAlias
+from collections.abc import Callable, Collection
+from typing import Any
 
-PreValidationHook: TypeAlias = Callable[[str, dict[str, Any]], dict[str, Any]]
-"""Callable shape for a pre-validation hook."""
+from adcp.server._hooks import (
+    PreValidationHook,
+    PreValidationHookChain,
+    PreValidationHooks,
+    compose_pre_validation_hooks,
+)
 
-PreValidationHookChain: TypeAlias = PreValidationHook | Sequence[PreValidationHook]
-"""One hook or an ordered sequence of hooks for a single tool."""
-
-PreValidationHooks: TypeAlias = dict[str, PreValidationHookChain]
-"""Type alias for the ``pre_validation_hooks`` parameter of ``serve()``."""
+__all__ = [
+    "CANONICAL_CREATIVE_AGENT_URL",
+    "PreValidationHook",
+    "PreValidationHookChain",
+    "PreValidationHooks",
+    "compose_pre_validation_hooks",
+    "spec_compat_hooks",
+]
 
 CANONICAL_CREATIVE_AGENT_URL = "https://creative.adcontextprotocol.org"
 """Canonical ``agent_url`` for the AdCP standard creative-format registry.
@@ -78,35 +85,6 @@ _KNOWN_ASSET_TYPES: frozenset[str] = frozenset(
         "catalog",
     }
 )
-
-
-def _flatten_hook_chain(chain: PreValidationHookChain) -> tuple[PreValidationHook, ...]:
-    if callable(chain):
-        return (chain,)
-    hooks = tuple(chain)
-    for hook in hooks:
-        if not callable(hook):
-            raise TypeError("pre-validation hook chains must contain callables")
-    return hooks
-
-
-def compose_pre_validation_hooks(
-    *hook_maps: Mapping[str, PreValidationHookChain] | None,
-) -> dict[str, tuple[PreValidationHook, ...]]:
-    """Compose ordered pre-validation hook maps.
-
-    Later maps append to earlier maps for overlapping tool names. Each
-    tool's hooks run left-to-right, feeding the returned args from one hook
-    into the next.
-    """
-
-    composed: dict[str, list[PreValidationHook]] = {}
-    for hook_map in hook_maps:
-        if hook_map is None:
-            continue
-        for tool_name, chain in hook_map.items():
-            composed.setdefault(tool_name, []).extend(_flatten_hook_chain(chain))
-    return {tool_name: tuple(hooks) for tool_name, hooks in composed.items()}
 
 
 def _hook_get_products(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
@@ -297,8 +275,8 @@ def _spec_compat_hooks_impl(
         Adopters who need granular control over the three sub-behaviors
         should copy the relevant logic from
         ``adcp.server.spec_compat._coerce_asset`` / ``_hook_get_products``
-        rather than trying to layer hooks — ``pre_validation_hooks`` allows
-        only one callable per tool name.
+        or compose an ordered hook chain with
+        :func:`adcp.server.compose_pre_validation_hooks`.
 
     Args:
         exclude: Tool names to exclude from the returned dict. Names not in

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -233,6 +233,45 @@ async def test_execute_with_datapart():
     assert result["products"][0]["id"] == "p1"
 
 
+async def test_pre_validation_hook_chain_runs_through_a2a_executor():
+    """A2A executor applies the same ordered hook-chain behavior as MCP."""
+
+    class _HookHandler(ADCPHandler):
+        async def get_products(self, params: dict[str, Any], context: Any = None):
+            return {"params_received": dict(params)}
+
+    calls: list[str] = []
+
+    def first(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"first:{tool_name}")
+        return {**args, "first": True}
+
+    def second(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"second:{tool_name}:{args['first']}")
+        return {**args, "second": True}
+
+    executor = ADCPAgentExecutor(
+        _HookHandler(),
+        pre_validation_hooks={"get_products": [first, second]},
+    )
+    ctx = RequestContext(
+        request=MessageSendParams(
+            message=_make_datapart_msg("get_products", {"buying_mode": "brief"})
+        )
+    )
+    queue = EventQueue()
+
+    await executor.execute(ctx, queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, Task)
+    assert event.status.state == pb.TaskState.TASK_STATE_COMPLETED
+    result = _first_data_part(event)
+    assert calls == ["first:get_products", "second:get_products:True"]
+    assert result["params_received"]["first"] is True
+    assert result["params_received"]["second"] is True
+
+
 async def test_context_auto_injected():
     """Context from request is automatically echoed in response."""
     executor = ADCPAgentExecutor(_TestHandler())

--- a/tests/test_pre_validation_hooks.py
+++ b/tests/test_pre_validation_hooks.py
@@ -186,7 +186,54 @@ async def test_hook_exception_surfaces_as_invalid_request() -> None:
     errors = exc_info.value.errors
     assert errors, "ADCPTaskError must carry at least one error"
     assert errors[0].code == "INVALID_REQUEST"
+    assert "pre_validation_hook[0]" in errors[0].message
+    assert "bad_hook" in errors[0].message
     assert "ValueError" in errors[0].message
+
+
+@pytest.mark.asyncio
+async def test_hook_chain_exception_identifies_failing_hook() -> None:
+    """Hook-chain failures name the index and callable that raised."""
+
+    def first_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {**args, "first": True}
+
+    def second_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("second failed")
+
+    handler = _MinimalHandler()
+    caller = create_tool_caller(
+        handler,
+        "get_products",
+        pre_validation_hook=[first_hook, second_hook],
+    )
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"buying_mode": "brief"})
+
+    message = exc_info.value.errors[0].message
+    assert "pre_validation_hook[1]" in message
+    assert "second_hook" in message
+    assert "RuntimeError" in message
+
+
+@pytest.mark.asyncio
+async def test_hook_chain_non_dict_return_identifies_failing_hook() -> None:
+    """Invalid hook return values also include chain index and hook name."""
+
+    def bad_return(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return ["not", "a", "dict"]  # type: ignore[return-value]
+
+    handler = _MinimalHandler()
+    caller = create_tool_caller(handler, "get_products", pre_validation_hook=[bad_return])
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"buying_mode": "brief"})
+
+    message = exc_info.value.errors[0].message
+    assert "pre_validation_hook[0]" in message
+    assert "bad_return" in message
+    assert "returned list, expected dict" in message
 
 
 # ---------------------------------------------------------------------------
@@ -253,33 +300,33 @@ async def test_in_place_mutation_is_safe_for_context_echo() -> None:
 
 
 # ---------------------------------------------------------------------------
-# MCPToolSet threading
+# MCPToolSet real-path behavior
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_tool_set_threads_hook_to_tool_caller() -> None:
-    """MCPToolSet must forward pre_validation_hooks to create_tool_caller."""
-    import importlib
-    from unittest.mock import patch
-
-    _serve_mod = importlib.import_module("adcp.server.mcp_tools")
+@pytest.mark.asyncio
+async def test_mcp_tool_set_applies_hook_chain_for_matching_tool() -> None:
+    """MCPToolSet applies ordered hook chains through the real call path."""
+    from adcp.server.mcp_tools import MCPToolSet
 
     handler = _MinimalHandler()
-    captured_hooks: list[Any] = []
-    real = _serve_mod.create_tool_caller
+    calls: list[str] = []
 
-    def spy(h: Any, name: str, **kw: Any) -> Any:
-        captured_hooks.append(kw.get("pre_validation_hook"))
-        return real(h, name, **kw)
+    def first(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"first:{tool_name}")
+        return {**args, "first": True}
 
-    my_hook = lambda n, a: a  # noqa: E731
-    hooks = {"get_products": my_hook}
+    def second(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"second:{tool_name}:{args['first']}")
+        return {**args, "second": True}
 
-    with patch.object(_serve_mod, "create_tool_caller", side_effect=spy):
-        from adcp.server.mcp_tools import MCPToolSet
+    tool_set = MCPToolSet(
+        handler,
+        validation=None,
+        pre_validation_hooks={"get_products": [first, second]},
+    )
+    result = await tool_set.call_tool("get_products", {"buying_mode": "brief"})
 
-        MCPToolSet(handler, pre_validation_hooks=hooks)
-
-    assert any(
-        h is my_hook for h in captured_hooks
-    ), "my_hook was not forwarded to create_tool_caller for get_products"
+    assert calls == ["first:get_products", "second:get_products:True"]
+    assert result["params_received"]["first"] is True
+    assert result["params_received"]["second"] is True


### PR DESCRIPTION
## Summary

Refs #859.

This is a focused follow-up to the hook-composition work that already landed in #860. Current `main` already supports ordered pre-validation hook chains, so this PR avoids reimplementing that behavior and only tightens the remaining pieces from the #859 brief and #860 review notes:

- Moves shared pre-validation hook types, composition, flattening, and application into `adcp.server._hooks`.
- Keeps `adcp.server.spec_compat` backward-compatible by re-exporting the public hook types/helper.
- Makes hook-chain failures surface the failing chain index and callable name in the `INVALID_REQUEST` message.
- Replaces mock-only MCP forwarding coverage with a real `MCPToolSet.call_tool(...)` behavior test.
- Adds real A2A executor coverage for ordered hook chains.

## Review note

I opened this as a draft because #860 already shipped most of #859. The main question is whether this small cleanup/diagnostic follow-up is still useful, or whether #859 should be closed as already covered by #860.

## Current CI note

The draft currently has red storyboard checks against the moving `adcp-3.1` npm dist-tag. The failing PR run installed `@adcp/sdk@8.1.0-beta.13`; the latest passing `main` CI run I checked used `@adcp/sdk@8.1.0-beta.12`. I also reproduced the same classes of storyboard failure from a detached current-`main` worktree with `ADCP_SDK_VERSION=adcp-3.1`, including the reference seller 3.1 storyboard and proposal-finalize recovery expectation.

I am therefore keeping this as draft rather than marking it ready while that runner/schema drift is active.

## Testing

- `uv run pytest tests/test_pre_validation_hooks.py tests/test_a2a_server.py -q`
- `uv run pytest tests/test_pre_validation_hooks.py tests/test_a2a_server.py tests/test_spec_compat_hooks.py tests/test_spec_compat_hooks_deprecation.py tests/test_unknown_field_policy_server.py tests/test_schema_validation_server.py tests/test_serve_validation_passthrough.py tests/test_testing_decisioning.py tests/test_public_api.py -q`
- `uv run ruff check src/adcp/server/_hooks.py src/adcp/server/spec_compat.py src/adcp/server/mcp_tools.py src/adcp/server/a2a_server.py src/adcp/server/serve.py src/adcp/server/__init__.py tests/test_pre_validation_hooks.py tests/test_a2a_server.py`
- `uv run mypy src/adcp/server`
- `uv run mypy src/adcp`
- `uv run pytest -q`
- `git diff --check`

Full `uv run ruff check` still fails on unrelated existing test lint drift outside this PR's touched files, including long lines and unused imports in existing tests.
