### PR TITLE
feat(server)!: harden stateful MCP sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,10 @@ jobs:
   storyboard-v3-reference-seller:
     name: AdCP storyboard runner — v3 reference seller (translator)
     runs-on: ubuntu-latest
+    env:
+      # Intentionally non-secret: gates loopback-only debug counters
+      # inside this CI job.
+      ADCP_DEBUG_TOKEN: storyboard-debug-token
     # Required as of @adcp/sdk@6.7.0 (sales-guaranteed mock-server
     # canonicalized; closes #449). Storyboard run + traffic-counter
     # assertions gate every PR's translator-pattern conformance.
@@ -668,7 +672,8 @@ jobs:
           # are empty/zero, the seller served stub data without translating
           # to upstream — the façade-mode failure this job exists to catch
           # (see #410).
-          curl -sf http://127.0.0.1:3001/_debug/traffic > traffic.json
+          curl -sf -H "X-Debug-Token: ${ADCP_DEBUG_TOKEN}" \
+            http://127.0.0.1:3001/_debug/traffic > traffic.json
           python -c "
           import json, sys
           with open('traffic.json') as f:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [6.3.0-beta.7](https://github.com/adcontextprotocol/adcp-client-python/compare/v6.3.0-beta.6...v6.3.0-beta.7) (2026-05-30)
 
+### Features
+
+* **client:** add explicit MCP Streamable HTTP session termination helper ([#903](https://github.com/adcontextprotocol/adcp-client-python/issues/903))
+* **server:** expose opt-in MCP session debug snapshots ([#903](https://github.com/adcontextprotocol/adcp-client-python/issues/903))
+
+### Breaking changes
+
+* **server:** `enable_debug_endpoints=True` now fails closed unless callers also pass `debug_validate_request=` or explicitly opt into unauthenticated local/test access with `debug_public=True`.
+
+### Security
+
+* **server:** debug endpoints are no longer exposed unauthenticated by default; use a validator such as an `X-Debug-Token` check for network-reachable deployments.
 
 ### Bug Fixes
 

--- a/docs/handler-authoring.md
+++ b/docs/handler-authoring.md
@@ -1393,6 +1393,13 @@ workflow, and closes the client session when the workflow ends. Do not create a
 fresh MCP client for every AdCP operation (`get_products`, `create_media_buy`,
 `sync_creatives`, etc.) unless you also close each session promptly.
 
+SDK clients can explicitly terminate the current stateful MCP session by sending
+DELETE with the current `Mcp-Session-Id`:
+
+```python
+await client.close_mcp_session()
+```
+
 The SDK defaults `session_idle_timeout=1800.0`, so abandoned sessions are reaped
 after 30 minutes. Public or service-to-service sellers that may see one-shot
 callers should tune this lower:
@@ -1427,6 +1434,39 @@ from adcp.server import create_mcp_server, get_mcp_session_stats
 mcp = create_mcp_server(handler, max_active_sessions=200)
 stats = get_mcp_session_stats(mcp).as_dict()
 # stats["active_sessions"], stats["session_age_seconds"], etc.
+```
+
+To expose session metrics through the opt-in debug surface, wire a session
+source when enabling debug endpoints:
+
+```python
+import hmac
+
+serve(
+    handler,
+    enable_debug_endpoints=True,
+    session_count_source=lambda: {
+        "active_sessions": current_session_count(),
+    },
+    debug_validate_request=lambda headers: hmac.compare_digest(
+        headers.get("x-debug-token", ""),
+        "secret",
+    ),
+)
+```
+
+`GET /_debug/sessions` returns the current snapshot. `GET /_debug/traffic` is
+still available when you also pass `debug_traffic_source`. For local-only
+storyboard runners, pass `debug_public=True` instead of
+`debug_validate_request`; do not use public debug routes on network-reachable
+deployments.
+
+If your caller is a one-shot container that cannot retain `Mcp-Session-Id`
+across operations, use `stateless_http=True` instead of creating abandoned
+stateful sessions:
+
+```python
+serve(handler, stateless_http=True)
 ```
 
 ## Testing

--- a/examples/v3_reference_seller/src/app.py
+++ b/examples/v3_reference_seller/src/app.py
@@ -49,6 +49,7 @@ code path against either URL.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -347,6 +348,7 @@ def main() -> None:
     )
     logger.info("Mock-mode upstream: %s (api_key=%s...)", upstream_url, upstream_api_key[:4])
     logger.info("Audit sink wired: %s. Tenant router cache: 256 hosts.", type(audit_sink).__name__)
+    debug_token = os.environ.get("ADCP_DEBUG_TOKEN")
 
     serve(
         platform=platform,
@@ -378,7 +380,16 @@ def main() -> None:
         # by simply omitting the kwarg.
         validation=ValidationHookConfig(requests="strict", responses="strict"),
         mock_ad_server=mock_ad_server,
-        enable_debug_endpoints=True,
+        enable_debug_endpoints=debug_token is not None,
+        debug_validate_request=(
+            (
+                lambda headers, token=debug_token: hmac.compare_digest(
+                    headers.get("x-debug-token", ""), token
+                )
+            )
+            if debug_token is not None
+            else None
+        ),
         # Auto-emit binds to the supervisor: when a webhook-signing PEM
         # is wired via the ADCP_WEBHOOK_SIGNING_KEY_PATH env var, the
         # supervisor signs every auto-emitted completion webhook per

--- a/src/adcp/client.py
+++ b/src/adcp/client.py
@@ -3859,6 +3859,21 @@ class ADCPClient:
             logger.debug(f"Closing adapter for agent {self.agent_config.id}")
             await self.adapter.close()
 
+    async def close_mcp_session(self, session_id: str | None = None) -> None:
+        """Explicitly terminate a stateful MCP Streamable HTTP session.
+
+        This sends ``DELETE`` to the configured MCP endpoint with the
+        ``Mcp-Session-Id`` header. When ``session_id`` is omitted, the
+        SDK-managed current session is closed. It is only valid for MCP
+        agents using ``mcp_transport="streamable_http"``.
+        """
+        if not isinstance(self.adapter, MCPAdapter):
+            raise TypeError(
+                "close_mcp_session is only supported for MCP clients; "
+                f"got {self.agent_config.protocol}"
+            )
+        await self.adapter.close_mcp_session(session_id)
+
     async def __aenter__(self) -> ADCPClient:
         """Async context manager entry."""
         return self

--- a/src/adcp/decisioning/mock_ad_server.py
+++ b/src/adcp/decisioning/mock_ad_server.py
@@ -49,6 +49,7 @@ Example
     serve(
         MyPlatform(mock_ad_server=InMemoryMockAdServer()),
         enable_debug_endpoints=True,
+        debug_public=True,  # local/storyboard only
     )
 """
 

--- a/src/adcp/protocols/mcp.py
+++ b/src/adcp/protocols/mcp.py
@@ -29,7 +29,8 @@ if TYPE_CHECKING:
 try:
     from mcp import ClientSession as _ClientSession
     from mcp.client.sse import sse_client
-    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.client.streamable_http import MCP_SESSION_ID, streamablehttp_client
+    from mcp.shared._httpx_utils import create_mcp_http_client
 
     MCP_AVAILABLE = True
 except ImportError:
@@ -201,6 +202,8 @@ class MCPAdapter(ProtocolAdapter):
             )
         self._session: Any = None
         self._exit_stack: Any = None
+        self._connected_url: str | None = None
+        self._get_session_id: Callable[[], str | None] | None = None
         # True when the session was injected by ADCPClient.from_mcp_client().
         # Caller owns the lifecycle — close() is a no-op on injected adapters.
         self._session_is_injected: bool = False
@@ -213,6 +216,42 @@ class MCPAdapter(ProtocolAdapter):
         """
         self._session = session
         self._session_is_injected = True
+
+    def _http_headers(self) -> dict[str, str]:
+        """Return transport headers for MCP HTTP requests."""
+        headers: dict[str, str] = {}
+        if self.agent_config.auth_token:
+            # Support custom auth headers and types
+            if self.agent_config.auth_type == "bearer":
+                headers[self.agent_config.auth_header] = f"Bearer {self.agent_config.auth_token}"
+            else:
+                headers[self.agent_config.auth_header] = self.agent_config.auth_token
+
+        if self.agent_config.extra_headers:
+            headers.update(self.agent_config.extra_headers)
+        return headers
+
+    def _urls_to_try(self) -> list[str]:
+        """Return MCP endpoint candidates, preserving the configured URL first."""
+        uri = self.agent_config.agent_uri
+        base = uri.rstrip("/")
+        urls_to_try = [uri]
+        if base.endswith("/mcp"):
+            # User pointed at the MCP endpoint; also try the other slash form.
+            urls_to_try.append(f"{base}/" if not uri.endswith("/") else base)
+        else:
+            urls_to_try.extend([f"{base}/mcp", f"{base}/mcp/"])
+        return urls_to_try
+
+    def _streamable_http_client_factory(self) -> Callable[..., httpx.AsyncClient]:
+        """Return the HTTP client factory used for streamable-http requests."""
+        if self.signing_request_hook is not None:
+            return _make_signing_http_factory(self.signing_request_hook)
+        return create_mcp_http_client
+
+    def current_mcp_session_id(self) -> str | None:
+        """Return the current SDK-managed MCP Streamable HTTP session id."""
+        return self._get_session_id() if self._get_session_id is not None else None
 
     async def _cleanup_failed_connection(self, context: str) -> None:
         """
@@ -228,6 +267,8 @@ class MCPAdapter(ProtocolAdapter):
             old_stack = self._exit_stack
             self._exit_stack = None
             self._session = None
+            self._connected_url = None
+            self._get_session_id = None
             try:
                 await old_stack.aclose()
             except BaseException as cleanup_error:
@@ -322,31 +363,11 @@ class MCPAdapter(ProtocolAdapter):
         if parsed.scheme in ("http", "https"):
             self._exit_stack = AsyncExitStack()
 
-            # Create SSE client with authentication header
-            headers = {}
-            if self.agent_config.auth_token:
-                # Support custom auth headers and types
-                if self.agent_config.auth_type == "bearer":
-                    headers[self.agent_config.auth_header] = (
-                        f"Bearer {self.agent_config.auth_token}"
-                    )
-                else:
-                    headers[self.agent_config.auth_header] = self.agent_config.auth_token
-
-            if self.agent_config.extra_headers:
-                headers.update(self.agent_config.extra_headers)
-
             # Try the user's exact URL first, then the alternate slash form, then
             # /mcp discovery paths. MCP servers disagree on whether their endpoint
             # is at /mcp or /mcp/ — try both rather than silently normalizing.
-            uri = self.agent_config.agent_uri
-            base = uri.rstrip("/")
-            urls_to_try = [uri]
-            if base.endswith("/mcp"):
-                # User pointed at the MCP endpoint; also try the other slash form.
-                urls_to_try.append(f"{base}/" if not uri.endswith("/") else base)
-            else:
-                urls_to_try.extend([f"{base}/mcp", f"{base}/mcp/"])
+            headers = self._http_headers()
+            urls_to_try = self._urls_to_try()
 
             # RFC 9421 auto-signing: if ADCPClient installed a signing request
             # hook, wire it into streamable_http via a custom httpx client
@@ -355,8 +376,8 @@ class MCPAdapter(ProtocolAdapter):
             streamable_http_extra: dict[str, Any] = {}
             if self.signing_request_hook is not None:
                 if self.agent_config.mcp_transport == "streamable_http":
-                    streamable_http_extra["httpx_client_factory"] = _make_signing_http_factory(
-                        self.signing_request_hook
+                    streamable_http_extra["httpx_client_factory"] = (
+                        self._streamable_http_client_factory()
                     )
                 else:
                     logger.warning(
@@ -369,10 +390,11 @@ class MCPAdapter(ProtocolAdapter):
             last_error = None
             for url in urls_to_try:
                 try:
+                    get_session_id: Callable[[], str | None] | None = None
                     # Choose transport based on configuration
                     if self.agent_config.mcp_transport == "streamable_http":
                         # Use streamable HTTP transport (newer, bidirectional)
-                        read, write, _get_session_id = await self._exit_stack.enter_async_context(
+                        read, write, get_session_id = await self._exit_stack.enter_async_context(
                             streamablehttp_client(
                                 url,
                                 headers=headers,
@@ -392,6 +414,9 @@ class MCPAdapter(ProtocolAdapter):
 
                     # Initialize the session
                     await self._session.initialize()
+                    self._connected_url = url
+                    if self.agent_config.mcp_transport == "streamable_http":
+                        self._get_session_id = get_session_id
 
                     logger.info(
                         f"Connected to MCP agent {self.agent_config.id} at {url} "
@@ -831,6 +856,78 @@ class MCPAdapter(ProtocolAdapter):
         if self._session_is_injected:
             return  # caller owns lifecycle; never close an injected session
         await self._cleanup_failed_connection("during close")
+
+    async def close_mcp_session(self, session_id: str | None = None) -> None:
+        """Terminate a stateful Streamable HTTP MCP session by id."""
+        if self._session_is_injected:
+            raise RuntimeError(
+                "close_mcp_session is unavailable for from_mcp_client() sessions; "
+                "the caller owns the injected transport lifecycle."
+            )
+        if self.agent_config.mcp_transport != "streamable_http":
+            raise TypeError(
+                "close_mcp_session is only supported for MCP streamable_http transport; "
+                f"got {self.agent_config.mcp_transport!r}."
+            )
+        if session_id is None:
+            session_id = self.current_mcp_session_id()
+            if session_id is None:
+                raise ValueError(
+                    "No active MCP session id is available; pass session_id explicitly "
+                    "or call after this client has initialized a Streamable HTTP session."
+                )
+        if not session_id or any(ch in session_id for ch in ("\r", "\n", "\x00")):
+            raise ValueError("session_id must be a non-empty MCP session id header value")
+        if not HTTPX_AVAILABLE:
+            raise ImportError("httpx is required to close MCP Streamable HTTP sessions")
+
+        headers = self._http_headers()
+        headers[MCP_SESSION_ID] = session_id
+        timeout = _httpx.Timeout(self.agent_config.timeout)
+        httpx_client_factory = self._streamable_http_client_factory()
+        urls_to_try = (
+            [self._connected_url] if self._connected_url is not None else self._urls_to_try()
+        )
+
+        last_error: BaseException | None = None
+        for url in urls_to_try:
+            try:
+                async with httpx_client_factory(headers=headers, timeout=timeout) as client:
+                    response = await client.delete(url)
+                if response.is_redirect:
+                    location = response.headers.get("location")
+                    suffix = f" to {location}" if location else ""
+                    raise HTTPStatusError(
+                        f"Unexpected redirect while closing MCP session{suffix}",
+                        request=response.request,
+                        response=response,
+                    )
+                response.raise_for_status()
+
+                current_session_id = self._get_session_id() if self._get_session_id else None
+                if current_session_id == session_id:
+                    await self._cleanup_failed_connection("after explicit MCP session close")
+                return
+            except _HTTP_STATUS_ERROR_TYPES as exc:
+                last_error = exc
+                # Keep fallback behavior symmetrical with session initialization:
+                # a 404/405 on one candidate usually means "try the slash variant".
+                exc_response = getattr(exc, "response", None)
+                status_code = getattr(exc_response, "status_code", None)
+                if status_code in (404, 405) and url != urls_to_try[-1]:
+                    continue
+                break
+            except Exception as exc:
+                last_error = exc
+                if url != urls_to_try[-1]:
+                    continue
+                break
+
+        raise ADCPConnectionError(
+            f"Failed to close MCP session {session_id!r}: {last_error}",
+            agent_id=self.agent_config.id,
+            agent_uri=self.agent_config.agent_uri,
+        ) from last_error
 
     # ========================================================================
     # V3 Protocol Methods - Protocol Discovery

--- a/src/adcp/server/debug_endpoints.py
+++ b/src/adcp/server/debug_endpoints.py
@@ -1,4 +1,4 @@
-"""ASGI middleware exposing ``GET /_debug/traffic``.
+"""ASGI middleware exposing opt-in debug endpoints.
 
 The endpoint is the storyboard runner's window into the seller's
 anti-façade traffic counters — an empty dict means the platform never
@@ -6,13 +6,14 @@ called its upstream ad server, which is the textbook façade-adapter
 failure mode AdCP's anti-façade contract is designed to catch.
 
 The middleware composes outside the MCP / A2A apps so a GET to
-``/_debug/traffic`` short-circuits before either inner app sees it.
+``/_debug/traffic`` and ``/_debug/sessions`` short-circuit before either
+inner app sees them.
 Other paths pass through unchanged.
 
 Production deployments stay closed: the middleware is only wired when
 ``serve(enable_debug_endpoints=True)`` is set. When unset, no route is
-mounted and a request to ``/_debug/traffic`` falls through to the
-inner app, which returns a normal 404.
+mounted and debug requests fall through to the inner app, which returns
+a normal 404.
 """
 
 from __future__ import annotations
@@ -23,16 +24,24 @@ from typing import Any
 
 
 class DebugTrafficMiddleware:
-    """ASGI middleware that handles ``GET /_debug/traffic``.
+    """ASGI middleware that handles ``GET /_debug/traffic`` and sessions.
 
     :param app: The downstream ASGI app.
     :param traffic_source: A zero-arg callable returning the current
         per-method count snapshot. Typically ``mock_ad_server.get_traffic``.
         Called fresh on every request — no caching, since the whole
         point is real-time visibility into upstream calls.
+    :param session_count_source: A zero-arg callable returning the current
+        MCP session snapshot for ``GET /_debug/sessions``. Typically
+        ``lambda: get_mcp_session_stats(mcp).as_dict()``.
+    :param debug_validate_request: Optional callable that receives the
+        request headers and returns whether the debug route may respond.
+    :param debug_public: When True, debug routes are reachable without
+        ``debug_validate_request``. Keep False for network-reachable
+        deployments.
 
     Other request methods (POST, PUT, etc.) and other paths fall
-    through to ``app`` unchanged. HEAD on ``/_debug/traffic`` is
+    through to ``app`` unchanged. HEAD on a debug endpoint is
     served as a 200 with no body (Starlette / uvicorn convention for
     this style of read-only endpoint).
     """
@@ -41,38 +50,92 @@ class DebugTrafficMiddleware:
         self,
         app: Any,
         *,
-        traffic_source: Callable[[], dict[str, int]],
+        traffic_source: Callable[[], dict[str, int]] | None = None,
+        session_count_source: Callable[[], dict[str, Any]] | None = None,
+        debug_validate_request: Callable[[dict[str, str]], bool] | None = None,
+        debug_public: bool = False,
     ) -> None:
         self._app = app
         self._traffic_source = traffic_source
+        self._session_count_source = session_count_source
+        self._debug_validate_request = debug_validate_request
+        self._debug_public = debug_public
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
-        if scope.get("type") != "http" or scope.get("path") != "/_debug/traffic":
+        if scope.get("type") != "http":
             await self._app(scope, receive, send)
             return
 
+        path = scope.get("path")
+        if path == "/_debug/traffic":
+            await self._handle_debug_route(
+                scope,
+                receive,
+                send,
+                source=self._traffic_source,
+            )
+            return
+        if path == "/_debug/sessions":
+            await self._handle_debug_route(
+                scope,
+                receive,
+                send,
+                source=self._session_count_source,
+            )
+            return
+
+        await self._app(scope, receive, send)
+
+    async def _handle_debug_route(
+        self,
+        scope: Any,
+        receive: Any,
+        send: Any,
+        *,
+        source: Callable[[], dict[str, Any]] | None,
+    ) -> None:
         method = scope.get("method", "GET").upper()
+        if source is None:
+            await _send_json(send, status=404, body=None)
+            return
+        if not self._debug_public:
+            headers = _headers_from_scope(scope)
+            if self._debug_validate_request is None or not self._debug_validate_request(headers):
+                await _send_json(send, status=404, body=None)
+                return
         if method not in {"GET", "HEAD"}:
             # Method-not-allowed — still own the route so a buggy
             # POST doesn't fall through to MCP / A2A and produce a
-            # confusing transport-level error.
+            # confusing transport-level error. This runs after auth so
+            # unauthenticated probes don't learn the route exists.
             await _send_json(send, status=405, body=None, extra_headers=[(b"allow", b"GET, HEAD")])
             return
 
-        traffic = self._traffic_source()
+        snapshot = source()
         # Defensive copy — the caller's snapshot might already be a
         # fresh dict, but if an adopter wires a custom source that
         # returns its internal dict, we don't want json.dumps to
         # observe a concurrent mutation mid-serialize.
-        body = None if method == "HEAD" else dict(traffic)
+        body = None if method == "HEAD" else dict(snapshot)
         await _send_json(send, status=200, body=body)
+
+
+def _headers_from_scope(scope: Any) -> dict[str, str]:
+    """Decode ASGI headers into a lower-case mapping for debug auth hooks."""
+    headers: dict[str, str] = {}
+    for raw_key, raw_value in scope.get("headers", []):
+        key = raw_key.decode("latin-1").lower()
+        # Last value wins: common reverse-proxy setups append trusted
+        # headers after client-supplied values.
+        headers[key] = raw_value.decode("latin-1")
+    return headers
 
 
 async def _send_json(
     send: Any,
     *,
     status: int,
-    body: dict[str, int] | None,
+    body: dict[str, Any] | None,
     extra_headers: list[tuple[bytes, bytes]] | None = None,
 ) -> None:
     """Write a JSON ASGI response (or empty body for 405 / HEAD)."""

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -181,6 +181,9 @@ class ServeConfig:
     # --- Debug endpoints ---
     enable_debug_endpoints: bool = False
     debug_traffic_source: Callable[[], dict[str, int]] | None = None
+    session_count_source: Callable[[], dict[str, Any]] | None = None
+    debug_validate_request: Callable[[dict[str, str]], bool] | None = None
+    debug_public: bool = False
 
     def __post_init__(self) -> None:
         _a2a_only = ("task_store", "push_config_store", "message_parser", "public_url")
@@ -608,6 +611,9 @@ def serve(
     pre_validation_hooks: PreValidationHooks | None = None,
     enable_debug_endpoints: bool = False,
     debug_traffic_source: Callable[[], dict[str, int]] | None = None,
+    session_count_source: Callable[[], dict[str, Any]] | None = None,
+    debug_validate_request: Callable[[dict[str, str]], bool] | None = None,
+    debug_public: bool = False,
     base_url: str | None = None,
     specialisms: list[str] | None = None,
     description: str | None = None,
@@ -761,18 +767,35 @@ def serve(
             session-creating requests are rejected with HTTP 429 while
             requests carrying an existing ``Mcp-Session-Id`` continue.
             Ignored when ``stateless_http=True``.
-        enable_debug_endpoints: When ``True``, mount ``GET /_debug/traffic``
-            on the outer HTTP app. Returns the JSON dict from
-            ``debug_traffic_source()`` — typically wired to the
-            seller's :class:`adcp.decisioning.MockAdServer.get_traffic`.
+        enable_debug_endpoints: When ``True``, mount debug routes on
+            the outer HTTP app. ``GET /_debug/traffic`` returns the JSON
+            dict from ``debug_traffic_source()`` — typically wired to
+            the seller's :class:`adcp.decisioning.MockAdServer.get_traffic`.
+            ``GET /_debug/sessions`` returns the JSON dict from
+            ``session_count_source()``.
             Defaults to ``False`` so production deployments stay
             closed; reference / dev sellers turn it on. Ignored on
-            stdio. The endpoint exposes per-method outbound call
-            counts for storyboard runners' anti-façade assertions.
+            stdio. The traffic endpoint exposes per-method outbound
+            call counts for storyboard runners' anti-façade assertions.
         debug_traffic_source: Zero-arg callable returning the
             per-method count snapshot for ``/_debug/traffic``. Required
-            when ``enable_debug_endpoints=True``; otherwise ignored.
+            when ``enable_debug_endpoints=True`` and no
+            ``session_count_source`` is supplied; otherwise ignored.
             Typically ``mock_ad_server.get_traffic``.
+        session_count_source: Zero-arg callable returning the active
+            MCP session snapshot for ``/_debug/sessions``. Required
+            when ``enable_debug_endpoints=True`` and no
+            ``debug_traffic_source`` is supplied; otherwise ignored.
+        debug_validate_request: Optional callable used to authorize
+            ``/_debug/*`` requests. Receives lower-case request headers
+            and returns ``True`` to serve the debug response. Required
+            when ``enable_debug_endpoints=True`` unless
+            ``debug_public=True`` is set.
+        debug_public: Set ``True`` only for local/storyboard runners
+            where the debug routes are intentionally unauthenticated.
+            Defaults to ``False`` so network-reachable deployments must
+            opt into public debug visibility explicitly or supply
+            ``debug_validate_request``.
         base_url: Optional public origin URL for the binary, used to
             populate the ``url`` field of each entry in the
             ``/.well-known/adcp-agents.json`` discovery manifest.
@@ -912,6 +935,9 @@ def serve(
         pre_validation_hooks = config.pre_validation_hooks
         enable_debug_endpoints = config.enable_debug_endpoints
         debug_traffic_source = config.debug_traffic_source
+        session_count_source = config.session_count_source
+        debug_validate_request = config.debug_validate_request
+        debug_public = config.debug_public
         base_url = config.base_url
         specialisms = config.specialisms
         description = config.description
@@ -927,17 +953,18 @@ def serve(
             name = handler.name
         handler = handler.build_handler()
 
-    # Compose the debug-traffic endpoint as the outermost ASGI
-    # middleware. Mounting it ahead of any seller-provided
-    # ``asgi_middleware`` means a runner's ``GET /_debug/traffic``
-    # short-circuits before tenant-resolution / auth middleware runs —
-    # the endpoint is for storyboard runners, not authenticated
-    # buyers, and should not require buyer credentials to reach.
-    asgi_middleware = _prepend_debug_endpoint(
-        asgi_middleware,
-        enable_debug_endpoints=enable_debug_endpoints,
-        debug_traffic_source=debug_traffic_source,
-    )
+    # Compose debug endpoints as the outermost ASGI middleware on HTTP
+    # transports. stdio has no HTTP layer, so debug endpoints are ignored
+    # there instead of forcing HTTP-only validation knobs onto shared configs.
+    if transport in ("a2a", "both", "streamable-http", "sse"):
+        asgi_middleware = _prepend_debug_endpoint(
+            asgi_middleware,
+            enable_debug_endpoints=enable_debug_endpoints,
+            debug_traffic_source=debug_traffic_source,
+            session_count_source=session_count_source,
+            debug_validate_request=debug_validate_request,
+            debug_public=debug_public,
+        )
 
     # Lifespan hooks ship today only for transport="both" because that's
     # the path with an SDK-owned parent Starlette where composition is
@@ -1053,6 +1080,9 @@ def _prepend_debug_endpoint(
     *,
     enable_debug_endpoints: bool,
     debug_traffic_source: Callable[[], dict[str, int]] | None,
+    session_count_source: Callable[[], dict[str, Any]] | None = None,
+    debug_validate_request: Callable[[dict[str, str]], bool] | None = None,
+    debug_public: bool = False,
 ) -> Sequence[ASGIMiddlewareEntry] | None:
     """Prepend :class:`DebugTrafficMiddleware` to the asgi_middleware
     sequence when debug endpoints are enabled.
@@ -1061,24 +1091,33 @@ def _prepend_debug_endpoint(
     mounted, ``/_debug/traffic`` falls through to the inner app, and
     the inner app returns 404. Production-default closed posture.
 
-    Raises ``ValueError`` when debug endpoints are enabled but no
-    traffic source is supplied — silently mounting an endpoint that
-    would error on every request is worse than a clear configuration
-    error at boot.
+    Raises ``ValueError`` when debug endpoints are enabled but no debug
+    source is supplied — silently mounting endpoints that would error on
+    every request is worse than a clear configuration error at boot.
     """
     if not enable_debug_endpoints:
         return asgi_middleware
-    if debug_traffic_source is None:
+    if debug_traffic_source is None and session_count_source is None:
         raise ValueError(
             "enable_debug_endpoints=True requires debug_traffic_source= "
-            "(typically mock_ad_server.get_traffic). Without a source the "
-            "/_debug/traffic endpoint has nothing to return."
+            "or session_count_source=. Without a source the debug endpoints "
+            "have nothing to return."
+        )
+    if not debug_public and debug_validate_request is None:
+        raise ValueError(
+            "enable_debug_endpoints=True requires debug_validate_request= "
+            "unless debug_public=True is set for local/storyboard use."
         )
     from adcp.server.debug_endpoints import DebugTrafficMiddleware
 
     debug_entry = (
         DebugTrafficMiddleware,
-        {"traffic_source": debug_traffic_source},
+        {
+            "traffic_source": debug_traffic_source,
+            "session_count_source": session_count_source,
+            "debug_validate_request": debug_validate_request,
+            "debug_public": debug_public,
+        },
     )
     if asgi_middleware is None:
         return [debug_entry]

--- a/tests/test_mock_ad_server.py
+++ b/tests/test_mock_ad_server.py
@@ -128,6 +128,7 @@ async def _drive(
     *,
     method: str = "GET",
     path: str = "/_debug/traffic",
+    headers: list[tuple[bytes, bytes]] | None = None,
 ) -> tuple[int, dict[str, str], bytes]:
     """Drive an ASGI app once with a synthetic HTTP request.
 
@@ -138,7 +139,7 @@ async def _drive(
         "method": method,
         "path": path,
         "raw_path": path.encode("ascii"),
-        "headers": [],
+        "headers": headers or [],
         "query_string": b"",
         "scheme": "http",
         "server": ("testserver", 80),
@@ -168,7 +169,9 @@ async def test_debug_endpoint_returns_traffic_json() -> None:
     recorder = InMemoryMockAdServer()
     recorder.record_call("creative.upload", {"count": 3})
     recorder.record_call("media_buy.create", {})
-    app = DebugTrafficMiddleware(_passthrough_app, traffic_source=recorder.get_traffic)
+    app = DebugTrafficMiddleware(
+        _passthrough_app, traffic_source=recorder.get_traffic, debug_public=True
+    )
 
     status, headers, body = await _drive(app)
     assert status == 200
@@ -180,7 +183,9 @@ async def test_debug_endpoint_returns_traffic_json() -> None:
 @pytest.mark.asyncio
 async def test_debug_endpoint_handles_head_with_empty_body() -> None:
     recorder = InMemoryMockAdServer()
-    app = DebugTrafficMiddleware(_passthrough_app, traffic_source=recorder.get_traffic)
+    app = DebugTrafficMiddleware(
+        _passthrough_app, traffic_source=recorder.get_traffic, debug_public=True
+    )
     status, headers, body = await _drive(app, method="HEAD")
     assert status == 200
     assert body == b""
@@ -193,10 +198,103 @@ async def test_debug_endpoint_rejects_post_with_405() -> None:
     doesn't fall through to MCP / A2A and emit a confusing transport
     error). Returns 405 with an ``Allow`` header."""
     recorder = InMemoryMockAdServer()
-    app = DebugTrafficMiddleware(_passthrough_app, traffic_source=recorder.get_traffic)
+    app = DebugTrafficMiddleware(
+        _passthrough_app, traffic_source=recorder.get_traffic, debug_public=True
+    )
     status, headers, _ = await _drive(app, method="POST")
     assert status == 405
     assert headers["allow"] == "GET, HEAD"
+
+
+@pytest.mark.asyncio
+async def test_debug_endpoint_hides_method_gate_until_authorized() -> None:
+    app = DebugTrafficMiddleware(
+        _passthrough_app,
+        traffic_source=lambda: {"ok": 1},
+        debug_validate_request=lambda headers: headers.get("x-debug-token") == "secret",
+    )
+
+    denied, denied_headers, _ = await _drive(app, method="POST")
+    assert denied == 404
+    assert "allow" not in denied_headers
+
+    allowed, allowed_headers, _ = await _drive(
+        app,
+        method="POST",
+        headers=[(b"x-debug-token", b"secret")],
+    )
+    assert allowed == 405
+    assert allowed_headers["allow"] == "GET, HEAD"
+
+
+@pytest.mark.asyncio
+async def test_debug_sessions_endpoint_returns_session_json() -> None:
+    app = DebugTrafficMiddleware(
+        _passthrough_app,
+        session_count_source=lambda: {
+            "active_sessions": 2,
+            "max_active_sessions": 5,
+            "sessions_created_last_60s": 3,
+        },
+        debug_public=True,
+    )
+
+    status, headers, body = await _drive(app, path="/_debug/sessions")
+    assert status == 200
+    assert headers["content-type"] == "application/json"
+    assert json.loads(body) == {
+        "active_sessions": 2,
+        "max_active_sessions": 5,
+        "sessions_created_last_60s": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_debug_endpoint_returns_404() -> None:
+    app = DebugTrafficMiddleware(_passthrough_app, traffic_source=lambda: {}, debug_public=True)
+    status, _, body = await _drive(app, path="/_debug/sessions")
+    assert status == 404
+    assert body == b""
+
+
+@pytest.mark.asyncio
+async def test_debug_endpoint_requires_validator_when_not_public() -> None:
+    app = DebugTrafficMiddleware(
+        _passthrough_app,
+        traffic_source=lambda: {"ok": 1},
+        debug_validate_request=lambda headers: headers.get("x-debug-token") == "secret",
+    )
+
+    denied, _, denied_body = await _drive(app)
+    assert denied == 404
+    assert denied_body == b""
+
+    allowed, _, allowed_body = await _drive(
+        app,
+        headers=[(b"x-debug-token", b"secret")],
+    )
+    assert allowed == 200
+    assert json.loads(allowed_body) == {"ok": 1}
+
+
+@pytest.mark.asyncio
+async def test_debug_endpoint_uses_last_duplicate_header_value() -> None:
+    app = DebugTrafficMiddleware(
+        _passthrough_app,
+        traffic_source=lambda: {"ok": 1},
+        debug_validate_request=lambda headers: headers.get("x-debug-token") == "secret",
+    )
+
+    status, _, body = await _drive(
+        app,
+        headers=[
+            (b"x-debug-token", b"attacker"),
+            (b"x-debug-token", b"secret"),
+        ],
+    )
+
+    assert status == 200
+    assert json.loads(body) == {"ok": 1}
 
 
 @pytest.mark.asyncio
@@ -204,7 +302,9 @@ async def test_debug_endpoint_passes_through_other_paths() -> None:
     """Any path other than ``/_debug/traffic`` reaches the inner
     app unchanged — the middleware must not swallow normal traffic."""
     recorder = InMemoryMockAdServer()
-    app = DebugTrafficMiddleware(_passthrough_app, traffic_source=recorder.get_traffic)
+    app = DebugTrafficMiddleware(
+        _passthrough_app, traffic_source=recorder.get_traffic, debug_public=True
+    )
     status, _, body = await _drive(app, path="/mcp")
     assert status == 404
     assert body == b"inner-fallthrough"
@@ -228,7 +328,7 @@ def test_serve_skips_debug_when_disabled() -> None:
     assert result is None
 
 
-def test_serve_requires_traffic_source_when_enabled() -> None:
+def test_serve_requires_debug_source_when_enabled() -> None:
     """``enable_debug_endpoints=True`` without a source must fail at
     boot — silently mounting an endpoint that errors on every request
     is worse than a clear configuration error."""
@@ -239,6 +339,32 @@ def test_serve_requires_traffic_source_when_enabled() -> None:
             None,
             enable_debug_endpoints=True,
             debug_traffic_source=None,
+        )
+
+
+def test_serve_accepts_session_source_without_traffic_source() -> None:
+    from adcp.server.serve import _prepend_debug_endpoint
+
+    result = _prepend_debug_endpoint(
+        None,
+        enable_debug_endpoints=True,
+        debug_traffic_source=None,
+        session_count_source=lambda: {"active_sessions": 0},
+        debug_public=True,
+    )
+    assert result is not None
+    assert result[0][1]["traffic_source"] is None
+    assert result[0][1]["session_count_source"] is not None
+
+
+def test_serve_requires_debug_auth_unless_public() -> None:
+    from adcp.server.serve import _prepend_debug_endpoint
+
+    with pytest.raises(ValueError, match="debug_validate_request"):
+        _prepend_debug_endpoint(
+            None,
+            enable_debug_endpoints=True,
+            debug_traffic_source=lambda: {},
         )
 
 
@@ -257,6 +383,8 @@ def test_serve_prepends_debug_middleware_when_enabled() -> None:
         seller_middleware,
         enable_debug_endpoints=True,
         debug_traffic_source=lambda: {},
+        session_count_source=lambda: {"active_sessions": 0},
+        debug_public=True,
     )
     assert result is not None
     assert len(result) == 2
@@ -275,7 +403,9 @@ async def test_smoke_record_then_observe_via_endpoint() -> None:
     poll ``GET /_debug/traffic`` and assert the counts. This is the
     storyboard runner's exact use case."""
     recorder = InMemoryMockAdServer()
-    app = DebugTrafficMiddleware(_passthrough_app, traffic_source=recorder.get_traffic)
+    app = DebugTrafficMiddleware(
+        _passthrough_app, traffic_source=recorder.get_traffic, debug_public=True
+    )
 
     # Simulate three sync_creatives calls and one create_media_buy.
     for _ in range(3):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -8,6 +8,7 @@ from a2a import types as pb
 from google.protobuf.json_format import ParseDict
 from google.protobuf.struct_pb2 import Value
 
+from adcp.exceptions import ADCPConnectionError
 from adcp.protocols.a2a import A2AAdapter, _part_data_dict
 from adcp.protocols.mcp import MCPAdapter
 from adcp.types.core import AgentConfig, Protocol, TaskStatus
@@ -2044,6 +2045,131 @@ class TestMCPUrlFallback:
                 pass
 
         assert real_urls == expected_urls
+
+
+class TestMCPSessionClose:
+    """Tests for explicit MCP Streamable HTTP session termination."""
+
+    @pytest.mark.asyncio
+    async def test_adapter_close_mcp_session_sends_delete(self) -> None:
+        import httpx
+        import respx
+
+        cfg = AgentConfig(
+            id="t",
+            agent_uri="https://host/mcp",
+            protocol=Protocol.MCP,
+            auth_token="secret",
+            auth_type="bearer",
+            auth_header="Authorization",
+            extra_headers={"X-Tenant": "acme"},
+        )
+        adapter = MCPAdapter(cfg)
+
+        with respx.mock(assert_all_called=True) as router:
+            route = router.delete("https://host/mcp").mock(return_value=httpx.Response(200))
+            await adapter.close_mcp_session("sess_123")
+
+        request = route.calls[0].request
+        assert request.headers["mcp-session-id"] == "sess_123"
+        assert request.headers["authorization"] == "Bearer secret"
+        assert request.headers["x-tenant"] == "acme"
+
+    @pytest.mark.asyncio
+    async def test_adapter_close_current_mcp_session_when_id_omitted(self) -> None:
+        import httpx
+        import respx
+
+        cfg = AgentConfig(id="t", agent_uri="https://host/mcp", protocol=Protocol.MCP)
+        adapter = MCPAdapter(cfg)
+        adapter._connected_url = "https://host/mcp"
+        adapter._get_session_id = lambda: "sess_123"
+
+        with respx.mock(assert_all_called=True) as router:
+            route = router.delete("https://host/mcp").mock(return_value=httpx.Response(200))
+            await adapter.close_mcp_session()
+
+        assert route.calls[0].request.headers["mcp-session-id"] == "sess_123"
+
+    @pytest.mark.asyncio
+    async def test_adapter_close_mcp_session_uses_mcp_redirect_defaults(self) -> None:
+        import httpx
+        import respx
+
+        cfg = AgentConfig(id="t", agent_uri="https://host/mcp", protocol=Protocol.MCP)
+        adapter = MCPAdapter(cfg)
+
+        with respx.mock(assert_all_called=True) as router:
+            router.delete("https://host/mcp").mock(
+                return_value=httpx.Response(307, headers={"location": "https://host/real-mcp"})
+            )
+            target = router.delete("https://host/real-mcp").mock(return_value=httpx.Response(200))
+            await adapter.close_mcp_session("sess_123")
+
+        assert target.calls[0].request.headers["mcp-session-id"] == "sess_123"
+
+    @pytest.mark.asyncio
+    async def test_adapter_close_mcp_session_runs_signing_request_hook(self) -> None:
+        import httpx
+        import respx
+
+        cfg = AgentConfig(id="t", agent_uri="https://host/mcp", protocol=Protocol.MCP)
+        adapter = MCPAdapter(cfg)
+
+        async def sign(request: httpx.Request) -> None:
+            request.headers["x-signed"] = "yes"
+
+        adapter.signing_request_hook = sign
+
+        with respx.mock(assert_all_called=True) as router:
+            route = router.delete("https://host/mcp").mock(return_value=httpx.Response(200))
+            await adapter.close_mcp_session("sess_123")
+
+        assert route.calls[0].request.headers["x-signed"] == "yes"
+
+    @pytest.mark.asyncio
+    async def test_adapter_close_mcp_session_rejects_signed_redirect(self) -> None:
+        import httpx
+        import respx
+
+        cfg = AgentConfig(id="t", agent_uri="https://host/mcp", protocol=Protocol.MCP)
+        adapter = MCPAdapter(cfg)
+
+        async def sign(request: httpx.Request) -> None:
+            request.headers["x-signed"] = "yes"
+
+        adapter.signing_request_hook = sign
+
+        with respx.mock(assert_all_called=True) as router:
+            route = router.delete("https://host/mcp").mock(
+                return_value=httpx.Response(307, headers={"location": "https://host/real-mcp"})
+            )
+            with pytest.raises(ADCPConnectionError, match="Unexpected redirect"):
+                await adapter.close_mcp_session("sess_123")
+
+        assert route.calls[0].request.headers["x-signed"] == "yes"
+
+    @pytest.mark.asyncio
+    async def test_client_close_mcp_session_delegates_to_mcp_adapter(self) -> None:
+        from adcp import ADCPClient
+
+        cfg = AgentConfig(id="t", agent_uri="https://host/mcp", protocol=Protocol.MCP)
+        client = ADCPClient(cfg)
+
+        with patch.object(client.adapter, "close_mcp_session", AsyncMock()) as close_session:
+            await client.close_mcp_session()
+
+        close_session.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_client_close_mcp_session_rejects_a2a_client(self) -> None:
+        from adcp import ADCPClient
+
+        client = ADCPClient(
+            AgentConfig(id="a2a", agent_uri="https://a2a.example.com", protocol=Protocol.A2A)
+        )
+        with pytest.raises(TypeError, match="only supported for MCP"):
+            await client.close_mcp_session("sess_123")
 
 
 class TestFromMcpClientFactory:

--- a/tests/test_serve_config.py
+++ b/tests/test_serve_config.py
@@ -46,6 +46,9 @@ def test_serve_config_defaults() -> None:
     assert cfg.streaming_responses is False
     assert cfg.max_active_sessions is None
     assert cfg.enable_debug_endpoints is False
+    assert cfg.session_count_source is None
+    assert cfg.debug_validate_request is None
+    assert cfg.debug_public is False
     assert cfg.middleware is None
     assert cfg.validation is None
 
@@ -186,3 +189,40 @@ def test_serve_config_max_active_sessions_propagates_to_both_transport() -> None
     mock_both.assert_called_once()
     _, kwargs = mock_both.call_args
     assert kwargs.get("max_active_sessions") == 10
+
+
+def test_serve_config_session_count_source_wires_debug_middleware() -> None:
+    handler = _StubHandler()
+    source = lambda: {"active_sessions": 0}  # noqa: E731
+    cfg = ServeConfig(
+        transport="streamable-http",
+        enable_debug_endpoints=True,
+        session_count_source=source,
+        debug_public=True,
+    )
+
+    with patch.object(_serve_mod, "_serve_mcp") as mock_mcp:
+        _serve_mod.serve(handler, config=cfg)
+
+    mock_mcp.assert_called_once()
+    _, kwargs = mock_mcp.call_args
+    middleware = kwargs.get("asgi_middleware")
+    assert middleware is not None
+    assert middleware[0][1]["session_count_source"] is source
+    assert middleware[0][1]["debug_public"] is True
+
+
+def test_serve_config_debug_endpoints_ignored_on_stdio() -> None:
+    handler = _StubHandler()
+    cfg = ServeConfig(
+        transport="stdio",
+        enable_debug_endpoints=True,
+        debug_traffic_source=lambda: {},
+    )
+
+    with patch.object(_serve_mod, "_serve_mcp") as mock_mcp:
+        _serve_mod.serve(handler, config=cfg)
+
+    mock_mcp.assert_called_once()
+    _, kwargs = mock_mcp.call_args
+    assert kwargs.get("asgi_middleware") is None


### PR DESCRIPTION
## Summary

Closes #903.

- Add explicit MCP Streamable HTTP session termination via `ADCPClient.close_mcp_session()`, including current-session cleanup without requiring callers to reach into internals.
- Add opt-in `/_debug/sessions` support through `session_count_source`, alongside the existing traffic debug endpoint.
- Harden debug endpoints so they require `debug_validate_request` unless callers explicitly set `debug_public=True` for local/storyboard use.
- Preserve streamable HTTP transport behavior on explicit DELETE, including redirect defaults and request signing hooks.
- Document stateful session lifecycle guidance, one-shot caller guidance, debug endpoint gating, and update the reference seller example to use `ADCP_DEBUG_TOKEN`.

## Validation

- Expert code review: no remaining blocking findings.
- Expert security review: no remaining Must Fix findings.
- `PYTHONPATH=src mypy src/`
- `PYTHONPATH=src ruff check ...` on changed files
- `PYTHONPATH=src black --check ...` on changed files
- `PYTHONPATH=src pytest tests/test_mock_ad_server.py tests/test_serve_config.py tests/test_protocols.py::TestMCPUrlFallback tests/test_protocols.py::TestMCPSessionClose tests/test_mcp_stateful_session.py`
- Pre-commit on commit: black, ruff, mypy, adopter type-check fixtures, bandit, whitespace/YAML/JSON/large-file/conflict/private-key hooks

## Notes

Full `pytest` was also attempted. It completed with one unrelated timing failure in `tests/test_permission_denied_budget.py::test_branch_parity_absorbs_registry_variance`; rerunning that single test reproduced the same timing assertion failure.

Full repo `ruff check .` and `black --check .` currently report pre-existing unrelated issues outside this change set, while changed-file lint and formatting pass.
