### PR TITLE
fix: accept beta-patch wire aliases (e.g. 3.1-beta.5) in detect_wire_version (closes #883)

### DIFF
--- a/src/adcp/validation/envelope.py
+++ b/src/adcp/validation/envelope.py
@@ -96,7 +96,27 @@ def detect_wire_version(
         except ValueError as exc:
             raise UnsupportedVersionError(explicit, supported) from exc
         if normalized not in supported:
-            raise UnsupportedVersionError(explicit, supported)
+            # Accept wire-compatible beta-patch aliases: if the incoming
+            # version shares the same major.minor-prerelease base as a
+            # supported version (differing only by the prerelease patch
+            # counter, e.g. "3.1-beta.5" vs "3.1-beta.4"), treat it as
+            # compatible and return the normalized incoming value so
+            # callers can record the exact wire version claimed.
+            import re as _re
+            _beta_patch = _re.compile(
+                r'^(?P<base>\d+\.\d+-[A-Za-z]+)\.\d+$'
+            )
+            m = _beta_patch.match(normalized)
+            if m:
+                base = m.group("base")
+                compatible = any(
+                    _beta_patch.match(s) and _beta_patch.match(s).group("base") == base
+                    for s in supported
+                )
+                if not compatible:
+                    raise UnsupportedVersionError(explicit, supported)
+            else:
+                raise UnsupportedVersionError(explicit, supported)
         return normalized
     # Empty-string ``adcp_version`` falls through to ``adcp_major_version``
     # intentionally — pre-3.1 buyers may set both fields, and an empty


### PR DESCRIPTION
## What

`detect_wire_version({"adcp_version": "3.1-beta.5"})` raises `UnsupportedVersionError` because `normalize_to_release_precision` preserves the prerelease patch label and `SUPPORTED_WIRE_VERSIONS` only contains `'3.1-beta.4'`. Buyers emitting `3.1-beta.5` (e.g. the current JS SDK) are rejected, forcing downstream adopters (e.g. Prebid Sales Agent #632) to monkey-patch the SDK.

## Fix

After the strict membership check fails, apply a beta-patch alias tolerance rule: if the normalized incoming version matches `MAJOR.MINOR-PRERELEASE.N` and at least one entry in `supported` shares the same `MAJOR.MINOR-PRERELEASE` base (differing only by the trailing patch counter), treat the version as wire-compatible and return the normalized value. This is safe because the AdCP 3.1 envelope shape has not changed between beta.4 and beta.5.

## Acceptance criteria

- `detect_wire_version({"adcp_version": "3.1-beta.5"})` returns `"3.1-beta.5"` instead of raising.
- Genuinely incompatible versions (different major/minor or different prerelease family) still raise `UnsupportedVersionError`.
- No monkey-patching required in downstream projects.

Closes #883