### PR TITLE
fix(validation): bundle schemas before wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
       - name: Build and install wheel
         run: |
           python -m pip install --upgrade pip build
+          python scripts/bundle_schemas.py
           python -m build --wheel --outdir dist/
           pip install dist/*.whl
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -95,6 +95,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
 
+      - name: Bundle schemas
+        if: ${{ steps.release.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.publish == true) }}
+        run: python scripts/bundle_schemas.py
+
       - name: Build package
         if: ${{ steps.release.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.publish == true) }}
         run: python -m build

--- a/src/adcp/validation/schema_loader.py
+++ b/src/adcp/validation/schema_loader.py
@@ -188,7 +188,8 @@ def _ensure_state(version: str | None = None) -> _LoaderState | None:
             return None
         root = _resolve_schema_root(bundle_key)
         if root is None:
-            logger.debug(
+            log_missing = logger.warning if version is None else logger.debug
+            log_missing(
                 "AdCP schemas not found for bundle_key=%s; validation will skip "
                 "all tools for this version",
                 bundle_key,

--- a/tests/test_schema_loader_per_version.py
+++ b/tests/test_schema_loader_per_version.py
@@ -11,6 +11,7 @@ packaged path wins) and from concurrent fixture cleanup.
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 from pathlib import Path
 
@@ -188,6 +189,38 @@ def test_validate_request_unknown_version_skips_safely(
     # ``skipped`` semantics: ``valid=True`` with no issues.
     assert outcome.valid
     assert outcome.issues == []
+
+
+def test_missing_sdk_pinned_bundle_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(_loader_mod, "_resolve_schema_root", lambda bundle_key=None: None)
+
+    _reset_for_tests()
+    try:
+        with caplog.at_level(logging.WARNING, logger="adcp.validation.schema_loader"):
+            outcome = validate_request("synthetic_tool", {"x": 1})
+    finally:
+        _reset_for_tests()
+
+    assert outcome.valid
+    assert any("AdCP schemas not found" in rec.message for rec in caplog.records)
+
+
+def test_missing_explicit_version_bundle_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(_loader_mod, "_resolve_schema_root", lambda bundle_key=None: None)
+
+    _reset_for_tests()
+    try:
+        with caplog.at_level(logging.WARNING, logger="adcp.validation.schema_loader"):
+            outcome = validate_request("synthetic_tool", {"x": 1}, version="9.9.9")
+    finally:
+        _reset_for_tests()
+
+    assert outcome.valid
+    assert not any("AdCP schemas not found" in rec.message for rec in caplog.records)
 
 
 def test_validate_response_threads_version_through(


### PR DESCRIPTION
## Summary
- run schema bundling before release-package builds so published wheels/sdists include `adcp/_schemas`
- run schema bundling in the CI wheel smoke build so tested wheels match release packaging
- surface missing SDK-pinned schema bundles at warning level while keeping explicit unsupported `version=` misses quiet

Fixes #897

## Validation
- expert review: DX/release packaging pass found the direct CI wheel-build gap; addressed in this PR
- expert review: code review pass found explicit-version warning noise; addressed with regression tests
- `uv run --extra dev --group dev pytest tests/test_schema_loader_per_version.py tests/test_legacy_schema_bundle_v2_5.py tests/test_schema_validation.py tests/test_validation_version.py`
- `uv run --extra dev --group dev pytest tests/ -v --cov=src/adcp --cov-report=term-missing`
- `uv run --extra dev --group dev ruff check src/ tests/test_schema_loader_per_version.py`
- `uv run --extra dev --group dev mypy src/adcp/`
- `uv run --extra dev --group dev mypy --strict tests/type_checks/`
- `uv run --extra dev --group dev python scripts/check_type_ignore_contract.py`
- `uv run --extra dev --group dev python scripts/bundle_schemas.py && uv run --extra dev --group dev --with build python -m build --wheel --outdir dist/`
- verified built wheel contains 3468 `adcp/_schemas/*.json` entries