### PR TITLE
ci(release): use app token for release PR updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,10 +19,22 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Release Please must write release PR branches with an installation token,
+      # not the default GITHUB_TOKEN. GITHUB_TOKEN-authored pushes do not trigger
+      # downstream pull_request workflows, so protected release PRs can sit
+      # blocked waiting for CI/IPR contexts that never start.
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.IPR_APP_ID }}
+          private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         id: release
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish != true }}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -31,6 +43,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Normalize release PR pyproject prerelease version
         if: ${{ steps.release.outputs.prs_created == 'true' }}
@@ -59,8 +72,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "aao-ipr-bot[bot]"
+          git config user.email "aao-ipr-bot[bot]@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore: normalize prerelease version to PEP 440"
           git push origin "HEAD:${RELEASE_PR_BRANCH}"


### PR DESCRIPTION
## Summary\n- mint an IPR GitHub App installation token in the Release Please workflow\n- pass that token to release-please-action so release PR branch updates trigger downstream protected checks\n- use the same token for the pyproject prerelease normalization checkout/push\n\n## Why\nRelease Please was using the default GITHUB_TOKEN. Branches updated with GITHUB_TOKEN do not trigger pull_request CI/IPR workflows, so generated release PRs could be green for CodeQL/GitGuardian but blocked waiting for required CI contexts that never ran.\n\n## Validation\n- uv run --extra dev --group dev pre-commit run --files .github/workflows/release-please.yml