### PR TITLE
fix(ci): block agent PR title prefixes

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,21 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-title:
+    name: Check PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for agent/tool PR title prefix
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check-pr-title.cjs "$PR_TITLE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # ADCP Python SDK - Agent Reference
 
+## PR Title Hygiene
+
+Use concrete conventional-commits PR titles (`fix(scope): summary`, `docs: summary`, `feat(scope): summary`). Do not prefix titles with the tool or model that authored the PR, such as `[codex]`, `[claude]`, `[cursor]`, or similar ownership tags. Put authoring-tool context in the PR body or labels when it matters, not in the review-facing title.
+
 ## Server Handler Methods
 
 Override these in your `ADCPHandler` subclass. Unimplemented methods return `not_supported()`.

--- a/scripts/check-pr-title.cjs
+++ b/scripts/check-pr-title.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+const title = (process.argv.slice(2).join(' ') || process.env.PR_TITLE || '').trim();
+
+if (!title) {
+  console.error('PR title is empty.');
+  process.exit(1);
+}
+
+const prefixMatch = title.match(/^\[([^\]]+)\](?:\s|:|-|$)/);
+const agentTokens = new Set([
+  'agent',
+  'agents',
+  'ai',
+  'aider',
+  'chatgpt',
+  'claude',
+  'codex',
+  'copilot',
+  'cursor',
+  'devin',
+  'openai',
+]);
+
+const hasAgentPrefix =
+  prefixMatch &&
+  prefixMatch[1]
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .some((token) => agentTokens.has(token));
+
+if (hasAgentPrefix) {
+  console.error(`Invalid PR title: ${title}`);
+  console.error('Remove the leading agent/tool prefix. Use a concrete conventional-commits title instead, for example:');
+  console.error('  fix(ci): block agent PR title prefixes');
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a PR title check workflow that blocks leading bracketed agent or tool ownership prefixes on PR titles. The checker accepts normal conventional-commits titles and rejects variants like [codex], [Claude Code], and [cursor-bot]. This also documents the title hygiene rule in AGENTS.md so coding agents keep review-facing titles concrete. Validation: node title-check smoke cases and git diff --check.