### PR TITLE
fix(types): generate schema enums as StrEnum

### DIFF
--- a/scripts/post_generate_fixes.py
+++ b/scripts/post_generate_fixes.py
@@ -6,12 +6,13 @@ Post-generation fixes for generated Pydantic models.
 This script applies necessary modifications to generated files that cannot be
 handled by datamodel-code-generator directly:
 
-1. Adds model_validators to types requiring mutual exclusivity checks
-2. Fixes self-referential RootModel type annotations
-3. Fixes BrandManifest forward references
-4. Adds deprecated=True to fields marked deprecated in JSON schema
-5. Unwraps specified RootModel unions to plain Union type aliases (#155)
-6. Widens canceled: Literal[True] = True on request types to | None = None (#641)
+1. Rewrites generated string enums to StrEnum
+2. Adds model_validators to types requiring mutual exclusivity checks
+3. Fixes self-referential RootModel type annotations
+4. Fixes BrandManifest forward references
+5. Adds deprecated=True to fields marked deprecated in JSON schema
+6. Unwraps specified RootModel unions to plain Union type aliases (#155)
+7. Widens canceled: Literal[True] = True on request types to | None = None (#641)
 """
 
 from __future__ import annotations
@@ -48,6 +49,8 @@ SCHEMA_DIR = REPO_ROOT / "schemas" / "cache" / _BUNDLE_KEY
 
 _PROTOCOL_ENVELOPE_IMPORT = "from ..core.protocol_envelope import ProtocolEnvelope\n"
 _VERSION_ENVELOPE_IMPORT = "from ..core.version_envelope import AdcpVersionEnvelope\n"
+_STR_ENUM_MEMBER_ASSIGNMENT_IGNORE = "  # type: ignore[assignment]"
+_STR_ATTRIBUTE_NAMES = set(dir(str))
 
 
 def _sync_protocol_envelope_import(source: str) -> str:
@@ -80,6 +83,90 @@ def add_model_validator_to_product():
     Keeping function as no-op for backwards compatibility with older schemas.
     """
     print("  product.py validation: no fixes needed (Pydantic handles discriminated unions)")
+
+
+def _ignore_strenum_member_method_collisions(source: str) -> tuple[str, int]:
+    """Suppress mypy for StrEnum members that intentionally shadow str methods."""
+    lines = source.splitlines()
+    updated: list[str] = []
+    class_indent: int | None = None
+    ignores_added = 0
+
+    for line in lines:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        class_match = re.match(r"class\s+\w+\(StrEnum\):", stripped)
+        if class_match is not None:
+            class_indent = indent
+            updated.append(line)
+            continue
+
+        if class_indent is not None and stripped and indent <= class_indent:
+            class_indent = None
+
+        if class_indent is not None and indent == class_indent + 4:
+            assignment_match = re.match(r"([A-Za-z_]\w*)\s*=", stripped)
+            if (
+                assignment_match is not None
+                and assignment_match.group(1) in _STR_ATTRIBUTE_NAMES
+                and _STR_ENUM_MEMBER_ASSIGNMENT_IGNORE not in line
+            ):
+                line = f"{line}{_STR_ENUM_MEMBER_ASSIGNMENT_IGNORE}"
+                ignores_added += 1
+
+        updated.append(line)
+
+    return "\n".join(updated) + ("\n" if source.endswith("\n") else ""), ignores_added
+
+
+def rewrite_generated_enums_to_strenum() -> None:
+    """Make all generated schema enums inherit from StrEnum.
+
+    datamodel-code-generator emits plain ``Enum`` classes for string-valued
+    JSON Schema enums. The generated enum members should behave like their wire
+    values for equality, hashing, formatting, and ``str()`` without widening or
+    narrowing any model field annotations.
+    """
+    files_changed = 0
+    classes_changed = 0
+    ignores_added = 0
+
+    for path in OUTPUT_DIR.rglob("*.py"):
+        source = path.read_text()
+        if (
+            "(Enum):" not in source
+            and "from enum import Enum" not in source
+            and "(StrEnum):" not in source
+        ):
+            continue
+
+        updated = source.replace(
+            "from enum import Enum, IntEnum\n",
+            "from enum import IntEnum\nfrom adcp.types._str_enum import StrEnum\n",
+        )
+        updated = updated.replace(
+            "from enum import IntEnum, Enum\n",
+            "from enum import IntEnum\nfrom adcp.types._str_enum import StrEnum\n",
+        )
+        updated = updated.replace(
+            "from enum import Enum\n",
+            "from adcp.types._str_enum import StrEnum\n",
+        )
+        updated, changed = re.subn(r"\((?:str,\s*)?Enum\):", "(StrEnum):", updated)
+        updated, file_ignores_added = _ignore_strenum_member_method_collisions(updated)
+
+        if updated != source:
+            path.write_text(updated)
+            files_changed += 1
+            classes_changed += changed
+            ignores_added += file_ignores_added
+
+    print(
+        f"  generated enums rewritten to StrEnum "
+        f"({classes_changed} classes across {files_changed} files, "
+        f"{ignores_added} member type ignore(s))"
+    )
 
 
 def fix_preview_render_self_reference():
@@ -3297,6 +3384,7 @@ def main():
         fix_response_payload_jws_required_literals,
         fix_verify_brand_claim_models,
         fix_signal_coverage_forecast_point_types,
+        rewrite_generated_enums_to_strenum,
         strip_extra_blank_lines_at_eof,
     ]
     for fix in fixes:

--- a/src/adcp/types/_str_enum.py
+++ b/src/adcp/types/_str_enum.py
@@ -1,0 +1,19 @@
+"""Python-version-compatible StrEnum export for generated schema enums."""
+
+from __future__ import annotations
+
+import sys
+from enum import Enum
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum as StrEnum
+else:
+
+    class StrEnum(str, Enum):
+        """Backport the stdlib StrEnum behavior needed by generated enums."""
+
+        def __str__(self) -> str:
+            return str.__str__(self)
+
+        def __format__(self, format_spec: str) -> str:
+            return str.__format__(self, format_spec)

--- a/src/adcp/types/generated_poc/a2ui/si_catalog.py
+++ b/src/adcp/types/generated_poc/a2ui/si_catalog.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import AnyUrl, Field
 from . import bound_value
 
 
-class Component(Enum):
+class Component(StrEnum):
     Text = 'Text'
     Button = 'Button'
     Link = 'Link'
@@ -36,7 +36,7 @@ class SiComponentCatalog(AdCPBaseModel):
     ] = None
 
 
-class Variant(Enum):
+class Variant(StrEnum):
     body = 'body'
     heading = 'heading'
     caption = 'caption'
@@ -56,7 +56,7 @@ class Action(AdCPBaseModel):
     ] = None
 
 
-class Variant5(Enum):
+class Variant5(StrEnum):
     primary = 'primary'
     secondary = 'secondary'
     text = 'text'
@@ -122,7 +122,7 @@ class Template(AdCPBaseModel):
     componentId: Annotated[str, Field(description='ID of component to use as template')]
 
 
-class Layout(Enum):
+class Layout(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     grid = 'grid'
@@ -137,16 +137,16 @@ class List(AdCPBaseModel):
     layout: Layout | None = Layout.vertical
 
 
-class Align(Enum):
+class Align(StrEnum):
     start = 'start'
-    center = 'center'
+    center = 'center'  # type: ignore[assignment]
     end = 'end'
     stretch = 'stretch'
 
 
-class Justify(Enum):
+class Justify(StrEnum):
     start = 'start'
-    center = 'center'
+    center = 'center'  # type: ignore[assignment]
     end = 'end'
     between = 'between'
     around = 'around'
@@ -165,7 +165,7 @@ class Column(AdCPBaseModel):
     align: Align | None = Align.stretch
 
 
-class Type(Enum):
+class Type(StrEnum):
     mcp = 'mcp'
     a2a = 'a2a'
 

--- a/src/adcp/types/generated_poc/aao/agent_publishers.py
+++ b/src/adcp/types/generated_poc/aao/agent_publishers.py
@@ -4,21 +4,21 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class DiscoveryMethod(Enum):
+class DiscoveryMethod(StrEnum):
     direct = 'direct'
     authoritative_location = 'authoritative_location'
     adagents_authoritative = 'adagents_authoritative'
     ads_txt_managerdomain = 'ads_txt_managerdomain'
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     revoked = 'revoked'
 

--- a/src/adcp/types/generated_poc/account/list_accounts_request.py
+++ b/src/adcp/types/generated_poc/account/list_accounts_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field
@@ -16,7 +16,7 @@ from ..core import pagination_request
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class Status(Enum):
+class Status(StrEnum):
     active = 'active'
     pending_approval = 'pending_approval'
     rejected = 'rejected'

--- a/src/adcp/types/generated_poc/adagents.py
+++ b/src/adcp/types/generated_poc/adagents.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -94,7 +94,7 @@ class Contact(AdCPBaseModel):
     ] = None
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     relationship_ended = 'relationship_ended'
     compliance_violation = 'compliance_violation'
     publisher_request = 'publisher_request'
@@ -144,7 +144,7 @@ class PlacementTags(AdCPBaseModel):
     ]
 
 
-class DelegationType(Enum):
+class DelegationType(StrEnum):
     direct = 'direct'
     delegated = 'delegated'
     ad_network = 'ad_network'

--- a/src/adcp/types/generated_poc/brand/__init__.py
+++ b/src/adcp/types/generated_poc/brand/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ..enums import feed_format as feed_format_1
 from ..enums import logo_slot, right_type, right_use, talent_role
 
 
-class RedirectReason(Enum):
+class RedirectReason(StrEnum):
     acquisition = 'acquisition'
     divestiture = 'divestiture'
     rebrand = 'rebrand'
@@ -81,7 +81,7 @@ class LogoId(RootModel[str]):
     ]
 
 
-class Status(Enum):
+class Status(StrEnum):
     active = 'active'
     pending = 'pending'
     abandoned = 'abandoned'
@@ -89,7 +89,7 @@ class Status(Enum):
     expired = 'expired'
 
 
-class LicenseType(Enum):
+class LicenseType(StrEnum):
     owned = 'owned'
     licensed_in = 'licensed_in'
     licensed_out = 'licensed_out'
@@ -175,27 +175,27 @@ class LocalizedName(RootModel[dict[str, str]]):
     root: Annotated[dict[str, str], Field(min_length=1)]
 
 
-class KellerType(Enum):
+class KellerType(StrEnum):
     master = 'master'
     sub_brand = 'sub_brand'
     endorsed = 'endorsed'
     independent = 'independent'
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     square = 'square'
     horizontal = 'horizontal'
     vertical = 'vertical'
     stacked = 'stacked'
 
 
-class Background(Enum):
+class Background(StrEnum):
     dark_bg = 'dark-bg'
     light_bg = 'light-bg'
     transparent_bg = 'transparent-bg'
 
 
-class Variant(Enum):
+class Variant(StrEnum):
     primary = 'primary'
     secondary = 'secondary'
     icon = 'icon'
@@ -227,13 +227,13 @@ class ColorValue(RootModel[ColorValue1 | ColorValue2]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Kind(Enum):
+class Kind(StrEnum):
     name = 'name'
     value = 'value'
     surface = 'surface'
 
 
-class Surface(Enum):
+class Surface(StrEnum):
     background = 'background'
     foreground = 'foreground'
     text = 'text'
@@ -319,7 +319,7 @@ class ColorRef(RootModel[ColorRef1 | ColorRef2 | ColorRef3]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class GuidelineSeverity(Enum):
+class GuidelineSeverity(StrEnum):
     must = 'must'
     should = 'should'
 
@@ -343,7 +343,7 @@ class WeightRangeItem(RootModel[int]):
     root: Annotated[int, Field(ge=100, le=900)]
 
 
-class Style(Enum):
+class Style(StrEnum):
     normal = 'normal'
     italic = 'italic'
     oblique = 'oblique'
@@ -449,7 +449,7 @@ class Asset(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -460,7 +460,7 @@ class Type(Enum):
     streaming_audio = 'streaming_audio'
 
 
-class Store(Enum):
+class Store(StrEnum):
     apple = 'apple'
     google = 'google'
     amazon = 'amazon'
@@ -470,7 +470,7 @@ class Store(Enum):
     other = 'other'
 
 
-class Relationship(Enum):
+class Relationship(StrEnum):
     owned = 'owned'
     direct = 'direct'
     delegated = 'delegated'
@@ -507,7 +507,7 @@ class Property(AdCPBaseModel):
     ] = Relationship.owned
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
@@ -603,7 +603,7 @@ class Contact1(AdCPBaseModel):
     phone: Annotated[str | None, Field(description='Contact phone number')] = None
 
 
-class Architecture(Enum):
+class Architecture(StrEnum):
     branded_house = 'branded_house'
     house_of_brands = 'house_of_brands'
     hybrid = 'hybrid'
@@ -636,7 +636,7 @@ class Brand1(RootModel[str]):
     root: Annotated[str, Field(pattern='^([a-z0-9_]+|\\*)$')]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     all = 'all'
     media_buying = 'media_buying'
     creative_generation = 'creative_generation'
@@ -687,26 +687,26 @@ class AuthorizedOperator(AdCPBaseModel):
     ] = None
 
 
-class Realism(Enum):
+class Realism(StrEnum):
     natural = 'natural'
     stylized = 'stylized'
     hyperreal = 'hyperreal'
     abstract = 'abstract'
 
 
-class ColorTemperature(Enum):
+class ColorTemperature(StrEnum):
     warm = 'warm'
     neutral = 'neutral'
     cool = 'cool'
 
 
-class Contrast(Enum):
+class Contrast(StrEnum):
     low = 'low'
     medium = 'medium'
     high = 'high'
 
 
-class DepthOfField(Enum):
+class DepthOfField(StrEnum):
     shallow = 'shallow'
     medium = 'medium'
     deep = 'deep'
@@ -725,7 +725,7 @@ class People(AdCPBaseModel):
     ] = None
 
 
-class ProductFocus(Enum):
+class ProductFocus(StrEnum):
     in_use = 'in-use'
     isolated = 'isolated'
     lifestyle = 'lifestyle'
@@ -806,7 +806,7 @@ class PhotographyStyle(AdCPBaseModel):
     tags: Annotated[list[str] | None, Field(description='Additional style descriptors')] = None
 
 
-class StyleType(Enum):
+class StyleType(StrEnum):
     flat_illustration = 'flat_illustration'
     geometric = 'geometric'
     gradient_mesh = 'gradient_mesh'
@@ -818,7 +818,7 @@ class StyleType(Enum):
     photographic_composite = 'photographic_composite'
 
 
-class StrokeStyle(Enum):
+class StrokeStyle(StrEnum):
     rounded = 'rounded'
     square = 'square'
     mixed = 'mixed'
@@ -933,7 +933,7 @@ class BrandShapes(AdCPBaseModel):
     usage: Annotated[Usage | None, Field(description='Shape usage rules')] = None
 
 
-class Style1(Enum):
+class Style1(StrEnum):
     outline = 'outline'
     filled = 'filled'
     duotone = 'duotone'
@@ -942,7 +942,7 @@ class Style1(Enum):
     hand_drawn = 'hand_drawn'
 
 
-class CornerStyle(Enum):
+class CornerStyle(StrEnum):
     rounded = 'rounded'
     square = 'square'
     mixed = 'mixed'
@@ -974,7 +974,7 @@ class Iconography(AdCPBaseModel):
     usage: Annotated[Usage1 | None, Field(description='Icon usage rules')] = None
 
 
-class GradientStyle(Enum):
+class GradientStyle(StrEnum):
     linear = 'linear'
     radial = 'radial'
     conic = 'conic'
@@ -994,7 +994,7 @@ class Overlays(AdCPBaseModel):
     opacity: Annotated[str | None, Field(description="Overlay opacity (e.g., '70%')")] = None
 
 
-class Style2(Enum):
+class Style2(StrEnum):
     none = 'none'
     subtle_grain = 'subtle_grain'
     noise = 'noise'
@@ -1013,7 +1013,7 @@ class Texture(AdCPBaseModel):
     intensity: Annotated[Contrast | None, Field(description='Texture intensity')] = None
 
 
-class TypesAllowedEnum(Enum):
+class TypesAllowedEnum(StrEnum):
     solid_color = 'solid_color'
     gradient = 'gradient'
     blurred_photo = 'blurred_photo'
@@ -1107,7 +1107,7 @@ class MinimumSize(AdCPBaseModel):
     height: Annotated[str | None, Field(description='Minimum height, such as 18px or 6mm.')] = None
 
 
-class LockupType(Enum):
+class LockupType(StrEnum):
     co_brand = 'co_brand'
     secondary_mark = 'secondary_mark'
     partner = 'partner'
@@ -1117,14 +1117,14 @@ class LockupType(Enum):
     custom = 'custom'
 
 
-class Ordering(Enum):
+class Ordering(StrEnum):
     brand_first = 'brand_first'
     partner_first = 'partner_first'
     equal = 'equal'
     contextual = 'contextual'
 
 
-class Type1(Enum):
+class Type1(StrEnum):
     none = 'none'
     keyline = 'keyline'
     space = 'space'
@@ -1198,11 +1198,11 @@ class MarkLockup(AdCPBaseModel):
     ] = None
 
 
-class TextTransform(Enum):
+class TextTransform(StrEnum):
     none = 'none'
     uppercase = 'uppercase'
     lowercase = 'lowercase'
-    capitalize = 'capitalize'
+    capitalize = 'capitalize'  # type: ignore[assignment]
 
 
 class TypeScaleEntry(AdCPBaseModel):
@@ -1226,7 +1226,7 @@ class TypeScaleEntry(AdCPBaseModel):
     text_transform: Annotated[TextTransform | None, Field(description='Text transformation')] = None
 
 
-class TransitionStyle(Enum):
+class TransitionStyle(StrEnum):
     cut = 'cut'
     dissolve = 'dissolve'
     slide = 'slide'
@@ -1235,13 +1235,13 @@ class TransitionStyle(Enum):
     fade = 'fade'
 
 
-class AnimationSpeed(Enum):
+class AnimationSpeed(StrEnum):
     slow = 'slow'
     moderate = 'moderate'
     fast = 'fast'
 
 
-class TextEntrance(Enum):
+class TextEntrance(StrEnum):
     fade = 'fade'
     typewriter = 'typewriter'
     slide_up = 'slide_up'
@@ -1250,7 +1250,7 @@ class TextEntrance(Enum):
     none = 'none'
 
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     lingering = 'lingering'
     moderate = 'moderate'
     fast_cuts = 'fast_cuts'
@@ -1282,17 +1282,17 @@ class MotionGuidelines(AdCPBaseModel):
     )
 
 
-class PreferredPosition(Enum):
+class PreferredPosition(StrEnum):
     top_left = 'top-left'
     top_center = 'top-center'
     top_right = 'top-right'
     bottom_left = 'bottom-left'
     bottom_center = 'bottom-center'
     bottom_right = 'bottom-right'
-    center = 'center'
+    center = 'center'  # type: ignore[assignment]
 
 
-class BackgroundContrast(Enum):
+class BackgroundContrast(StrEnum):
     light_only = 'light_only'
     dark_only = 'dark_only'
     any = 'any'
@@ -1320,7 +1320,7 @@ class LogoPlacement(AdCPBaseModel):
     ] = None
 
 
-class Type2(Enum):
+class Type2(StrEnum):
     border = 'border'
     divider = 'divider'
     frame = 'frame'
@@ -1330,7 +1330,7 @@ class Type2(Enum):
     decorative = 'decorative'
 
 
-class Orientation1(Enum):
+class Orientation1(StrEnum):
     horizontal = 'horizontal'
     vertical = 'vertical'
     any = 'any'
@@ -1359,7 +1359,7 @@ class GraphicElement(AdCPBaseModel):
     max_per_layout: Annotated[int | None, Field(description='Maximum instances per layout')] = None
 
 
-class Type3(Enum):
+class Type3(StrEnum):
     icon_set = 'icon_set'
     illustration_system = 'illustration_system'
     image_library = 'image_library'

--- a/src/adcp/types/generated_poc/brand/get_brand_identity_request.py
+++ b/src/adcp/types/generated_poc/brand/get_brand_identity_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field
@@ -14,7 +14,7 @@ from ..core import ext as ext_1
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class FieldModel(Enum):
+class FieldModel(StrEnum):
     description = 'description'
     industries = 'industries'
     keller_type = 'keller_type'

--- a/src/adcp/types/generated_poc/brand/get_brand_identity_response.py
+++ b/src/adcp/types/generated_poc/brand/get_brand_identity_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -17,7 +17,7 @@ class WeightRangeItem(RootModel[int]):
     root: Annotated[int, Field(ge=100, le=900)]
 
 
-class Style(Enum):
+class Style(StrEnum):
     normal = 'normal'
     italic = 'italic'
     oblique = 'oblique'

--- a/src/adcp/types/generated_poc/brand/search_brands_response.py
+++ b/src/adcp/types/generated_poc/brand/search_brands_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -23,27 +23,27 @@ class House(AdCPBaseModel):
     name: Annotated[str, Field(description='House display name')]
 
 
-class KellerType(Enum):
+class KellerType(StrEnum):
     master = 'master'
     sub_brand = 'sub_brand'
     endorsed = 'endorsed'
     independent = 'independent'
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     square = 'square'
     horizontal = 'horizontal'
     vertical = 'vertical'
     stacked = 'stacked'
 
 
-class Background(Enum):
+class Background(StrEnum):
     dark_bg = 'dark-bg'
     light_bg = 'light-bg'
     transparent_bg = 'transparent-bg'
 
 
-class Variant(Enum):
+class Variant(StrEnum):
     primary = 'primary'
     secondary = 'secondary'
     icon = 'icon'

--- a/src/adcp/types/generated_poc/brand/verification_status.py
+++ b/src/adcp/types/generated_poc/brand/verification_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class VerificationStatus(Enum):
+class VerificationStatus(StrEnum):
     owned = 'owned'
     pending_review = 'pending_review'
     transferring = 'transferring'

--- a/src/adcp/types/generated_poc/brand/verify_brand_claim_request.py
+++ b/src/adcp/types/generated_poc/brand/verify_brand_claim_request.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated
 
 from pydantic import AnyUrl, ConfigDict, Field
@@ -11,7 +11,7 @@ from pydantic import AnyUrl, ConfigDict, Field
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class ClaimType(Enum):
+class ClaimType(StrEnum):
     subsidiary = 'subsidiary'
     parent = 'parent'
     property = 'property'

--- a/src/adcp/types/generated_poc/brand/verify_brand_claim_response.py
+++ b/src/adcp/types/generated_poc/brand/verify_brand_claim_response.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -17,7 +17,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from . import verification_status
 
 
-class ClaimType(Enum):
+class ClaimType(StrEnum):
     subsidiary = 'subsidiary'
     parent = 'parent'
     property = 'property'

--- a/src/adcp/types/generated_poc/brand/verify_brand_claims_request.py
+++ b/src/adcp/types/generated_poc/brand/verify_brand_claims_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -69,7 +69,7 @@ class ClaimEntry2(AdCPBaseModel):
     claim: Claim1
 
 
-class Type(Enum):
+class Type(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -80,7 +80,7 @@ class Type(Enum):
     streaming_audio = 'streaming_audio'
 
 
-class Store(Enum):
+class Store(StrEnum):
     apple = 'apple'
     google = 'google'
     amazon = 'amazon'

--- a/src/adcp/types/generated_poc/brand/verify_brand_claims_response.py
+++ b/src/adcp/types/generated_poc/brand/verify_brand_claims_response.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -17,7 +17,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from . import verification_status
 
 
-class ClaimType(Enum):
+class ClaimType(StrEnum):
     subsidiary = 'subsidiary'
     parent = 'parent'
     property = 'property'

--- a/src/adcp/types/generated_poc/bundled/content_standards/calibrate_content_request.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/calibrate_content_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -51,8 +51,8 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Role(Enum):
-    title = 'title'
+class Role(StrEnum):
+    title = 'title'  # type: ignore[assignment]
     paragraph = 'paragraph'
     heading = 'heading'
     caption = 'caption'
@@ -61,7 +61,7 @@ class Role(Enum):
     description = 'description'
 
 
-class ContentFormat(Enum):
+class ContentFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     text_html = 'text/html'
@@ -92,7 +92,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -100,7 +100,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role4(Enum):
+class Role4(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -164,7 +164,7 @@ class VerifyAgent3(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -212,13 +212,13 @@ class VerificationItem2(VerificationItem):
     pass
 
 
-class TranscriptFormat(Enum):
+class TranscriptFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     application_json = 'application/json'
 
 
-class TranscriptSource(Enum):
+class TranscriptSource(StrEnum):
     original_script = 'original_script'
     subtitles = 'subtitles'
     closed_captions = 'closed_captions'
@@ -242,7 +242,7 @@ class VerificationItem3(VerificationItem):
     pass
 
 
-class TranscriptSource3(Enum):
+class TranscriptSource3(StrEnum):
     original_script = 'original_script'
     closed_captions = 'closed_captions'
     generated = 'generated'
@@ -314,7 +314,7 @@ class AssetAccess4(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -344,7 +344,7 @@ class AssetAccess(RootModel[AssetAccess4 | AssetAccess5 | AssetAccess6]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -356,30 +356,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/calibrate_content_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/calibrate_content_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/content_standards/create_content_standards_request.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/create_content_standards_request.py
@@ -5,30 +5,30 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Source(Enum):
+class Source(StrEnum):
     registry = 'registry'
     inline = 'inline'
 
 
-class Category(Enum):
+class Category(StrEnum):
     regulation = 'regulation'
     standard = 'standard'
 
 
-class Enforcement(Enum):
+class Enforcement(StrEnum):
     must = 'must'
     should = 'should'
     may = 'may'
 
 
-class GovernanceDomain(Enum):
+class GovernanceDomain(StrEnum):
     campaign = 'campaign'
     property = 'property'
     creative = 'creative'
@@ -88,8 +88,8 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Role(Enum):
-    title = 'title'
+class Role(StrEnum):
+    title = 'title'  # type: ignore[assignment]
     paragraph = 'paragraph'
     heading = 'heading'
     caption = 'caption'
@@ -98,7 +98,7 @@ class Role(Enum):
     description = 'description'
 
 
-class ContentFormat(Enum):
+class ContentFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     text_html = 'text/html'
@@ -129,7 +129,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -137,7 +137,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role10(Enum):
+class Role10(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -201,7 +201,7 @@ class VerifyAgent13(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -249,13 +249,13 @@ class VerificationItem7(VerificationItem):
     pass
 
 
-class TranscriptFormat(Enum):
+class TranscriptFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     application_json = 'application/json'
 
 
-class TranscriptSource(Enum):
+class TranscriptSource(StrEnum):
     original_script = 'original_script'
     subtitles = 'subtitles'
     closed_captions = 'closed_captions'
@@ -279,7 +279,7 @@ class VerificationItem8(VerificationItem):
     pass
 
 
-class TranscriptSource5(Enum):
+class TranscriptSource5(StrEnum):
     original_script = 'original_script'
     closed_captions = 'closed_captions'
     generated = 'generated'
@@ -455,7 +455,7 @@ class AssetAccess7(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -485,7 +485,7 @@ class AssetAccess(RootModel[AssetAccess7 | AssetAccess8 | AssetAccess9]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -508,7 +508,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -520,30 +520,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/create_content_standards_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/create_content_standards_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/content_standards/get_content_standards_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/get_content_standards_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -318,7 +318,7 @@ class AssetAccess10(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -348,7 +348,7 @@ class AssetAccess(RootModel[AssetAccess10 | AssetAccess11 | AssetAccess12]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -371,7 +371,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -383,30 +383,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/get_media_buy_artifacts_request.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/get_media_buy_artifacts_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent423(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/content_standards/get_media_buy_artifacts_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/get_media_buy_artifacts_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -307,7 +307,7 @@ class AssetAccess13(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -337,7 +337,7 @@ class AssetAccess(RootModel[AssetAccess13 | AssetAccess14 | AssetAccess15]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -349,30 +349,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/list_content_standards_request.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/list_content_standards_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Channel(Enum):
+class Channel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'

--- a/src/adcp/types/generated_poc/bundled/content_standards/list_content_standards_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/list_content_standards_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -318,7 +318,7 @@ class AssetAccess16(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -348,7 +348,7 @@ class AssetAccess(RootModel[AssetAccess16 | AssetAccess17 | AssetAccess18]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -371,7 +371,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -383,30 +383,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/update_content_standards_request.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/update_content_standards_request.py
@@ -5,30 +5,30 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Source(Enum):
+class Source(StrEnum):
     registry = 'registry'
     inline = 'inline'
 
 
-class Category(Enum):
+class Category(StrEnum):
     regulation = 'regulation'
     standard = 'standard'
 
 
-class Enforcement(Enum):
+class Enforcement(StrEnum):
     must = 'must'
     should = 'should'
     may = 'may'
 
 
-class GovernanceDomain(Enum):
+class GovernanceDomain(StrEnum):
     campaign = 'campaign'
     property = 'property'
     creative = 'creative'
@@ -88,8 +88,8 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Role(Enum):
-    title = 'title'
+class Role(StrEnum):
+    title = 'title'  # type: ignore[assignment]
     paragraph = 'paragraph'
     heading = 'heading'
     caption = 'caption'
@@ -98,7 +98,7 @@ class Role(Enum):
     description = 'description'
 
 
-class ContentFormat(Enum):
+class ContentFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     text_html = 'text/html'
@@ -129,7 +129,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -137,7 +137,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role1283(Enum):
+class Role1283(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -201,7 +201,7 @@ class VerifyAgent2437(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -249,13 +249,13 @@ class VerificationItem1219(VerificationItem):
     pass
 
 
-class TranscriptFormat(Enum):
+class TranscriptFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     application_json = 'application/json'
 
 
-class TranscriptSource(Enum):
+class TranscriptSource(StrEnum):
     original_script = 'original_script'
     subtitles = 'subtitles'
     closed_captions = 'closed_captions'
@@ -279,7 +279,7 @@ class VerificationItem1220(VerificationItem):
     pass
 
 
-class TranscriptSource9(Enum):
+class TranscriptSource9(StrEnum):
     original_script = 'original_script'
     closed_captions = 'closed_captions'
     generated = 'generated'
@@ -455,7 +455,7 @@ class AssetAccess19(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -485,7 +485,7 @@ class AssetAccess(RootModel[AssetAccess19 | AssetAccess20 | AssetAccess21]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -508,7 +508,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -520,30 +520,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/update_content_standards_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/update_content_standards_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/content_standards/validate_content_delivery_request.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/validate_content_delivery_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -51,8 +51,8 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Role(Enum):
-    title = 'title'
+class Role(StrEnum):
+    title = 'title'  # type: ignore[assignment]
     paragraph = 'paragraph'
     heading = 'heading'
     caption = 'caption'
@@ -61,7 +61,7 @@ class Role(Enum):
     description = 'description'
 
 
-class ContentFormat(Enum):
+class ContentFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     text_html = 'text/html'
@@ -92,7 +92,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -100,7 +100,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role1300(Enum):
+class Role1300(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -164,7 +164,7 @@ class VerifyAgent2465(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -212,13 +212,13 @@ class VerificationItem1233(VerificationItem):
     pass
 
 
-class TranscriptFormat(Enum):
+class TranscriptFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     application_json = 'application/json'
 
 
-class TranscriptSource(Enum):
+class TranscriptSource(StrEnum):
     original_script = 'original_script'
     subtitles = 'subtitles'
     closed_captions = 'closed_captions'
@@ -242,7 +242,7 @@ class VerificationItem1234(VerificationItem):
     pass
 
 
-class TranscriptSource13(Enum):
+class TranscriptSource13(StrEnum):
     original_script = 'original_script'
     closed_captions = 'closed_captions'
     generated = 'generated'
@@ -319,7 +319,7 @@ class AssetAccess22(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -349,7 +349,7 @@ class AssetAccess(RootModel[AssetAccess22 | AssetAccess23 | AssetAccess24]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -361,30 +361,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/content_standards/validate_content_delivery_response.py
+++ b/src/adcp/types/generated_poc/bundled/content_standards/validate_content_delivery_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/core/tasks_get_response.py
+++ b/src/adcp/types/generated_poc/bundled/core/tasks_get_response.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -71,13 +72,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -142,7 +143,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'
@@ -183,7 +184,7 @@ class Progress(AdCPBaseModel):
     step_number: Annotated[int | None, Field(description='Current step number', ge=1)] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     request = 'request'
     response = 'response'
 
@@ -436,7 +437,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'
@@ -465,7 +466,7 @@ class FormatSchema(AdCPBaseModel):
     ]
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
@@ -474,7 +475,7 @@ class PlatformExtension(FormatSchema):
     pass
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -498,7 +499,7 @@ class AssetType(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -520,14 +521,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status(Enum):
+class Status(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'
@@ -630,7 +631,7 @@ class RequiredConnection(AdCPBaseModel):
     ] = None
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'
@@ -644,7 +645,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -653,7 +654,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -662,7 +663,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 
@@ -671,12 +672,12 @@ class RequiredConnection121(RequiredConnection):
     pass
 
 
-class MraidVersion(Enum):
+class MraidVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 
@@ -685,7 +686,7 @@ class RequiredConnection122(RequiredConnection):
     pass
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'
@@ -695,7 +696,7 @@ class RequiredConnection123(RequiredConnection):
     pass
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 
@@ -704,7 +705,7 @@ class RequiredConnection124(RequiredConnection):
     pass
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -714,7 +715,7 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class VideoCodec(Enum):
+class VideoCodec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -723,20 +724,20 @@ class VideoCodec(Enum):
     prores = 'prores'
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -754,7 +755,7 @@ class RequiredConnection125(RequiredConnection):
     pass
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -762,7 +763,7 @@ class VastVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 
@@ -775,7 +776,7 @@ class RequiredConnection126(RequiredConnection):
     pass
 
 
-class AudioCodec25(Enum):
+class AudioCodec25(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -787,7 +788,7 @@ class AudioSampleRate(CompanionBannerWidth):
     pass
 
 
-class AudioChannel(Enum):
+class AudioChannel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
@@ -796,7 +797,7 @@ class RequiredConnection127(RequiredConnection):
     pass
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
@@ -805,7 +806,7 @@ class RequiredConnection128(RequiredConnection):
     pass
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -820,13 +821,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -842,7 +843,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -861,7 +862,7 @@ class IconSize(Size):
     pass
 
 
-class ImageFormat23(Enum):
+class ImageFormat23(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -869,7 +870,7 @@ class ImageFormat23(Enum):
     webp = 'webp'
 
 
-class AssetSource48(Enum):
+class AssetSource48(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -885,18 +886,18 @@ class RequiredConnection131(RequiredConnection):
     pass
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     publisher_ref = 'publisher_ref'
     seller_inline = 'seller_inline'
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     targetable = 'targetable'
     included = 'included'
 
@@ -1030,7 +1031,7 @@ class Parameters21(AdCPBaseModel):
     ] = None
 
 
-class TimeUnit(Enum):
+class TimeUnit(StrEnum):
     hour = 'hour'
     day = 'day'
     week = 'week'
@@ -1165,7 +1166,7 @@ class SignalRef120(AdCPBaseModel):
     ]
 
 
-class Presence(Enum):
+class Presence(StrEnum):
     present = 'present'
     absent = 'absent'
 
@@ -1457,7 +1458,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -1465,7 +1466,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -1529,7 +1530,7 @@ class VerifyAgent1765(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -1606,7 +1607,7 @@ class Value(AudienceSize):
     pass
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -1722,7 +1723,7 @@ class NoticePeriod(AdCPBaseModel):
     ]
 
 
-class Type49(Enum):
+class Type49(StrEnum):
     percent_remaining = 'percent_remaining'
     full_commitment = 'full_commitment'
     fixed_fee = 'fixed_fee'
@@ -1835,7 +1836,7 @@ class SupportsGeoBreakdown(AdCPBaseModel):
     ] = None
 
 
-class DateRangeSupport(Enum):
+class DateRangeSupport(StrEnum):
     date_range = 'date_range'
     lifetime_only = 'lifetime_only'
 
@@ -2002,12 +2003,12 @@ class Range(AdCPBaseModel):
 
 
 
-class ActivationStatus(Enum):
+class ActivationStatus(StrEnum):
     ready = 'ready'
     requires_activation = 'requires_activation'
 
 
-class AllowedTargetingMode(Enum):
+class AllowedTargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 
@@ -2060,7 +2061,7 @@ class PricingOption232(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -2215,12 +2216,12 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class ResolutionModel(Enum):
+class ResolutionModel(StrEnum):
     direct_targeting = 'direct_targeting'
     seller_planned = 'seller_planned'
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     optional = 'optional'
     required = 'required'
     fixed = 'fixed'
@@ -2320,7 +2321,7 @@ class SignalTargetingRules(AdCPBaseModel):
     ] = None
 
 
-class SupportedMetric(Enum):
+class SupportedMetric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -2338,7 +2339,7 @@ class SupportedViewDuration(RootModel[float]):
     root: Annotated[float, Field(gt=0.0)]
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 
@@ -2359,7 +2360,7 @@ class VerificationItem888(VerificationItem):
     pass
 
 
-class Severity(Enum):
+class Severity(StrEnum):
     error = 'error'
     warning = 'warning'
     info = 'info'
@@ -2381,7 +2382,7 @@ class Issue90(AdCPBaseModel):
     ]
 
 
-class SupportedTarget20(Enum):
+class SupportedTarget20(StrEnum):
     cost_per = 'cost_per'
     per_ad_spend = 'per_ad_spend'
     maximize_value = 'maximize_value'
@@ -3294,7 +3295,7 @@ class VerificationItem903(VerificationItem):
     pass
 
 
-class ProposalStatus(Enum):
+class ProposalStatus(StrEnum):
     draft = 'draft'
     committed = 'committed'
 
@@ -3306,7 +3307,7 @@ class TotalBudget(AdCPBaseModel):
     ]
 
 
-class PaymentTerms4(Enum):
+class PaymentTerms4(StrEnum):
     net_30 = 'net_30'
     net_60 = 'net_60'
     net_90 = 'net_90'
@@ -3530,7 +3531,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class Status255(Enum):
+class Status255(StrEnum):
     applied = 'applied'
     partial = 'partial'
     unable = 'unable'
@@ -3618,7 +3619,7 @@ class RefinementApplied8(RootModel[RefinementApplied | RefinementApplied10 | Ref
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Scope182(Enum):
+class Scope182(StrEnum):
     products = 'products'
     pricing = 'pricing'
     forecast = 'forecast'
@@ -3651,7 +3652,7 @@ class IncompleteItem(AdCPBaseModel):
     ] = None
 
 
-class Semantics(Enum):
+class Semantics(StrEnum):
     only = 'only'
     any = 'any'
     approximate = 'approximate'
@@ -3729,7 +3730,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 
@@ -3768,7 +3769,7 @@ class Result948(AdCPBaseModel):
     ] = None
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     CLARIFICATION_NEEDED = 'CLARIFICATION_NEEDED'
     BUDGET_REQUIRED = 'BUDGET_REQUIRED'
 
@@ -5130,7 +5131,7 @@ class AdcpError47(AdCPBaseModel):
 
 
 
-class SignalType(Enum):
+class SignalType(StrEnum):
     marketplace = 'marketplace'
     custom = 'custom'
     owned = 'owned'
@@ -5338,7 +5339,7 @@ class VerificationItem927(VerificationItem):
     pass
 
 
-class Kind22(Enum):
+class Kind22(StrEnum):
     inventory = 'inventory'
     product = 'product'
     account = 'account'
@@ -5390,12 +5391,12 @@ class Scope231(AdCPBaseModel):
     ] = None
 
 
-class BucketSemantics(Enum):
+class BucketSemantics(StrEnum):
     exclusive = 'exclusive'
     overlapping = 'overlapping'
 
 
-class BucketCompleteness(Enum):
+class BucketCompleteness(StrEnum):
     complete = 'complete'
     partial = 'partial'
 
@@ -5574,7 +5575,7 @@ class PricingOption27(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class RestrictedAttribute(Enum):
+class RestrictedAttribute(StrEnum):
     racial_ethnic_origin = 'racial_ethnic_origin'
     political_opinions = 'political_opinions'
     religious_beliefs = 'religious_beliefs'
@@ -5606,7 +5607,7 @@ class ValueMapping(AdCPBaseModel):
     modifiers: list[str] | None = None
 
 
-class ParentMatchBehavior(Enum):
+class ParentMatchBehavior(StrEnum):
     exact_only = 'exact_only'
     descendants_supported = 'descendants_supported'
     unknown = 'unknown'
@@ -5625,7 +5626,7 @@ class Taxonomy(AdCPBaseModel):
     parent_match_behavior: ParentMatchBehavior | None = None
 
 
-class DataSource(Enum):
+class DataSource(StrEnum):
     app_behavior = 'app_behavior'
     app_usage = 'app_usage'
     web_usage = 'web_usage'
@@ -5645,7 +5646,7 @@ class DataSource(Enum):
     offline_transaction = 'offline_transaction'
 
 
-class Methodology(Enum):
+class Methodology(StrEnum):
     observed = 'observed'
     declared = 'declared'
     derived = 'derived'
@@ -5653,7 +5654,7 @@ class Methodology(Enum):
     modeled = 'modeled'
 
 
-class RefreshCadence(Enum):
+class RefreshCadence(StrEnum):
     intra_day = 'intra_day'
     daily = 'daily'
     weekly = 'weekly'
@@ -5664,7 +5665,7 @@ class RefreshCadence(Enum):
     annually = 'annually'
 
 
-class MatchKey(Enum):
+class MatchKey(StrEnum):
     name = 'name'
     address = 'address'
     email = 'email'
@@ -5677,7 +5678,7 @@ class MatchKey(Enum):
     phone = 'phone'
 
 
-class PreOnboardingPrecisionLevel(Enum):
+class PreOnboardingPrecisionLevel(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -5694,28 +5695,28 @@ class Onboarder(AdCPBaseModel):
     pre_onboarding_precision_level: PreOnboardingPrecisionLevel | None = None
 
 
-class ConsentBasi(Enum):
+class ConsentBasi(StrEnum):
     consent = 'consent'
     legitimate_interest = 'legitimate_interest'
     contract = 'contract'
     legal_obligation = 'legal_obligation'
 
 
-class Art9Basis(Enum):
+class Art9Basis(StrEnum):
     explicit_consent = 'explicit_consent'
     manifestly_made_public = 'manifestly_made_public'
     substantial_public_interest = 'substantial_public_interest'
     vital_interests = 'vital_interests'
 
 
-class Method(Enum):
+class Method(StrEnum):
     lookalike = 'lookalike'
     supervised = 'supervised'
     embedding = 'embedding'
     rules = 'rules'
 
 
-class Type53(Enum):
+class Type53(StrEnum):
     first_party_crm = 'first_party_crm'
     panel = 'panel'
     declared_survey = 'declared_survey'
@@ -5740,13 +5741,13 @@ class TrainingDataJurisdiction(Country):
     pass
 
 
-class AiActRiskClass(Enum):
+class AiActRiskClass(StrEnum):
     minimal = 'minimal'
     limited = 'limited'
     high_risk = 'high_risk'
 
 
-class Audience(Enum):
+class Audience(StrEnum):
     buyer = 'buyer'
     data_subject = 'data_subject'
     regulator = 'regulator'
@@ -5829,7 +5830,7 @@ class Modeling(AdCPBaseModel):
     ] = None
 
 
-class Right(Enum):
+class Right(StrEnum):
     access = 'access'
     rectification = 'rectification'
     erasure = 'erasure'
@@ -5928,7 +5929,7 @@ class Error44(AdCPBaseModel):
     ] = None
 
 
-class Scope232(Enum):
+class Scope232(StrEnum):
     signals = 'signals'
     pricing = 'pricing'
     wholesale_feed = 'wholesale_feed'
@@ -6205,7 +6206,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role977(Enum):
+class Role977(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'
@@ -6338,7 +6339,7 @@ class GovernanceAgent(AdCPBaseModel):
     url: Annotated[AnyUrl, Field(description='Governance agent endpoint URL. Must use HTTPS.')]
 
 
-class Format(Enum):
+class Format(StrEnum):
     jsonl = 'jsonl'
     csv = 'csv'
     parquet = 'parquet'
@@ -6346,7 +6347,7 @@ class Format(Enum):
     orc = 'orc'
 
 
-class Compression(Enum):
+class Compression(StrEnum):
     gzip = 'gzip'
     none = 'none'
 
@@ -6412,11 +6413,11 @@ class Gtin(MatchedGtin):
     pass
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -6568,7 +6569,7 @@ class GeoRegionsExcludeItem(GeoRegion):
     pass
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 
@@ -7002,7 +7003,7 @@ class StoreCatchment(AdCPBaseModel):
     ] = None
 
 
-class Type54(Enum):
+class Type54(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -7693,7 +7694,7 @@ class Result984(AdCPBaseModel):
     ] = None
 
 
-class Reason20(Enum):
+class Reason20(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     BUDGET_EXCEEDS_LIMIT = 'BUDGET_EXCEEDS_LIMIT'
 
@@ -8791,7 +8792,7 @@ class Result994(Result984):
     pass
 
 
-class Reason21(Enum):
+class Reason21(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CHANGE_CONFIRMATION = 'CHANGE_CONFIRMATION'
 
@@ -8928,7 +8929,7 @@ class Result996(AdCPBaseModel):
     ] = None
 
 
-class NotificationType3(Enum):
+class NotificationType3(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -8952,7 +8953,7 @@ class PostView5(Window):
     pass
 
 
-class Status306(Enum):
+class Status306(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     pending = 'pending'
@@ -8965,7 +8966,7 @@ class Status306(Enum):
     reporting_delayed = 'reporting_delayed'
 
 
-class Kind23(Enum):
+class Kind23(StrEnum):
     cumulative = 'cumulative'
     period = 'period'
     rolling = 'rolling'
@@ -9135,7 +9136,7 @@ class VerificationItem940(VerificationItem):
     pass
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     completed = 'completed'
     budget_exhausted = 'budget_exhausted'
@@ -9288,7 +9289,7 @@ class VerificationItem941(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -9296,7 +9297,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -9304,7 +9305,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -9548,7 +9549,7 @@ class VerificationItem954(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -9568,7 +9569,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role1006(Enum):
+class Role1006(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -9622,7 +9623,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status307(Enum):
+class Status307(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -9739,7 +9740,7 @@ class VerificationItem959(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -9749,7 +9750,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method54(Enum):
+class Method54(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -9770,7 +9771,7 @@ class VerificationItem960(VerificationItem):
     pass
 
 
-class Target104(Enum):
+class Target104(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -9792,7 +9793,7 @@ class VerificationItem961(VerificationItem):
     pass
 
 
-class Target105(Enum):
+class Target105(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -10202,7 +10203,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -14858,13 +14859,13 @@ class Error54(AdCPBaseModel):
     ] = None
 
 
-class KeepModeApplied(Enum):
+class KeepModeApplied(StrEnum):
     keep_all = 'keep_all'
     keep_one = 'keep_one'
     keep_some = 'keep_some'
 
 
-class SelectionStrategyApplied(Enum):
+class SelectionStrategyApplied(StrEnum):
     audience_relevance = 'audience_relevance'
     contextual_fit = 'contextual_fit'
     performance = 'performance'
@@ -14873,7 +14874,7 @@ class SelectionStrategyApplied(Enum):
     random = 'random'
 
 
-class BudgetStatus(Enum):
+class BudgetStatus(StrEnum):
     complete = 'complete'
     capped = 'capped'
 
@@ -15006,7 +15007,7 @@ class AdcpError57(AdCPBaseModel):
     ] = None
 
 
-class Basis(Enum):
+class Basis(StrEnum):
     fixed = 'fixed'
     estimated_units = 'estimated_units'
     cpm_deferred = 'cpm_deferred'
@@ -15373,7 +15374,7 @@ class Result1284(AdCPBaseModel):
     ] = None
 
 
-class Reason22(Enum):
+class Reason22(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CREATIVE_DIRECTION_NEEDED = 'CREATIVE_DIRECTION_NEEDED'
     ASSET_SELECTION_NEEDED = 'ASSET_SELECTION_NEEDED'
@@ -15718,7 +15719,7 @@ class BillingEntity4(AdCPBaseModel):
     ] = None
 
 
-class Action(Enum):
+class Action(StrEnum):
     created = 'created'
     updated = 'updated'
     unchanged = 'unchanged'
@@ -15726,7 +15727,7 @@ class Action(Enum):
     deleted = 'deleted'
 
 
-class Status319(Enum):
+class Status319(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -16091,7 +16092,7 @@ class Result1291(AdCPBaseModel):
     ] = None
 
 
-class Reason23(Enum):
+class Reason23(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     ASSET_CONFIRMATION = 'ASSET_CONFIRMATION'
     FORMAT_CLARIFICATION = 'FORMAT_CLARIFICATION'
@@ -16293,7 +16294,7 @@ class AdcpError63(AdCPBaseModel):
     ] = None
 
 
-class Status320(Enum):
+class Status320(StrEnum):
     approved = 'approved'
     pending = 'pending'
     rejected = 'rejected'
@@ -16751,7 +16752,7 @@ class Result1297(AdCPBaseModel):
     ] = None
 
 
-class Reason24(Enum):
+class Reason24(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     FEED_VALIDATION = 'FEED_VALIDATION'
     ITEM_REVIEW = 'ITEM_REVIEW'
@@ -16893,7 +16894,7 @@ class Result1299(AdCPBaseModel):
     ] = None
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -16905,12 +16906,12 @@ class TaskStatus(Enum):
     unknown = 'unknown'
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
 
-class AdCPProtocol(Enum):
+class AdCPProtocol(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
     governance = 'governance'
@@ -16920,7 +16921,7 @@ class AdCPProtocol(Enum):
     measurement = 'measurement'
 
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -16943,7 +16944,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'
@@ -16959,20 +16960,20 @@ class LogoSlot(Enum):
     marketplace_listing = 'marketplace_listing'
 
 
-class VideoPlacementType(Enum):
+class VideoPlacementType(StrEnum):
     instream = 'instream'
     accompanying_content = 'accompanying_content'
     interstitial = 'interstitial'
     standalone = 'standalone'
 
 
-class SponsoredPlacementType(Enum):
+class SponsoredPlacementType(StrEnum):
     sponsored_search = 'sponsored_search'
     sponsored_display = 'sponsored_display'
     sponsored_native = 'sponsored_native'
 
 
-class SocialPlacementSurface(Enum):
+class SocialPlacementSurface(StrEnum):
     feed = 'feed'
     stories = 'stories'
     short_video = 'short_video'
@@ -16980,25 +16981,25 @@ class SocialPlacementSurface(Enum):
     search = 'search'
 
 
-class DeliveryType(Enum):
+class DeliveryType(StrEnum):
     guaranteed = 'guaranteed'
     non_guaranteed = 'non_guaranteed'
 
 
-class Exclusivity(Enum):
+class Exclusivity(StrEnum):
     none = 'none'
     category = 'category'
     exclusive = 'exclusive'
 
 
-class PriceAdjustmentKind(Enum):
+class PriceAdjustmentKind(StrEnum):
     fee = 'fee'
     discount = 'discount'
     commission = 'commission'
     settlement = 'settlement'
 
 
-class DemographicSystem(Enum):
+class DemographicSystem(StrEnum):
     nielsen = 'nielsen'
     barb = 'barb'
     agf = 'agf'
@@ -17007,7 +17008,7 @@ class DemographicSystem(Enum):
     custom = 'custom'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -17041,14 +17042,14 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class GeographicTargetingLevel(Enum):
+class GeographicTargetingLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
     postal_area = 'postal_area'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -17056,7 +17057,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -17070,7 +17071,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -17079,7 +17080,7 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -17094,7 +17095,7 @@ class DevicePlatform(Enum):
     unknown = 'unknown'
 
 
-class AudienceSource(Enum):
+class AudienceSource(StrEnum):
     synced = 'synced'
     platform = 'platform'
     third_party = 'third_party'
@@ -17103,7 +17104,7 @@ class AudienceSource(Enum):
     unknown = 'unknown'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -17115,30 +17116,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -17149,12 +17150,12 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class ForecastRangeUnit(Enum):
+class ForecastRangeUnit(StrEnum):
     spend = 'spend'
     availability = 'availability'
     reach_freq = 'reach_freq'
@@ -17165,13 +17166,13 @@ class ForecastRangeUnit(Enum):
     package = 'package'
 
 
-class ForecastMethod(Enum):
+class ForecastMethod(StrEnum):
     estimate = 'estimate'
     modeled = 'modeled'
     guaranteed = 'guaranteed'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -17180,13 +17181,13 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class MakegoodRemedy(Enum):
+class MakegoodRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'
 
 
-class PerformanceStandardMetric(Enum):
+class PerformanceStandardMetric(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -17194,7 +17195,7 @@ class PerformanceStandardMetric(Enum):
     attention_score = 'attention_score'
 
 
-class MediaBuyValidAction(Enum):
+class MediaBuyValidAction(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'
@@ -17218,13 +17219,13 @@ class MediaBuyValidAction(Enum):
     sync_creatives = 'sync_creatives'
 
 
-class MediaBuyActionMode(Enum):
+class MediaBuyActionMode(StrEnum):
     self_serve = 'self_serve'
     conditional_self_serve = 'conditional_self_serve'
     requires_approval = 'requires_approval'
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -17234,13 +17235,13 @@ class MediaBuyStatus(Enum):
     canceled = 'canceled'
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -17279,25 +17280,25 @@ class AvailableMetric(Enum):
     brand_search_lift = 'brand_search_lift'
 
 
-class CoBrandingRequirement(Enum):
+class CoBrandingRequirement(StrEnum):
     required = 'required'
     optional = 'optional'
     none = 'none'
 
 
-class LandingPageRequirement(Enum):
+class LandingPageRequirement(StrEnum):
     any = 'any'
     retailer_site_only = 'retailer_site_only'
     must_include_retailer = 'must_include_retailer'
 
 
-class SignalValueType(Enum):
+class SignalValueType(StrEnum):
     binary = 'binary'
     categorical = 'categorical'
     numeric = 'numeric'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -17313,14 +17314,14 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class AssessmentStatus(Enum):
+class AssessmentStatus(StrEnum):
     insufficient = 'insufficient'
     minimum = 'minimum'
     good = 'good'
     excellent = 'excellent'
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -17332,7 +17333,7 @@ class ActionSource(Enum):
     other = 'other'
 
 
-class InstallmentStatus(Enum):
+class InstallmentStatus(StrEnum):
     scheduled = 'scheduled'
     tentative = 'tentative'
     live = 'live'
@@ -17342,7 +17343,7 @@ class InstallmentStatus(Enum):
     published = 'published'
 
 
-class ContentRatingSystem(Enum):
+class ContentRatingSystem(StrEnum):
     tv_parental = 'tv_parental'
     mpaa = 'mpaa'
     podcast = 'podcast'
@@ -17356,7 +17357,7 @@ class ContentRatingSystem(Enum):
     custom = 'custom'
 
 
-class SpecialCategory(Enum):
+class SpecialCategory(StrEnum):
     awards = 'awards'
     championship = 'championship'
     concert = 'concert'
@@ -17371,7 +17372,7 @@ class SpecialCategory(Enum):
     tribute = 'tribute'
 
 
-class TalentRole(Enum):
+class TalentRole(StrEnum):
     host = 'host'
     guest = 'guest'
     creator = 'creator'
@@ -17383,7 +17384,7 @@ class TalentRole(Enum):
     analyst = 'analyst'
 
 
-class DerivativeType(Enum):
+class DerivativeType(StrEnum):
     clip = 'clip'
     highlight = 'highlight'
     recap = 'recap'
@@ -17391,14 +17392,14 @@ class DerivativeType(Enum):
     bonus = 'bonus'
 
 
-class TMPResponseType(Enum):
+class TMPResponseType(StrEnum):
     activation = 'activation'
     catalog_items = 'catalog_items'
     creative = 'creative'
     deal = 'deal'
 
 
-class UIDType(Enum):
+class UIDType(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'
@@ -17411,7 +17412,7 @@ class UIDType(Enum):
     other = 'other'
 
 
-class DayOfWeek(Enum):
+class DayOfWeek(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -17421,7 +17422,7 @@ class DayOfWeek(Enum):
     sunday = 'sunday'
 
 
-class AccountStatus(Enum):
+class AccountStatus(StrEnum):
     active = 'active'
     pending_approval = 'pending_approval'
     rejected = 'rejected'
@@ -17430,13 +17431,13 @@ class AccountStatus(Enum):
     closed = 'closed'
 
 
-class BillingParty(Enum):
+class BillingParty(StrEnum):
     operator = 'operator'
     agent = 'agent'
     advertiser = 'advertiser'
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_15 = 'net_15'
     net_30 = 'net_30'
     net_45 = 'net_45'
@@ -17445,20 +17446,20 @@ class PaymentTerms(Enum):
     prepay = 'prepay'
 
 
-class AccountScope(Enum):
+class AccountScope(StrEnum):
     operator = 'operator'
     brand = 'brand'
     operator_brand = 'operator_brand'
     agent = 'agent'
 
 
-class CloudStorageProtocol(Enum):
+class CloudStorageProtocol(StrEnum):
     s3 = 's3'
     gcs = 'gcs'
     azure_blob = 'azure_blob'
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -17477,13 +17478,13 @@ class NotificationType(Enum):
     wholesale_feed_bulk_change = 'wholesale_feed.bulk_change'
 
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     even = 'even'
     asap = 'asap'
     front_loaded = 'front_loaded'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -17494,14 +17495,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -17516,7 +17517,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -17532,7 +17533,7 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class AgeVerificationMethod(Enum):
+class AgeVerificationMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -17540,43 +17541,43 @@ class AgeVerificationMethod(Enum):
     world_id = 'world_id'
 
 
-class TravelTimeUnit(Enum):
+class TravelTimeUnit(StrEnum):
     min = 'min'
     hr = 'hr'
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class DistanceUnit(Enum):
+class DistanceUnit(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'
     modeled = 'modeled'
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'
@@ -17584,7 +17585,7 @@ class LiftDimension(Enum):
     ad_recall = 'ad_recall'
 
 
-class AttributionModel(Enum):
+class AttributionModel(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -17592,12 +17593,12 @@ class AttributionModel(Enum):
     data_driven = 'data_driven'
 
 
-class CanceledBy(Enum):
+class CanceledBy(StrEnum):
     buyer = 'buyer'
     seller = 'seller'
 
 
-class PricingModel(Enum):
+class PricingModel(StrEnum):
     cpm = 'cpm'
     vcpm = 'vcpm'
     cpc = 'cpc'
@@ -17609,34 +17610,34 @@ class PricingModel(Enum):
     time = 'time'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -17675,24 +17676,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -17770,20 +17771,20 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -17809,12 +17810,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class RightUse(Enum):
+class RightUse(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -17829,7 +17830,7 @@ class RightUse(Enum):
     ai_generated_image = 'ai_generated_image'
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -17837,7 +17838,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class CreativeIdentifierType(Enum):
+class CreativeIdentifierType(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'

--- a/src/adcp/types/generated_poc/bundled/core/tasks_list_request.py
+++ b/src/adcp/types/generated_poc/bundled/core/tasks_list_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AwareDatetime, ConfigDict, Field
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     created_at = 'created_at'
     updated_at = 'updated_at'
     status = 'status'
@@ -19,7 +19,7 @@ class Field1(Enum):
     protocol = 'protocol'
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -47,7 +47,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class AdCPProtocol(Enum):
+class AdCPProtocol(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
     governance = 'governance'
@@ -57,7 +57,7 @@ class AdCPProtocol(Enum):
     measurement = 'measurement'
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -69,7 +69,7 @@ class TaskStatus(Enum):
     unknown = 'unknown'
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'

--- a/src/adcp/types/generated_poc/bundled/core/tasks_list_response.py
+++ b/src/adcp/types/generated_poc/bundled/core/tasks_list_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -69,13 +69,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -140,7 +140,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -211,7 +211,7 @@ class DomainBreakdown(AdCPBaseModel):
     ] = None
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -249,7 +249,7 @@ class QuerySummary(AdCPBaseModel):
     ] = None
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'
@@ -274,7 +274,7 @@ class TaskType(Enum):
     acquire_rights = 'acquire_rights'
 
 
-class Domain(Enum):
+class Domain(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
 
@@ -301,7 +301,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'

--- a/src/adcp/types/generated_poc/bundled/creative/get_creative_delivery_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/get_creative_delivery_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent43(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/creative/get_creative_delivery_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/get_creative_delivery_response.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -12,7 +13,7 @@ from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel, StringConstraints
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -82,13 +83,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -153,7 +154,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -265,13 +266,13 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     cumulative = 'cumulative'
     period = 'period'
     rolling = 'rolling'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -394,7 +395,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -402,7 +403,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -466,7 +467,7 @@ class VerifyAgent45(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -581,7 +582,7 @@ class VerificationItem25(VerificationItem):
     pass
 
 
-class FormatKind(Enum):
+class FormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -657,7 +658,7 @@ class VerificationItem26(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -665,7 +666,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -673,7 +674,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -917,7 +918,7 @@ class VerificationItem39(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -937,7 +938,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role45(Enum):
+class Role45(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -976,11 +977,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -1072,7 +1073,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status24(Enum):
+class Status24(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -1208,7 +1209,7 @@ class VerificationItem44(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -1218,7 +1219,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -1239,7 +1240,7 @@ class VerificationItem45(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -1261,7 +1262,7 @@ class VerificationItem46(VerificationItem):
     pass
 
 
-class Target2(Enum):
+class Target2(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1667,7 +1668,7 @@ class RightsAgent(AdCPBaseModel):
     id: Annotated[str, Field(description='Agent identifier')]
 
 
-class Use(Enum):
+class Use(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -1690,7 +1691,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -1698,7 +1699,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -1771,7 +1772,7 @@ class Right(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -2584,7 +2585,7 @@ class VerificationItem117(VerificationItem):
     pass
 
 
-class Type15(Enum):
+class Type15(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'
@@ -2760,7 +2761,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -2794,7 +2795,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -2803,7 +2804,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -2815,30 +2816,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -2849,12 +2850,12 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -2866,34 +2867,34 @@ class ActionSource(Enum):
     other = 'other'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -2901,7 +2902,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -2940,24 +2941,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -3035,25 +3036,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -3079,12 +3080,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -3100,7 +3101,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -3111,14 +3112,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/bundled/creative/get_creative_features_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/get_creative_features_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -51,7 +52,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class FormatKind(Enum):
+class FormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -135,7 +136,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -143,7 +144,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -207,7 +208,7 @@ class VerifyAgent237(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -239,7 +240,7 @@ class VerificationItem(AdCPBaseModel):
     ] = None
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -247,7 +248,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -255,7 +256,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -499,7 +500,7 @@ class VerificationItem131(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -519,7 +520,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role141(Enum):
+class Role141(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -558,11 +559,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -654,7 +655,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -790,7 +791,7 @@ class VerificationItem136(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -800,7 +801,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -821,7 +822,7 @@ class VerificationItem137(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -843,7 +844,7 @@ class VerificationItem138(VerificationItem):
     pass
 
 
-class Target10(Enum):
+class Target10(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1267,7 +1268,7 @@ class RightsAgent(AdCPBaseModel):
     id: Annotated[str, Field(description='Agent identifier')]
 
 
-class Use(Enum):
+class Use(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -1290,7 +1291,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -1298,7 +1299,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -1371,7 +1372,7 @@ class Right(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -2212,7 +2213,7 @@ class VerificationItem210(VerificationItem):
     pass
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -2224,30 +2225,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -2258,34 +2259,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -2293,7 +2294,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -2332,24 +2333,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -2427,25 +2428,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -2471,12 +2472,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -2492,7 +2493,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -2503,14 +2504,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -2544,7 +2545,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/bundled/creative/get_creative_features_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/get_creative_features_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/creative/list_creative_formats_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/list_creative_formats_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -51,14 +51,14 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     audio = 'audio'
     video = 'video'
     display = 'display'
     dooh = 'dooh'
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -76,7 +76,7 @@ class AssetType(Enum):
     published_post = 'published_post'
 
 
-class WcagLevel(Enum):
+class WcagLevel(StrEnum):
     A = 'A'
     AA = 'AA'
     AAA = 'AAA'
@@ -111,7 +111,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -147,7 +147,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -155,7 +155,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -183,7 +183,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -240,7 +240,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -265,7 +265,7 @@ class VerifyAgent1109(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -304,7 +304,7 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -358,7 +358,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -369,7 +369,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'

--- a/src/adcp/types/generated_poc/bundled/creative/list_creative_formats_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/list_creative_formats_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -250,7 +250,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class AcceptsParameter(Enum):
+class AcceptsParameter(StrEnum):
     dimensions = 'dimensions'
     duration = 'duration'
 
@@ -260,7 +260,7 @@ class Responsive(AdCPBaseModel):
     height: bool
 
 
-class Format(Enum):
+class Format(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -290,13 +290,13 @@ class Bleed3(AdCPBaseModel):
     left: Annotated[float, Field(ge=0.0)]
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rgb = 'rgb'
     cmyk = 'cmyk'
     grayscale = 'grayscale'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
@@ -304,7 +304,7 @@ class Container(Enum):
     mkv = 'mkv'
 
 
-class Codec(Enum):
+class Codec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -317,7 +317,7 @@ class FrameRate(RootModel[float]):
     root: Annotated[float, Field(ge=1.0)]
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     pcm = 'pcm'
     ac3 = 'ac3'
@@ -332,7 +332,7 @@ class AudioSampleRate(RootModel[int]):
     root: Annotated[int, Field(ge=1)]
 
 
-class Format20(Enum):
+class Format20(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -344,7 +344,7 @@ class SampleRate(AudioSampleRate):
     pass
 
 
-class Channel(Enum):
+class Channel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
@@ -413,7 +413,7 @@ class Requirements4(AdCPBaseModel):
     max_length: Annotated[int | None, Field(description='Maximum character length', ge=1)] = None
 
 
-class Sandbox(Enum):
+class Sandbox(StrEnum):
     none = 'none'
     iframe = 'iframe'
     safeframe = 'safeframe'
@@ -456,7 +456,7 @@ class Requirements6(AdCPBaseModel):
     ] = None
 
 
-class ModuleType(Enum):
+class ModuleType(StrEnum):
     script = 'script'
     module = 'module'
     iife = 'iife'
@@ -491,7 +491,7 @@ class Requirements7(AdCPBaseModel):
     ] = None
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -516,7 +516,7 @@ class Requirements9(AdCPBaseModel):
     ] = None
 
 
-class Role(Enum):
+class Role(StrEnum):
     clickthrough = 'clickthrough'
     landing_page = 'landing_page'
     impression_tracker = 'impression_tracker'
@@ -525,7 +525,7 @@ class Role(Enum):
     third_party_tracker = 'third_party_tracker'
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     https = 'https'
     http = 'http'
 
@@ -556,7 +556,7 @@ class Requirements10(AdCPBaseModel):
     ] = None
 
 
-class Method(Enum):
+class Method(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
@@ -568,7 +568,7 @@ class Requirements11(AdCPBaseModel):
     methods: Annotated[list[Method] | None, Field(description='Allowed HTTP methods')] = None
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -584,7 +584,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -595,7 +595,7 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -661,7 +661,7 @@ class AssetRequirements12(Requirements11):
     pass
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     sequential = 'sequential'
     optimize = 'optimize'
 
@@ -714,7 +714,7 @@ class Requirements24(Requirements11):
     pass
 
 
-class SupportedMacros(Enum):
+class SupportedMacros(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -817,7 +817,7 @@ class FormatCard(AdCPBaseModel):
     ]
 
 
-class WcagLevel(Enum):
+class WcagLevel(StrEnum):
     A = 'A'
     AA = 'AA'
     AAA = 'AAA'
@@ -839,7 +839,7 @@ class Accessibility(AdCPBaseModel):
     ] = None
 
 
-class PersistenceEnum(Enum):
+class PersistenceEnum(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
@@ -864,7 +864,7 @@ class FormatCardDetailed(AdCPBaseModel):
     ]
 
 
-class ReportedMetric(Enum):
+class ReportedMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -951,7 +951,7 @@ class PricingOption192(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -1106,7 +1106,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Kind(Enum):
+class Kind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -1122,7 +1122,7 @@ class Kind(Enum):
     custom = 'custom'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -1187,7 +1187,7 @@ class Canonical(AdCPBaseModel):
     ] = None
 
 
-class AppliesToChannel(Enum):
+class AppliesToChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -1210,7 +1210,7 @@ class AppliesToChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'
@@ -1239,7 +1239,7 @@ class FormatSchema(AdCPBaseModel):
     ]
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
@@ -1248,7 +1248,7 @@ class PlatformExtension(FormatSchema):
     pass
 
 
-class AssetType111(Enum):
+class AssetType111(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -1272,7 +1272,7 @@ class AssetType111(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -1294,14 +1294,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status159(Enum):
+class Status159(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'
@@ -1404,7 +1404,7 @@ class RequiredConnection(AdCPBaseModel):
     ] = None
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'
@@ -1418,7 +1418,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -1427,7 +1427,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 
@@ -1436,12 +1436,12 @@ class RequiredConnection109(RequiredConnection):
     pass
 
 
-class MraidVersion(Enum):
+class MraidVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 
@@ -1450,7 +1450,7 @@ class RequiredConnection110(RequiredConnection):
     pass
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'
@@ -1460,7 +1460,7 @@ class RequiredConnection111(RequiredConnection):
     pass
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 
@@ -1469,7 +1469,7 @@ class RequiredConnection112(RequiredConnection):
     pass
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -1479,20 +1479,20 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class AudioCodec22(Enum):
+class AudioCodec22(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container12(Enum):
+class Container12(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -1510,7 +1510,7 @@ class RequiredConnection113(RequiredConnection):
     pass
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 
@@ -1523,7 +1523,7 @@ class RequiredConnection114(RequiredConnection):
     pass
 
 
-class AudioCodec23(Enum):
+class AudioCodec23(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -1535,7 +1535,7 @@ class RequiredConnection115(RequiredConnection):
     pass
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
@@ -1544,7 +1544,7 @@ class RequiredConnection116(RequiredConnection):
     pass
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -1559,13 +1559,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -1581,7 +1581,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -1600,7 +1600,7 @@ class IconSize(Size):
     pass
 
 
-class ImageFormat20(Enum):
+class ImageFormat20(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -1608,7 +1608,7 @@ class ImageFormat20(Enum):
     webp = 'webp'
 
 
-class AssetSource43(Enum):
+class AssetSource43(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -1624,7 +1624,7 @@ class RequiredConnection119(RequiredConnection):
     pass
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'
@@ -1709,7 +1709,7 @@ class CanonicalParameters12(AdCPBaseModel):
     ]
 
 
-class Capability(Enum):
+class Capability(StrEnum):
     validation = 'validation'
     assembly = 'assembly'
     generation = 'generation'
@@ -1870,14 +1870,14 @@ class AssetPoolBinding(AdCPBaseModel):
     ] = None
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class DimensionUnit(Enum):
+class DimensionUnit(StrEnum):
     px = 'px'
     dp = 'dp'
     inches = 'inches'
@@ -1886,7 +1886,7 @@ class DimensionUnit(Enum):
     pt = 'pt'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -1897,17 +1897,17 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'
@@ -1923,12 +1923,12 @@ class LogoSlot(Enum):
     marketplace_listing = 'marketplace_listing'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
@@ -1955,7 +1955,7 @@ class Visual(AdCPBaseModel):
     ] = None
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     px = 'px'
     fraction = 'fraction'
     inches = 'inches'

--- a/src/adcp/types/generated_poc/bundled/creative/list_creatives_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/list_creatives_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -56,7 +56,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -64,7 +64,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -128,7 +128,7 @@ class VerifyAgent1111(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -169,7 +169,7 @@ class Colors(AdCPBaseModel):
     accent: Annotated[str | None, Field(pattern='^#[0-9a-fA-F]{6}$')] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -218,7 +218,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     created_date = 'created_date'
     updated_date = 'updated_date'
     name = 'name'
@@ -226,7 +226,7 @@ class Field1(Enum):
     assignment_count = 'assignment_count'
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -276,7 +276,7 @@ class VerificationItem556(VerificationItem):
     pass
 
 
-class Field6(Enum):
+class Field6(StrEnum):
     creative_id = 'creative_id'
     name = 'name'
     format_id = 'format_id'
@@ -292,7 +292,7 @@ class Field6(Enum):
     pricing_options = 'pricing_options'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -304,30 +304,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/creative/list_creatives_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/list_creatives_response.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -12,7 +13,7 @@ from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel, StringConstraints
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -82,13 +83,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -153,7 +154,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -207,7 +208,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class Status173(Enum):
+class Status173(StrEnum):
     active = 'active'
     pending_approval = 'pending_approval'
     rejected = 'rejected'
@@ -249,7 +250,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -257,7 +258,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -321,7 +322,7 @@ class VerifyAgent1115(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -362,7 +363,7 @@ class Colors(AdCPBaseModel):
     accent: Annotated[str | None, Field(pattern='^#[0-9a-fA-F]{6}$')] = None
 
 
-class Billing(Enum):
+class Billing(StrEnum):
     operator = 'operator'
     agent = 'agent'
     advertiser = 'advertiser'
@@ -385,7 +386,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role590(Enum):
+class Role590(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'
@@ -490,7 +491,7 @@ class BillingEntity(AdCPBaseModel):
     ] = None
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_15 = 'net_15'
     net_30 = 'net_30'
     net_45 = 'net_45'
@@ -520,7 +521,7 @@ class Setup(AdCPBaseModel):
     ] = None
 
 
-class AccountScope(Enum):
+class AccountScope(StrEnum):
     operator = 'operator'
     brand = 'brand'
     operator_brand = 'operator_brand'
@@ -534,13 +535,13 @@ class GovernanceAgent(AdCPBaseModel):
     url: Annotated[AnyUrl, Field(description='Governance agent endpoint URL. Must use HTTPS.')]
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     s3 = 's3'
     gcs = 'gcs'
     azure_blob = 'azure_blob'
 
 
-class Format(Enum):
+class Format(StrEnum):
     jsonl = 'jsonl'
     csv = 'csv'
     parquet = 'parquet'
@@ -548,7 +549,7 @@ class Format(Enum):
     orc = 'orc'
 
 
-class Compression(Enum):
+class Compression(StrEnum):
     gzip = 'gzip'
     none = 'none'
 
@@ -652,7 +653,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class Status174(Enum):
+class Status174(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -677,7 +678,7 @@ class VerificationItem558(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -685,7 +686,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -693,7 +694,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -937,7 +938,7 @@ class VerificationItem571(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -957,7 +958,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role605(Enum):
+class Role605(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -996,11 +997,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -1092,7 +1093,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status175(Enum):
+class Status175(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -1228,7 +1229,7 @@ class VerificationItem576(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -1238,7 +1239,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -1259,7 +1260,7 @@ class VerificationItem577(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -1281,7 +1282,7 @@ class VerificationItem578(VerificationItem):
     pass
 
 
-class Target56(Enum):
+class Target56(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1666,7 +1667,7 @@ class VerificationItem601(VerificationItem):
     pass
 
 
-class VariableType(Enum):
+class VariableType(StrEnum):
     text = 'text'
     image = 'image'
     video = 'video'
@@ -1752,7 +1753,7 @@ class Snapshot(AdCPBaseModel):
     ] = None
 
 
-class SnapshotUnavailableReason(Enum):
+class SnapshotUnavailableReason(StrEnum):
     SNAPSHOT_UNSUPPORTED = 'SNAPSHOT_UNSUPPORTED'
     SNAPSHOT_TEMPORARILY_UNAVAILABLE = 'SNAPSHOT_TEMPORARILY_UNAVAILABLE'
     SNAPSHOT_PERMISSION_DENIED = 'SNAPSHOT_PERMISSION_DENIED'
@@ -1866,7 +1867,7 @@ class PricingOption202(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -2021,7 +2022,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class ReasonCode(Enum):
+class ReasonCode(StrEnum):
     review_passed = 'review_passed'
     review_failure = 'review_failure'
     processing_failure = 'processing_failure'
@@ -2064,7 +2065,7 @@ class Purge(AdCPBaseModel):
     ]
 
 
-class Status177(Enum):
+class Status177(StrEnum):
     success = 'success'
     failed = 'failed'
     timeout = 'timeout'
@@ -2151,12 +2152,12 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -2168,30 +2169,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -2202,7 +2203,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -2221,34 +2222,34 @@ class NotificationType(Enum):
     wholesale_feed_bulk_change = 'wholesale_feed.bulk_change'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -2256,7 +2257,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -2295,24 +2296,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -2390,25 +2391,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -2434,12 +2435,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -2455,7 +2456,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -2466,14 +2467,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -2507,7 +2508,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/bundled/creative/list_transformers_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/list_transformers_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -89,7 +89,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -125,7 +125,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -133,7 +133,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -161,7 +161,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -218,7 +218,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -243,7 +243,7 @@ class VerifyAgent1211(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -282,13 +282,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -380,7 +380,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/creative/list_transformers_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/list_transformers_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -279,14 +279,14 @@ class OutputFormatId(InputFormatId):
     pass
 
 
-class Type(Enum):
+class Type(StrEnum):
     string = 'string'
     number = 'number'
     integer = 'integer'
     boolean = 'boolean'
 
 
-class ValueSource(Enum):
+class ValueSource(StrEnum):
     inline = 'inline'
     range = 'range'
     enumerable = 'enumerable'
@@ -427,7 +427,7 @@ class PricingOption222(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -582,7 +582,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class VariantDimension(Enum):
+class VariantDimension(StrEnum):
     voice = 'voice'
     theme = 'theme'
     best_of_n = 'best_of_n'

--- a/src/adcp/types/generated_poc/bundled/creative/preview_creative_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/preview_creative_request.py
@@ -4,14 +4,15 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel, StringConstraints
 
 
-class RequestType(Enum):
+class RequestType(StrEnum):
     single = 'single'
     batch = 'batch'
     variant = 'variant'
@@ -125,7 +126,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -133,7 +134,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -197,7 +198,7 @@ class VerifyAgent1213(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -229,7 +230,7 @@ class VerificationItem(AdCPBaseModel):
     ] = None
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -237,7 +238,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -245,7 +246,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -489,7 +490,7 @@ class VerificationItem619(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -509,7 +510,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role655(Enum):
+class Role655(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -548,11 +549,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -644,7 +645,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -780,7 +781,7 @@ class VerificationItem624(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -790,7 +791,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -811,7 +812,7 @@ class VerificationItem625(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -833,7 +834,7 @@ class VerificationItem626(VerificationItem):
     pass
 
 
-class Target67(Enum):
+class Target67(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1265,7 +1266,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -3608,7 +3609,7 @@ class Input7(AdCPBaseModel):
     ] = None
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -3624,7 +3625,7 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -3636,30 +3637,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -3670,34 +3671,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -3705,7 +3706,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -3744,24 +3745,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -3839,25 +3840,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -3883,12 +3884,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -3904,7 +3905,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -3915,14 +3916,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -3956,7 +3957,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -3971,7 +3972,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class RightUse(Enum):
+class RightUse(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -3986,7 +3987,7 @@ class RightUse(Enum):
     ai_generated_image = 'ai_generated_image'
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -3994,19 +3995,19 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class CreativeIdentifierType(Enum):
+class CreativeIdentifierType(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
     idcrea = 'idcrea'
 
 
-class CreativeQuality(Enum):
+class CreativeQuality(StrEnum):
     draft = 'draft'
     production = 'production'
 
 
-class PreviewOutputFormat(Enum):
+class PreviewOutputFormat(StrEnum):
     url = 'url'
     html = 'html'
 

--- a/src/adcp/types/generated_poc/bundled/creative/preview_creative_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/preview_creative_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -302,7 +302,7 @@ class PreviewCreativeResponse(AdCPBaseModel):
     ] = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -314,30 +314,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -348,34 +348,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -383,7 +383,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -422,24 +422,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -517,25 +517,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -561,12 +561,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -582,7 +582,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -593,14 +593,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -634,7 +634,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/bundled/creative/sync_creatives_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/sync_creatives_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -56,7 +57,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -64,7 +65,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -128,7 +129,7 @@ class VerifyAgent1583(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -209,7 +210,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class FormatKind(Enum):
+class FormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -285,7 +286,7 @@ class VerificationItem792(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -293,7 +294,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -301,7 +302,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -545,7 +546,7 @@ class VerificationItem805(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -565,7 +566,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role850(Enum):
+class Role850(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -604,11 +605,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -700,7 +701,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -836,7 +837,7 @@ class VerificationItem810(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -846,7 +847,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -867,7 +868,7 @@ class VerificationItem811(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -889,7 +890,7 @@ class VerificationItem812(VerificationItem):
     pass
 
 
-class Target83(Enum):
+class Target83(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1288,7 +1289,7 @@ class Input(AdCPBaseModel):
     ] = None
 
 
-class Status200(Enum):
+class Status200(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -1316,7 +1317,7 @@ class PlacementRef(AdCPBaseModel):
     ]
 
 
-class Type(Enum):
+class Type(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -2132,12 +2133,12 @@ class Assignment(AdCPBaseModel):
     ] = None
 
 
-class ValidationMode(Enum):
+class ValidationMode(StrEnum):
     strict = 'strict'
     lenient = 'lenient'
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -2195,7 +2196,7 @@ class PushNotificationConfig(AdCPBaseModel):
     ] = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -2207,30 +2208,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -2241,34 +2242,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -2276,7 +2277,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -2315,24 +2316,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -2410,25 +2411,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -2454,12 +2455,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -2475,7 +2476,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -2486,14 +2487,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -2527,7 +2528,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/bundled/creative/sync_creatives_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/sync_creatives_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/creative/validate_input_request.py
+++ b/src/adcp/types/generated_poc/bundled/creative/validate_input_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -56,7 +57,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -64,7 +65,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -128,7 +129,7 @@ class VerifyAgent2475(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -225,7 +226,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class FormatKind(Enum):
+class FormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -301,7 +302,7 @@ class VerificationItem1239(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -309,7 +310,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -317,7 +318,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -561,7 +562,7 @@ class VerificationItem1252(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -581,7 +582,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role1321(Enum):
+class Role1321(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -620,11 +621,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -716,7 +717,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -852,7 +853,7 @@ class VerificationItem1257(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -862,7 +863,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -883,7 +884,7 @@ class VerificationItem1258(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -905,7 +906,7 @@ class VerificationItem1259(VerificationItem):
     pass
 
 
-class Target129(Enum):
+class Target129(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1311,7 +1312,7 @@ class RightsAgent(AdCPBaseModel):
     id: Annotated[str, Field(description='Agent identifier')]
 
 
-class Use(Enum):
+class Use(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -1334,7 +1335,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -1342,7 +1343,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -1415,7 +1416,7 @@ class Right(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -2266,7 +2267,7 @@ class Targets4(RootModel[Targets | Targets6 | Targets7]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -2278,30 +2279,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -2312,34 +2313,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -2347,7 +2348,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -2386,24 +2387,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -2481,25 +2482,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -2525,12 +2526,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -2546,7 +2547,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -2557,14 +2558,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -2598,7 +2599,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/bundled/creative/validate_input_response.py
+++ b/src/adcp/types/generated_poc/bundled/creative/validate_input_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -210,7 +210,7 @@ class PushNotificationConfig(AdCPBaseModel):
     ] = None
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     canonical = 'canonical'
     product = 'product'
     third_party_format = 'third_party_format'
@@ -229,7 +229,7 @@ class Target(AdCPBaseModel):
     ]
 
 
-class ResultKind(Enum):
+class ResultKind(StrEnum):
     validated_pass = 'validated_pass'
     validated_fail = 'validated_fail'
     unvalidatable_nondeterministic = 'unvalidatable_nondeterministic'

--- a/src/adcp/types/generated_poc/bundled/media_buy/build_creative_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/build_creative_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -51,7 +52,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class FormatKind(Enum):
+class FormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -135,7 +136,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -143,7 +144,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -207,7 +208,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -239,7 +240,7 @@ class VerificationItem(AdCPBaseModel):
     ] = None
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -247,7 +248,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -255,7 +256,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -499,7 +500,7 @@ class VerificationItem13(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -519,7 +520,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role14(Enum):
+class Role14(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -558,11 +559,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -654,7 +655,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -790,7 +791,7 @@ class VerificationItem18(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -800,7 +801,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -821,7 +822,7 @@ class VerificationItem19(VerificationItem):
     pass
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -843,7 +844,7 @@ class VerificationItem20(VerificationItem):
     pass
 
 
-class Target1(Enum):
+class Target1(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -1267,7 +1268,7 @@ class RightsAgent(AdCPBaseModel):
     id: Annotated[str, Field(description='Agent identifier')]
 
 
-class Use(Enum):
+class Use(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -1290,7 +1291,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -1298,7 +1299,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -1371,7 +1372,7 @@ class Right(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -2188,7 +2189,7 @@ class TargetFormatId(FormatId):
     pass
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     execute = 'execute'
     estimate = 'estimate'
 
@@ -2465,7 +2466,7 @@ class SignalCondition(RootModel[SignalCondition5 | SignalCondition6 | SignalCond
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Dimension(Enum):
+class Dimension(StrEnum):
     voice = 'voice'
     theme = 'theme'
     best_of_n = 'best_of_n'
@@ -2502,13 +2503,13 @@ class VariantAxis(AdCPBaseModel):
     ] = None
 
 
-class KeepMode(Enum):
+class KeepMode(StrEnum):
     keep_all = 'keep_all'
     keep_one = 'keep_one'
     keep_some = 'keep_some'
 
 
-class SelectionStrategy(Enum):
+class SelectionStrategy(StrEnum):
     audience_relevance = 'audience_relevance'
     contextual_fit = 'contextual_fit'
     performance = 'performance'
@@ -2561,7 +2562,7 @@ class VerificationItem93(VerificationItem):
     pass
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -2601,7 +2602,7 @@ class FeatureRequirementItem(AdCPBaseModel):
     ] = None
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     maximize = 'maximize'
     minimize = 'minimize'
 
@@ -2656,8 +2657,8 @@ class EvalBudget(AdCPBaseModel):
     ] = None
 
 
-class Role98(Enum):
-    title = 'title'
+class Role98(StrEnum):
+    title = 'title'  # type: ignore[assignment]
     paragraph = 'paragraph'
     heading = 'heading'
     caption = 'caption'
@@ -2666,7 +2667,7 @@ class Role98(Enum):
     description = 'description'
 
 
-class ContentFormat(Enum):
+class ContentFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     text_html = 'text/html'
@@ -2705,13 +2706,13 @@ class VerificationItem95(VerificationItem):
     pass
 
 
-class TranscriptFormat(Enum):
+class TranscriptFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     application_json = 'application/json'
 
 
-class TranscriptSource(Enum):
+class TranscriptSource(StrEnum):
     original_script = 'original_script'
     subtitles = 'subtitles'
     closed_captions = 'closed_captions'
@@ -2735,7 +2736,7 @@ class VerificationItem96(VerificationItem):
     pass
 
 
-class TranscriptSource1(Enum):
+class TranscriptSource1(StrEnum):
     original_script = 'original_script'
     closed_captions = 'closed_captions'
     generated = 'generated'
@@ -3007,7 +3008,7 @@ class PreviewInput(AdCPBaseModel):
     ] = None
 
 
-class PreviewOutputFormat(Enum):
+class PreviewOutputFormat(StrEnum):
     url = 'url'
     html = 'html'
 
@@ -3017,7 +3018,7 @@ class AssetAccess1(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 
@@ -3047,7 +3048,7 @@ class AssetAccess(RootModel[AssetAccess1 | AssetAccess2 | AssetAccess3]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -3059,30 +3060,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -3093,34 +3094,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -3128,7 +3129,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -3167,24 +3168,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -3262,25 +3263,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -3306,12 +3307,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -3327,7 +3328,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -3338,14 +3339,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -3379,7 +3380,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -3394,7 +3395,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class CreativeQuality(Enum):
+class CreativeQuality(StrEnum):
     draft = 'draft'
     production = 'production'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/build_creative_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/build_creative_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -302,7 +302,7 @@ class BuildCreativeResponse(AdCPBaseModel):
     ] = None
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -318,7 +318,7 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -330,30 +330,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -364,34 +364,34 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -399,7 +399,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -438,24 +438,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -533,25 +533,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -577,12 +577,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -598,7 +598,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -609,14 +609,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -650,7 +650,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -665,7 +665,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class RightUse(Enum):
+class RightUse(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -680,7 +680,7 @@ class RightUse(Enum):
     ai_generated_image = 'ai_generated_image'
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -688,7 +688,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class CreativeIdentifierType(Enum):
+class CreativeIdentifierType(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'

--- a/src/adcp/types/generated_poc/bundled/media_buy/create_media_buy_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/create_media_buy_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -57,7 +58,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -65,7 +66,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -129,7 +130,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -277,7 +278,7 @@ class FormatOptionRefs(RootModel[FormatOptionRefs1 | FormatOptionRefs2]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     even = 'even'
     asap = 'asap'
     front_loaded = 'front_loaded'
@@ -287,11 +288,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -368,7 +369,7 @@ class FeedFieldMapping(AdCPBaseModel):
     ] = None
 
 
-class Metric(Enum):
+class Metric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -382,7 +383,7 @@ class Metric(Enum):
     reach = 'reach'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -486,7 +487,7 @@ class PostView(Window):
     pass
 
 
-class Model(Enum):
+class Model(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -576,7 +577,7 @@ class GeoRegionsExcludeItem(GeoRegion):
     pass
 
 
-class Day(Enum):
+class Day(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -621,7 +622,7 @@ class DaypartTarget(AdCPBaseModel):
     ] = None
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 
@@ -1165,7 +1166,7 @@ class CollectionListExclude(CollectionList):
     pass
 
 
-class AcceptedMethod(Enum):
+class AcceptedMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -1191,7 +1192,7 @@ class AgeRestriction(AdCPBaseModel):
     ] = None
 
 
-class DevicePlatformEnum(Enum):
+class DevicePlatformEnum(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -1229,7 +1230,7 @@ class StoreCatchment(AdCPBaseModel):
     ] = None
 
 
-class Unit5(Enum):
+class Unit5(StrEnum):
     min = 'min'
     hr = 'hr'
 
@@ -1248,14 +1249,14 @@ class TravelTime(AdCPBaseModel):
     ]
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class Unit6(Enum):
+class Unit6(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
@@ -1269,7 +1270,7 @@ class Radius(AdCPBaseModel):
     unit: Annotated[Unit6, Field(description='Distance unit.', title='Distance Unit')]
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -1367,7 +1368,7 @@ class VerificationItem2(VerificationItem):
     pass
 
 
-class AvailableRemedy(Enum):
+class AvailableRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'
@@ -1386,7 +1387,7 @@ class MakegoodPolicy(AdCPBaseModel):
     ]
 
 
-class Metric1(Enum):
+class Metric1(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -1410,12 +1411,12 @@ class VerificationItem3(VerificationItem):
     pass
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'
@@ -1437,7 +1438,7 @@ class AttributionWindow1(AdCPBaseModel):
     ]
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'
@@ -1526,7 +1527,7 @@ class VerificationItem5(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -1534,7 +1535,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -1542,7 +1543,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -1786,7 +1787,7 @@ class VerificationItem18(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -1806,7 +1807,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role19(Enum):
+class Role19(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -1860,7 +1861,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -1996,7 +1997,7 @@ class VerificationItem23(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -2006,7 +2007,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -2027,7 +2028,7 @@ class VerificationItem24(VerificationItem):
     pass
 
 
-class Target7(Enum):
+class Target7(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -2049,7 +2050,7 @@ class VerificationItem25(VerificationItem):
     pass
 
 
-class Target8(Enum):
+class Target8(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -2448,7 +2449,7 @@ class Input(AdCPBaseModel):
     ] = None
 
 
-class Status2(Enum):
+class Status2(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -2457,7 +2458,7 @@ class Status2(Enum):
     archived = 'archived'
 
 
-class Type1(Enum):
+class Type1(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -3266,7 +3267,7 @@ class VerificationItem95(VerificationItem):
     pass
 
 
-class AdvertiserIndustry(Enum):
+class AdvertiserIndustry(StrEnum):
     automotive = 'automotive'
     automotive_electric_vehicles = 'automotive.electric_vehicles'
     automotive_parts_accessories = 'automotive.parts_accessories'
@@ -3367,7 +3368,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role100(Enum):
+class Role100(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'
@@ -3498,23 +3499,23 @@ class IoAcceptance(AdCPBaseModel):
     ] = None
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'
 
 
-class DeliveryMode(Enum):
+class DeliveryMode(StrEnum):
     realtime = 'realtime'
     batched = 'batched'
 
 
-class BatchFrequency(Enum):
+class BatchFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -3526,30 +3527,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -3560,7 +3561,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -3576,7 +3577,7 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -3592,7 +3593,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -3603,14 +3604,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -3644,7 +3645,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -3659,7 +3660,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -3668,7 +3669,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -3676,7 +3677,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -3690,7 +3691,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -3699,18 +3700,18 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -3749,34 +3750,34 @@ class AvailableMetric(Enum):
     brand_search_lift = 'brand_search_lift'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -3784,7 +3785,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -3823,24 +3824,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -3918,25 +3919,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -3962,12 +3963,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/create_media_buy_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/create_media_buy_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,12 +152,12 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -169,30 +169,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -203,7 +203,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -213,7 +213,7 @@ class MediaBuyStatus(Enum):
     canceled = 'canceled'
 
 
-class MediaBuyValidAction(Enum):
+class MediaBuyValidAction(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'
@@ -237,7 +237,7 @@ class MediaBuyValidAction(Enum):
     sync_creatives = 'sync_creatives'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -271,7 +271,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -279,7 +279,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -293,7 +293,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -302,7 +302,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -311,13 +311,13 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/get_media_buy_delivery_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/get_media_buy_delivery_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -561,13 +561,13 @@ class Account1(AdCPBaseModel):
     ] = False
 
 
-class TimeGranularity(Enum):
+class TimeGranularity(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -591,7 +591,7 @@ class PostView(PostClick):
     pass
 
 
-class Model(Enum):
+class Model(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -618,14 +618,14 @@ class AttributionWindow(AdCPBaseModel):
     ] = None
 
 
-class GeoLevel(Enum):
+class GeoLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
     postal_area = 'postal_area'
 
 
-class System(Enum):
+class System(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -633,7 +633,7 @@ class System(Enum):
     custom = 'custom'
 
 
-class System1(Enum):
+class System1(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -647,7 +647,7 @@ class System1(Enum):
     at_plz = 'at_plz'
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -657,7 +657,7 @@ class MediaBuyStatus(Enum):
     canceled = 'canceled'
 
 
-class SortMetric(Enum):
+class SortMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'

--- a/src/adcp/types/generated_poc/bundled/media_buy/get_media_buy_delivery_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/get_media_buy_delivery_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -12,7 +12,7 @@ from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -82,13 +82,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -153,7 +153,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -211,7 +211,7 @@ class PushNotificationConfig(AdCPBaseModel):
     ] = None
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -233,7 +233,7 @@ class ReportingPeriod(AdCPBaseModel):
     ]
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -257,7 +257,7 @@ class PostView(PostClick):
     pass
 
 
-class Model(Enum):
+class Model(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -338,7 +338,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -346,7 +346,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -410,7 +410,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -451,7 +451,7 @@ class Colors(AdCPBaseModel):
     accent: Annotated[str | None, Field(pattern='^#[0-9a-fA-F]{6}$')] = None
 
 
-class Status1(Enum):
+class Status1(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     pending = 'pending'
@@ -464,7 +464,7 @@ class Status1(Enum):
     reporting_delayed = 'reporting_delayed'
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     cumulative = 'cumulative'
     period = 'period'
     rolling = 'rolling'
@@ -634,7 +634,7 @@ class VerificationItem4(VerificationItem):
     pass
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     completed = 'completed'
     budget_exhausted = 'budget_exhausted'
@@ -720,7 +720,7 @@ class VerificationItem7(VerificationItem):
     pass
 
 
-class ContentIdType(Enum):
+class ContentIdType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -851,7 +851,7 @@ class VerificationItem11(VerificationItem):
     pass
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
@@ -915,7 +915,7 @@ class VerificationItem13(VerificationItem):
     pass
 
 
-class GeoLevel(Enum):
+class GeoLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
@@ -980,7 +980,7 @@ class VerificationItem15(VerificationItem):
     pass
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -1047,7 +1047,7 @@ class VerificationItem17(VerificationItem):
     pass
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -1120,7 +1120,7 @@ class VerificationItem19(VerificationItem):
     pass
 
 
-class AudienceSource(Enum):
+class AudienceSource(StrEnum):
     synced = 'synced'
     platform = 'platform'
     third_party = 'third_party'
@@ -1419,7 +1419,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -1428,7 +1428,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -1467,24 +1467,24 @@ class AvailableMetric(Enum):
     brand_search_lift = 'brand_search_lift'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'
     modeled = 'modeled'
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'
@@ -1492,7 +1492,7 @@ class LiftDimension(Enum):
     ad_recall = 'ad_recall'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -1504,30 +1504,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -1538,7 +1538,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PricingModel(Enum):
+class PricingModel(StrEnum):
     cpm = 'cpm'
     vcpm = 'vcpm'
     cpc = 'cpc'
@@ -1550,7 +1550,7 @@ class PricingModel(Enum):
     time = 'time'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -1584,7 +1584,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'

--- a/src/adcp/types/generated_poc/bundled/media_buy/get_media_buys_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/get_media_buys_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -574,7 +574,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'

--- a/src/adcp/types/generated_poc/bundled/media_buy/get_media_buys_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/get_media_buys_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -12,7 +12,7 @@ from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -82,13 +82,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -153,7 +153,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Status1(Enum):
+class Status1(StrEnum):
     active = 'active'
     pending_approval = 'pending_approval'
     rejected = 'rejected'
@@ -171,7 +171,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -207,7 +207,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -215,7 +215,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -243,7 +243,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -300,7 +300,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -325,7 +325,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -364,13 +364,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -462,7 +462,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -669,7 +669,7 @@ class Brand(AdCPBaseModel):
     ] = None
 
 
-class Billing(Enum):
+class Billing(StrEnum):
     operator = 'operator'
     agent = 'agent'
     advertiser = 'advertiser'
@@ -692,7 +692,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role1(Enum):
+class Role1(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'
@@ -797,7 +797,7 @@ class BillingEntity(AdCPBaseModel):
     ] = None
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_15 = 'net_15'
     net_30 = 'net_30'
     net_45 = 'net_45'
@@ -827,7 +827,7 @@ class Setup(AdCPBaseModel):
     ] = None
 
 
-class AccountScope(Enum):
+class AccountScope(StrEnum):
     operator = 'operator'
     brand = 'brand'
     operator_brand = 'operator_brand'
@@ -841,13 +841,13 @@ class GovernanceAgent(AdCPBaseModel):
     url: Annotated[AnyUrl, Field(description='Governance agent endpoint URL. Must use HTTPS.')]
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     s3 = 's3'
     gcs = 'gcs'
     azure_blob = 'azure_blob'
 
 
-class Format(Enum):
+class Format(StrEnum):
     jsonl = 'jsonl'
     csv = 'csv'
     parquet = 'parquet'
@@ -855,7 +855,7 @@ class Format(Enum):
     orc = 'orc'
 
 
-class Compression(Enum):
+class Compression(StrEnum):
     gzip = 'gzip'
     none = 'none'
 
@@ -976,7 +976,7 @@ class InvoiceRecipient(AdCPBaseModel):
     ] = None
 
 
-class Status2(Enum):
+class Status2(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -990,7 +990,7 @@ class Health(AdCPBaseModel):
     pass
 
 
-class ResourceType(Enum):
+class ResourceType(StrEnum):
     audience = 'audience'
     creative = 'creative'
     catalog_item = 'catalog_item'
@@ -998,7 +998,7 @@ class ResourceType(Enum):
     property = 'property'
 
 
-class To(Enum):
+class To(StrEnum):
     suspended = 'suspended'
     rejected = 'rejected'
     withdrawn = 'withdrawn'
@@ -1027,7 +1027,7 @@ class Transition(AdCPBaseModel):
     ]
 
 
-class ReasonCode(Enum):
+class ReasonCode(StrEnum):
     policy_violation = 'policy_violation'
     consent_expired = 'consent_expired'
     ttl_expired = 'ttl_expired'
@@ -1103,7 +1103,7 @@ class Impairment(AdCPBaseModel):
     ] = None
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     self_serve = 'self_serve'
     conditional_self_serve = 'conditional_self_serve'
     requires_approval = 'requires_approval'
@@ -1132,7 +1132,7 @@ class Sla(AdCPBaseModel):
     ] = None
 
 
-class Status3(Enum):
+class Status3(StrEnum):
     success = 'success'
     failed = 'failed'
     timeout = 'timeout'
@@ -1279,7 +1279,7 @@ class FormatOptionRefs(RootModel[FormatOptionRefs1 | FormatOptionRefs2]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class FormatKind(Enum):
+class FormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -1311,7 +1311,7 @@ class GeoRegionsExcludeItem(GeoRegion):
     pass
 
 
-class Day(Enum):
+class Day(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -1356,7 +1356,7 @@ class DaypartTarget(AdCPBaseModel):
     ] = None
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 
@@ -1856,7 +1856,7 @@ class SignalTargeting(RootModel[SignalTargeting1 | SignalTargeting2 | SignalTarg
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -1958,7 +1958,7 @@ class CollectionListExclude(CollectionList):
     pass
 
 
-class AcceptedMethod(Enum):
+class AcceptedMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -1984,7 +1984,7 @@ class AgeRestriction(AdCPBaseModel):
     ] = None
 
 
-class DevicePlatformEnum(Enum):
+class DevicePlatformEnum(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -2022,7 +2022,7 @@ class StoreCatchment(AdCPBaseModel):
     ] = None
 
 
-class Unit2(Enum):
+class Unit2(StrEnum):
     min = 'min'
     hr = 'hr'
 
@@ -2041,14 +2041,14 @@ class TravelTime(AdCPBaseModel):
     ]
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class Unit3(Enum):
+class Unit3(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
@@ -2062,7 +2062,7 @@ class Radius(AdCPBaseModel):
     unit: Annotated[Unit3, Field(description='Distance unit.', title='Distance Unit')]
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -2144,7 +2144,7 @@ class LanguageItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[a-z]{2}$')]
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending_review = 'pending_review'
     approved = 'approved'
     rejected = 'rejected'
@@ -2174,13 +2174,13 @@ class FormatIdsPendingItem(FormatId):
     pass
 
 
-class SnapshotUnavailableReason(Enum):
+class SnapshotUnavailableReason(StrEnum):
     SNAPSHOT_UNSUPPORTED = 'SNAPSHOT_UNSUPPORTED'
     SNAPSHOT_TEMPORARILY_UNAVAILABLE = 'SNAPSHOT_TEMPORARILY_UNAVAILABLE'
     SNAPSHOT_PERMISSION_DENIED = 'SNAPSHOT_PERMISSION_DENIED'
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     not_delivering = 'not_delivering'
     completed = 'completed'
@@ -2332,12 +2332,12 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -2356,12 +2356,12 @@ class NotificationType(Enum):
     wholesale_feed_bulk_change = 'wholesale_feed.bulk_change'
 
 
-class CanceledBy(Enum):
+class CanceledBy(StrEnum):
     buyer = 'buyer'
     seller = 'seller'
 
 
-class MediaBuyValidAction(Enum):
+class MediaBuyValidAction(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'
@@ -2385,7 +2385,7 @@ class MediaBuyValidAction(Enum):
     sync_creatives = 'sync_creatives'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -2393,7 +2393,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -2407,7 +2407,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -2416,7 +2416,7 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'

--- a/src/adcp/types/generated_poc/bundled/media_buy/get_products_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/get_products_request.py
@@ -5,14 +5,14 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class BuyingMode(Enum):
+class BuyingMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
     refine = 'refine'
@@ -37,7 +37,7 @@ class Refine1(AdCPBaseModel):
     ]
 
 
-class Action(Enum):
+class Action(StrEnum):
     include = 'include'
     omit = 'omit'
     more_like_this = 'more_like_this'
@@ -66,7 +66,7 @@ class Refine2(AdCPBaseModel):
     ] = None
 
 
-class Action1(Enum):
+class Action1(StrEnum):
     include = 'include'
     omit = 'omit'
     finalize = 'finalize'
@@ -138,7 +138,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -146,7 +146,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -210,7 +210,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -251,7 +251,7 @@ class Colors(AdCPBaseModel):
     accent: Annotated[str | None, Field(pattern='^#[0-9a-fA-F]{6}$')] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -267,7 +267,7 @@ class Type(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -278,7 +278,7 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
@@ -289,7 +289,7 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class ConversionEvent(Enum):
+class ConversionEvent(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -323,7 +323,7 @@ class ConversionEvent(Enum):
     custom = 'custom'
 
 
-class ContentIdType(Enum):
+class ContentIdType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -338,11 +338,11 @@ class ContentIdType(Enum):
     app_id = 'app_id'
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -553,7 +553,7 @@ class VerificationItem1(VerificationItem):
     pass
 
 
-class Exclusivity(Enum):
+class Exclusivity(StrEnum):
     none = 'none'
     category = 'category'
     exclusive = 'exclusive'
@@ -630,7 +630,7 @@ class Region(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}-[A-Z0-9]+$')]
 
 
-class System(Enum):
+class System(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -650,7 +650,7 @@ class Metro(AdCPBaseModel):
     ]
 
 
-class Channel(Enum):
+class Channel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -673,20 +673,20 @@ class Channel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class VideoPlacementType(Enum):
+class VideoPlacementType(StrEnum):
     instream = 'instream'
     accompanying_content = 'accompanying_content'
     interstitial = 'interstitial'
     standalone = 'standalone'
 
 
-class SponsoredPlacementType(Enum):
+class SponsoredPlacementType(StrEnum):
     sponsored_search = 'sponsored_search'
     sponsored_display = 'sponsored_display'
     sponsored_native = 'sponsored_native'
 
 
-class SocialPlacementSurface(Enum):
+class SocialPlacementSurface(StrEnum):
     feed = 'feed'
     stories = 'stories'
     short_video = 'short_video'
@@ -708,7 +708,7 @@ class Provider(AdCPBaseModel):
     ] = None
 
 
-class ResponseType(Enum):
+class ResponseType(StrEnum):
     activation = 'activation'
     catalog_items = 'catalog_items'
     creative = 'creative'
@@ -760,7 +760,7 @@ class RequiredFeatures(AdCPBaseModel):
     ] = None
 
 
-class Level(Enum):
+class Level(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
@@ -1013,7 +1013,7 @@ class SignalTargetingItem3(AdCPBaseModel):
     ] = None
 
 
-class TargetingMode(Enum):
+class TargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 
@@ -1064,7 +1064,7 @@ class SignalTargetingItem(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class System1(Enum):
+class System1(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -1098,7 +1098,7 @@ class PostalArea(AdCPBaseModel):
     ]
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     min = 'min'
     hr = 'hr'
 
@@ -1117,14 +1117,14 @@ class TravelTime(AdCPBaseModel):
     ]
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class Unit1(Enum):
+class Unit1(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
@@ -1138,7 +1138,7 @@ class Radius(AdCPBaseModel):
     unit: Annotated[Unit1, Field(description='Distance unit', title='Distance Unit')]
 
 
-class Type1(Enum):
+class Type1(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -1183,7 +1183,7 @@ class GeoProximityItem(AdCPBaseModel):
     ] = None
 
 
-class Metric(Enum):
+class Metric(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -1191,7 +1191,7 @@ class Metric(Enum):
     attention_score = 'attention_score'
 
 
-class Standard(Enum):
+class Standard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
@@ -1212,7 +1212,7 @@ class VerificationItem2(VerificationItem):
     pass
 
 
-class RequiredMetric(Enum):
+class RequiredMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -1267,7 +1267,7 @@ class VerificationItem3(VerificationItem):
     pass
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
@@ -1303,7 +1303,7 @@ class PropertyList(AdCPBaseModel):
     ] = None
 
 
-class FieldModel(Enum):
+class FieldModel(StrEnum):
     product_id = 'product_id'
     name = 'name'
     description = 'description'
@@ -1344,7 +1344,7 @@ class FieldModel(Enum):
     trusted_match = 'trusted_match'
 
 
-class Unit2(Enum):
+class Unit2(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -1364,7 +1364,7 @@ class TimeBudget(AdCPBaseModel):
     ]
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -1435,7 +1435,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -1447,30 +1447,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -1481,7 +1481,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class DeliveryType(Enum):
+class DeliveryType(StrEnum):
     guaranteed = 'guaranteed'
     non_guaranteed = 'non_guaranteed'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/get_products_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/get_products_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -12,7 +12,7 @@ from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel, StringConstraints
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -82,13 +82,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -153,7 +153,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -382,7 +382,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'
@@ -411,7 +411,7 @@ class FormatSchema(AdCPBaseModel):
     ]
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
@@ -420,7 +420,7 @@ class PlatformExtension(FormatSchema):
     pass
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -444,7 +444,7 @@ class AssetType(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -466,14 +466,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status1(Enum):
+class Status1(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'
@@ -576,7 +576,7 @@ class RequiredConnection(AdCPBaseModel):
     ] = None
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'
@@ -590,7 +590,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -599,7 +599,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -608,7 +608,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 
@@ -617,12 +617,12 @@ class RequiredConnection1(RequiredConnection):
     pass
 
 
-class MraidVersion(Enum):
+class MraidVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 
@@ -631,7 +631,7 @@ class RequiredConnection2(RequiredConnection):
     pass
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'
@@ -641,7 +641,7 @@ class RequiredConnection3(RequiredConnection):
     pass
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 
@@ -650,7 +650,7 @@ class RequiredConnection4(RequiredConnection):
     pass
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -660,7 +660,7 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class VideoCodec(Enum):
+class VideoCodec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -669,20 +669,20 @@ class VideoCodec(Enum):
     prores = 'prores'
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -700,7 +700,7 @@ class RequiredConnection5(RequiredConnection):
     pass
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -708,7 +708,7 @@ class VastVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 
@@ -721,7 +721,7 @@ class RequiredConnection6(RequiredConnection):
     pass
 
 
-class AudioCodec1(Enum):
+class AudioCodec1(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -733,7 +733,7 @@ class AudioSampleRate(CompanionBannerWidth):
     pass
 
 
-class AudioChannel(Enum):
+class AudioChannel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
@@ -742,7 +742,7 @@ class RequiredConnection7(RequiredConnection):
     pass
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
@@ -751,7 +751,7 @@ class RequiredConnection8(RequiredConnection):
     pass
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -766,13 +766,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -788,7 +788,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -807,7 +807,7 @@ class IconSize(Size):
     pass
 
 
-class ImageFormat1(Enum):
+class ImageFormat1(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -815,7 +815,7 @@ class ImageFormat1(Enum):
     webp = 'webp'
 
 
-class AssetSource3(Enum):
+class AssetSource3(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -831,18 +831,18 @@ class RequiredConnection11(RequiredConnection):
     pass
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     publisher_ref = 'publisher_ref'
     seller_inline = 'seller_inline'
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     targetable = 'targetable'
     included = 'included'
 
@@ -895,12 +895,12 @@ class RequiredConnection23(RequiredConnection):
     pass
 
 
-class DeliveryType(Enum):
+class DeliveryType(StrEnum):
     guaranteed = 'guaranteed'
     non_guaranteed = 'non_guaranteed'
 
 
-class Exclusivity(Enum):
+class Exclusivity(StrEnum):
     none = 'none'
     category = 'category'
     exclusive = 'exclusive'
@@ -987,7 +987,7 @@ class Parameters2(AdCPBaseModel):
     ] = None
 
 
-class TimeUnit(Enum):
+class TimeUnit(StrEnum):
     hour = 'hour'
     day = 'day'
     week = 'week'
@@ -1122,7 +1122,7 @@ class SignalRef2(AdCPBaseModel):
     ]
 
 
-class Presence(Enum):
+class Presence(StrEnum):
     present = 'present'
     absent = 'absent'
 
@@ -1414,7 +1414,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -1422,7 +1422,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -1486,7 +1486,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -1563,7 +1563,7 @@ class Value(AudienceSize):
     pass
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -1648,7 +1648,7 @@ class VerificationItem3(VerificationItem):
     pass
 
 
-class AvailableRemedy(Enum):
+class AvailableRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'
@@ -1667,7 +1667,7 @@ class MakegoodPolicy(AdCPBaseModel):
     ]
 
 
-class Metric(Enum):
+class Metric(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -1706,7 +1706,7 @@ class NoticePeriod(AdCPBaseModel):
     ]
 
 
-class Type(Enum):
+class Type(StrEnum):
     percent_remaining = 'percent_remaining'
     full_commitment = 'full_commitment'
     fixed_fee = 'fixed_fee'
@@ -1756,7 +1756,7 @@ class CancellationPolicy(AdCPBaseModel):
     ]
 
 
-class Action(Enum):
+class Action(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'
@@ -1780,13 +1780,13 @@ class Action(Enum):
     sync_creatives = 'sync_creatives'
 
 
-class Mode1(Enum):
+class Mode1(StrEnum):
     self_serve = 'self_serve'
     conditional_self_serve = 'conditional_self_serve'
     requires_approval = 'requires_approval'
 
 
-class AllowedStatus(Enum):
+class AllowedStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -1855,7 +1855,7 @@ class AllowedAction(AdCPBaseModel):
     ] = None
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -1934,7 +1934,7 @@ class SupportsGeoBreakdown(AdCPBaseModel):
     ] = None
 
 
-class DateRangeSupport(Enum):
+class DateRangeSupport(StrEnum):
     date_range = 'date_range'
     lifetime_only = 'lifetime_only'
 
@@ -1987,13 +1987,13 @@ class MeasurementWindow(AdCPBaseModel):
     ] = None
 
 
-class CoBranding(Enum):
+class CoBranding(StrEnum):
     required = 'required'
     optional = 'optional'
     none = 'none'
 
 
-class LandingPage(Enum):
+class LandingPage(StrEnum):
     any = 'any'
     retailer_site_only = 'retailer_site_only'
     must_include_retailer = 'must_include_retailer'
@@ -2148,12 +2148,12 @@ class Range(AdCPBaseModel):
 
 
 
-class ActivationStatus(Enum):
+class ActivationStatus(StrEnum):
     ready = 'ready'
     requires_activation = 'requires_activation'
 
 
-class AllowedTargetingMode(Enum):
+class AllowedTargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 
@@ -2206,7 +2206,7 @@ class PricingOption2(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -2351,12 +2351,12 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class ResolutionModel(Enum):
+class ResolutionModel(StrEnum):
     direct_targeting = 'direct_targeting'
     seller_planned = 'seller_planned'
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     optional = 'optional'
     required = 'required'
     fixed = 'fixed'
@@ -2456,7 +2456,7 @@ class SignalTargetingRules(AdCPBaseModel):
     ] = None
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -2472,7 +2472,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class SupportedMetric(Enum):
+class SupportedMetric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -2490,7 +2490,7 @@ class SupportedViewDuration(RootModel[float]):
     root: Annotated[float, Field(gt=0.0)]
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 
@@ -2511,14 +2511,14 @@ class VerificationItem6(VerificationItem):
     pass
 
 
-class Status25(Enum):
+class Status25(StrEnum):
     insufficient = 'insufficient'
     minimum = 'minimum'
     good = 'good'
     excellent = 'excellent'
 
 
-class Severity(Enum):
+class Severity(StrEnum):
     error = 'error'
     warning = 'warning'
     info = 'info'
@@ -2540,7 +2540,7 @@ class Issue1(AdCPBaseModel):
     ]
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -2552,7 +2552,7 @@ class ActionSource(Enum):
     other = 'other'
 
 
-class SupportedTarget2(Enum):
+class SupportedTarget2(StrEnum):
     cost_per = 'cost_per'
     per_ad_spend = 'per_ad_spend'
     maximize_value = 'maximize_value'
@@ -2686,7 +2686,7 @@ class Collection(AdCPBaseModel):
     ]
 
 
-class Status26(Enum):
+class Status26(StrEnum):
     scheduled = 'scheduled'
     tentative = 'tentative'
     live = 'live'
@@ -2696,7 +2696,7 @@ class Status26(Enum):
     published = 'published'
 
 
-class System(Enum):
+class System(StrEnum):
     tv_parental = 'tv_parental'
     mpaa = 'mpaa'
     podcast = 'podcast'
@@ -2722,7 +2722,7 @@ class ContentRating(AdCPBaseModel):
     ]
 
 
-class Category(Enum):
+class Category(StrEnum):
     awards = 'awards'
     championship = 'championship'
     concert = 'concert'
@@ -2756,7 +2756,7 @@ class Special(AdCPBaseModel):
     ] = None
 
 
-class Role10(Enum):
+class Role10(StrEnum):
     host = 'host'
     guest = 'guest'
     creator = 'creator'
@@ -2865,7 +2865,7 @@ class Deadlines(AdCPBaseModel):
     ] = None
 
 
-class Type1(Enum):
+class Type1(StrEnum):
     clip = 'clip'
     highlight = 'highlight'
     recap = 'recap'
@@ -2979,7 +2979,7 @@ class Installment(AdCPBaseModel):
     ] = None
 
 
-class ResponseType(Enum):
+class ResponseType(StrEnum):
     activation = 'activation'
     catalog_items = 'catalog_items'
     creative = 'creative'
@@ -2990,7 +2990,7 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class UidType(Enum):
+class UidType(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'
@@ -3875,7 +3875,7 @@ class Extensions(AdCPBaseModel):
     description: str | None = None
 
 
-class Day(Enum):
+class Day(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -4005,7 +4005,7 @@ class VerificationItem21(VerificationItem):
     pass
 
 
-class ProposalStatus(Enum):
+class ProposalStatus(StrEnum):
     draft = 'draft'
     committed = 'committed'
 
@@ -4017,7 +4017,7 @@ class TotalBudget(AdCPBaseModel):
     ]
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_30 = 'net_30'
     net_60 = 'net_60'
     net_90 = 'net_90'
@@ -4241,7 +4241,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class Status53(Enum):
+class Status53(StrEnum):
     applied = 'applied'
     partial = 'partial'
     unable = 'unable'
@@ -4329,7 +4329,7 @@ class RefinementApplied(RootModel[RefinementApplied1 | RefinementApplied2 | Refi
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Scope48(Enum):
+class Scope48(StrEnum):
     products = 'products'
     pricing = 'pricing'
     forecast = 'forecast'
@@ -4362,7 +4362,7 @@ class IncompleteItem(AdCPBaseModel):
     ] = None
 
 
-class Semantics(Enum):
+class Semantics(StrEnum):
     only = 'only'
     any = 'any'
     approximate = 'approximate'
@@ -4440,12 +4440,12 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -4468,7 +4468,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'
@@ -4484,20 +4484,20 @@ class LogoSlot(Enum):
     marketplace_listing = 'marketplace_listing'
 
 
-class VideoPlacementType(Enum):
+class VideoPlacementType(StrEnum):
     instream = 'instream'
     accompanying_content = 'accompanying_content'
     interstitial = 'interstitial'
     standalone = 'standalone'
 
 
-class SponsoredPlacementType(Enum):
+class SponsoredPlacementType(StrEnum):
     sponsored_search = 'sponsored_search'
     sponsored_display = 'sponsored_display'
     sponsored_native = 'sponsored_native'
 
 
-class SocialPlacementSurface(Enum):
+class SocialPlacementSurface(StrEnum):
     feed = 'feed'
     stories = 'stories'
     short_video = 'short_video'
@@ -4505,14 +4505,14 @@ class SocialPlacementSurface(Enum):
     search = 'search'
 
 
-class PriceAdjustmentKind(Enum):
+class PriceAdjustmentKind(StrEnum):
     fee = 'fee'
     discount = 'discount'
     commission = 'commission'
     settlement = 'settlement'
 
 
-class DemographicSystem(Enum):
+class DemographicSystem(StrEnum):
     nielsen = 'nielsen'
     barb = 'barb'
     agf = 'agf'
@@ -4521,7 +4521,7 @@ class DemographicSystem(Enum):
     custom = 'custom'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -4555,14 +4555,14 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class GeographicTargetingLevel(Enum):
+class GeographicTargetingLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
     postal_area = 'postal_area'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -4570,7 +4570,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -4584,7 +4584,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -4593,7 +4593,7 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -4608,7 +4608,7 @@ class DevicePlatform(Enum):
     unknown = 'unknown'
 
 
-class AudienceSource(Enum):
+class AudienceSource(StrEnum):
     synced = 'synced'
     platform = 'platform'
     third_party = 'third_party'
@@ -4617,7 +4617,7 @@ class AudienceSource(Enum):
     unknown = 'unknown'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -4629,30 +4629,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -4663,12 +4663,12 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class ForecastRangeUnit(Enum):
+class ForecastRangeUnit(StrEnum):
     spend = 'spend'
     availability = 'availability'
     reach_freq = 'reach_freq'
@@ -4679,13 +4679,13 @@ class ForecastRangeUnit(Enum):
     package = 'package'
 
 
-class ForecastMethod(Enum):
+class ForecastMethod(StrEnum):
     estimate = 'estimate'
     modeled = 'modeled'
     guaranteed = 'guaranteed'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -4694,13 +4694,13 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'
 
 
-class SignalValueType(Enum):
+class SignalValueType(StrEnum):
     binary = 'binary'
     categorical = 'categorical'
     numeric = 'numeric'

--- a/src/adcp/types/generated_poc/bundled/media_buy/list_creative_formats_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/list_creative_formats_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -51,7 +51,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -69,13 +69,13 @@ class AssetType(Enum):
     published_post = 'published_post'
 
 
-class WcagLevel(Enum):
+class WcagLevel(StrEnum):
     A = 'A'
     AA = 'AA'
     AAA = 'AAA'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -86,7 +86,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class DisclosurePersistenceEnum(Enum):
+class DisclosurePersistenceEnum(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'

--- a/src/adcp/types/generated_poc/bundled/media_buy/list_creative_formats_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/list_creative_formats_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -250,7 +250,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class AcceptsParameter(Enum):
+class AcceptsParameter(StrEnum):
     dimensions = 'dimensions'
     duration = 'duration'
 
@@ -260,7 +260,7 @@ class Responsive(AdCPBaseModel):
     height: bool
 
 
-class Format1(Enum):
+class Format1(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -290,13 +290,13 @@ class Bleed1(AdCPBaseModel):
     left: Annotated[float, Field(ge=0.0)]
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rgb = 'rgb'
     cmyk = 'cmyk'
     grayscale = 'grayscale'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
@@ -304,7 +304,7 @@ class Container(Enum):
     mkv = 'mkv'
 
 
-class Codec(Enum):
+class Codec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -317,7 +317,7 @@ class FrameRate(RootModel[float]):
     root: Annotated[float, Field(ge=1.0)]
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     pcm = 'pcm'
     ac3 = 'ac3'
@@ -332,7 +332,7 @@ class AudioSampleRate(RootModel[int]):
     root: Annotated[int, Field(ge=1)]
 
 
-class Format2(Enum):
+class Format2(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -344,7 +344,7 @@ class SampleRate(AudioSampleRate):
     pass
 
 
-class Channel(Enum):
+class Channel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
@@ -413,7 +413,7 @@ class Requirements4(AdCPBaseModel):
     max_length: Annotated[int | None, Field(description='Maximum character length', ge=1)] = None
 
 
-class Sandbox(Enum):
+class Sandbox(StrEnum):
     none = 'none'
     iframe = 'iframe'
     safeframe = 'safeframe'
@@ -456,7 +456,7 @@ class Requirements6(AdCPBaseModel):
     ] = None
 
 
-class ModuleType(Enum):
+class ModuleType(StrEnum):
     script = 'script'
     module = 'module'
     iife = 'iife'
@@ -491,7 +491,7 @@ class Requirements7(AdCPBaseModel):
     ] = None
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -516,7 +516,7 @@ class Requirements9(AdCPBaseModel):
     ] = None
 
 
-class Role(Enum):
+class Role(StrEnum):
     clickthrough = 'clickthrough'
     landing_page = 'landing_page'
     impression_tracker = 'impression_tracker'
@@ -525,7 +525,7 @@ class Role(Enum):
     third_party_tracker = 'third_party_tracker'
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     https = 'https'
     http = 'http'
 
@@ -556,7 +556,7 @@ class Requirements10(AdCPBaseModel):
     ] = None
 
 
-class Method(Enum):
+class Method(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
@@ -568,7 +568,7 @@ class Requirements11(AdCPBaseModel):
     methods: Annotated[list[Method] | None, Field(description='Allowed HTTP methods')] = None
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -584,7 +584,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -595,7 +595,7 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -661,7 +661,7 @@ class AssetRequirements11(Requirements11):
     pass
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     sequential = 'sequential'
     optimize = 'optimize'
 
@@ -714,7 +714,7 @@ class Requirements24(Requirements11):
     pass
 
 
-class SupportedMacros(Enum):
+class SupportedMacros(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -817,7 +817,7 @@ class FormatCard(AdCPBaseModel):
     ]
 
 
-class WcagLevel(Enum):
+class WcagLevel(StrEnum):
     A = 'A'
     AA = 'AA'
     AAA = 'AAA'
@@ -839,7 +839,7 @@ class Accessibility(AdCPBaseModel):
     ] = None
 
 
-class PersistenceEnum(Enum):
+class PersistenceEnum(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
@@ -864,7 +864,7 @@ class FormatCardDetailed(AdCPBaseModel):
     ]
 
 
-class ReportedMetric(Enum):
+class ReportedMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -951,7 +951,7 @@ class PricingOption2(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -1096,7 +1096,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Kind(Enum):
+class Kind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -1112,7 +1112,7 @@ class Kind(Enum):
     custom = 'custom'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -1177,7 +1177,7 @@ class Canonical(AdCPBaseModel):
     ] = None
 
 
-class AppliesToChannel(Enum):
+class AppliesToChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -1200,7 +1200,7 @@ class AppliesToChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'
@@ -1229,7 +1229,7 @@ class FormatSchema(AdCPBaseModel):
     ]
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
@@ -1238,7 +1238,7 @@ class PlatformExtension(FormatSchema):
     pass
 
 
-class AssetType1(Enum):
+class AssetType1(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -1262,7 +1262,7 @@ class AssetType1(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -1284,14 +1284,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status1(Enum):
+class Status1(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'
@@ -1394,7 +1394,7 @@ class RequiredConnection(AdCPBaseModel):
     ] = None
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'
@@ -1408,7 +1408,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -1417,7 +1417,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 
@@ -1426,12 +1426,12 @@ class RequiredConnection1(RequiredConnection):
     pass
 
 
-class MraidVersion(Enum):
+class MraidVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 
@@ -1440,7 +1440,7 @@ class RequiredConnection2(RequiredConnection):
     pass
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'
@@ -1450,7 +1450,7 @@ class RequiredConnection3(RequiredConnection):
     pass
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 
@@ -1459,7 +1459,7 @@ class RequiredConnection4(RequiredConnection):
     pass
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -1469,20 +1469,20 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class AudioCodec3(Enum):
+class AudioCodec3(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container3(Enum):
+class Container3(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -1500,7 +1500,7 @@ class RequiredConnection5(RequiredConnection):
     pass
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 
@@ -1513,7 +1513,7 @@ class RequiredConnection6(RequiredConnection):
     pass
 
 
-class AudioCodec4(Enum):
+class AudioCodec4(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -1525,7 +1525,7 @@ class RequiredConnection7(RequiredConnection):
     pass
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
@@ -1534,7 +1534,7 @@ class RequiredConnection8(RequiredConnection):
     pass
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -1549,13 +1549,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -1571,7 +1571,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -1590,7 +1590,7 @@ class IconSize(Size):
     pass
 
 
-class ImageFormat1(Enum):
+class ImageFormat1(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -1598,7 +1598,7 @@ class ImageFormat1(Enum):
     webp = 'webp'
 
 
-class AssetSource4(Enum):
+class AssetSource4(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -1614,7 +1614,7 @@ class RequiredConnection11(RequiredConnection):
     pass
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'
@@ -1699,13 +1699,13 @@ class CanonicalParameters12(AdCPBaseModel):
     ]
 
 
-class Source1(Enum):
+class Source1(StrEnum):
     publisher = 'publisher'
     aao_mirror = 'aao_mirror'
     agent_derived = 'agent_derived'
 
 
-class Capability(Enum):
+class Capability(StrEnum):
     validation = 'validation'
     assembly = 'assembly'
     generation = 'generation'
@@ -1866,14 +1866,14 @@ class AssetPoolBinding(AdCPBaseModel):
     ] = None
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class DimensionUnit(Enum):
+class DimensionUnit(StrEnum):
     px = 'px'
     dp = 'dp'
     inches = 'inches'
@@ -1882,7 +1882,7 @@ class DimensionUnit(Enum):
     pt = 'pt'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -1893,17 +1893,17 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'
@@ -1919,12 +1919,12 @@ class LogoSlot(Enum):
     marketplace_listing = 'marketplace_listing'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
@@ -1951,7 +1951,7 @@ class Visual(AdCPBaseModel):
     ] = None
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     px = 'px'
     fraction = 'fraction'
     inches = 'inches'

--- a/src/adcp/types/generated_poc/bundled/media_buy/log_event_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/log_event_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -45,7 +45,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class Type(Enum):
+class Type(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'
@@ -181,7 +181,7 @@ class CustomData(AdCPBaseModel):
     ] = None
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -193,7 +193,7 @@ class ActionSource(Enum):
     other = 'other'
 
 
-class Category(Enum):
+class Category(StrEnum):
     owned_property = 'owned_property'
     website = 'website'
     app = 'app'

--- a/src/adcp/types/generated_poc/bundled/media_buy/log_event_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/log_event_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/package_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/package_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -111,7 +112,7 @@ class FormatOptionRefs(RootModel[FormatOptionRefs1 | FormatOptionRefs2]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     even = 'even'
     asap = 'asap'
     front_loaded = 'front_loaded'
@@ -121,11 +122,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -202,7 +203,7 @@ class FeedFieldMapping(AdCPBaseModel):
     ] = None
 
 
-class Metric(Enum):
+class Metric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -216,7 +217,7 @@ class Metric(Enum):
     reach = 'reach'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -320,7 +321,7 @@ class PostView(Window):
     pass
 
 
-class Model(Enum):
+class Model(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -383,7 +384,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -391,7 +392,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -455,7 +456,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -540,7 +541,7 @@ class GeoRegionsExcludeItem(GeoRegion):
     pass
 
 
-class Day(Enum):
+class Day(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -585,7 +586,7 @@ class DaypartTarget(AdCPBaseModel):
     ] = None
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 
@@ -1129,7 +1130,7 @@ class CollectionListExclude(CollectionList):
     pass
 
 
-class AcceptedMethod(Enum):
+class AcceptedMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -1155,7 +1156,7 @@ class AgeRestriction(AdCPBaseModel):
     ] = None
 
 
-class DevicePlatformEnum(Enum):
+class DevicePlatformEnum(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -1193,7 +1194,7 @@ class StoreCatchment(AdCPBaseModel):
     ] = None
 
 
-class Unit5(Enum):
+class Unit5(StrEnum):
     min = 'min'
     hr = 'hr'
 
@@ -1212,14 +1213,14 @@ class TravelTime(AdCPBaseModel):
     ]
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class Unit6(Enum):
+class Unit6(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
@@ -1233,7 +1234,7 @@ class Radius(AdCPBaseModel):
     unit: Annotated[Unit6, Field(description='Distance unit.', title='Distance Unit')]
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -1331,7 +1332,7 @@ class VerificationItem1(VerificationItem):
     pass
 
 
-class AvailableRemedy(Enum):
+class AvailableRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'
@@ -1350,7 +1351,7 @@ class MakegoodPolicy(AdCPBaseModel):
     ]
 
 
-class Metric1(Enum):
+class Metric1(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -1374,7 +1375,7 @@ class VerificationItem2(VerificationItem):
     pass
 
 
-class MetricId(Enum):
+class MetricId(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -1413,12 +1414,12 @@ class MetricId(Enum):
     brand_search_lift = 'brand_search_lift'
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'
@@ -1440,7 +1441,7 @@ class AttributionWindow1(AdCPBaseModel):
     ]
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'
@@ -1529,7 +1530,7 @@ class VerificationItem4(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -1537,7 +1538,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -1545,7 +1546,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -1789,7 +1790,7 @@ class VerificationItem17(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -1809,7 +1810,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role18(Enum):
+class Role18(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -1863,7 +1864,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -1999,7 +2000,7 @@ class VerificationItem22(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -2009,7 +2010,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -2030,7 +2031,7 @@ class VerificationItem23(VerificationItem):
     pass
 
 
-class Target7(Enum):
+class Target7(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -2052,7 +2053,7 @@ class VerificationItem24(VerificationItem):
     pass
 
 
-class Target8(Enum):
+class Target8(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -2451,7 +2452,7 @@ class Input(AdCPBaseModel):
     ] = None
 
 
-class Status2(Enum):
+class Status2(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -2460,7 +2461,7 @@ class Status2(Enum):
     archived = 'archived'
 
 
-class Type1(Enum):
+class Type1(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
@@ -3253,7 +3254,7 @@ class VerificationItem93(VerificationItem):
     pass
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -3269,7 +3270,7 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -3285,7 +3286,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -3296,14 +3297,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -3337,7 +3338,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -3352,7 +3353,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -3361,7 +3362,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -3373,30 +3374,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -3407,7 +3408,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -3415,7 +3416,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -3429,7 +3430,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -3438,45 +3439,45 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -3484,7 +3485,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -3523,24 +3524,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -3618,25 +3619,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -3662,7 +3663,7 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/provide_performance_feedback_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/provide_performance_feedback_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -19,7 +19,7 @@ class MeasurementPeriod(AdCPBaseModel):
     end: Annotated[AwareDatetime, Field(description='End timestamp (inclusive), ISO 8601')]
 
 
-class MetricType(Enum):
+class MetricType(StrEnum):
     overall_performance = 'overall_performance'
     conversion_rate = 'conversion_rate'
     brand_lift = 'brand_lift'
@@ -30,7 +30,7 @@ class MetricType(Enum):
     cost_efficiency = 'cost_efficiency'
 
 
-class FeedbackSource(Enum):
+class FeedbackSource(StrEnum):
     buyer_attribution = 'buyer_attribution'
     third_party_measurement = 'third_party_measurement'
     platform_analytics = 'platform_analytics'

--- a/src/adcp/types/generated_poc/bundled/media_buy/provide_performance_feedback_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/provide_performance_feedback_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/sync_audiences_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/sync_audiences_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -561,7 +561,7 @@ class Account1(AdCPBaseModel):
     ] = False
 
 
-class AudienceType(Enum):
+class AudienceType(StrEnum):
     crm = 'crm'
     suppression = 'suppression'
     lookalike_seed = 'lookalike_seed'
@@ -571,14 +571,14 @@ class Tag(RootModel[str]):
     root: Annotated[str, Field(min_length=1)]
 
 
-class ConsentBasis(Enum):
+class ConsentBasis(StrEnum):
     consent = 'consent'
     legitimate_interest = 'legitimate_interest'
     contract = 'contract'
     legal_obligation = 'legal_obligation'
 
 
-class UIDType(Enum):
+class UIDType(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'

--- a/src/adcp/types/generated_poc/bundled/media_buy/sync_audiences_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/sync_audiences_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/sync_catalogs_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/sync_catalogs_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -561,7 +561,7 @@ class Account1(AdCPBaseModel):
     ] = False
 
 
-class Type(Enum):
+class Type(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -577,7 +577,7 @@ class Type(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -588,7 +588,7 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
@@ -599,7 +599,7 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class ConversionEvent(Enum):
+class ConversionEvent(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -633,7 +633,7 @@ class ConversionEvent(Enum):
     custom = 'custom'
 
 
-class ContentIdType(Enum):
+class ContentIdType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -648,11 +648,11 @@ class ContentIdType(Enum):
     app_id = 'app_id'
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -835,12 +835,12 @@ class Catalog(AdCPBaseModel):
     ] = None
 
 
-class ValidationMode(Enum):
+class ValidationMode(StrEnum):
     strict = 'strict'
     lenient = 'lenient'
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/sync_catalogs_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/sync_catalogs_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/sync_event_sources_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/sync_event_sources_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -561,7 +561,7 @@ class Account1(AdCPBaseModel):
     ] = False
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -595,7 +595,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -607,7 +607,7 @@ class ActionSource(Enum):
     other = 'other'
 
 
-class Category(Enum):
+class Category(StrEnum):
     owned_property = 'owned_property'
     website = 'website'
     app = 'app'

--- a/src/adcp/types/generated_poc/bundled/media_buy/sync_event_sources_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/sync_event_sources_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/update_media_buy_request.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/update_media_buy_request.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -57,7 +58,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -65,7 +66,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -129,7 +130,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -174,11 +175,11 @@ class Gtin(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9]{8,14}$')]
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -255,7 +256,7 @@ class FeedFieldMapping(AdCPBaseModel):
     ] = None
 
 
-class Metric(Enum):
+class Metric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -269,7 +270,7 @@ class Metric(Enum):
     reach = 'reach'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -433,7 +434,7 @@ class GeoRegionsExcludeItem(GeoRegion):
     pass
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 
@@ -1000,7 +1001,7 @@ class StoreCatchment(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -1170,7 +1171,7 @@ class VerificationItem2(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -1178,7 +1179,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -1186,7 +1187,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -1430,7 +1431,7 @@ class VerificationItem15(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -1450,7 +1451,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role16(Enum):
+class Role16(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -1504,7 +1505,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -1640,7 +1641,7 @@ class VerificationItem20(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -1650,7 +1651,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -1671,7 +1672,7 @@ class VerificationItem21(VerificationItem):
     pass
 
 
-class Target7(Enum):
+class Target7(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -1693,7 +1694,7 @@ class VerificationItem22(VerificationItem):
     pass
 
 
-class Target8(Enum):
+class Target8(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -2870,7 +2871,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role96(Enum):
+class Role96(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'
@@ -3445,7 +3446,7 @@ class VerificationItem93(VerificationItem):
     pass
 
 
-class AvailableRemedy(Enum):
+class AvailableRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'
@@ -3464,7 +3465,7 @@ class MakegoodPolicy(AdCPBaseModel):
     ]
 
 
-class Metric2(Enum):
+class Metric2(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -3488,12 +3489,12 @@ class VerificationItem94(VerificationItem):
     pass
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'
@@ -3515,7 +3516,7 @@ class AttributionWindow2(AdCPBaseModel):
     ]
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'
@@ -5033,13 +5034,13 @@ class VerificationItem185(VerificationItem):
     pass
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -5051,30 +5052,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -5085,13 +5086,13 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     even = 'even'
     asap = 'asap'
     front_loaded = 'front_loaded'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -5107,7 +5108,7 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -5118,14 +5119,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -5159,7 +5160,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -5174,7 +5175,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -5183,7 +5184,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class AttributionModel(Enum):
+class AttributionModel(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -5191,7 +5192,7 @@ class AttributionModel(Enum):
     data_driven = 'data_driven'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -5199,7 +5200,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -5213,7 +5214,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DayOfWeek(Enum):
+class DayOfWeek(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -5223,7 +5224,7 @@ class DayOfWeek(Enum):
     sunday = 'sunday'
 
 
-class AgeVerificationMethod(Enum):
+class AgeVerificationMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -5231,7 +5232,7 @@ class AgeVerificationMethod(Enum):
     world_id = 'world_id'
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -5246,7 +5247,7 @@ class DevicePlatform(Enum):
     unknown = 'unknown'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -5255,31 +5256,31 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class TravelTimeUnit(Enum):
+class TravelTimeUnit(StrEnum):
     min = 'min'
     hr = 'hr'
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class DistanceUnit(Enum):
+class DistanceUnit(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -5295,34 +5296,34 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTVersion(Enum):
+class VASTVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -5330,7 +5331,7 @@ class VASTVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -5369,24 +5370,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -5464,25 +5465,25 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTVersion(Enum):
+class DAASTVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -5508,12 +5509,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class CreativeStatus(Enum):
+class CreativeStatus(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -5522,19 +5523,19 @@ class CreativeStatus(Enum):
     archived = 'archived'
 
 
-class CreativeIdentifierType(Enum):
+class CreativeIdentifierType(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'
     idcrea = 'idcrea'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -5573,7 +5574,7 @@ class AvailableMetric(Enum):
     brand_search_lift = 'brand_search_lift'
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/media_buy/update_media_buy_response.py
+++ b/src/adcp/types/generated_poc/bundled/media_buy/update_media_buy_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -302,7 +302,7 @@ class UpdateMediaBuyResponse(AdCPBaseModel):
     ] = None
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -312,7 +312,7 @@ class MediaBuyStatus(Enum):
     canceled = 'canceled'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -346,7 +346,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -354,7 +354,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -368,7 +368,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -377,7 +377,7 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -386,13 +386,13 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -404,30 +404,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -438,12 +438,12 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class MediaBuyValidAction(Enum):
+class MediaBuyValidAction(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'

--- a/src/adcp/types/generated_poc/bundled/property/create_property_list_request.py
+++ b/src/adcp/types/generated_poc/bundled/property/create_property_list_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -56,7 +56,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -64,7 +64,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -128,7 +128,7 @@ class VerifyAgent33(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -244,7 +244,7 @@ class CountriesAllItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class ChannelsAnyEnum(Enum):
+class ChannelsAnyEnum(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -267,7 +267,7 @@ class ChannelsAnyEnum(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -280,7 +280,7 @@ class PropertyType(Enum):
     ai_assistant = 'ai_assistant'
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -336,7 +336,7 @@ class VerificationItem17(VerificationItem):
     pass
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -348,30 +348,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -382,7 +382,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/create_property_list_response.py
+++ b/src/adcp/types/generated_poc/bundled/property/create_property_list_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -255,7 +255,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -263,7 +263,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -327,7 +327,7 @@ class VerifyAgent37(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -443,7 +443,7 @@ class CountriesAllItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class ChannelsAnyEnum(Enum):
+class ChannelsAnyEnum(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -466,7 +466,7 @@ class ChannelsAnyEnum(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -479,7 +479,7 @@ class PropertyType(Enum):
     ai_assistant = 'ai_assistant'
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -619,7 +619,7 @@ class PricingOption2(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -764,7 +764,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -776,30 +776,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -810,7 +810,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/delete_property_list_request.py
+++ b/src/adcp/types/generated_poc/bundled/property/delete_property_list_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent41(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/property/delete_property_list_response.py
+++ b/src/adcp/types/generated_poc/bundled/property/delete_property_list_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/property/get_property_list_request.py
+++ b/src/adcp/types/generated_poc/bundled/property/get_property_list_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent425(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/property/get_property_list_response.py
+++ b/src/adcp/types/generated_poc/bundled/property/get_property_list_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -255,7 +255,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -263,7 +263,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -327,7 +327,7 @@ class VerifyAgent427(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -443,7 +443,7 @@ class CountriesAllItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class ChannelsAnyEnum(Enum):
+class ChannelsAnyEnum(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -466,7 +466,7 @@ class ChannelsAnyEnum(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -479,7 +479,7 @@ class PropertyType(Enum):
     ai_assistant = 'ai_assistant'
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -619,7 +619,7 @@ class PricingOption122(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -796,7 +796,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -808,30 +808,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -842,7 +842,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/list_property_lists_request.py
+++ b/src/adcp/types/generated_poc/bundled/property/list_property_lists_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent1205(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/property/list_property_lists_response.py
+++ b/src/adcp/types/generated_poc/bundled/property/list_property_lists_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -255,7 +255,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -263,7 +263,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -327,7 +327,7 @@ class VerifyAgent1207(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -443,7 +443,7 @@ class CountriesAllItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class ChannelsAnyEnum(Enum):
+class ChannelsAnyEnum(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -466,7 +466,7 @@ class ChannelsAnyEnum(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -479,7 +479,7 @@ class PropertyType(Enum):
     ai_assistant = 'ai_assistant'
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -619,7 +619,7 @@ class PricingOption212(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -796,7 +796,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -808,30 +808,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -842,7 +842,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/update_property_list_request.py
+++ b/src/adcp/types/generated_poc/bundled/property/update_property_list_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -56,7 +56,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -64,7 +64,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -128,7 +128,7 @@ class VerifyAgent2457(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -244,7 +244,7 @@ class CountriesAllItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class ChannelsAnyEnum(Enum):
+class ChannelsAnyEnum(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -267,7 +267,7 @@ class ChannelsAnyEnum(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -280,7 +280,7 @@ class PropertyType(Enum):
     ai_assistant = 'ai_assistant'
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -336,7 +336,7 @@ class VerificationItem1229(VerificationItem):
     pass
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -348,30 +348,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -382,7 +382,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/update_property_list_response.py
+++ b/src/adcp/types/generated_poc/bundled/property/update_property_list_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -255,7 +255,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -263,7 +263,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -327,7 +327,7 @@ class VerifyAgent2461(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -443,7 +443,7 @@ class CountriesAllItem(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class ChannelsAnyEnum(Enum):
+class ChannelsAnyEnum(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -466,7 +466,7 @@ class ChannelsAnyEnum(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -479,7 +479,7 @@ class PropertyType(Enum):
     ai_assistant = 'ai_assistant'
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 
@@ -619,7 +619,7 @@ class PricingOption282(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -774,7 +774,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -786,30 +786,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -820,7 +820,7 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/validate_property_delivery_request.py
+++ b/src/adcp/types/generated_poc/bundled/property/validate_property_delivery_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -68,7 +68,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -76,7 +76,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -104,7 +104,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -161,7 +161,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -186,7 +186,7 @@ class VerifyAgent2663(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -225,13 +225,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -323,7 +323,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -561,7 +561,7 @@ class Account49(AdCPBaseModel):
     ] = False
 
 
-class Type(Enum):
+class Type(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/bundled/property/validate_property_delivery_response.py
+++ b/src/adcp/types/generated_poc/bundled/property/validate_property_delivery_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -293,7 +293,7 @@ class AuthorizationSummary(AdCPBaseModel):
     ]
 
 
-class Type(Enum):
+class Type(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'
@@ -344,14 +344,14 @@ class Identifier(AdCPBaseModel):
     ]
 
 
-class Status330(Enum):
+class Status330(StrEnum):
     compliant = 'compliant'
     non_compliant = 'non_compliant'
     not_covered = 'not_covered'
     unidentified = 'unidentified'
 
 
-class Status331(Enum):
+class Status331(StrEnum):
     passed = 'passed'
     failed = 'failed'
     warning = 'warning'
@@ -411,7 +411,7 @@ class Feature(AdCPBaseModel):
     ] = None
 
 
-class Status332(Enum):
+class Status332(StrEnum):
     authorized = 'authorized'
     unauthorized = 'unauthorized'
     unknown = 'unknown'

--- a/src/adcp/types/generated_poc/bundled/protocol/get_adcp_capabilities_request.py
+++ b/src/adcp/types/generated_poc/bundled/protocol/get_adcp_capabilities_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     media_buy = 'media_buy'
     signals = 'signals'
     governance = 'governance'

--- a/src/adcp/types/generated_poc/bundled/protocol/get_adcp_capabilities_response.py
+++ b/src/adcp/types/generated_poc/bundled/protocol/get_adcp_capabilities_response.py
@@ -5,14 +5,14 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -82,13 +82,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -153,7 +153,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -295,7 +295,7 @@ class Adcp(AdCPBaseModel):
     ]
 
 
-class SupportedProtocol(Enum):
+class SupportedProtocol(StrEnum):
     media_buy = 'media_buy'
     signals = 'signals'
     governance = 'governance'
@@ -305,7 +305,7 @@ class SupportedProtocol(Enum):
     measurement = 'measurement'
 
 
-class SupportedBillingEnum(Enum):
+class SupportedBillingEnum(StrEnum):
     operator = 'operator'
     agent = 'agent'
     advertiser = 'advertiser'
@@ -351,7 +351,7 @@ class Account(AdCPBaseModel):
     ] = False
 
 
-class SupportedPricingModel(Enum):
+class SupportedPricingModel(StrEnum):
     cpm = 'cpm'
     vcpm = 'vcpm'
     cpc = 'cpc'
@@ -363,30 +363,30 @@ class SupportedPricingModel(Enum):
     time = 'time'
 
 
-class BuyingMode(Enum):
+class BuyingMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
     refine = 'refine'
 
 
-class ReportingDeliveryMethod(Enum):
+class ReportingDeliveryMethod(StrEnum):
     webhook = 'webhook'
     offline = 'offline'
 
 
-class OfflineDeliveryProtocol(Enum):
+class OfflineDeliveryProtocol(StrEnum):
     s3 = 's3'
     gcs = 'gcs'
     azure_blob = 'azure_blob'
 
 
-class PropagationSurface(Enum):
+class PropagationSurface(StrEnum):
     snapshot = 'snapshot'
     webhook = 'webhook'
     out_of_band = 'out_of_band'
 
 
-class CreativeApprovalMode(Enum):
+class CreativeApprovalMode(StrEnum):
     auto_approve = 'auto_approve'
     require_human = 'require_human'
 
@@ -416,7 +416,7 @@ class Features(AdCPBaseModel):
     ] = None
 
 
-class Surface(Enum):
+class Surface(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -485,7 +485,7 @@ class GeoPostalAreas(AdCPBaseModel):
     at_plz: bool | None = None
 
 
-class VerificationMethod(Enum):
+class VerificationMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -503,7 +503,7 @@ class AgeRestriction(AdCPBaseModel):
     ] = None
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
@@ -538,7 +538,7 @@ class GeoProximity(AdCPBaseModel):
     ] = None
 
 
-class SupportedIdentifierType(Enum):
+class SupportedIdentifierType(StrEnum):
     hashed_email = 'hashed_email'
     hashed_phone = 'hashed_phone'
 
@@ -551,7 +551,7 @@ class MatchingLatencyHours(AdCPBaseModel):
     max: Annotated[int | None, Field(ge=0)] = None
 
 
-class SupportedOptimizationMetric(Enum):
+class SupportedOptimizationMetric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -565,7 +565,7 @@ class SupportedOptimizationMetric(Enum):
     reach = 'reach'
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 
@@ -583,13 +583,13 @@ class VendorMetricOptimization(AdCPBaseModel):
     ] = None
 
 
-class SupportedTarget3(Enum):
+class SupportedTarget3(StrEnum):
     cost_per = 'cost_per'
     per_ad_spend = 'per_ad_spend'
     maximize_value = 'maximize_value'
 
 
-class SupportedActionSource(Enum):
+class SupportedActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -601,7 +601,7 @@ class SupportedActionSource(Enum):
     other = 'other'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -628,7 +628,7 @@ class PostViewItem(PostClickItem):
     pass
 
 
-class SupportedPerUnit(Enum):
+class SupportedPerUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -671,7 +671,7 @@ class DataProviderDomain(PublisherDomain):
     pass
 
 
-class DiscoveryMode(Enum):
+class DiscoveryMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
 
@@ -706,7 +706,7 @@ class Signals(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     binary = 'binary'
     quantitative = 'quantitative'
     categorical = 'categorical'
@@ -800,7 +800,7 @@ class Governance(AdCPBaseModel):
     ] = None
 
 
-class Type12(Enum):
+class Type12(StrEnum):
     mcp = 'mcp'
     a2a = 'a2a'
 
@@ -872,7 +872,7 @@ class Modalities(AdCPBaseModel):
     ] = None
 
 
-class StandardEnum(Enum):
+class StandardEnum(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'
@@ -945,7 +945,7 @@ class SponsoredIntelligence(AdCPBaseModel):
     ] = None
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -953,7 +953,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class AvailableUs(Enum):
+class AvailableUs(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -997,7 +997,7 @@ class Brand(AdCPBaseModel):
     ] = None
 
 
-class VariantDimension(Enum):
+class VariantDimension(StrEnum):
     voice = 'voice'
     theme = 'theme'
     best_of_n = 'best_of_n'
@@ -1005,7 +1005,7 @@ class VariantDimension(Enum):
     custom = 'custom'
 
 
-class SelectionStrategy(Enum):
+class SelectionStrategy(StrEnum):
     audience_relevance = 'audience_relevance'
     contextual_fit = 'contextual_fit'
     performance = 'performance'
@@ -1063,7 +1063,7 @@ class Multiplicity(AdCPBaseModel):
     ] = None
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'
@@ -1128,7 +1128,7 @@ class FormatSchema(AdCPBaseModel):
     ]
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
@@ -1137,7 +1137,7 @@ class PlatformExtension(FormatSchema):
     pass
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -1161,7 +1161,7 @@ class AssetType(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -1183,14 +1183,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status10(Enum):
+class Status10(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'
@@ -1293,7 +1293,7 @@ class RequiredConnection(AdCPBaseModel):
     ] = None
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'
@@ -1307,7 +1307,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -1316,7 +1316,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -1325,7 +1325,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 
@@ -1334,12 +1334,12 @@ class RequiredConnection1(RequiredConnection):
     pass
 
 
-class MraidVersion2(Enum):
+class MraidVersion2(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 
@@ -1348,7 +1348,7 @@ class RequiredConnection2(RequiredConnection):
     pass
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'
@@ -1358,7 +1358,7 @@ class RequiredConnection3(RequiredConnection):
     pass
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 
@@ -1367,7 +1367,7 @@ class RequiredConnection4(RequiredConnection):
     pass
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -1377,7 +1377,7 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class VideoCodec(Enum):
+class VideoCodec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -1386,20 +1386,20 @@ class VideoCodec(Enum):
     prores = 'prores'
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -1417,7 +1417,7 @@ class RequiredConnection5(RequiredConnection):
     pass
 
 
-class VastVersion2(Enum):
+class VastVersion2(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -1425,7 +1425,7 @@ class VastVersion2(Enum):
     field_4_2 = '4.2'
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 
@@ -1438,7 +1438,7 @@ class RequiredConnection6(RequiredConnection):
     pass
 
 
-class AudioCodec2(Enum):
+class AudioCodec2(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -1450,7 +1450,7 @@ class AudioSampleRate(MajorVersion):
     pass
 
 
-class AudioChannel(Enum):
+class AudioChannel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
@@ -1459,7 +1459,7 @@ class RequiredConnection7(RequiredConnection):
     pass
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
@@ -1468,7 +1468,7 @@ class RequiredConnection8(RequiredConnection):
     pass
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -1483,13 +1483,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -1505,7 +1505,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -1524,7 +1524,7 @@ class IconSize(Size):
     pass
 
 
-class ImageFormat1(Enum):
+class ImageFormat1(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -1532,7 +1532,7 @@ class ImageFormat1(Enum):
     webp = 'webp'
 
 
-class AssetSource5(Enum):
+class AssetSource5(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -1548,13 +1548,13 @@ class RequiredConnection11(RequiredConnection):
     pass
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'
 
 
-class CoversContentDigest(Enum):
+class CoversContentDigest(StrEnum):
     required = 'required'
     forbidden = 'forbidden'
     either = 'either'
@@ -1626,7 +1626,7 @@ class RequestSigning(AdCPBaseModel):
     ] = []
 
 
-class Algorithm(Enum):
+class Algorithm(StrEnum):
     ed25519 = 'ed25519'
     ecdsa_p256_sha256 = 'ecdsa-p256-sha256'
 
@@ -1849,7 +1849,7 @@ class ComplianceTesting(AdCPBaseModel):
     ]
 
 
-class Specialism(Enum):
+class Specialism(StrEnum):
     audience_sync = 'audience-sync'
     brand_rights = 'brand-rights'
     collection_lists = 'collection-lists'
@@ -1979,7 +1979,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class EventType2(Enum):
+class EventType2(StrEnum):
     product_created = 'product.created'
     product_updated = 'product.updated'
     product_priced = 'product.priced'
@@ -2010,13 +2010,13 @@ class WholesaleFeedWebhooks(AdCPBaseModel):
     ] = None
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class UIDType(Enum):
+class UIDType(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'
@@ -2029,7 +2029,7 @@ class UIDType(Enum):
     other = 'other'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -2063,7 +2063,7 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -2086,7 +2086,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'

--- a/src/adcp/types/generated_poc/bundled/protocol/get_task_status_response.py
+++ b/src/adcp/types/generated_poc/bundled/protocol/get_task_status_response.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -71,13 +72,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -142,7 +143,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'
@@ -183,7 +184,7 @@ class Progress(AdCPBaseModel):
     step_number: Annotated[int | None, Field(description='Current step number', ge=1)] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     request = 'request'
     response = 'response'
 
@@ -434,7 +435,7 @@ class FormatId(AdCPBaseModel):
     ] = None
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'
@@ -463,7 +464,7 @@ class FormatSchema(AdCPBaseModel):
     ]
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
@@ -472,7 +473,7 @@ class PlatformExtension(FormatSchema):
     pass
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -496,7 +497,7 @@ class AssetType(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -518,14 +519,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status(Enum):
+class Status(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'
@@ -628,7 +629,7 @@ class RequiredConnection(AdCPBaseModel):
     ] = None
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'
@@ -642,7 +643,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -651,7 +652,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -660,7 +661,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 
@@ -669,12 +670,12 @@ class RequiredConnection13(RequiredConnection):
     pass
 
 
-class MraidVersion(Enum):
+class MraidVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 
@@ -683,7 +684,7 @@ class RequiredConnection14(RequiredConnection):
     pass
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'
@@ -693,7 +694,7 @@ class RequiredConnection15(RequiredConnection):
     pass
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 
@@ -702,7 +703,7 @@ class RequiredConnection16(RequiredConnection):
     pass
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -712,7 +713,7 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class VideoCodec(Enum):
+class VideoCodec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -721,20 +722,20 @@ class VideoCodec(Enum):
     prores = 'prores'
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -752,7 +753,7 @@ class RequiredConnection17(RequiredConnection):
     pass
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -760,7 +761,7 @@ class VastVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 
@@ -773,7 +774,7 @@ class RequiredConnection18(RequiredConnection):
     pass
 
 
-class AudioCodec4(Enum):
+class AudioCodec4(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -785,7 +786,7 @@ class AudioSampleRate(CompanionBannerWidth):
     pass
 
 
-class AudioChannel(Enum):
+class AudioChannel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
@@ -794,7 +795,7 @@ class RequiredConnection19(RequiredConnection):
     pass
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 
@@ -803,7 +804,7 @@ class RequiredConnection20(RequiredConnection):
     pass
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -818,13 +819,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -840,7 +841,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -859,7 +860,7 @@ class IconSize(Size):
     pass
 
 
-class ImageFormat3(Enum):
+class ImageFormat3(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -867,7 +868,7 @@ class ImageFormat3(Enum):
     webp = 'webp'
 
 
-class AssetSource9(Enum):
+class AssetSource9(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -883,18 +884,18 @@ class RequiredConnection23(RequiredConnection):
     pass
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     publisher_ref = 'publisher_ref'
     seller_inline = 'seller_inline'
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     targetable = 'targetable'
     included = 'included'
 
@@ -1028,7 +1029,7 @@ class Parameters5(AdCPBaseModel):
     ] = None
 
 
-class TimeUnit(Enum):
+class TimeUnit(StrEnum):
     hour = 'hour'
     day = 'day'
     week = 'week'
@@ -1163,7 +1164,7 @@ class SignalRef12(AdCPBaseModel):
     ]
 
 
-class Presence(Enum):
+class Presence(StrEnum):
     present = 'present'
     absent = 'absent'
 
@@ -1455,7 +1456,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -1463,7 +1464,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -1527,7 +1528,7 @@ class VerifyAgent437(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -1604,7 +1605,7 @@ class Value(AudienceSize):
     pass
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -1720,7 +1721,7 @@ class NoticePeriod(AdCPBaseModel):
     ]
 
 
-class Type23(Enum):
+class Type23(StrEnum):
     percent_remaining = 'percent_remaining'
     full_commitment = 'full_commitment'
     fixed_fee = 'fixed_fee'
@@ -1833,7 +1834,7 @@ class SupportsGeoBreakdown(AdCPBaseModel):
     ] = None
 
 
-class DateRangeSupport(Enum):
+class DateRangeSupport(StrEnum):
     date_range = 'date_range'
     lifetime_only = 'lifetime_only'
 
@@ -2000,12 +2001,12 @@ class Range(AdCPBaseModel):
 
 
 
-class ActivationStatus(Enum):
+class ActivationStatus(StrEnum):
     ready = 'ready'
     requires_activation = 'requires_activation'
 
 
-class AllowedTargetingMode(Enum):
+class AllowedTargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 
@@ -2058,7 +2059,7 @@ class PricingOption142(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -2213,12 +2214,12 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class ResolutionModel(Enum):
+class ResolutionModel(StrEnum):
     direct_targeting = 'direct_targeting'
     seller_planned = 'seller_planned'
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     optional = 'optional'
     required = 'required'
     fixed = 'fixed'
@@ -2318,7 +2319,7 @@ class SignalTargetingRules(AdCPBaseModel):
     ] = None
 
 
-class SupportedMetric(Enum):
+class SupportedMetric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -2336,7 +2337,7 @@ class SupportedViewDuration(RootModel[float]):
     root: Annotated[float, Field(gt=0.0)]
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 
@@ -2357,7 +2358,7 @@ class VerificationItem224(VerificationItem):
     pass
 
 
-class Severity(Enum):
+class Severity(StrEnum):
     error = 'error'
     warning = 'warning'
     info = 'info'
@@ -2379,7 +2380,7 @@ class Issue18(AdCPBaseModel):
     ]
 
 
-class SupportedTarget6(Enum):
+class SupportedTarget6(StrEnum):
     cost_per = 'cost_per'
     per_ad_spend = 'per_ad_spend'
     maximize_value = 'maximize_value'
@@ -3292,7 +3293,7 @@ class VerificationItem239(VerificationItem):
     pass
 
 
-class ProposalStatus(Enum):
+class ProposalStatus(StrEnum):
     draft = 'draft'
     committed = 'committed'
 
@@ -3304,7 +3305,7 @@ class TotalBudget(AdCPBaseModel):
     ]
 
 
-class PaymentTerms1(Enum):
+class PaymentTerms1(StrEnum):
     net_30 = 'net_30'
     net_60 = 'net_60'
     net_90 = 'net_90'
@@ -3528,7 +3529,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class Status90(Enum):
+class Status90(StrEnum):
     applied = 'applied'
     partial = 'partial'
     unable = 'unable'
@@ -3616,7 +3617,7 @@ class RefinementApplied4(RootModel[RefinementApplied | RefinementApplied6 | Refi
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Scope69(Enum):
+class Scope69(StrEnum):
     products = 'products'
     pricing = 'pricing'
     forecast = 'forecast'
@@ -3649,7 +3650,7 @@ class IncompleteItem(AdCPBaseModel):
     ] = None
 
 
-class Semantics(Enum):
+class Semantics(StrEnum):
     only = 'only'
     any = 'any'
     approximate = 'approximate'
@@ -3727,7 +3728,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 
@@ -3766,7 +3767,7 @@ class Result243(AdCPBaseModel):
     ] = None
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     CLARIFICATION_NEEDED = 'CLARIFICATION_NEEDED'
     BUDGET_REQUIRED = 'BUDGET_REQUIRED'
 
@@ -5128,7 +5129,7 @@ class AdcpError14(AdCPBaseModel):
 
 
 
-class SignalType(Enum):
+class SignalType(StrEnum):
     marketplace = 'marketplace'
     custom = 'custom'
     owned = 'owned'
@@ -5336,7 +5337,7 @@ class VerificationItem263(VerificationItem):
     pass
 
 
-class Kind12(Enum):
+class Kind12(StrEnum):
     inventory = 'inventory'
     product = 'product'
     account = 'account'
@@ -5388,12 +5389,12 @@ class Scope118(AdCPBaseModel):
     ] = None
 
 
-class BucketSemantics(Enum):
+class BucketSemantics(StrEnum):
     exclusive = 'exclusive'
     overlapping = 'overlapping'
 
 
-class BucketCompleteness(Enum):
+class BucketCompleteness(StrEnum):
     complete = 'complete'
     partial = 'partial'
 
@@ -5572,7 +5573,7 @@ class PricingOption18(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class RestrictedAttribute(Enum):
+class RestrictedAttribute(StrEnum):
     racial_ethnic_origin = 'racial_ethnic_origin'
     political_opinions = 'political_opinions'
     religious_beliefs = 'religious_beliefs'
@@ -5604,7 +5605,7 @@ class ValueMapping(AdCPBaseModel):
     modifiers: list[str] | None = None
 
 
-class ParentMatchBehavior(Enum):
+class ParentMatchBehavior(StrEnum):
     exact_only = 'exact_only'
     descendants_supported = 'descendants_supported'
     unknown = 'unknown'
@@ -5623,7 +5624,7 @@ class Taxonomy(AdCPBaseModel):
     parent_match_behavior: ParentMatchBehavior | None = None
 
 
-class DataSource(Enum):
+class DataSource(StrEnum):
     app_behavior = 'app_behavior'
     app_usage = 'app_usage'
     web_usage = 'web_usage'
@@ -5643,7 +5644,7 @@ class DataSource(Enum):
     offline_transaction = 'offline_transaction'
 
 
-class Methodology(Enum):
+class Methodology(StrEnum):
     observed = 'observed'
     declared = 'declared'
     derived = 'derived'
@@ -5651,7 +5652,7 @@ class Methodology(Enum):
     modeled = 'modeled'
 
 
-class RefreshCadence(Enum):
+class RefreshCadence(StrEnum):
     intra_day = 'intra_day'
     daily = 'daily'
     weekly = 'weekly'
@@ -5662,7 +5663,7 @@ class RefreshCadence(Enum):
     annually = 'annually'
 
 
-class MatchKey(Enum):
+class MatchKey(StrEnum):
     name = 'name'
     address = 'address'
     email = 'email'
@@ -5675,7 +5676,7 @@ class MatchKey(Enum):
     phone = 'phone'
 
 
-class PreOnboardingPrecisionLevel(Enum):
+class PreOnboardingPrecisionLevel(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -5692,28 +5693,28 @@ class Onboarder(AdCPBaseModel):
     pre_onboarding_precision_level: PreOnboardingPrecisionLevel | None = None
 
 
-class ConsentBasi(Enum):
+class ConsentBasi(StrEnum):
     consent = 'consent'
     legitimate_interest = 'legitimate_interest'
     contract = 'contract'
     legal_obligation = 'legal_obligation'
 
 
-class Art9Basis(Enum):
+class Art9Basis(StrEnum):
     explicit_consent = 'explicit_consent'
     manifestly_made_public = 'manifestly_made_public'
     substantial_public_interest = 'substantial_public_interest'
     vital_interests = 'vital_interests'
 
 
-class Method(Enum):
+class Method(StrEnum):
     lookalike = 'lookalike'
     supervised = 'supervised'
     embedding = 'embedding'
     rules = 'rules'
 
 
-class Type27(Enum):
+class Type27(StrEnum):
     first_party_crm = 'first_party_crm'
     panel = 'panel'
     declared_survey = 'declared_survey'
@@ -5738,13 +5739,13 @@ class TrainingDataJurisdiction(Country):
     pass
 
 
-class AiActRiskClass(Enum):
+class AiActRiskClass(StrEnum):
     minimal = 'minimal'
     limited = 'limited'
     high_risk = 'high_risk'
 
 
-class Audience(Enum):
+class Audience(StrEnum):
     buyer = 'buyer'
     data_subject = 'data_subject'
     regulator = 'regulator'
@@ -5827,7 +5828,7 @@ class Modeling(AdCPBaseModel):
     ] = None
 
 
-class Right(Enum):
+class Right(StrEnum):
     access = 'access'
     rectification = 'rectification'
     erasure = 'erasure'
@@ -5926,7 +5927,7 @@ class Error8(AdCPBaseModel):
     ] = None
 
 
-class Scope119(Enum):
+class Scope119(StrEnum):
     signals = 'signals'
     pricing = 'pricing'
     wholesale_feed = 'wholesale_feed'
@@ -6203,7 +6204,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role278(Enum):
+class Role278(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'
@@ -6336,7 +6337,7 @@ class GovernanceAgent(AdCPBaseModel):
     url: Annotated[AnyUrl, Field(description='Governance agent endpoint URL. Must use HTTPS.')]
 
 
-class Format(Enum):
+class Format(StrEnum):
     jsonl = 'jsonl'
     csv = 'csv'
     parquet = 'parquet'
@@ -6344,7 +6345,7 @@ class Format(Enum):
     orc = 'orc'
 
 
-class Compression(Enum):
+class Compression(StrEnum):
     gzip = 'gzip'
     none = 'none'
 
@@ -6410,11 +6411,11 @@ class Gtin(MatchedGtin):
     pass
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class FeedFieldMapping(AdCPBaseModel):
@@ -6566,7 +6567,7 @@ class GeoRegionsExcludeItem(GeoRegion):
     pass
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 
@@ -7000,7 +7001,7 @@ class StoreCatchment(AdCPBaseModel):
     ] = None
 
 
-class Type28(Enum):
+class Type28(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 
@@ -7691,7 +7692,7 @@ class Result279(AdCPBaseModel):
     ] = None
 
 
-class Reason8(Enum):
+class Reason8(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     BUDGET_EXCEEDS_LIMIT = 'BUDGET_EXCEEDS_LIMIT'
 
@@ -8789,7 +8790,7 @@ class Result289(Result279):
     pass
 
 
-class Reason9(Enum):
+class Reason9(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CHANGE_CONFIRMATION = 'CHANGE_CONFIRMATION'
 
@@ -8926,7 +8927,7 @@ class Result291(AdCPBaseModel):
     ] = None
 
 
-class NotificationType1(Enum):
+class NotificationType1(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -8950,7 +8951,7 @@ class PostView2(Window):
     pass
 
 
-class Status141(Enum):
+class Status141(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     pending = 'pending'
@@ -8963,7 +8964,7 @@ class Status141(Enum):
     reporting_delayed = 'reporting_delayed'
 
 
-class Kind13(Enum):
+class Kind13(StrEnum):
     cumulative = 'cumulative'
     period = 'period'
     rolling = 'rolling'
@@ -9133,7 +9134,7 @@ class VerificationItem276(VerificationItem):
     pass
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     completed = 'completed'
     budget_exhausted = 'budget_exhausted'
@@ -9286,7 +9287,7 @@ class VerificationItem277(VerificationItem):
     pass
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -9294,7 +9295,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -9302,7 +9303,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'
@@ -9546,7 +9547,7 @@ class VerificationItem290(VerificationItem):
     pass
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'
@@ -9566,7 +9567,7 @@ class Messaging(AdCPBaseModel):
     ] = None
 
 
-class Role307(Enum):
+class Role307(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'
@@ -9620,7 +9621,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status142(Enum):
+class Status142(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'
@@ -9737,7 +9738,7 @@ class VerificationItem295(VerificationItem):
     pass
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -9747,7 +9748,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method18(Enum):
+class Method18(StrEnum):
     img = 'img'
     js = 'js'
 
@@ -9768,7 +9769,7 @@ class VerificationItem296(VerificationItem):
     pass
 
 
-class Target31(Enum):
+class Target31(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'
@@ -9790,7 +9791,7 @@ class VerificationItem297(VerificationItem):
     pass
 
 
-class Target32(Enum):
+class Target32(StrEnum):
     linear = 'linear'
     companion = 'companion'
 
@@ -10200,7 +10201,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'
@@ -14856,13 +14857,13 @@ class Error18(AdCPBaseModel):
     ] = None
 
 
-class KeepModeApplied(Enum):
+class KeepModeApplied(StrEnum):
     keep_all = 'keep_all'
     keep_one = 'keep_one'
     keep_some = 'keep_some'
 
 
-class SelectionStrategyApplied(Enum):
+class SelectionStrategyApplied(StrEnum):
     audience_relevance = 'audience_relevance'
     contextual_fit = 'contextual_fit'
     performance = 'performance'
@@ -14871,7 +14872,7 @@ class SelectionStrategyApplied(Enum):
     random = 'random'
 
 
-class BudgetStatus(Enum):
+class BudgetStatus(StrEnum):
     complete = 'complete'
     capped = 'capped'
 
@@ -15004,7 +15005,7 @@ class AdcpError24(AdCPBaseModel):
     ] = None
 
 
-class Basis(Enum):
+class Basis(StrEnum):
     fixed = 'fixed'
     estimated_units = 'estimated_units'
     cpm_deferred = 'cpm_deferred'
@@ -15371,7 +15372,7 @@ class Result579(AdCPBaseModel):
     ] = None
 
 
-class Reason10(Enum):
+class Reason10(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CREATIVE_DIRECTION_NEEDED = 'CREATIVE_DIRECTION_NEEDED'
     ASSET_SELECTION_NEEDED = 'ASSET_SELECTION_NEEDED'
@@ -15716,7 +15717,7 @@ class BillingEntity1(AdCPBaseModel):
     ] = None
 
 
-class Action(Enum):
+class Action(StrEnum):
     created = 'created'
     updated = 'updated'
     unchanged = 'unchanged'
@@ -15724,7 +15725,7 @@ class Action(Enum):
     deleted = 'deleted'
 
 
-class Status154(Enum):
+class Status154(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -16089,7 +16090,7 @@ class Result586(AdCPBaseModel):
     ] = None
 
 
-class Reason11(Enum):
+class Reason11(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     ASSET_CONFIRMATION = 'ASSET_CONFIRMATION'
     FORMAT_CLARIFICATION = 'FORMAT_CLARIFICATION'
@@ -16291,7 +16292,7 @@ class AdcpError30(AdCPBaseModel):
     ] = None
 
 
-class Status155(Enum):
+class Status155(StrEnum):
     approved = 'approved'
     pending = 'pending'
     rejected = 'rejected'
@@ -16749,7 +16750,7 @@ class Result592(AdCPBaseModel):
     ] = None
 
 
-class Reason12(Enum):
+class Reason12(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     FEED_VALIDATION = 'FEED_VALIDATION'
     ITEM_REVIEW = 'ITEM_REVIEW'
@@ -16891,7 +16892,7 @@ class Result594(AdCPBaseModel):
     ] = None
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -16903,12 +16904,12 @@ class TaskStatus(Enum):
     unknown = 'unknown'
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
 
-class AdCPProtocol(Enum):
+class AdCPProtocol(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
     governance = 'governance'
@@ -16918,7 +16919,7 @@ class AdCPProtocol(Enum):
     measurement = 'measurement'
 
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'
@@ -16941,7 +16942,7 @@ class MediaChannel(Enum):
     sponsored_intelligence = 'sponsored_intelligence'
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'
@@ -16957,20 +16958,20 @@ class LogoSlot(Enum):
     marketplace_listing = 'marketplace_listing'
 
 
-class VideoPlacementType(Enum):
+class VideoPlacementType(StrEnum):
     instream = 'instream'
     accompanying_content = 'accompanying_content'
     interstitial = 'interstitial'
     standalone = 'standalone'
 
 
-class SponsoredPlacementType(Enum):
+class SponsoredPlacementType(StrEnum):
     sponsored_search = 'sponsored_search'
     sponsored_display = 'sponsored_display'
     sponsored_native = 'sponsored_native'
 
 
-class SocialPlacementSurface(Enum):
+class SocialPlacementSurface(StrEnum):
     feed = 'feed'
     stories = 'stories'
     short_video = 'short_video'
@@ -16978,25 +16979,25 @@ class SocialPlacementSurface(Enum):
     search = 'search'
 
 
-class DeliveryType(Enum):
+class DeliveryType(StrEnum):
     guaranteed = 'guaranteed'
     non_guaranteed = 'non_guaranteed'
 
 
-class Exclusivity(Enum):
+class Exclusivity(StrEnum):
     none = 'none'
     category = 'category'
     exclusive = 'exclusive'
 
 
-class PriceAdjustmentKind(Enum):
+class PriceAdjustmentKind(StrEnum):
     fee = 'fee'
     discount = 'discount'
     commission = 'commission'
     settlement = 'settlement'
 
 
-class DemographicSystem(Enum):
+class DemographicSystem(StrEnum):
     nielsen = 'nielsen'
     barb = 'barb'
     agf = 'agf'
@@ -17005,7 +17006,7 @@ class DemographicSystem(Enum):
     custom = 'custom'
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'
@@ -17039,14 +17040,14 @@ class EventType(Enum):
     custom = 'custom'
 
 
-class GeographicTargetingLevel(Enum):
+class GeographicTargetingLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
     postal_area = 'postal_area'
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'
@@ -17054,7 +17055,7 @@ class MetroAreaSystem(Enum):
     custom = 'custom'
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'
@@ -17068,7 +17069,7 @@ class PostalCodeSystem(Enum):
     at_plz = 'at_plz'
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -17077,7 +17078,7 @@ class DeviceType(Enum):
     unknown = 'unknown'
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -17092,7 +17093,7 @@ class DevicePlatform(Enum):
     unknown = 'unknown'
 
 
-class AudienceSource(Enum):
+class AudienceSource(StrEnum):
     synced = 'synced'
     platform = 'platform'
     third_party = 'third_party'
@@ -17101,7 +17102,7 @@ class AudienceSource(Enum):
     unknown = 'unknown'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -17113,30 +17114,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -17147,12 +17148,12 @@ class DisclosurePosition(Enum):
     companion = 'companion'
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
 
-class ForecastRangeUnit(Enum):
+class ForecastRangeUnit(StrEnum):
     spend = 'spend'
     availability = 'availability'
     reach_freq = 'reach_freq'
@@ -17163,13 +17164,13 @@ class ForecastRangeUnit(Enum):
     package = 'package'
 
 
-class ForecastMethod(Enum):
+class ForecastMethod(StrEnum):
     estimate = 'estimate'
     modeled = 'modeled'
     guaranteed = 'guaranteed'
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'
@@ -17178,13 +17179,13 @@ class ReachUnit(Enum):
     custom = 'custom'
 
 
-class MakegoodRemedy(Enum):
+class MakegoodRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'
 
 
-class PerformanceStandardMetric(Enum):
+class PerformanceStandardMetric(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'
@@ -17192,7 +17193,7 @@ class PerformanceStandardMetric(Enum):
     attention_score = 'attention_score'
 
 
-class MediaBuyValidAction(Enum):
+class MediaBuyValidAction(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'
@@ -17216,13 +17217,13 @@ class MediaBuyValidAction(Enum):
     sync_creatives = 'sync_creatives'
 
 
-class MediaBuyActionMode(Enum):
+class MediaBuyActionMode(StrEnum):
     self_serve = 'self_serve'
     conditional_self_serve = 'conditional_self_serve'
     requires_approval = 'requires_approval'
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'
@@ -17232,13 +17233,13 @@ class MediaBuyStatus(Enum):
     canceled = 'canceled'
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'
@@ -17277,25 +17278,25 @@ class AvailableMetric(Enum):
     brand_search_lift = 'brand_search_lift'
 
 
-class CoBrandingRequirement(Enum):
+class CoBrandingRequirement(StrEnum):
     required = 'required'
     optional = 'optional'
     none = 'none'
 
 
-class LandingPageRequirement(Enum):
+class LandingPageRequirement(StrEnum):
     any = 'any'
     retailer_site_only = 'retailer_site_only'
     must_include_retailer = 'must_include_retailer'
 
 
-class SignalValueType(Enum):
+class SignalValueType(StrEnum):
     binary = 'binary'
     categorical = 'categorical'
     numeric = 'numeric'
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'
@@ -17311,14 +17312,14 @@ class CatalogType(Enum):
     app = 'app'
 
 
-class AssessmentStatus(Enum):
+class AssessmentStatus(StrEnum):
     insufficient = 'insufficient'
     minimum = 'minimum'
     good = 'good'
     excellent = 'excellent'
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'
@@ -17330,7 +17331,7 @@ class ActionSource(Enum):
     other = 'other'
 
 
-class InstallmentStatus(Enum):
+class InstallmentStatus(StrEnum):
     scheduled = 'scheduled'
     tentative = 'tentative'
     live = 'live'
@@ -17340,7 +17341,7 @@ class InstallmentStatus(Enum):
     published = 'published'
 
 
-class ContentRatingSystem(Enum):
+class ContentRatingSystem(StrEnum):
     tv_parental = 'tv_parental'
     mpaa = 'mpaa'
     podcast = 'podcast'
@@ -17354,7 +17355,7 @@ class ContentRatingSystem(Enum):
     custom = 'custom'
 
 
-class SpecialCategory(Enum):
+class SpecialCategory(StrEnum):
     awards = 'awards'
     championship = 'championship'
     concert = 'concert'
@@ -17369,7 +17370,7 @@ class SpecialCategory(Enum):
     tribute = 'tribute'
 
 
-class TalentRole(Enum):
+class TalentRole(StrEnum):
     host = 'host'
     guest = 'guest'
     creator = 'creator'
@@ -17381,7 +17382,7 @@ class TalentRole(Enum):
     analyst = 'analyst'
 
 
-class DerivativeType(Enum):
+class DerivativeType(StrEnum):
     clip = 'clip'
     highlight = 'highlight'
     recap = 'recap'
@@ -17389,14 +17390,14 @@ class DerivativeType(Enum):
     bonus = 'bonus'
 
 
-class TMPResponseType(Enum):
+class TMPResponseType(StrEnum):
     activation = 'activation'
     catalog_items = 'catalog_items'
     creative = 'creative'
     deal = 'deal'
 
 
-class UIDType(Enum):
+class UIDType(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'
@@ -17409,7 +17410,7 @@ class UIDType(Enum):
     other = 'other'
 
 
-class DayOfWeek(Enum):
+class DayOfWeek(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'
@@ -17419,7 +17420,7 @@ class DayOfWeek(Enum):
     sunday = 'sunday'
 
 
-class AccountStatus(Enum):
+class AccountStatus(StrEnum):
     active = 'active'
     pending_approval = 'pending_approval'
     rejected = 'rejected'
@@ -17428,13 +17429,13 @@ class AccountStatus(Enum):
     closed = 'closed'
 
 
-class BillingParty(Enum):
+class BillingParty(StrEnum):
     operator = 'operator'
     agent = 'agent'
     advertiser = 'advertiser'
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_15 = 'net_15'
     net_30 = 'net_30'
     net_45 = 'net_45'
@@ -17443,20 +17444,20 @@ class PaymentTerms(Enum):
     prepay = 'prepay'
 
 
-class AccountScope(Enum):
+class AccountScope(StrEnum):
     operator = 'operator'
     brand = 'brand'
     operator_brand = 'operator_brand'
     agent = 'agent'
 
 
-class CloudStorageProtocol(Enum):
+class CloudStorageProtocol(StrEnum):
     s3 = 's3'
     gcs = 'gcs'
     azure_blob = 'azure_blob'
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -17475,13 +17476,13 @@ class NotificationType(Enum):
     wholesale_feed_bulk_change = 'wholesale_feed.bulk_change'
 
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     even = 'even'
     asap = 'asap'
     front_loaded = 'front_loaded'
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'
@@ -17492,14 +17493,14 @@ class FeedFormat(Enum):
     custom = 'custom'
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'
     weekly = 'weekly'
 
 
-class ContentIDType(Enum):
+class ContentIDType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'
@@ -17514,7 +17515,7 @@ class ContentIDType(Enum):
     app_id = 'app_id'
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'
@@ -17530,7 +17531,7 @@ class CanonicalFormatKind(Enum):
     custom = 'custom'
 
 
-class AgeVerificationMethod(Enum):
+class AgeVerificationMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'
@@ -17538,43 +17539,43 @@ class AgeVerificationMethod(Enum):
     world_id = 'world_id'
 
 
-class TravelTimeUnit(Enum):
+class TravelTimeUnit(StrEnum):
     min = 'min'
     hr = 'hr'
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'
     public_transport = 'public_transport'
 
 
-class DistanceUnit(Enum):
+class DistanceUnit(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'
     modeled = 'modeled'
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'
@@ -17582,7 +17583,7 @@ class LiftDimension(Enum):
     ad_recall = 'ad_recall'
 
 
-class AttributionModel(Enum):
+class AttributionModel(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'
@@ -17590,12 +17591,12 @@ class AttributionModel(Enum):
     data_driven = 'data_driven'
 
 
-class CanceledBy(Enum):
+class CanceledBy(StrEnum):
     buyer = 'buyer'
     seller = 'seller'
 
 
-class PricingModel(Enum):
+class PricingModel(StrEnum):
     cpm = 'cpm'
     vcpm = 'vcpm'
     cpc = 'cpc'
@@ -17607,34 +17608,34 @@ class PricingModel(Enum):
     time = 'time'
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'
 
 
-class GOPType(Enum):
+class GOPType(StrEnum):
     closed = 'closed'
     open = 'open'
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'
     field_7_1 = '7.1'
 
 
-class VASTTrackingEvent(Enum):
+class VASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'
@@ -17673,24 +17674,24 @@ class VASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class URLAssetType(Enum):
+class URLAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'
 
 
-class JavaScriptModuleType(Enum):
+class JavaScriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'
 
 
-class HTTPMethod(Enum):
+class HTTPMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'
@@ -17768,20 +17769,20 @@ class UniversalMacro(Enum):
     ITEM_PRICE_CURRENCY = 'ITEM_PRICE_CURRENCY'
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'
     javascript = 'javascript'
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'
 
 
-class DAASTTrackingEvent(Enum):
+class DAASTTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'
@@ -17807,12 +17808,12 @@ class DAASTTrackingEvent(Enum):
     viewableImpression = 'viewableImpression'
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'
 
 
-class RightUse(Enum):
+class RightUse(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'
@@ -17827,7 +17828,7 @@ class RightUse(Enum):
     ai_generated_image = 'ai_generated_image'
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'
@@ -17835,7 +17836,7 @@ class RightType(Enum):
     stock_media = 'stock_media'
 
 
-class CreativeIdentifierType(Enum):
+class CreativeIdentifierType(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'

--- a/src/adcp/types/generated_poc/bundled/protocol/list_tasks_request.py
+++ b/src/adcp/types/generated_poc/bundled/protocol/list_tasks_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AwareDatetime, ConfigDict, Field
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     created_at = 'created_at'
     updated_at = 'updated_at'
     status = 'status'
@@ -19,7 +19,7 @@ class Field1(Enum):
     protocol = 'protocol'
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -47,7 +47,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class AdCPProtocol(Enum):
+class AdCPProtocol(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
     governance = 'governance'
@@ -57,7 +57,7 @@ class AdCPProtocol(Enum):
     measurement = 'measurement'
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -69,7 +69,7 @@ class TaskStatus(Enum):
     unknown = 'unknown'
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'

--- a/src/adcp/types/generated_poc/bundled/protocol/list_tasks_response.py
+++ b/src/adcp/types/generated_poc/bundled/protocol/list_tasks_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -69,13 +69,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -140,7 +140,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -211,7 +211,7 @@ class DomainBreakdown(AdCPBaseModel):
     ] = None
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -249,7 +249,7 @@ class QuerySummary(AdCPBaseModel):
     ] = None
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'
@@ -274,7 +274,7 @@ class TaskType(Enum):
     acquire_rights = 'acquire_rights'
 
 
-class Domain(Enum):
+class Domain(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
 
@@ -301,7 +301,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'

--- a/src/adcp/types/generated_poc/bundled/signals/activate_signal_request.py
+++ b/src/adcp/types/generated_poc/bundled/signals/activate_signal_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Action(Enum):
+class Action(StrEnum):
     activate = 'activate'
     deactivate = 'deactivate'
 
@@ -85,7 +85,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -121,7 +121,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -129,7 +129,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -157,7 +157,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -214,7 +214,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -239,7 +239,7 @@ class VerifyAgent1(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -278,13 +278,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -376,7 +376,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/bundled/signals/activate_signal_response.py
+++ b/src/adcp/types/generated_poc/bundled/signals/activate_signal_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/signals/get_signals_request.py
+++ b/src/adcp/types/generated_poc/bundled/signals/get_signals_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class DiscoveryMode(Enum):
+class DiscoveryMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
 
@@ -37,7 +37,7 @@ class DataSubjectContestation(AdCPBaseModel):
     languages: list[str] | None = None
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -73,7 +73,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -81,7 +81,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -109,7 +109,7 @@ class C2pa(AdCPBaseModel):
     ]
 
 
-class Method(Enum):
+class Method(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
@@ -166,7 +166,7 @@ class EmbeddedProvenanceItem(AdCPBaseModel):
     ] = None
 
 
-class MediaType(Enum):
+class MediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
@@ -191,7 +191,7 @@ class VerifyAgent431(AdCPBaseModel):
     ] = None
 
 
-class C2paAction(Enum):
+class C2paAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
@@ -230,13 +230,13 @@ class Watermark(AdCPBaseModel):
     ] = None
 
 
-class Persistence(Enum):
+class Persistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class Position(Enum):
+class Position(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'
@@ -328,7 +328,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -766,7 +766,7 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     marketplace = 'marketplace'
     custom = 'custom'
     owned = 'owned'
@@ -806,7 +806,7 @@ class Filters(AdCPBaseModel):
     ] = None
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     signal_ref = 'signal_ref'
     signal_id = 'signal_id'
     signal_agent_segment_id = 'signal_agent_segment_id'
@@ -854,7 +854,7 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 

--- a/src/adcp/types/generated_poc/bundled/signals/get_signals_response.py
+++ b/src/adcp/types/generated_poc/bundled/signals/get_signals_response.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from collections.abc import Sequence
 
@@ -13,7 +13,7 @@ from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -83,13 +83,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -154,7 +154,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -341,13 +341,13 @@ class Range(AdCPBaseModel):
     max: Annotated[float, Field(description='Maximum value, inclusive.')]
 
 
-class SignalType(Enum):
+class SignalType(StrEnum):
     marketplace = 'marketplace'
     custom = 'custom'
     owned = 'owned'
 
 
-class GeoLevel(Enum):
+class GeoLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'
@@ -425,7 +425,7 @@ class Dimensions3(AdCPBaseModel):
     ] = None
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'
@@ -445,7 +445,7 @@ class Dimensions4(AdCPBaseModel):
     ]
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'
@@ -476,7 +476,7 @@ class Dimensions5(AdCPBaseModel):
     ]
 
 
-class AudienceSource(Enum):
+class AudienceSource(StrEnum):
     synced = 'synced'
     platform = 'platform'
     third_party = 'third_party'
@@ -504,7 +504,7 @@ class Dimensions6(AdCPBaseModel):
 
 
 
-class Presence(Enum):
+class Presence(StrEnum):
     present = 'present'
     absent = 'absent'
 
@@ -796,7 +796,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -804,7 +804,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -868,7 +868,7 @@ class VerifyAgent433(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'
@@ -925,7 +925,7 @@ class ViewedSeconds(AudienceSize):
     pass
 
 
-class Standard(Enum):
+class Standard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'
 
@@ -950,13 +950,13 @@ class Value(AudienceSize):
     pass
 
 
-class Method(Enum):
+class Method(StrEnum):
     estimate = 'estimate'
     modeled = 'modeled'
     guaranteed = 'guaranteed'
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     inventory = 'inventory'
     product = 'product'
     account = 'account'
@@ -1012,12 +1012,12 @@ class Scope(AdCPBaseModel):
     ] = None
 
 
-class BucketSemantics(Enum):
+class BucketSemantics(StrEnum):
     exclusive = 'exclusive'
     overlapping = 'overlapping'
 
 
-class BucketCompleteness(Enum):
+class BucketCompleteness(StrEnum):
     complete = 'complete'
     partial = 'partial'
 
@@ -1210,7 +1210,7 @@ class PricingOption132(AdCPBaseModel):
     ] = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'
@@ -1365,7 +1365,7 @@ class PricingOption(
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class RestrictedAttribute(Enum):
+class RestrictedAttribute(StrEnum):
     racial_ethnic_origin = 'racial_ethnic_origin'
     political_opinions = 'political_opinions'
     religious_beliefs = 'religious_beliefs'
@@ -1397,7 +1397,7 @@ class ValueMapping(AdCPBaseModel):
     modifiers: list[str] | None = None
 
 
-class ParentMatchBehavior(Enum):
+class ParentMatchBehavior(StrEnum):
     exact_only = 'exact_only'
     descendants_supported = 'descendants_supported'
     unknown = 'unknown'
@@ -1416,7 +1416,7 @@ class Taxonomy(AdCPBaseModel):
     parent_match_behavior: ParentMatchBehavior | None = None
 
 
-class DataSource(Enum):
+class DataSource(StrEnum):
     app_behavior = 'app_behavior'
     app_usage = 'app_usage'
     web_usage = 'web_usage'
@@ -1436,7 +1436,7 @@ class DataSource(Enum):
     offline_transaction = 'offline_transaction'
 
 
-class Methodology(Enum):
+class Methodology(StrEnum):
     observed = 'observed'
     declared = 'declared'
     derived = 'derived'
@@ -1444,7 +1444,7 @@ class Methodology(Enum):
     modeled = 'modeled'
 
 
-class RefreshCadence(Enum):
+class RefreshCadence(StrEnum):
     intra_day = 'intra_day'
     daily = 'daily'
     weekly = 'weekly'
@@ -1455,7 +1455,7 @@ class RefreshCadence(Enum):
     annually = 'annually'
 
 
-class MatchKey(Enum):
+class MatchKey(StrEnum):
     name = 'name'
     address = 'address'
     email = 'email'
@@ -1468,7 +1468,7 @@ class MatchKey(Enum):
     phone = 'phone'
 
 
-class PreOnboardingPrecisionLevel(Enum):
+class PreOnboardingPrecisionLevel(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -1485,28 +1485,28 @@ class Onboarder(AdCPBaseModel):
     pre_onboarding_precision_level: PreOnboardingPrecisionLevel | None = None
 
 
-class ConsentBasi(Enum):
+class ConsentBasi(StrEnum):
     consent = 'consent'
     legitimate_interest = 'legitimate_interest'
     contract = 'contract'
     legal_obligation = 'legal_obligation'
 
 
-class Art9Basis(Enum):
+class Art9Basis(StrEnum):
     explicit_consent = 'explicit_consent'
     manifestly_made_public = 'manifestly_made_public'
     substantial_public_interest = 'substantial_public_interest'
     vital_interests = 'vital_interests'
 
 
-class Method16(Enum):
+class Method16(StrEnum):
     lookalike = 'lookalike'
     supervised = 'supervised'
     embedding = 'embedding'
     rules = 'rules'
 
 
-class Type(Enum):
+class Type(StrEnum):
     first_party_crm = 'first_party_crm'
     panel = 'panel'
     declared_survey = 'declared_survey'
@@ -1531,13 +1531,13 @@ class TrainingDataJurisdiction(Country):
     pass
 
 
-class AiActRiskClass(Enum):
+class AiActRiskClass(StrEnum):
     minimal = 'minimal'
     limited = 'limited'
     high_risk = 'high_risk'
 
 
-class Audience(Enum):
+class Audience(StrEnum):
     buyer = 'buyer'
     data_subject = 'data_subject'
     regulator = 'regulator'
@@ -1620,7 +1620,7 @@ class Modeling(AdCPBaseModel):
     ] = None
 
 
-class Right(Enum):
+class Right(StrEnum):
     access = 'access'
     rectification = 'rectification'
     erasure = 'erasure'
@@ -1719,13 +1719,13 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class Scope20(Enum):
+class Scope20(StrEnum):
     signals = 'signals'
     pricing = 'pricing'
     wholesale_feed = 'wholesale_feed'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'
@@ -1766,7 +1766,7 @@ class IncompleteItem(AdCPBaseModel):
     ] = None
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 
@@ -1793,13 +1793,13 @@ class Pagination(AdCPBaseModel):
     ] = None
 
 
-class SignalValueType(Enum):
+class SignalValueType(StrEnum):
     binary = 'binary'
     categorical = 'categorical'
     numeric = 'numeric'
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'
@@ -1811,30 +1811,30 @@ class DigitalSourceType(Enum):
     data_driven_media = 'data_driven_media'
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'
     text = 'text'
 
 
-class C2PAWatermarkAction(Enum):
+class C2PAWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_get_offering_response.py
+++ b/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_get_offering_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -274,7 +274,7 @@ class Error(AdCPBaseModel):
     ] = None
 
 
-class OfferingAvailabilityStatus(Enum):
+class OfferingAvailabilityStatus(StrEnum):
     available = 'available'
     limited = 'limited'
     sold_out = 'sold_out'

--- a/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_initiate_session_request.py
+++ b/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_initiate_session_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field
 
 
-class ConsentScopeEnum(Enum):
+class ConsentScopeEnum(StrEnum):
     name = 'name'
     email = 'email'
     shipping_address = 'shipping_address'
@@ -124,7 +124,7 @@ class Modalities(AdCPBaseModel):
     ] = None
 
 
-class StandardEnum(Enum):
+class StandardEnum(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'

--- a/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_initiate_session_response.py
+++ b/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_initiate_session_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -210,7 +210,7 @@ class PushNotificationConfig(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'
@@ -287,7 +287,7 @@ class Modalities(AdCPBaseModel):
     ] = None
 
 
-class StandardEnum(Enum):
+class StandardEnum(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'
@@ -347,7 +347,7 @@ class NegotiatedCapabilities(AdCPBaseModel):
     ] = False
 
 
-class SessionStatus(Enum):
+class SessionStatus(StrEnum):
     active = 'active'
     pending_handoff = 'pending_handoff'
     complete = 'complete'

--- a/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_send_message_response.py
+++ b/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_send_message_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -244,7 +244,7 @@ class Surface(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'
@@ -283,14 +283,14 @@ class Response(AdCPBaseModel):
     ] = None
 
 
-class SessionStatus(Enum):
+class SessionStatus(StrEnum):
     active = 'active'
     pending_handoff = 'pending_handoff'
     complete = 'complete'
     terminated = 'terminated'
 
 
-class Type40(Enum):
+class Type40(StrEnum):
     transaction = 'transaction'
     complete = 'complete'
 

--- a/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_terminate_session_request.py
+++ b/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_terminate_session_request.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     handoff_transaction = 'handoff_transaction'
     handoff_complete = 'handoff_complete'
     user_exit = 'user_exit'
@@ -19,7 +19,7 @@ class Reason(Enum):
     host_terminated = 'host_terminated'
 
 
-class Action(Enum):
+class Action(StrEnum):
     purchase = 'purchase'
     subscribe = 'subscribe'
 

--- a/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_terminate_session_response.py
+++ b/src/adcp/types/generated_poc/bundled/sponsored_intelligence/si_terminate_session_response.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'
@@ -81,13 +81,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 
@@ -152,7 +152,7 @@ class AdcpError(AdCPBaseModel):
     ] = None
 
 
-class Scheme(Enum):
+class Scheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'
 
@@ -210,7 +210,7 @@ class PushNotificationConfig(AdCPBaseModel):
     ] = None
 
 
-class SessionStatus(Enum):
+class SessionStatus(StrEnum):
     active = 'active'
     pending_handoff = 'pending_handoff'
     complete = 'complete'
@@ -247,7 +247,7 @@ class AcpHandoff(AdCPBaseModel):
     ] = None
 
 
-class Action(Enum):
+class Action(StrEnum):
     save_for_later = 'save_for_later'
     set_reminder = 'set_reminder'
     subscribe_updates = 'subscribe_updates'

--- a/src/adcp/types/generated_poc/compliance/comply_test_controller_request.py
+++ b/src/adcp/types/generated_poc/compliance/comply_test_controller_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -19,7 +19,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import creative_event_reason_code, viewability_standard
 
 
-class PurgeKind(Enum):
+class PurgeKind(StrEnum):
     soft = 'soft'
     hard = 'hard'
 
@@ -29,13 +29,13 @@ class ReportedSpend(AdCPBaseModel):
     currency: Annotated[str, Field(pattern='^[A-Z]{3}$')]
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     cumulative = 'cumulative'
     period = 'period'
     rolling = 'rolling'
 
 
-class Arm(Enum):
+class Arm(StrEnum):
     submitted = 'submitted'
     input_required = 'input-required'
 

--- a/src/adcp/types/generated_poc/content_standards/artifact.py
+++ b/src/adcp/types/generated_poc/content_standards/artifact.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -14,8 +14,8 @@ from ..core import format_id as format_id_1
 from ..core import provenance as provenance_1
 
 
-class Role(Enum):
-    title = 'title'
+class Role(StrEnum):
+    title = 'title'  # type: ignore[assignment]
     paragraph = 'paragraph'
     heading = 'heading'
     caption = 'caption'
@@ -24,20 +24,20 @@ class Role(Enum):
     description = 'description'
 
 
-class ContentFormat(Enum):
+class ContentFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     text_html = 'text/html'
     application_json = 'application/json'
 
 
-class TranscriptFormat(Enum):
+class TranscriptFormat(StrEnum):
     text_plain = 'text/plain'
     text_markdown = 'text/markdown'
     application_json = 'application/json'
 
 
-class TranscriptSource(Enum):
+class TranscriptSource(StrEnum):
     original_script = 'original_script'
     subtitles = 'subtitles'
     closed_captions = 'closed_captions'
@@ -45,7 +45,7 @@ class TranscriptSource(Enum):
     generated = 'generated'
 
 
-class TranscriptSource1(Enum):
+class TranscriptSource1(StrEnum):
     original_script = 'original_script'
     closed_captions = 'closed_captions'
     generated = 'generated'
@@ -85,7 +85,7 @@ class AssetAccess1(AdCPBaseModel):
     token: Annotated[str, Field(description='OAuth2 bearer token for Authorization header')]
 
 
-class Provider(Enum):
+class Provider(StrEnum):
     gcp = 'gcp'
     aws = 'aws'
 

--- a/src/adcp/types/generated_poc/core/account.py
+++ b/src/adcp/types/generated_poc/core/account.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -46,7 +46,7 @@ class GovernanceAgent(AdCPBaseModel):
     url: Annotated[AnyUrl, Field(description='Governance agent endpoint URL. Must use HTTPS.')]
 
 
-class Format(Enum):
+class Format(StrEnum):
     jsonl = 'jsonl'
     csv = 'csv'
     parquet = 'parquet'
@@ -54,7 +54,7 @@ class Format(Enum):
     orc = 'orc'
 
 
-class Compression(Enum):
+class Compression(StrEnum):
     gzip = 'gzip'
     none = 'none'
 

--- a/src/adcp/types/generated_poc/core/app_item.py
+++ b/src/adcp/types/generated_poc/core/app_item.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from . import offering_asset_group
 from . import price as price_1
 
 
-class Platform(Enum):
+class Platform(StrEnum):
     ios = 'ios'
     android = 'android'
 

--- a/src/adcp/types/generated_poc/core/assets/daast_tracker_asset.py
+++ b/src/adcp/types/generated_poc/core/assets/daast_tracker_asset.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ...enums import daast_tracking_event
 from .. import provenance as provenance_1
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     companion = 'companion'
 

--- a/src/adcp/types/generated_poc/core/assets/pixel_tracker_asset.py
+++ b/src/adcp/types/generated_poc/core/assets/pixel_tracker_asset.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from .. import provenance as provenance_1
 
 
-class Event(Enum):
+class Event(StrEnum):
     impression = 'impression'
     viewable_mrc_50 = 'viewable_mrc_50'
     viewable_mrc_100 = 'viewable_mrc_100'
@@ -23,7 +23,7 @@ class Event(Enum):
     custom = 'custom'
 
 
-class Method(Enum):
+class Method(StrEnum):
     img = 'img'
     js = 'js'
 

--- a/src/adcp/types/generated_poc/core/assets/published_post_asset.py
+++ b/src/adcp/types/generated_poc/core/assets/published_post_asset.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -28,7 +28,7 @@ class IdentityRef(AdCPBaseModel):
     ] = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     pending = 'pending'
     expired = 'expired'

--- a/src/adcp/types/generated_poc/core/assets/vast_tracker_asset.py
+++ b/src/adcp/types/generated_poc/core/assets/vast_tracker_asset.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ...enums import vast_tracking_event
 from .. import provenance as provenance_1
 
 
-class Target(Enum):
+class Target(StrEnum):
     linear = 'linear'
     non_linear = 'non_linear'
     companion = 'companion'

--- a/src/adcp/types/generated_poc/core/assets/video_asset.py
+++ b/src/adcp/types/generated_poc/core/assets/video_asset.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -18,7 +19,7 @@ from ...enums import scan_type as scan_type_1
 from .. import provenance as provenance_1
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rec709 = 'rec709'
     rec2020 = 'rec2020'
     rec2100 = 'rec2100'
@@ -26,7 +27,7 @@ class ColorSpace(Enum):
     dci_p3 = 'dci_p3'
 
 
-class HdrFormat(Enum):
+class HdrFormat(StrEnum):
     sdr = 'sdr'
     hdr10 = 'hdr10'
     hdr10_plus = 'hdr10_plus'
@@ -34,7 +35,7 @@ class HdrFormat(Enum):
     dolby_vision = 'dolby_vision'
 
 
-class ChromaSubsampling(Enum):
+class ChromaSubsampling(StrEnum):
     field_4_2_0 = '4:2:0'
     field_4_2_2 = '4:2:2'
     field_4_4_4 = '4:4:4'

--- a/src/adcp/types/generated_poc/core/async_response_refs/creative/sync_creatives_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/core/async_response_refs/creative/sync_creatives_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ... import context as context_1
 from ... import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     ASSET_CONFIRMATION = 'ASSET_CONFIRMATION'
     FORMAT_CLARIFICATION = 'FORMAT_CLARIFICATION'

--- a/src/adcp/types/generated_poc/core/async_response_refs/media_buy/build_creative_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/core/async_response_refs/media_buy/build_creative_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ... import error
 from ... import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CREATIVE_DIRECTION_NEEDED = 'CREATIVE_DIRECTION_NEEDED'
     ASSET_SELECTION_NEEDED = 'ASSET_SELECTION_NEEDED'

--- a/src/adcp/types/generated_poc/core/async_response_refs/media_buy/create_media_buy_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/core/async_response_refs/media_buy/create_media_buy_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ... import error
 from ... import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     BUDGET_EXCEEDS_LIMIT = 'BUDGET_EXCEEDS_LIMIT'
 

--- a/src/adcp/types/generated_poc/core/async_response_refs/media_buy/get_products_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/core/async_response_refs/media_buy/get_products_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ... import ext as ext_1
 from ... import product
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     CLARIFICATION_NEEDED = 'CLARIFICATION_NEEDED'
     BUDGET_REQUIRED = 'BUDGET_REQUIRED'
 

--- a/src/adcp/types/generated_poc/core/async_response_refs/media_buy/sync_catalogs_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/core/async_response_refs/media_buy/sync_catalogs_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ... import context as context_1
 from ... import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     FEED_VALIDATION = 'FEED_VALIDATION'
     ITEM_REVIEW = 'ITEM_REVIEW'

--- a/src/adcp/types/generated_poc/core/async_response_refs/media_buy/update_media_buy_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/core/async_response_refs/media_buy/update_media_buy_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ... import context as context_1
 from ... import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CHANGE_CONFIRMATION = 'CHANGE_CONFIRMATION'
 

--- a/src/adcp/types/generated_poc/core/business_entity.py
+++ b/src/adcp/types/generated_poc/core/business_entity.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -30,7 +30,7 @@ class Address(AdCPBaseModel):
     ]
 
 
-class Role(Enum):
+class Role(StrEnum):
     billing = 'billing'
     legal = 'legal'
     creative = 'creative'

--- a/src/adcp/types/generated_poc/core/cancellation_policy.py
+++ b/src/adcp/types/generated_poc/core/cancellation_policy.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from . import duration
 
 
-class Type(Enum):
+class Type(StrEnum):
     percent_remaining = 'percent_remaining'
     full_commitment = 'full_commitment'
     fixed_fee = 'fixed_fee'

--- a/src/adcp/types/generated_poc/core/canonical_format_kind.py
+++ b/src/adcp/types/generated_poc/core/canonical_format_kind.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CanonicalFormatKind(Enum):
+class CanonicalFormatKind(StrEnum):
     image = 'image'
     html5 = 'html5'
     display_tag = 'display_tag'

--- a/src/adcp/types/generated_poc/core/canonical_projection_ref.py
+++ b/src/adcp/types/generated_poc/core/canonical_projection_ref.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from . import canonical_format_kind, canonical_projection_slot_override
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'

--- a/src/adcp/types/generated_poc/core/catalog_field_mapping.py
+++ b/src/adcp/types/generated_poc/core/catalog_field_mapping.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -13,11 +13,11 @@ from pydantic import ConfigDict, Field
 from . import ext as ext_1
 
 
-class Transform(Enum):
+class Transform(StrEnum):
     date = 'date'
     divide = 'divide'
     boolean = 'boolean'
-    split = 'split'
+    split = 'split'  # type: ignore[assignment]
 
 
 class CatalogFieldMapping(AdCPBaseModel):

--- a/src/adcp/types/generated_poc/core/catchment.py
+++ b/src/adcp/types/generated_poc/core/catchment.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -16,7 +16,7 @@ from ..enums import travel_time_unit
 from . import ext as ext_1
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 

--- a/src/adcp/types/generated_poc/core/creative_brief.py
+++ b/src/adcp/types/generated_poc/core/creative_brief.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..enums import disclosure_persistence, disclosure_position
 from . import reference_asset
 
 
-class Objective(Enum):
+class Objective(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     conversion = 'conversion'

--- a/src/adcp/types/generated_poc/core/creative_variable.py
+++ b/src/adcp/types/generated_poc/core/creative_variable.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class VariableType(Enum):
+class VariableType(StrEnum):
     text = 'text'
     image = 'image'
     video = 'video'

--- a/src/adcp/types/generated_poc/core/delivery_metrics.py
+++ b/src/adcp/types/generated_poc/core/delivery_metrics.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -17,7 +17,7 @@ from ..enums import viewability_standard
 from . import brand_ref, duration, vendor_metric_value
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     cumulative = 'cumulative'
     period = 'period'
     rolling = 'rolling'

--- a/src/adcp/types/generated_poc/core/destination_item.py
+++ b/src/adcp/types/generated_poc/core/destination_item.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -27,7 +27,7 @@ class Location(AdCPBaseModel):
     ]
 
 
-class DestinationType(Enum):
+class DestinationType(StrEnum):
     beach = 'beach'
     mountain = 'mountain'
     urban = 'urban'

--- a/src/adcp/types/generated_poc/core/diagnostic_issue.py
+++ b/src/adcp/types/generated_poc/core/diagnostic_issue.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Severity(Enum):
+class Severity(StrEnum):
     error = 'error'
     warning = 'warning'
     info = 'info'

--- a/src/adcp/types/generated_poc/core/downstream_connection_requirement.py
+++ b/src/adcp/types/generated_poc/core/downstream_connection_requirement.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, RootModel
 
 
-class ConnectionType(Enum):
+class ConnectionType(StrEnum):
     advertiser_account = 'advertiser_account'
     publisher_identity = 'publisher_identity'
     post_authorization = 'post_authorization'
@@ -33,14 +33,14 @@ class RequiredForItem(RootModel[str]):
     ]
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     identity = 'identity'
     post = 'post'
     unknown = 'unknown'
 
 
-class Status(Enum):
+class Status(StrEnum):
     connected = 'connected'
     missing = 'missing'
     pending = 'pending'

--- a/src/adcp/types/generated_poc/core/duration.py
+++ b/src/adcp/types/generated_poc/core/duration.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     seconds = 'seconds'
     minutes = 'minutes'
     hours = 'hours'

--- a/src/adcp/types/generated_poc/core/education_item.py
+++ b/src/adcp/types/generated_poc/core/education_item.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -16,7 +16,7 @@ from . import offering_asset_group
 from . import price as price_1
 
 
-class DegreeType(Enum):
+class DegreeType(StrEnum):
     certificate = 'certificate'
     associate = 'associate'
     bachelor = 'bachelor'
@@ -26,13 +26,13 @@ class DegreeType(Enum):
     bootcamp = 'bootcamp'
 
 
-class Level(Enum):
+class Level(StrEnum):
     beginner = 'beginner'
     intermediate = 'intermediate'
     advanced = 'advanced'
 
 
-class Modality(Enum):
+class Modality(StrEnum):
     online = 'online'
     in_person = 'in_person'
     hybrid = 'hybrid'

--- a/src/adcp/types/generated_poc/core/error.py
+++ b/src/adcp/types/generated_poc/core/error.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -69,13 +69,13 @@ class Issue(AdCPBaseModel):
     ] = None
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'
 
 
-class Source(Enum):
+class Source(StrEnum):
     producer = 'producer'
     sdk = 'sdk'
 

--- a/src/adcp/types/generated_poc/core/evaluator_spec.py
+++ b/src/adcp/types/generated_poc/core/evaluator_spec.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from . import ext as ext_1
 from . import feature_requirement as feature_requirement_1
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     maximize = 'maximize'
     minimize = 'minimize'
 

--- a/src/adcp/types/generated_poc/core/event_surface.py
+++ b/src/adcp/types/generated_poc/core/event_surface.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from . import ext as ext_1
 
 
-class Category(Enum):
+class Category(StrEnum):
     owned_property = 'owned_property'
     website = 'website'
     app = 'app'

--- a/src/adcp/types/generated_poc/core/feature_requirement.py
+++ b/src/adcp/types/generated_poc/core/feature_requirement.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class IfNotCovered(Enum):
+class IfNotCovered(StrEnum):
     exclude = 'exclude'
     include = 'include'
 

--- a/src/adcp/types/generated_poc/core/forecast_dimension_signal.py
+++ b/src/adcp/types/generated_poc/core/forecast_dimension_signal.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from . import signal_ref as signal_ref_1
 
 
-class Presence(Enum):
+class Presence(StrEnum):
     present = 'present'
     absent = 'absent'
 

--- a/src/adcp/types/generated_poc/core/format.py
+++ b/src/adcp/types/generated_poc/core/format.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -131,7 +131,7 @@ class Renders1(AdCPBaseModel):
     ] = None
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     sequential = 'sequential'
     optimize = 'optimize'
 

--- a/src/adcp/types/generated_poc/core/impairment.py
+++ b/src/adcp/types/generated_poc/core/impairment.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import AwareDatetime, ConfigDict, Field
 from ..enums import impairment_offline_state, impairment_reason_code
 
 
-class ResourceType(Enum):
+class ResourceType(StrEnum):
     audience = 'audience'
     creative = 'creative'
     catalog_item = 'catalog_item'

--- a/src/adcp/types/generated_poc/core/insertion_order.py
+++ b/src/adcp/types/generated_poc/core/insertion_order.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -18,7 +18,7 @@ class TotalBudget(AdCPBaseModel):
     ]
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_30 = 'net_30'
     net_60 = 'net_60'
     net_90 = 'net_90'

--- a/src/adcp/types/generated_poc/core/job_item.py
+++ b/src/adcp/types/generated_poc/core/job_item.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from . import ext as ext_1
 from . import offering_asset_group
 
 
-class EmploymentType(Enum):
+class EmploymentType(StrEnum):
     full_time = 'full_time'
     part_time = 'part_time'
     contract = 'contract'
@@ -24,7 +24,7 @@ class EmploymentType(Enum):
     freelance = 'freelance'
 
 
-class ExperienceLevel(Enum):
+class ExperienceLevel(StrEnum):
     entry_level = 'entry_level'
     mid_level = 'mid_level'
     senior = 'senior'
@@ -32,7 +32,7 @@ class ExperienceLevel(Enum):
     executive = 'executive'
 
 
-class Period(Enum):
+class Period(StrEnum):
     hour = 'hour'
     month = 'month'
     year = 'year'

--- a/src/adcp/types/generated_poc/core/optimization_goal.py
+++ b/src/adcp/types/generated_poc/core/optimization_goal.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -16,7 +16,7 @@ from . import attribution_window as attribution_window_1
 from . import brand_ref, duration, vendor_metric_id
 
 
-class Metric(Enum):
+class Metric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'

--- a/src/adcp/types/generated_poc/core/overlay.py
+++ b/src/adcp/types/generated_poc/core/overlay.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -33,7 +33,7 @@ class Visual(AdCPBaseModel):
     ] = None
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     px = 'px'
     fraction = 'fraction'
     inches = 'inches'

--- a/src/adcp/types/generated_poc/core/package_signal_targeting_group.py
+++ b/src/adcp/types/generated_poc/core/package_signal_targeting_group.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from . import package_signal_targeting
 
 
-class Operator(Enum):
+class Operator(StrEnum):
     any = 'any'
     none = 'none'
 

--- a/src/adcp/types/generated_poc/core/performance_feedback.py
+++ b/src/adcp/types/generated_poc/core/performance_feedback.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class MeasurementPeriod(AdCPBaseModel):
     ]
 
 
-class Status(Enum):
+class Status(StrEnum):
     accepted = 'accepted'
     queued = 'queued'
     applied = 'applied'

--- a/src/adcp/types/generated_poc/core/placement.py
+++ b/src/adcp/types/generated_poc/core/placement.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 from collections.abc import Sequence
 
@@ -15,12 +15,12 @@ from ..enums import social_placement_surface, sponsored_placement_type, video_pl
 from . import format_id, product_format_declaration
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     publisher_ref = 'publisher_ref'
     seller_inline = 'seller_inline'
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     targetable = 'targetable'
     included = 'included'
 

--- a/src/adcp/types/generated_poc/core/price.py
+++ b/src/adcp/types/generated_poc/core/price.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Period(Enum):
+class Period(StrEnum):
     night = 'night'
     month = 'month'
     year = 'year'

--- a/src/adcp/types/generated_poc/core/product.py
+++ b/src/adcp/types/generated_poc/core/product.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -89,7 +89,7 @@ class PublisherProperty115(PublisherProperty111, PublisherProperty114):
     pass
 
 
-class SupportedMetric(Enum):
+class SupportedMetric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -107,12 +107,12 @@ class SupportedViewDuration(RootModel[float]):
     root: Annotated[float, Field(gt=0.0)]
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 
 
-class SupportedTarget17(Enum):
+class SupportedTarget17(StrEnum):
     cost_per = 'cost_per'
     per_ad_spend = 'per_ad_spend'
     maximize_value = 'maximize_value'

--- a/src/adcp/types/generated_poc/core/product_filters.py
+++ b/src/adcp/types/generated_poc/core/product_filters.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -108,7 +108,7 @@ class RequiredGeoTargetingItem(AdCPBaseModel):
     ] = None
 
 
-class TargetingMode(Enum):
+class TargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 
@@ -147,7 +147,7 @@ class Radius(AdCPBaseModel):
     unit: Annotated[distance_unit.DistanceUnit, Field(description='Distance unit')]
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 

--- a/src/adcp/types/generated_poc/core/product_format_declaration.py
+++ b/src/adcp/types/generated_poc/core/product_format_declaration.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..enums import channels
 from . import format_id, platform_extension_ref
 
 
-class SellerPreference(Enum):
+class SellerPreference(StrEnum):
     preferred = 'preferred'
     accepted = 'accepted'
     discouraged = 'discouraged'

--- a/src/adcp/types/generated_poc/core/product_signal_targeting_option.py
+++ b/src/adcp/types/generated_poc/core/product_signal_targeting_option.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field
@@ -13,12 +13,12 @@ from . import signal_ref, vendor_pricing_option
 from .signal_listing import SignalListing
 
 
-class ActivationStatus(Enum):
+class ActivationStatus(StrEnum):
     ready = 'ready'
     requires_activation = 'requires_activation'
 
 
-class AllowedTargetingMode(Enum):
+class AllowedTargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 

--- a/src/adcp/types/generated_poc/core/provenance.py
+++ b/src/adcp/types/generated_poc/core/provenance.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -45,7 +45,7 @@ class AiTool(AdCPBaseModel):
     ] = None
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     none = 'none'
     prompt_only = 'prompt_only'
     selected = 'selected'
@@ -53,7 +53,7 @@ class HumanOversight(Enum):
     directed = 'directed'
 
 
-class Role(Enum):
+class Role(StrEnum):
     creator = 'creator'
     advertiser = 'advertiser'
     agency = 'agency'
@@ -222,7 +222,7 @@ class Disclosure(AdCPBaseModel):
     ] = None
 
 
-class Result(Enum):
+class Result(StrEnum):
     authentic = 'authentic'
     ai_generated = 'ai_generated'
     ai_modified = 'ai_modified'

--- a/src/adcp/types/generated_poc/core/real_estate_item.py
+++ b/src/adcp/types/generated_poc/core/real_estate_item.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -28,7 +28,7 @@ class Address(AdCPBaseModel):
     ] = None
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     house = 'house'
     apartment = 'apartment'
     condo = 'condo'
@@ -37,12 +37,12 @@ class PropertyType(Enum):
     commercial = 'commercial'
 
 
-class ListingType(Enum):
+class ListingType(StrEnum):
     for_sale = 'for_sale'
     for_rent = 'for_rent'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     sqft = 'sqft'
     sqm = 'sqm'
 

--- a/src/adcp/types/generated_poc/core/reference_asset.py
+++ b/src/adcp/types/generated_poc/core/reference_asset.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, ConfigDict, Field
 
 
-class Role(Enum):
+class Role(StrEnum):
     style_reference = 'style_reference'
     product_shot = 'product_shot'
     mood_board = 'mood_board'

--- a/src/adcp/types/generated_poc/core/registry_event.py
+++ b/src/adcp/types/generated_poc/core/registry_event.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
@@ -16,7 +16,7 @@ from . import property as property_1
 from . import property_id, property_tag, publisher_property_selector
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     property_created = 'property.created'
     property_updated = 'property.updated'
     property_merged = 'property.merged'
@@ -35,7 +35,7 @@ class EventType(Enum):
     authorization_modified = 'authorization.modified'
 
 
-class EntityType(Enum):
+class EntityType(StrEnum):
     property = 'property'
     agent = 'agent'
     publisher = 'publisher'
@@ -149,7 +149,7 @@ class RegistryEvent4(AdCPBaseModel):
     ]
 
 
-class Tracks(Enum):
+class Tracks(StrEnum):
     pass_ = 'pass'
     fail = 'fail'
     partial = 'partial'
@@ -160,7 +160,7 @@ class Tracks(Enum):
     skipped = 'skipped'
 
 
-class AuthorizationType(Enum):
+class AuthorizationType(StrEnum):
     property_ids = 'property_ids'
     property_tags = 'property_tags'
     inline_properties = 'inline_properties'
@@ -169,13 +169,13 @@ class AuthorizationType(Enum):
     signal_tags = 'signal_tags'
 
 
-class DelegationType(Enum):
+class DelegationType(StrEnum):
     direct = 'direct'
     delegated = 'delegated'
     ad_network = 'ad_network'
 
 
-class Evidence(Enum):
+class Evidence(StrEnum):
     adagents_json = 'adagents_json'
     agent_claim = 'agent_claim'
     community = 'community'
@@ -208,7 +208,7 @@ class PublisherAdagentsPayload(AdCPBaseModel):
     source: str | None = None
 
 
-class BadgeRole(Enum):
+class BadgeRole(StrEnum):
     media_buy = 'media-buy'
     creative = 'creative'
     signals = 'signals'
@@ -231,7 +231,7 @@ class ChangedFields(RootModel[list[str]]):
     ]
 
 
-class Classification(Enum):
+class Classification(StrEnum):
     property = 'property'
     ad_infra = 'ad_infra'
     publisher_mask = 'publisher_mask'
@@ -239,13 +239,13 @@ class Classification(Enum):
     unclassified = 'unclassified'
 
 
-class PropertySource(Enum):
+class PropertySource(StrEnum):
     authoritative = 'authoritative'
     enriched = 'enriched'
     contributed = 'contributed'
 
 
-class Type(Enum):
+class Type(StrEnum):
     sales = 'sales'
     creative = 'creative'
     signals = 'signals'
@@ -287,14 +287,14 @@ class Countries(RootModel[list[Country]]):
     root: Annotated[list[Country], Field(min_length=1)]
 
 
-class ComplianceStatus(Enum):
+class ComplianceStatus(StrEnum):
     passing = 'passing'
     degraded = 'degraded'
     failing = 'failing'
     unknown = 'unknown'
 
 
-class StoryboardStatus(Enum):
+class StoryboardStatus(StrEnum):
     passing = 'passing'
     failing = 'failing'
     partial = 'partial'

--- a/src/adcp/types/generated_poc/core/reporting_capabilities.py
+++ b/src/adcp/types/generated_poc/core/reporting_capabilities.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..enums import available_metric, reporting_frequency
 from . import brand_ref, geo_breakdown_support, measurement_window, vendor_metric_id
 
 
-class DateRangeSupport(Enum):
+class DateRangeSupport(StrEnum):
     date_range = 'date_range'
     lifetime_only = 'lifetime_only'
 

--- a/src/adcp/types/generated_poc/core/reporting_webhook.py
+++ b/src/adcp/types/generated_poc/core/reporting_webhook.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -34,7 +34,7 @@ class Authentication(AdCPBaseModel):
     ]
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'

--- a/src/adcp/types/generated_poc/core/requirements/audio_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/audio_asset_requirements.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field, RootModel
 
 
-class Format(Enum):
+class Format(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -23,7 +23,7 @@ class SampleRate(RootModel[int]):
     root: Annotated[int, Field(ge=1)]
 
 
-class Channel(Enum):
+class Channel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 

--- a/src/adcp/types/generated_poc/core/requirements/html_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/html_asset_requirements.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Sandbox(Enum):
+class Sandbox(StrEnum):
     none = 'none'
     iframe = 'iframe'
     safeframe = 'safeframe'

--- a/src/adcp/types/generated_poc/core/requirements/image_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/image_asset_requirements.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from ...enums import dimension_unit
 
 
-class Format(Enum):
+class Format(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -43,7 +43,7 @@ class Bleed1(AdCPBaseModel):
     left: Annotated[float, Field(ge=0.0)]
 
 
-class ColorSpace(Enum):
+class ColorSpace(StrEnum):
     rgb = 'rgb'
     cmyk = 'cmyk'
     grayscale = 'grayscale'

--- a/src/adcp/types/generated_poc/core/requirements/javascript_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/javascript_asset_requirements.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class ModuleType(Enum):
+class ModuleType(StrEnum):
     script = 'script'
     module = 'module'
     iife = 'iife'

--- a/src/adcp/types/generated_poc/core/requirements/url_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/url_asset_requirements.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Role(Enum):
+class Role(StrEnum):
     clickthrough = 'clickthrough'
     landing_page = 'landing_page'
     impression_tracker = 'impression_tracker'
@@ -20,7 +20,7 @@ class Role(Enum):
     third_party_tracker = 'third_party_tracker'
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     https = 'https'
     http = 'http'
 

--- a/src/adcp/types/generated_poc/core/requirements/vast_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/vast_asset_requirements.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'

--- a/src/adcp/types/generated_poc/core/requirements/video_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/video_asset_requirements.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -17,7 +17,7 @@ from ...enums import moov_atom_position as moov_atom_position_1
 from ...enums import scan_type as scan_type_1
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
@@ -25,7 +25,7 @@ class Container(Enum):
     mkv = 'mkv'
 
 
-class Codec(Enum):
+class Codec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -38,7 +38,7 @@ class FrameRate(RootModel[float]):
     root: Annotated[float, Field(ge=1.0)]
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     pcm = 'pcm'
     ac3 = 'ac3'

--- a/src/adcp/types/generated_poc/core/requirements/webhook_asset_requirements.py
+++ b/src/adcp/types/generated_poc/core/requirements/webhook_asset_requirements.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Method(Enum):
+class Method(StrEnum):
     GET = 'GET'
     POST = 'POST'
 

--- a/src/adcp/types/generated_poc/core/response_payload_jws_envelope.py
+++ b/src/adcp/types/generated_poc/core/response_payload_jws_envelope.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, ConfigDict, Field
 
 
-class Task(Enum):
+class Task(StrEnum):
     verify_brand_claim = 'verify_brand_claim'
     verify_brand_claims = 'verify_brand_claims'
 

--- a/src/adcp/types/generated_poc/core/rights_constraint.py
+++ b/src/adcp/types/generated_poc/core/rights_constraint.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -28,7 +28,7 @@ class ExcludedCountry(Country):
     pass
 
 
-class ApprovalStatus(Enum):
+class ApprovalStatus(StrEnum):
     pending = 'pending'
     approved = 'approved'
     rejected = 'rejected'

--- a/src/adcp/types/generated_poc/core/signal_coverage_forecast.py
+++ b/src/adcp/types/generated_poc/core/signal_coverage_forecast.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -53,7 +53,7 @@ class Metrics(forecast_point.Metrics):
     ]
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     inventory = 'inventory'
     product = 'product'
     account = 'account'
@@ -98,12 +98,12 @@ class Scope(AdCPBaseModel):
     ] = None
 
 
-class BucketSemantics(Enum):
+class BucketSemantics(StrEnum):
     exclusive = 'exclusive'
     overlapping = 'overlapping'
 
 
-class BucketCompleteness(Enum):
+class BucketCompleteness(StrEnum):
     complete = 'complete'
     partial = 'partial'
 

--- a/src/adcp/types/generated_poc/core/signal_definition.py
+++ b/src/adcp/types/generated_poc/core/signal_definition.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -67,7 +67,7 @@ class ValueMapping(AdCPBaseModel):
     ] = None
 
 
-class ParentMatchBehavior(Enum):
+class ParentMatchBehavior(StrEnum):
     exact_only = 'exact_only'
     descendants_supported = 'descendants_supported'
     unknown = 'unknown'
@@ -121,7 +121,7 @@ class Taxonomy(AdCPBaseModel):
     ] = None
 
 
-class DataSource(Enum):
+class DataSource(StrEnum):
     app_behavior = 'app_behavior'
     app_usage = 'app_usage'
     web_usage = 'web_usage'
@@ -141,7 +141,7 @@ class DataSource(Enum):
     offline_transaction = 'offline_transaction'
 
 
-class Methodology(Enum):
+class Methodology(StrEnum):
     observed = 'observed'
     declared = 'declared'
     derived = 'derived'
@@ -149,7 +149,7 @@ class Methodology(Enum):
     modeled = 'modeled'
 
 
-class RefreshCadence(Enum):
+class RefreshCadence(StrEnum):
     intra_day = 'intra_day'
     daily = 'daily'
     weekly = 'weekly'
@@ -160,7 +160,7 @@ class RefreshCadence(Enum):
     annually = 'annually'
 
 
-class MatchKey(Enum):
+class MatchKey(StrEnum):
     name = 'name'
     address = 'address'
     email = 'email'
@@ -173,7 +173,7 @@ class MatchKey(Enum):
     phone = 'phone'
 
 
-class PreOnboardingPrecisionLevel(Enum):
+class PreOnboardingPrecisionLevel(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -190,7 +190,7 @@ class Onboarder(AdCPBaseModel):
     pre_onboarding_precision_level: PreOnboardingPrecisionLevel | None = None
 
 
-class SubjectType(Enum):
+class SubjectType(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -198,7 +198,7 @@ class SubjectType(Enum):
     none = 'none'
 
 
-class ResolutionMethod(Enum):
+class ResolutionMethod(StrEnum):
     deterministic_id = 'deterministic_id'
     probabilistic_device = 'probabilistic_device'
     browser = 'browser'
@@ -207,14 +207,14 @@ class ResolutionMethod(Enum):
     mixed = 'mixed'
 
 
-class IdType(Enum):
+class IdType(StrEnum):
     cookie = 'cookie'
     mobile_id = 'mobile_id'
     platform_id = 'platform_id'
     user_enabled_id = 'user_enabled_id'
 
 
-class AudienceScope(Enum):
+class AudienceScope(StrEnum):
     single_domain = 'single_domain'
     cross_domain_owned = 'cross_domain_owned'
     cross_domain_unowned = 'cross_domain_unowned'
@@ -225,21 +225,21 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class Art9Basis(Enum):
+class Art9Basis(StrEnum):
     explicit_consent = 'explicit_consent'
     manifestly_made_public = 'manifestly_made_public'
     substantial_public_interest = 'substantial_public_interest'
     vital_interests = 'vital_interests'
 
 
-class Method(Enum):
+class Method(StrEnum):
     lookalike = 'lookalike'
     supervised = 'supervised'
     embedding = 'embedding'
     rules = 'rules'
 
 
-class Type(Enum):
+class Type(StrEnum):
     first_party_crm = 'first_party_crm'
     panel = 'panel'
     declared_survey = 'declared_survey'
@@ -264,13 +264,13 @@ class TrainingDataJurisdiction(Country):
     pass
 
 
-class AiActRiskClass(Enum):
+class AiActRiskClass(StrEnum):
     minimal = 'minimal'
     limited = 'limited'
     high_risk = 'high_risk'
 
 
-class Right(Enum):
+class Right(StrEnum):
     access = 'access'
     rectification = 'rectification'
     erasure = 'erasure'

--- a/src/adcp/types/generated_poc/core/signal_definition_enrichment.py
+++ b/src/adcp/types/generated_poc/core/signal_definition_enrichment.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -34,7 +34,7 @@ class ValueMapping(AdCPBaseModel):
     modifiers: list[str] | None = None
 
 
-class ParentMatchBehavior(Enum):
+class ParentMatchBehavior(StrEnum):
     exact_only = 'exact_only'
     descendants_supported = 'descendants_supported'
     unknown = 'unknown'
@@ -53,7 +53,7 @@ class Taxonomy(AdCPBaseModel):
     parent_match_behavior: ParentMatchBehavior | None = None
 
 
-class DataSource(Enum):
+class DataSource(StrEnum):
     app_behavior = 'app_behavior'
     app_usage = 'app_usage'
     web_usage = 'web_usage'
@@ -73,7 +73,7 @@ class DataSource(Enum):
     offline_transaction = 'offline_transaction'
 
 
-class Methodology(Enum):
+class Methodology(StrEnum):
     observed = 'observed'
     declared = 'declared'
     derived = 'derived'
@@ -81,7 +81,7 @@ class Methodology(Enum):
     modeled = 'modeled'
 
 
-class RefreshCadence(Enum):
+class RefreshCadence(StrEnum):
     intra_day = 'intra_day'
     daily = 'daily'
     weekly = 'weekly'
@@ -92,7 +92,7 @@ class RefreshCadence(Enum):
     annually = 'annually'
 
 
-class MatchKey(Enum):
+class MatchKey(StrEnum):
     name = 'name'
     address = 'address'
     email = 'email'
@@ -105,7 +105,7 @@ class MatchKey(Enum):
     phone = 'phone'
 
 
-class PreOnboardingPrecisionLevel(Enum):
+class PreOnboardingPrecisionLevel(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -126,21 +126,21 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class Art9Basis(Enum):
+class Art9Basis(StrEnum):
     explicit_consent = 'explicit_consent'
     manifestly_made_public = 'manifestly_made_public'
     substantial_public_interest = 'substantial_public_interest'
     vital_interests = 'vital_interests'
 
 
-class Method(Enum):
+class Method(StrEnum):
     lookalike = 'lookalike'
     supervised = 'supervised'
     embedding = 'embedding'
     rules = 'rules'
 
 
-class Type(Enum):
+class Type(StrEnum):
     first_party_crm = 'first_party_crm'
     panel = 'panel'
     declared_survey = 'declared_survey'
@@ -165,13 +165,13 @@ class TrainingDataJurisdiction(Country):
     pass
 
 
-class AiActRiskClass(Enum):
+class AiActRiskClass(StrEnum):
     minimal = 'minimal'
     limited = 'limited'
     high_risk = 'high_risk'
 
 
-class Right(Enum):
+class Right(StrEnum):
     access = 'access'
     rectification = 'rectification'
     erasure = 'erasure'

--- a/src/adcp/types/generated_poc/core/signal_modeling_disclosure.py
+++ b/src/adcp/types/generated_poc/core/signal_modeling_disclosure.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, ConfigDict, Field
 
 
-class Audience(Enum):
+class Audience(StrEnum):
     buyer = 'buyer'
     data_subject = 'data_subject'
     regulator = 'regulator'

--- a/src/adcp/types/generated_poc/core/signal_pricing.py
+++ b/src/adcp/types/generated_poc/core/signal_pricing.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -45,7 +45,7 @@ class VendorPricing2(AdCPBaseModel):
     ext: ext_1.ExtensionObject | None = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'

--- a/src/adcp/types/generated_poc/core/signal_selection_group_rule.py
+++ b/src/adcp/types/generated_poc/core/signal_selection_group_rule.py
@@ -4,19 +4,19 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class TargetingMode(Enum):
+class TargetingMode(StrEnum):
     include = 'include'
     exclude = 'exclude'
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     optional = 'optional'
     required = 'required'
     fixed = 'fixed'

--- a/src/adcp/types/generated_poc/core/signal_targeting_rules.py
+++ b/src/adcp/types/generated_poc/core/signal_targeting_rules.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,12 +13,12 @@ from pydantic import ConfigDict, Field
 from . import signal_selection_group_rule
 
 
-class ResolutionModel(Enum):
+class ResolutionModel(StrEnum):
     direct_targeting = 'direct_targeting'
     seller_planned = 'seller_planned'
 
 
-class SelectionMode(Enum):
+class SelectionMode(StrEnum):
     optional = 'optional'
     required = 'required'
     fixed = 'fixed'

--- a/src/adcp/types/generated_poc/core/targeting.py
+++ b/src/adcp/types/generated_poc/core/targeting.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 from collections.abc import Sequence
 
@@ -163,7 +163,7 @@ class Radius(AdCPBaseModel):
     unit: Annotated[distance_unit.DistanceUnit, Field(description='Distance unit.')]
 
 
-class Type(Enum):
+class Type(StrEnum):
     Polygon = 'Polygon'
     MultiPolygon = 'MultiPolygon'
 

--- a/src/adcp/types/generated_poc/core/tasks_get_response.py
+++ b/src/adcp/types/generated_poc/core/tasks_get_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -57,7 +57,7 @@ class Error(AdCPBaseModel):
     details: Annotated[Details | None, Field(description='Additional error context')] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     request = 'request'
     response = 'response'
 

--- a/src/adcp/types/generated_poc/core/tasks_list_request.py
+++ b/src/adcp/types/generated_poc/core/tasks_list_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -72,7 +72,7 @@ class Filters(AdCPBaseModel):
     ] = None
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     created_at = 'created_at'
     updated_at = 'updated_at'
     status = 'status'

--- a/src/adcp/types/generated_poc/core/tasks_list_response.py
+++ b/src/adcp/types/generated_poc/core/tasks_list_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DomainBreakdown(AdCPBaseModel):
     ] = None
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -70,7 +70,7 @@ class QuerySummary(AdCPBaseModel):
     ] = None
 
 
-class Domain(Enum):
+class Domain(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
 

--- a/src/adcp/types/generated_poc/core/transformer.py
+++ b/src/adcp/types/generated_poc/core/transformer.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -38,7 +38,7 @@ class VoiceSynthesisRefItem(AdCPBaseModel):
     ] = None
 
 
-class VariantDimension(Enum):
+class VariantDimension(StrEnum):
     voice = 'voice'
     theme = 'theme'
     best_of_n = 'best_of_n'

--- a/src/adcp/types/generated_poc/core/transformer_param.py
+++ b/src/adcp/types/generated_poc/core/transformer_param.py
@@ -4,21 +4,21 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Type(Enum):
+class Type(StrEnum):
     string = 'string'
     number = 'number'
     integer = 'integer'
     boolean = 'boolean'
 
 
-class ValueSource(Enum):
+class ValueSource(StrEnum):
     inline = 'inline'
     range = 'range'
     enumerable = 'enumerable'

--- a/src/adcp/types/generated_poc/core/vehicle_item.py
+++ b/src/adcp/types/generated_poc/core/vehicle_item.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,13 +15,13 @@ from . import offering_asset_group
 from . import price as price_1
 
 
-class Condition(Enum):
+class Condition(StrEnum):
     new = 'new'
     used = 'used'
     certified_pre_owned = 'certified_pre_owned'
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     km = 'km'
     mi = 'mi'
 
@@ -34,7 +34,7 @@ class Mileage(AdCPBaseModel):
     unit: Annotated[Unit, Field(description='Distance unit.')]
 
 
-class BodyStyle(Enum):
+class BodyStyle(StrEnum):
     sedan = 'sedan'
     suv = 'suv'
     truck = 'truck'
@@ -45,13 +45,13 @@ class BodyStyle(Enum):
     hatchback = 'hatchback'
 
 
-class Transmission(Enum):
+class Transmission(StrEnum):
     automatic = 'automatic'
     manual = 'manual'
     cvt = 'cvt'
 
 
-class FuelType(Enum):
+class FuelType(StrEnum):
     gasoline = 'gasoline'
     diesel = 'diesel'
     electric = 'electric'

--- a/src/adcp/types/generated_poc/core/vendor_metric_optimization_supported_metric.py
+++ b/src/adcp/types/generated_poc/core/vendor_metric_optimization_supported_metric.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from . import brand_ref, vendor_metric_id
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 

--- a/src/adcp/types/generated_poc/core/vendor_pricing_option.py
+++ b/src/adcp/types/generated_poc/core/vendor_pricing_option.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -46,7 +46,7 @@ class VendorPricingOption2(AdCPBaseModel):
     ext: ext_1.ExtensionObject | None = None
 
 
-class Period(Enum):
+class Period(StrEnum):
     monthly = 'monthly'
     quarterly = 'quarterly'
     annual = 'annual'

--- a/src/adcp/types/generated_poc/core/webhook_activity_record.py
+++ b/src/adcp/types/generated_poc/core/webhook_activity_record.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..enums import notification_type as notification_type_1
 from . import ext as ext_1
 
 
-class Status(Enum):
+class Status(StrEnum):
     success = 'success'
     failed = 'failed'
     timeout = 'timeout'

--- a/src/adcp/types/generated_poc/core/webhook_challenge.py
+++ b/src/adcp/types/generated_poc/core/webhook_challenge.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import AnyUrl, ConfigDict, Field
 from ..enums import notification_type
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     rfc9421 = 'rfc9421'
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'

--- a/src/adcp/types/generated_poc/core/wholesale_feed_event.py
+++ b/src/adcp/types/generated_poc/core/wholesale_feed_event.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 from collections.abc import Sequence
 from uuid import UUID
@@ -22,7 +22,7 @@ from . import vendor_pricing_option
 from .signal_listing import Range, SignalListing
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     product_created = 'product.created'
     product_updated = 'product.updated'
     product_priced = 'product.priced'
@@ -34,13 +34,13 @@ class EventType(Enum):
     wholesale_feed_bulk_change = 'wholesale_feed.bulk_change'
 
 
-class EntityType(Enum):
+class EntityType(StrEnum):
     product = 'product'
     signal = 'signal'
     feed = 'feed'
 
 
-class AffectedEntityType(Enum):
+class AffectedEntityType(StrEnum):
     product = 'product'
     signal = 'signal'
 
@@ -81,7 +81,7 @@ class AppliesTo(RootModel[AppliesTo1 | AppliesTo2]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class RemovalReason(Enum):
+class RemovalReason(StrEnum):
     withdrawn = 'withdrawn'
     cancellation = 'cancellation'
     expired = 'expired'

--- a/src/adcp/types/generated_poc/core/wholesale_feed_webhook.py
+++ b/src/adcp/types/generated_poc/core/wholesale_feed_webhook.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 from uuid import UUID
 
@@ -15,7 +15,7 @@ from . import ext as ext_1
 from . import wholesale_feed_event
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     product_created = 'product.created'
     product_updated = 'product.updated'
     product_priced = 'product.priced'
@@ -27,7 +27,7 @@ class NotificationType(Enum):
     wholesale_feed_bulk_change = 'wholesale_feed.bulk_change'
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 

--- a/src/adcp/types/generated_poc/core/x_entity_types.py
+++ b/src/adcp/types/generated_poc/core/x_entity_types.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class XEntityTypes(Enum):
+class XEntityTypes(StrEnum):
     advertiser_brand = 'advertiser_brand'
     rights_holder_brand = 'rights_holder_brand'
     rights_grant = 'rights_grant'

--- a/src/adcp/types/generated_poc/creative/audit_observation.py
+++ b/src/adcp/types/generated_poc/creative/audit_observation.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import AnyUrl, ConfigDict, Field
 from ..core import ext as ext_1
 
 
-class HumanOversight(Enum):
+class HumanOversight(StrEnum):
     edited = 'edited'
     directed = 'directed'
 

--- a/src/adcp/types/generated_poc/creative/creative_purged_webhook.py
+++ b/src/adcp/types/generated_poc/creative/creative_purged_webhook.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -14,12 +14,12 @@ from ..core import ext as ext_1
 from ..enums import creative_event_reason_code
 
 
-class PurgeKind(Enum):
+class PurgeKind(StrEnum):
     soft = 'soft'
     hard = 'hard'
 
 
-class Initiator(Enum):
+class Initiator(StrEnum):
     seller = 'seller'
     system = 'system'
 

--- a/src/adcp/types/generated_poc/creative/creative_status_changed_webhook.py
+++ b/src/adcp/types/generated_poc/creative/creative_status_changed_webhook.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..core import ext as ext_1
 from ..enums import creative_event_reason_code, creative_status
 
 
-class From(Enum):
+class From(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'
@@ -41,7 +41,7 @@ class Transition(AdCPBaseModel):
     ]
 
 
-class Initiator(Enum):
+class Initiator(StrEnum):
     seller = 'seller'
     system = 'system'
 

--- a/src/adcp/types/generated_poc/creative/list_creative_formats_request.py
+++ b/src/adcp/types/generated_poc/creative/list_creative_formats_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field
@@ -20,7 +20,7 @@ from ..enums import disclosure_position
 from ..enums import wcag_level as wcag_level_1
 
 
-class Type(Enum):
+class Type(StrEnum):
     audio = 'audio'
     video = 'video'
     display = 'display'

--- a/src/adcp/types/generated_poc/creative/list_creatives_request.py
+++ b/src/adcp/types/generated_poc/creative/list_creatives_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -19,7 +19,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import creative_sort_field, sort_direction
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     creative_id = 'creative_id'
     name = 'name'
     format_id = 'format_id'

--- a/src/adcp/types/generated_poc/creative/preview_creative_request.py
+++ b/src/adcp/types/generated_poc/creative/preview_creative_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -18,7 +18,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import creative_quality, preview_output_format
 
 
-class RequestType(Enum):
+class RequestType(StrEnum):
     single = 'single'
     batch = 'batch'
     variant = 'variant'

--- a/src/adcp/types/generated_poc/creative/sync_creatives_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/creative/sync_creatives_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..core import context as context_1
 from ..core import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     ASSET_CONFIRMATION = 'ASSET_CONFIRMATION'
     FORMAT_CLARIFICATION = 'FORMAT_CLARIFICATION'

--- a/src/adcp/types/generated_poc/creative/validate_input_result.py
+++ b/src/adcp/types/generated_poc/creative/validate_input_result.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     canonical = 'canonical'
     product = 'product'
     third_party_format = 'third_party_format'
@@ -30,7 +30,7 @@ class Target(AdCPBaseModel):
     ]
 
 
-class ResultKind(Enum):
+class ResultKind(StrEnum):
     validated_pass = 'validated_pass'
     validated_fail = 'validated_fail'
     unvalidatable_nondeterministic = 'unvalidatable_nondeterministic'

--- a/src/adcp/types/generated_poc/enums/account_scope.py
+++ b/src/adcp/types/generated_poc/enums/account_scope.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AccountScope(Enum):
+class AccountScope(StrEnum):
     operator = 'operator'
     brand = 'brand'
     operator_brand = 'operator_brand'

--- a/src/adcp/types/generated_poc/enums/account_status.py
+++ b/src/adcp/types/generated_poc/enums/account_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AccountStatus(Enum):
+class AccountStatus(StrEnum):
     active = 'active'
     pending_approval = 'pending_approval'
     rejected = 'rejected'

--- a/src/adcp/types/generated_poc/enums/action_not_allowed_reason.py
+++ b/src/adcp/types/generated_poc/enums/action_not_allowed_reason.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ActionNotAllowedReason(Enum):
+class ActionNotAllowedReason(StrEnum):
     wrong_status = 'wrong_status'
     not_supported_on_product = 'not_supported_on_product'
     not_supported_on_buy = 'not_supported_on_buy'

--- a/src/adcp/types/generated_poc/enums/action_source.py
+++ b/src/adcp/types/generated_poc/enums/action_source.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ActionSource(Enum):
+class ActionSource(StrEnum):
     website = 'website'
     app = 'app'
     offline = 'offline'

--- a/src/adcp/types/generated_poc/enums/adcp_protocol.py
+++ b/src/adcp/types/generated_poc/enums/adcp_protocol.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AdcpProtocol(Enum):
+class AdcpProtocol(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
     governance = 'governance'

--- a/src/adcp/types/generated_poc/enums/adjustment_kind.py
+++ b/src/adcp/types/generated_poc/enums/adjustment_kind.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PriceAdjustmentKind(Enum):
+class PriceAdjustmentKind(StrEnum):
     fee = 'fee'
     discount = 'discount'
     commission = 'commission'

--- a/src/adcp/types/generated_poc/enums/advertiser_industry.py
+++ b/src/adcp/types/generated_poc/enums/advertiser_industry.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AdvertiserIndustry(Enum):
+class AdvertiserIndustry(StrEnum):
     automotive = 'automotive'
     automotive_electric_vehicles = 'automotive.electric_vehicles'
     automotive_parts_accessories = 'automotive.parts_accessories'

--- a/src/adcp/types/generated_poc/enums/age_verification_method.py
+++ b/src/adcp/types/generated_poc/enums/age_verification_method.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AgeVerificationMethod(Enum):
+class AgeVerificationMethod(StrEnum):
     facial_age_estimation = 'facial_age_estimation'
     id_document = 'id_document'
     digital_id = 'digital_id'

--- a/src/adcp/types/generated_poc/enums/assessment_status.py
+++ b/src/adcp/types/generated_poc/enums/assessment_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AssessmentStatus(Enum):
+class AssessmentStatus(StrEnum):
     insufficient = 'insufficient'
     minimum = 'minimum'
     good = 'good'

--- a/src/adcp/types/generated_poc/enums/asset_content_type.py
+++ b/src/adcp/types/generated_poc/enums/asset_content_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AssetContentType(Enum):
+class AssetContentType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/enums/attribution_methodology.py
+++ b/src/adcp/types/generated_poc/enums/attribution_methodology.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AttributionMethodology(Enum):
+class AttributionMethodology(StrEnum):
     deterministic_purchase = 'deterministic_purchase'
     probabilistic = 'probabilistic'
     panel_based = 'panel_based'

--- a/src/adcp/types/generated_poc/enums/attribution_model.py
+++ b/src/adcp/types/generated_poc/enums/attribution_model.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AttributionModel(Enum):
+class AttributionModel(StrEnum):
     last_touch = 'last_touch'
     first_touch = 'first_touch'
     linear = 'linear'

--- a/src/adcp/types/generated_poc/enums/audience_source.py
+++ b/src/adcp/types/generated_poc/enums/audience_source.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AudienceSource(Enum):
+class AudienceSource(StrEnum):
     synced = 'synced'
     platform = 'platform'
     third_party = 'third_party'

--- a/src/adcp/types/generated_poc/enums/audience_status.py
+++ b/src/adcp/types/generated_poc/enums/audience_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AudienceStatus(Enum):
+class AudienceStatus(StrEnum):
     processing = 'processing'
     ready = 'ready'
     too_small = 'too_small'

--- a/src/adcp/types/generated_poc/enums/audio_channel_layout.py
+++ b/src/adcp/types/generated_poc/enums/audio_channel_layout.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AudioChannelLayout(Enum):
+class AudioChannelLayout(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
     field_5_1 = '5.1'

--- a/src/adcp/types/generated_poc/enums/auth_scheme.py
+++ b/src/adcp/types/generated_poc/enums/auth_scheme.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AuthenticationScheme(Enum):
+class AuthenticationScheme(StrEnum):
     Bearer = 'Bearer'
     HMAC_SHA256 = 'HMAC-SHA256'

--- a/src/adcp/types/generated_poc/enums/available_metric.py
+++ b/src/adcp/types/generated_poc/enums/available_metric.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AvailableMetric(Enum):
+class AvailableMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'

--- a/src/adcp/types/generated_poc/enums/billing_party.py
+++ b/src/adcp/types/generated_poc/enums/billing_party.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class BillingParty(Enum):
+class BillingParty(StrEnum):
     operator = 'operator'
     agent = 'agent'
     advertiser = 'advertiser'

--- a/src/adcp/types/generated_poc/enums/binary_verdict.py
+++ b/src/adcp/types/generated_poc/enums/binary_verdict.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class BinaryVerdict(Enum):
+class BinaryVerdict(StrEnum):
     pass_ = 'pass'
     fail = 'fail'

--- a/src/adcp/types/generated_poc/enums/brand_agent_type.py
+++ b/src/adcp/types/generated_poc/enums/brand_agent_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class BrandAgentType(Enum):
+class BrandAgentType(StrEnum):
     brand = 'brand'
     rights = 'rights'
     measurement = 'measurement'

--- a/src/adcp/types/generated_poc/enums/c2pa_watermark_action.py
+++ b/src/adcp/types/generated_poc/enums/c2pa_watermark_action.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class C2PaWatermarkAction(Enum):
+class C2PaWatermarkAction(StrEnum):
     c2pa_watermarked_bound = 'c2pa.watermarked.bound'
     c2pa_watermarked_unbound = 'c2pa.watermarked.unbound'

--- a/src/adcp/types/generated_poc/enums/canceled_by.py
+++ b/src/adcp/types/generated_poc/enums/canceled_by.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CanceledBy(Enum):
+class CanceledBy(StrEnum):
     buyer = 'buyer'
     seller = 'seller'

--- a/src/adcp/types/generated_poc/enums/catalog_action.py
+++ b/src/adcp/types/generated_poc/enums/catalog_action.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CatalogAction(Enum):
+class CatalogAction(StrEnum):
     created = 'created'
     updated = 'updated'
     unchanged = 'unchanged'

--- a/src/adcp/types/generated_poc/enums/catalog_item_status.py
+++ b/src/adcp/types/generated_poc/enums/catalog_item_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CatalogItemStatus(Enum):
+class CatalogItemStatus(StrEnum):
     approved = 'approved'
     pending = 'pending'
     rejected = 'rejected'

--- a/src/adcp/types/generated_poc/enums/catalog_type.py
+++ b/src/adcp/types/generated_poc/enums/catalog_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CatalogType(Enum):
+class CatalogType(StrEnum):
     offering = 'offering'
     product = 'product'
     inventory = 'inventory'

--- a/src/adcp/types/generated_poc/enums/channels.py
+++ b/src/adcp/types/generated_poc/enums/channels.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MediaChannel(Enum):
+class MediaChannel(StrEnum):
     display = 'display'
     olv = 'olv'
     social = 'social'

--- a/src/adcp/types/generated_poc/enums/cloud_storage_protocol.py
+++ b/src/adcp/types/generated_poc/enums/cloud_storage_protocol.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CloudStorageProtocol(Enum):
+class CloudStorageProtocol(StrEnum):
     s3 = 's3'
     gcs = 'gcs'
     azure_blob = 'azure_blob'

--- a/src/adcp/types/generated_poc/enums/co_branding_requirement.py
+++ b/src/adcp/types/generated_poc/enums/co_branding_requirement.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CoBrandingRequirement(Enum):
+class CoBrandingRequirement(StrEnum):
     required = 'required'
     optional = 'optional'
     none = 'none'

--- a/src/adcp/types/generated_poc/enums/collection_cadence.py
+++ b/src/adcp/types/generated_poc/enums/collection_cadence.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CollectionCadence(Enum):
+class CollectionCadence(StrEnum):
     daily = 'daily'
     weekly = 'weekly'
     monthly = 'monthly'

--- a/src/adcp/types/generated_poc/enums/collection_kind.py
+++ b/src/adcp/types/generated_poc/enums/collection_kind.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CollectionKind(Enum):
+class CollectionKind(StrEnum):
     series = 'series'
     publication = 'publication'
     event_series = 'event_series'

--- a/src/adcp/types/generated_poc/enums/collection_relationship.py
+++ b/src/adcp/types/generated_poc/enums/collection_relationship.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CollectionRelationship(Enum):
+class CollectionRelationship(StrEnum):
     spinoff = 'spinoff'
     companion = 'companion'
     sequel = 'sequel'

--- a/src/adcp/types/generated_poc/enums/collection_status.py
+++ b/src/adcp/types/generated_poc/enums/collection_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CollectionStatus(Enum):
+class CollectionStatus(StrEnum):
     active = 'active'
     hiatus = 'hiatus'
     ended = 'ended'

--- a/src/adcp/types/generated_poc/enums/completion_source.py
+++ b/src/adcp/types/generated_poc/enums/completion_source.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CompletionSource(Enum):
+class CompletionSource(StrEnum):
     seller_attested = 'seller_attested'
     vendor_attested = 'vendor_attested'

--- a/src/adcp/types/generated_poc/enums/consent_basis.py
+++ b/src/adcp/types/generated_poc/enums/consent_basis.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ConsentBasis(Enum):
+class ConsentBasis(StrEnum):
     consent = 'consent'
     legitimate_interest = 'legitimate_interest'
     contract = 'contract'

--- a/src/adcp/types/generated_poc/enums/content_id_type.py
+++ b/src/adcp/types/generated_poc/enums/content_id_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ContentIdType(Enum):
+class ContentIdType(StrEnum):
     sku = 'sku'
     gtin = 'gtin'
     offering_id = 'offering_id'

--- a/src/adcp/types/generated_poc/enums/content_rating_system.py
+++ b/src/adcp/types/generated_poc/enums/content_rating_system.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ContentRatingSystem(Enum):
+class ContentRatingSystem(StrEnum):
     tv_parental = 'tv_parental'
     mpaa = 'mpaa'
     podcast = 'podcast'

--- a/src/adcp/types/generated_poc/enums/creative_action.py
+++ b/src/adcp/types/generated_poc/enums/creative_action.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeAction(Enum):
+class CreativeAction(StrEnum):
     created = 'created'
     updated = 'updated'
     unchanged = 'unchanged'

--- a/src/adcp/types/generated_poc/enums/creative_agent_capability.py
+++ b/src/adcp/types/generated_poc/enums/creative_agent_capability.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeAgentCapability(Enum):
+class CreativeAgentCapability(StrEnum):
     validation = 'validation'
     assembly = 'assembly'
     generation = 'generation'

--- a/src/adcp/types/generated_poc/enums/creative_approval_status.py
+++ b/src/adcp/types/generated_poc/enums/creative_approval_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeApprovalStatus(Enum):
+class CreativeApprovalStatus(StrEnum):
     pending_review = 'pending_review'
     approved = 'approved'
     rejected = 'rejected'

--- a/src/adcp/types/generated_poc/enums/creative_event_reason_code.py
+++ b/src/adcp/types/generated_poc/enums/creative_event_reason_code.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeEventReasonCode(Enum):
+class CreativeEventReasonCode(StrEnum):
     review_passed = 'review_passed'
     review_failure = 'review_failure'
     processing_failure = 'processing_failure'

--- a/src/adcp/types/generated_poc/enums/creative_identifier_type.py
+++ b/src/adcp/types/generated_poc/enums/creative_identifier_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeIdentifierType(Enum):
+class CreativeIdentifierType(StrEnum):
     ad_id = 'ad_id'
     isci = 'isci'
     clearcast_clock = 'clearcast_clock'

--- a/src/adcp/types/generated_poc/enums/creative_quality.py
+++ b/src/adcp/types/generated_poc/enums/creative_quality.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeQuality(Enum):
+class CreativeQuality(StrEnum):
     draft = 'draft'
     production = 'production'

--- a/src/adcp/types/generated_poc/enums/creative_selection_strategy.py
+++ b/src/adcp/types/generated_poc/enums/creative_selection_strategy.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeSelectionStrategy(Enum):
+class CreativeSelectionStrategy(StrEnum):
     audience_relevance = 'audience_relevance'
     contextual_fit = 'contextual_fit'
     performance = 'performance'

--- a/src/adcp/types/generated_poc/enums/creative_sort_field.py
+++ b/src/adcp/types/generated_poc/enums/creative_sort_field.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeSortField(Enum):
+class CreativeSortField(StrEnum):
     created_date = 'created_date'
     updated_date = 'updated_date'
     name = 'name'

--- a/src/adcp/types/generated_poc/enums/creative_status.py
+++ b/src/adcp/types/generated_poc/enums/creative_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class CreativeStatus(Enum):
+class CreativeStatus(StrEnum):
     processing = 'processing'
     pending_review = 'pending_review'
     approved = 'approved'

--- a/src/adcp/types/generated_poc/enums/daast_tracking_event.py
+++ b/src/adcp/types/generated_poc/enums/daast_tracking_event.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DaastTrackingEvent(Enum):
+class DaastTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     start = 'start'

--- a/src/adcp/types/generated_poc/enums/daast_version.py
+++ b/src/adcp/types/generated_poc/enums/daast_version.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'

--- a/src/adcp/types/generated_poc/enums/day_of_week.py
+++ b/src/adcp/types/generated_poc/enums/day_of_week.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DayOfWeek(Enum):
+class DayOfWeek(StrEnum):
     monday = 'monday'
     tuesday = 'tuesday'
     wednesday = 'wednesday'

--- a/src/adcp/types/generated_poc/enums/delegation_authority.py
+++ b/src/adcp/types/generated_poc/enums/delegation_authority.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DelegationAuthority(Enum):
+class DelegationAuthority(StrEnum):
     full = 'full'
     execute_only = 'execute_only'
     propose_only = 'propose_only'

--- a/src/adcp/types/generated_poc/enums/delivery_type.py
+++ b/src/adcp/types/generated_poc/enums/delivery_type.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DeliveryType(Enum):
+class DeliveryType(StrEnum):
     guaranteed = 'guaranteed'
     non_guaranteed = 'non_guaranteed'

--- a/src/adcp/types/generated_poc/enums/demographic_system.py
+++ b/src/adcp/types/generated_poc/enums/demographic_system.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DemographicSystem(Enum):
+class DemographicSystem(StrEnum):
     nielsen = 'nielsen'
     barb = 'barb'
     agf = 'agf'

--- a/src/adcp/types/generated_poc/enums/derivative_type.py
+++ b/src/adcp/types/generated_poc/enums/derivative_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DerivativeType(Enum):
+class DerivativeType(StrEnum):
     clip = 'clip'
     highlight = 'highlight'
     recap = 'recap'

--- a/src/adcp/types/generated_poc/enums/device_platform.py
+++ b/src/adcp/types/generated_poc/enums/device_platform.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DevicePlatform(Enum):
+class DevicePlatform(StrEnum):
     ios = 'ios'
     android = 'android'
     windows = 'windows'

--- a/src/adcp/types/generated_poc/enums/device_type.py
+++ b/src/adcp/types/generated_poc/enums/device_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DeviceType(Enum):
+class DeviceType(StrEnum):
     desktop = 'desktop'
     mobile = 'mobile'
     tablet = 'tablet'

--- a/src/adcp/types/generated_poc/enums/digital_source_type.py
+++ b/src/adcp/types/generated_poc/enums/digital_source_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DigitalSourceType(Enum):
+class DigitalSourceType(StrEnum):
     digital_capture = 'digital_capture'
     digital_creation = 'digital_creation'
     trained_algorithmic_media = 'trained_algorithmic_media'

--- a/src/adcp/types/generated_poc/enums/dimension_unit.py
+++ b/src/adcp/types/generated_poc/enums/dimension_unit.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DimensionUnit(Enum):
+class DimensionUnit(StrEnum):
     px = 'px'
     dp = 'dp'
     inches = 'inches'

--- a/src/adcp/types/generated_poc/enums/disclosure_persistence.py
+++ b/src/adcp/types/generated_poc/enums/disclosure_persistence.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DisclosurePersistence(Enum):
+class DisclosurePersistence(StrEnum):
     continuous = 'continuous'
     initial = 'initial'
     flexible = 'flexible'

--- a/src/adcp/types/generated_poc/enums/disclosure_position.py
+++ b/src/adcp/types/generated_poc/enums/disclosure_position.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DisclosurePosition(Enum):
+class DisclosurePosition(StrEnum):
     prominent = 'prominent'
     footer = 'footer'
     audio = 'audio'

--- a/src/adcp/types/generated_poc/enums/distance_unit.py
+++ b/src/adcp/types/generated_poc/enums/distance_unit.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DistanceUnit(Enum):
+class DistanceUnit(StrEnum):
     km = 'km'
     mi = 'mi'
     m = 'm'

--- a/src/adcp/types/generated_poc/enums/distribution_identifier_type.py
+++ b/src/adcp/types/generated_poc/enums/distribution_identifier_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class DistributionIdentifierType(Enum):
+class DistributionIdentifierType(StrEnum):
     apple_podcast_id = 'apple_podcast_id'
     spotify_collection_id = 'spotify_collection_id'
     rss_url = 'rss_url'

--- a/src/adcp/types/generated_poc/enums/embedded_provenance_method.py
+++ b/src/adcp/types/generated_poc/enums/embedded_provenance_method.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class EmbeddedProvenanceMethod(Enum):
+class EmbeddedProvenanceMethod(StrEnum):
     manifest_wrapper = 'manifest_wrapper'
     provenance_markers = 'provenance_markers'

--- a/src/adcp/types/generated_poc/enums/error_code.py
+++ b/src/adcp/types/generated_poc/enums/error_code.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ErrorCode(Enum):
+class ErrorCode(StrEnum):
     INVALID_REQUEST = 'INVALID_REQUEST'
     AUTH_REQUIRED = 'AUTH_REQUIRED'
     AUTH_MISSING = 'AUTH_MISSING'

--- a/src/adcp/types/generated_poc/enums/error_scope.py
+++ b/src/adcp/types/generated_poc/enums/error_scope.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ErrorScope(Enum):
+class ErrorScope(StrEnum):
     capability = 'capability'
     account = 'account'
     agent = 'agent'

--- a/src/adcp/types/generated_poc/enums/escalation_severity.py
+++ b/src/adcp/types/generated_poc/enums/escalation_severity.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class EscalationSeverity(Enum):
+class EscalationSeverity(StrEnum):
     info = 'info'
     warning = 'warning'
     critical = 'critical'

--- a/src/adcp/types/generated_poc/enums/event_type.py
+++ b/src/adcp/types/generated_poc/enums/event_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     page_view = 'page_view'
     view_content = 'view_content'
     select_content = 'select_content'

--- a/src/adcp/types/generated_poc/enums/exclusivity.py
+++ b/src/adcp/types/generated_poc/enums/exclusivity.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class Exclusivity(Enum):
+class Exclusivity(StrEnum):
     none = 'none'
     category = 'category'
     exclusive = 'exclusive'

--- a/src/adcp/types/generated_poc/enums/feature_check_status.py
+++ b/src/adcp/types/generated_poc/enums/feature_check_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class FeatureCheckStatus(Enum):
+class FeatureCheckStatus(StrEnum):
     passed = 'passed'
     failed = 'failed'
     warning = 'warning'

--- a/src/adcp/types/generated_poc/enums/feed_format.py
+++ b/src/adcp/types/generated_poc/enums/feed_format.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class FeedFormat(Enum):
+class FeedFormat(StrEnum):
     google_merchant_center = 'google_merchant_center'
     facebook_catalog = 'facebook_catalog'
     shopify = 'shopify'

--- a/src/adcp/types/generated_poc/enums/feedback_source.py
+++ b/src/adcp/types/generated_poc/enums/feedback_source.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class FeedbackSource(Enum):
+class FeedbackSource(StrEnum):
     buyer_attribution = 'buyer_attribution'
     third_party_measurement = 'third_party_measurement'
     platform_analytics = 'platform_analytics'

--- a/src/adcp/types/generated_poc/enums/forecast_method.py
+++ b/src/adcp/types/generated_poc/enums/forecast_method.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ForecastMethod(Enum):
+class ForecastMethod(StrEnum):
     estimate = 'estimate'
     modeled = 'modeled'
     guaranteed = 'guaranteed'

--- a/src/adcp/types/generated_poc/enums/forecast_range_unit.py
+++ b/src/adcp/types/generated_poc/enums/forecast_range_unit.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ForecastRangeUnit(Enum):
+class ForecastRangeUnit(StrEnum):
     spend = 'spend'
     availability = 'availability'
     reach_freq = 'reach_freq'

--- a/src/adcp/types/generated_poc/enums/forecastable_metric.py
+++ b/src/adcp/types/generated_poc/enums/forecastable_metric.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ForecastableMetric(Enum):
+class ForecastableMetric(StrEnum):
     audience_size = 'audience_size'
     reach = 'reach'
     frequency = 'frequency'

--- a/src/adcp/types/generated_poc/enums/format_id_parameter.py
+++ b/src/adcp/types/generated_poc/enums/format_id_parameter.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class FormatIdParameter(Enum):
+class FormatIdParameter(StrEnum):
     dimensions = 'dimensions'
     duration = 'duration'

--- a/src/adcp/types/generated_poc/enums/frame_rate_type.py
+++ b/src/adcp/types/generated_poc/enums/frame_rate_type.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class FrameRateType(Enum):
+class FrameRateType(StrEnum):
     constant = 'constant'
     variable = 'variable'

--- a/src/adcp/types/generated_poc/enums/genre_taxonomy.py
+++ b/src/adcp/types/generated_poc/enums/genre_taxonomy.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GenreTaxonomy(Enum):
+class GenreTaxonomy(StrEnum):
     iab_content_3_0 = 'iab_content_3.0'
     iab_content_2_2 = 'iab_content_2.2'
     gracenote = 'gracenote'

--- a/src/adcp/types/generated_poc/enums/geo_level.py
+++ b/src/adcp/types/generated_poc/enums/geo_level.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GeographicTargetingLevel(Enum):
+class GeographicTargetingLevel(StrEnum):
     country = 'country'
     region = 'region'
     metro = 'metro'

--- a/src/adcp/types/generated_poc/enums/gop_type.py
+++ b/src/adcp/types/generated_poc/enums/gop_type.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GopType(Enum):
+class GopType(StrEnum):
     closed = 'closed'
     open = 'open'

--- a/src/adcp/types/generated_poc/enums/governance_decision.py
+++ b/src/adcp/types/generated_poc/enums/governance_decision.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GovernanceDecision(Enum):
+class GovernanceDecision(StrEnum):
     approved = 'approved'
     denied = 'denied'
     conditions = 'conditions'

--- a/src/adcp/types/generated_poc/enums/governance_domain.py
+++ b/src/adcp/types/generated_poc/enums/governance_domain.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GovernanceDomain(Enum):
+class GovernanceDomain(StrEnum):
     campaign = 'campaign'
     property = 'property'
     creative = 'creative'

--- a/src/adcp/types/generated_poc/enums/governance_mode.py
+++ b/src/adcp/types/generated_poc/enums/governance_mode.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GovernanceMode(Enum):
+class GovernanceMode(StrEnum):
     audit = 'audit'
     advisory = 'advisory'
     enforce = 'enforce'

--- a/src/adcp/types/generated_poc/enums/governance_phase.py
+++ b/src/adcp/types/generated_poc/enums/governance_phase.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class GovernancePhase(Enum):
+class GovernancePhase(StrEnum):
     purchase = 'purchase'
     modification = 'modification'
     delivery = 'delivery'

--- a/src/adcp/types/generated_poc/enums/history_entry_type.py
+++ b/src/adcp/types/generated_poc/enums/history_entry_type.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class HistoryEntryType(Enum):
+class HistoryEntryType(StrEnum):
     request = 'request'
     response = 'response'

--- a/src/adcp/types/generated_poc/enums/http_method.py
+++ b/src/adcp/types/generated_poc/enums/http_method.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class HttpMethod(Enum):
+class HttpMethod(StrEnum):
     GET = 'GET'
     POST = 'POST'

--- a/src/adcp/types/generated_poc/enums/identifier_types.py
+++ b/src/adcp/types/generated_poc/enums/identifier_types.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PropertyIdentifierTypes(Enum):
+class PropertyIdentifierTypes(StrEnum):
     domain = 'domain'
     subdomain = 'subdomain'
     network_id = 'network_id'

--- a/src/adcp/types/generated_poc/enums/impairment_offline_state.py
+++ b/src/adcp/types/generated_poc/enums/impairment_offline_state.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ImpairmentOfflineState(Enum):
+class ImpairmentOfflineState(StrEnum):
     suspended = 'suspended'
     rejected = 'rejected'
     withdrawn = 'withdrawn'

--- a/src/adcp/types/generated_poc/enums/impairment_reason_code.py
+++ b/src/adcp/types/generated_poc/enums/impairment_reason_code.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ImpairmentReasonCode(Enum):
+class ImpairmentReasonCode(StrEnum):
     policy_violation = 'policy_violation'
     consent_expired = 'consent_expired'
     ttl_expired = 'ttl_expired'

--- a/src/adcp/types/generated_poc/enums/installment_status.py
+++ b/src/adcp/types/generated_poc/enums/installment_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class InstallmentStatus(Enum):
+class InstallmentStatus(StrEnum):
     scheduled = 'scheduled'
     tentative = 'tentative'
     live = 'live'

--- a/src/adcp/types/generated_poc/enums/javascript_module_type.py
+++ b/src/adcp/types/generated_poc/enums/javascript_module_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class JavascriptModuleType(Enum):
+class JavascriptModuleType(StrEnum):
     esm = 'esm'
     commonjs = 'commonjs'
     script = 'script'

--- a/src/adcp/types/generated_poc/enums/landing_page_requirement.py
+++ b/src/adcp/types/generated_poc/enums/landing_page_requirement.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class LandingPageRequirement(Enum):
+class LandingPageRequirement(StrEnum):
     any = 'any'
     retailer_site_only = 'retailer_site_only'
     must_include_retailer = 'must_include_retailer'

--- a/src/adcp/types/generated_poc/enums/lift_dimension.py
+++ b/src/adcp/types/generated_poc/enums/lift_dimension.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class LiftDimension(Enum):
+class LiftDimension(StrEnum):
     awareness = 'awareness'
     consideration = 'consideration'
     favorability = 'favorability'

--- a/src/adcp/types/generated_poc/enums/logo_slot.py
+++ b/src/adcp/types/generated_poc/enums/logo_slot.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class LogoSlot(Enum):
+class LogoSlot(StrEnum):
     logo_card_light = 'logo_card_light'
     logo_card_dark = 'logo_card_dark'
     profile_mark = 'profile_mark'

--- a/src/adcp/types/generated_poc/enums/makegood_remedy.py
+++ b/src/adcp/types/generated_poc/enums/makegood_remedy.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MakegoodRemedy(Enum):
+class MakegoodRemedy(StrEnum):
     additional_delivery = 'additional_delivery'
     credit = 'credit'
     invoice_adjustment = 'invoice_adjustment'

--- a/src/adcp/types/generated_poc/enums/markdown_flavor.py
+++ b/src/adcp/types/generated_poc/enums/markdown_flavor.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MarkdownFlavor(Enum):
+class MarkdownFlavor(StrEnum):
     commonmark = 'commonmark'
     gfm = 'gfm'

--- a/src/adcp/types/generated_poc/enums/match_id_type.py
+++ b/src/adcp/types/generated_poc/enums/match_id_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MatchIdType(Enum):
+class MatchIdType(StrEnum):
     hashed_email = 'hashed_email'
     hashed_phone = 'hashed_phone'
     rampid = 'rampid'

--- a/src/adcp/types/generated_poc/enums/match_type.py
+++ b/src/adcp/types/generated_poc/enums/match_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MatchType(Enum):
+class MatchType(StrEnum):
     broad = 'broad'
     phrase = 'phrase'
     exact = 'exact'

--- a/src/adcp/types/generated_poc/enums/media_buy_action_mode.py
+++ b/src/adcp/types/generated_poc/enums/media_buy_action_mode.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MediaBuyActionMode(Enum):
+class MediaBuyActionMode(StrEnum):
     self_serve = 'self_serve'
     conditional_self_serve = 'conditional_self_serve'
     requires_approval = 'requires_approval'

--- a/src/adcp/types/generated_poc/enums/media_buy_health.py
+++ b/src/adcp/types/generated_poc/enums/media_buy_health.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MediaBuyHealth(Enum):
+class MediaBuyHealth(StrEnum):
     ok = 'ok'
     impaired = 'impaired'

--- a/src/adcp/types/generated_poc/enums/media_buy_status.py
+++ b/src/adcp/types/generated_poc/enums/media_buy_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MediaBuyStatus(Enum):
+class MediaBuyStatus(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     active = 'active'

--- a/src/adcp/types/generated_poc/enums/media_buy_valid_action.py
+++ b/src/adcp/types/generated_poc/enums/media_buy_valid_action.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MediaBuyValidAction(Enum):
+class MediaBuyValidAction(StrEnum):
     pause = 'pause'
     resume = 'resume'
     cancel = 'cancel'

--- a/src/adcp/types/generated_poc/enums/metric_scope.py
+++ b/src/adcp/types/generated_poc/enums/metric_scope.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MetricScope(Enum):
+class MetricScope(StrEnum):
     standard = 'standard'
     vendor = 'vendor'

--- a/src/adcp/types/generated_poc/enums/metric_type.py
+++ b/src/adcp/types/generated_poc/enums/metric_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MetricTypeDeprecated(Enum):
+class MetricTypeDeprecated(StrEnum):
     overall_performance = 'overall_performance'
     conversion_rate = 'conversion_rate'
     brand_lift = 'brand_lift'

--- a/src/adcp/types/generated_poc/enums/metro_system.py
+++ b/src/adcp/types/generated_poc/enums/metro_system.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MetroAreaSystem(Enum):
+class MetroAreaSystem(StrEnum):
     nielsen_dma = 'nielsen_dma'
     uk_itl1 = 'uk_itl1'
     uk_itl2 = 'uk_itl2'

--- a/src/adcp/types/generated_poc/enums/moov_atom_position.py
+++ b/src/adcp/types/generated_poc/enums/moov_atom_position.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class MoovAtomPosition(Enum):
+class MoovAtomPosition(StrEnum):
     start = 'start'
     end = 'end'

--- a/src/adcp/types/generated_poc/enums/notification_type.py
+++ b/src/adcp/types/generated_poc/enums/notification_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'

--- a/src/adcp/types/generated_poc/enums/offering_availability_status.py
+++ b/src/adcp/types/generated_poc/enums/offering_availability_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class OfferingAvailabilityStatus(Enum):
+class OfferingAvailabilityStatus(StrEnum):
     available = 'available'
     limited = 'limited'
     sold_out = 'sold_out'

--- a/src/adcp/types/generated_poc/enums/outcome_type.py
+++ b/src/adcp/types/generated_poc/enums/outcome_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class OutcomeType(Enum):
+class OutcomeType(StrEnum):
     completed = 'completed'
     failed = 'failed'
     delivery = 'delivery'

--- a/src/adcp/types/generated_poc/enums/pacing.py
+++ b/src/adcp/types/generated_poc/enums/pacing.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     even = 'even'
     asap = 'asap'
     front_loaded = 'front_loaded'

--- a/src/adcp/types/generated_poc/enums/payment_terms.py
+++ b/src/adcp/types/generated_poc/enums/payment_terms.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PaymentTerms(Enum):
+class PaymentTerms(StrEnum):
     net_15 = 'net_15'
     net_30 = 'net_30'
     net_45 = 'net_45'

--- a/src/adcp/types/generated_poc/enums/performance_standard_metric.py
+++ b/src/adcp/types/generated_poc/enums/performance_standard_metric.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PerformanceStandardMetric(Enum):
+class PerformanceStandardMetric(StrEnum):
     viewability = 'viewability'
     ivt = 'ivt'
     completion_rate = 'completion_rate'

--- a/src/adcp/types/generated_poc/enums/policy_category.py
+++ b/src/adcp/types/generated_poc/enums/policy_category.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PolicyCategory(Enum):
+class PolicyCategory(StrEnum):
     regulation = 'regulation'
     standard = 'standard'

--- a/src/adcp/types/generated_poc/enums/policy_enforcement.py
+++ b/src/adcp/types/generated_poc/enums/policy_enforcement.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PolicyEnforcementLevel(Enum):
+class PolicyEnforcementLevel(StrEnum):
     must = 'must'
     should = 'should'
     may = 'may'

--- a/src/adcp/types/generated_poc/enums/postal_system.py
+++ b/src/adcp/types/generated_poc/enums/postal_system.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PostalCodeSystem(Enum):
+class PostalCodeSystem(StrEnum):
     us_zip = 'us_zip'
     us_zip_plus_four = 'us_zip_plus_four'
     gb_outward = 'gb_outward'

--- a/src/adcp/types/generated_poc/enums/preview_output_format.py
+++ b/src/adcp/types/generated_poc/enums/preview_output_format.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PreviewOutputFormat(Enum):
+class PreviewOutputFormat(StrEnum):
     url = 'url'
     html = 'html'

--- a/src/adcp/types/generated_poc/enums/pricing_model.py
+++ b/src/adcp/types/generated_poc/enums/pricing_model.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PricingModel(Enum):
+class PricingModel(StrEnum):
     cpm = 'cpm'
     vcpm = 'vcpm'
     cpc = 'cpc'

--- a/src/adcp/types/generated_poc/enums/production_quality.py
+++ b/src/adcp/types/generated_poc/enums/production_quality.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ProductionQuality(Enum):
+class ProductionQuality(StrEnum):
     professional = 'professional'
     prosumer = 'prosumer'
     ugc = 'ugc'

--- a/src/adcp/types/generated_poc/enums/property_type.py
+++ b/src/adcp/types/generated_poc/enums/property_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PropertyType(Enum):
+class PropertyType(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'

--- a/src/adcp/types/generated_poc/enums/proposal_status.py
+++ b/src/adcp/types/generated_poc/enums/proposal_status.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ProposalStatus(Enum):
+class ProposalStatus(StrEnum):
     draft = 'draft'
     committed = 'committed'

--- a/src/adcp/types/generated_poc/enums/publisher_identifier_types.py
+++ b/src/adcp/types/generated_poc/enums/publisher_identifier_types.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PublisherIdentifierTypes(Enum):
+class PublisherIdentifierTypes(StrEnum):
     tag_id = 'tag_id'
     duns = 'duns'
     lei = 'lei'

--- a/src/adcp/types/generated_poc/enums/purchase_type.py
+++ b/src/adcp/types/generated_poc/enums/purchase_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class PurchaseType(Enum):
+class PurchaseType(StrEnum):
     media_buy = 'media_buy'
     rights_license = 'rights_license'
     signal_activation = 'signal_activation'

--- a/src/adcp/types/generated_poc/enums/reach_unit.py
+++ b/src/adcp/types/generated_poc/enums/reach_unit.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ReachUnit(Enum):
+class ReachUnit(StrEnum):
     individuals = 'individuals'
     households = 'households'
     devices = 'devices'

--- a/src/adcp/types/generated_poc/enums/reporting_frequency.py
+++ b/src/adcp/types/generated_poc/enums/reporting_frequency.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ReportingFrequency(Enum):
+class ReportingFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
     monthly = 'monthly'

--- a/src/adcp/types/generated_poc/enums/response_type.py
+++ b/src/adcp/types/generated_poc/enums/response_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class TmpResponseType(Enum):
+class TmpResponseType(StrEnum):
     activation = 'activation'
     catalog_items = 'catalog_items'
     creative = 'creative'

--- a/src/adcp/types/generated_poc/enums/restricted_attribute.py
+++ b/src/adcp/types/generated_poc/enums/restricted_attribute.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class RestrictedAttribute(Enum):
+class RestrictedAttribute(StrEnum):
     racial_ethnic_origin = 'racial_ethnic_origin'
     political_opinions = 'political_opinions'
     religious_beliefs = 'religious_beliefs'

--- a/src/adcp/types/generated_poc/enums/right_type.py
+++ b/src/adcp/types/generated_poc/enums/right_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class RightType(Enum):
+class RightType(StrEnum):
     talent = 'talent'
     character = 'character'
     brand_ip = 'brand_ip'

--- a/src/adcp/types/generated_poc/enums/right_use.py
+++ b/src/adcp/types/generated_poc/enums/right_use.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class RightUse(Enum):
+class RightUse(StrEnum):
     likeness = 'likeness'
     voice = 'voice'
     name = 'name'

--- a/src/adcp/types/generated_poc/enums/rights_billing_period.py
+++ b/src/adcp/types/generated_poc/enums/rights_billing_period.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class RightsBillingPeriod(Enum):
+class RightsBillingPeriod(StrEnum):
     daily = 'daily'
     weekly = 'weekly'
     monthly = 'monthly'

--- a/src/adcp/types/generated_poc/enums/scan_type.py
+++ b/src/adcp/types/generated_poc/enums/scan_type.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ScanType(Enum):
+class ScanType(StrEnum):
     progressive = 'progressive'
     interlaced = 'interlaced'

--- a/src/adcp/types/generated_poc/enums/si_session_status.py
+++ b/src/adcp/types/generated_poc/enums/si_session_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SiSessionStatus(Enum):
+class SiSessionStatus(StrEnum):
     active = 'active'
     pending_handoff = 'pending_handoff'
     complete = 'complete'

--- a/src/adcp/types/generated_poc/enums/signal_catalog_type.py
+++ b/src/adcp/types/generated_poc/enums/signal_catalog_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SignalAvailabilityType(Enum):
+class SignalAvailabilityType(StrEnum):
     marketplace = 'marketplace'
     custom = 'custom'
     owned = 'owned'

--- a/src/adcp/types/generated_poc/enums/signal_source.py
+++ b/src/adcp/types/generated_poc/enums/signal_source.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SignalSource(Enum):
+class SignalSource(StrEnum):
     catalog = 'catalog'
     agent = 'agent'

--- a/src/adcp/types/generated_poc/enums/signal_value_type.py
+++ b/src/adcp/types/generated_poc/enums/signal_value_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SignalValueType(Enum):
+class SignalValueType(StrEnum):
     binary = 'binary'
     categorical = 'categorical'
     numeric = 'numeric'

--- a/src/adcp/types/generated_poc/enums/snapshot_unavailable_reason.py
+++ b/src/adcp/types/generated_poc/enums/snapshot_unavailable_reason.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SnapshotUnavailableReason(Enum):
+class SnapshotUnavailableReason(StrEnum):
     SNAPSHOT_UNSUPPORTED = 'SNAPSHOT_UNSUPPORTED'
     SNAPSHOT_TEMPORARILY_UNAVAILABLE = 'SNAPSHOT_TEMPORARILY_UNAVAILABLE'
     SNAPSHOT_PERMISSION_DENIED = 'SNAPSHOT_PERMISSION_DENIED'

--- a/src/adcp/types/generated_poc/enums/social_placement_surface.py
+++ b/src/adcp/types/generated_poc/enums/social_placement_surface.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SocialPlacementSurface(Enum):
+class SocialPlacementSurface(StrEnum):
     feed = 'feed'
     stories = 'stories'
     short_video = 'short_video'

--- a/src/adcp/types/generated_poc/enums/sort_direction.py
+++ b/src/adcp/types/generated_poc/enums/sort_direction.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SortDirection(Enum):
+class SortDirection(StrEnum):
     asc = 'asc'
     desc = 'desc'

--- a/src/adcp/types/generated_poc/enums/sort_metric.py
+++ b/src/adcp/types/generated_poc/enums/sort_metric.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SortMetric(Enum):
+class SortMetric(StrEnum):
     impressions = 'impressions'
     spend = 'spend'
     clicks = 'clicks'

--- a/src/adcp/types/generated_poc/enums/special_category.py
+++ b/src/adcp/types/generated_poc/enums/special_category.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SpecialCategory(Enum):
+class SpecialCategory(StrEnum):
     awards = 'awards'
     championship = 'championship'
     concert = 'concert'

--- a/src/adcp/types/generated_poc/enums/specialism.py
+++ b/src/adcp/types/generated_poc/enums/specialism.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class AdcpSpecialism(Enum):
+class AdcpSpecialism(StrEnum):
     audience_sync = 'audience-sync'
     brand_rights = 'brand-rights'
     collection_lists = 'collection-lists'

--- a/src/adcp/types/generated_poc/enums/sponsored_placement_type.py
+++ b/src/adcp/types/generated_poc/enums/sponsored_placement_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class SponsoredPlacementType(Enum):
+class SponsoredPlacementType(StrEnum):
     sponsored_search = 'sponsored_search'
     sponsored_display = 'sponsored_display'
     sponsored_native = 'sponsored_native'

--- a/src/adcp/types/generated_poc/enums/talent_role.py
+++ b/src/adcp/types/generated_poc/enums/talent_role.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class TalentRole(Enum):
+class TalentRole(StrEnum):
     host = 'host'
     guest = 'guest'
     creator = 'creator'

--- a/src/adcp/types/generated_poc/enums/task_status.py
+++ b/src/adcp/types/generated_poc/enums/task_status.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class TaskStatus(Enum):
+class TaskStatus(StrEnum):
     submitted = 'submitted'
     working = 'working'
     input_required = 'input-required'

--- a/src/adcp/types/generated_poc/enums/task_type.py
+++ b/src/adcp/types/generated_poc/enums/task_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class TaskType(Enum):
+class TaskType(StrEnum):
     create_media_buy = 'create_media_buy'
     update_media_buy = 'update_media_buy'
     media_buy_delivery = 'media_buy_delivery'

--- a/src/adcp/types/generated_poc/enums/transport_mode.py
+++ b/src/adcp/types/generated_poc/enums/transport_mode.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class TransportMode(Enum):
+class TransportMode(StrEnum):
     walking = 'walking'
     cycling = 'cycling'
     driving = 'driving'

--- a/src/adcp/types/generated_poc/enums/travel_time_unit.py
+++ b/src/adcp/types/generated_poc/enums/travel_time_unit.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class TravelTimeUnit(Enum):
+class TravelTimeUnit(StrEnum):
     min = 'min'
     hr = 'hr'

--- a/src/adcp/types/generated_poc/enums/uid_type.py
+++ b/src/adcp/types/generated_poc/enums/uid_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class UidType(Enum):
+class UidType(StrEnum):
     rampid = 'rampid'
     rampid_derived = 'rampid_derived'
     id5 = 'id5'

--- a/src/adcp/types/generated_poc/enums/universal_macro.py
+++ b/src/adcp/types/generated_poc/enums/universal_macro.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class UniversalMacro(Enum):
+class UniversalMacro(StrEnum):
     MEDIA_BUY_ID = 'MEDIA_BUY_ID'
     PACKAGE_ID = 'PACKAGE_ID'
     CREATIVE_ID = 'CREATIVE_ID'

--- a/src/adcp/types/generated_poc/enums/update_frequency.py
+++ b/src/adcp/types/generated_poc/enums/update_frequency.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class UpdateFrequency(Enum):
+class UpdateFrequency(StrEnum):
     realtime = 'realtime'
     hourly = 'hourly'
     daily = 'daily'

--- a/src/adcp/types/generated_poc/enums/url_asset_type.py
+++ b/src/adcp/types/generated_poc/enums/url_asset_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class UrlAssetType(Enum):
+class UrlAssetType(StrEnum):
     clickthrough = 'clickthrough'
     tracker_pixel = 'tracker_pixel'
     tracker_script = 'tracker_script'

--- a/src/adcp/types/generated_poc/enums/validation_mode.py
+++ b/src/adcp/types/generated_poc/enums/validation_mode.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ValidationMode(Enum):
+class ValidationMode(StrEnum):
     strict = 'strict'
     lenient = 'lenient'

--- a/src/adcp/types/generated_poc/enums/vast_tracking_event.py
+++ b/src/adcp/types/generated_poc/enums/vast_tracking_event.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class VastTrackingEvent(Enum):
+class VastTrackingEvent(StrEnum):
     impression = 'impression'
     creativeView = 'creativeView'
     loaded = 'loaded'

--- a/src/adcp/types/generated_poc/enums/vast_version.py
+++ b/src/adcp/types/generated_poc/enums/vast_version.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'

--- a/src/adcp/types/generated_poc/enums/video_placement_type.py
+++ b/src/adcp/types/generated_poc/enums/video_placement_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class VideoPlacementType(Enum):
+class VideoPlacementType(StrEnum):
     instream = 'instream'
     accompanying_content = 'accompanying_content'
     interstitial = 'interstitial'

--- a/src/adcp/types/generated_poc/enums/viewability_standard.py
+++ b/src/adcp/types/generated_poc/enums/viewability_standard.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class ViewabilityStandard(Enum):
+class ViewabilityStandard(StrEnum):
     mrc = 'mrc'
     groupm = 'groupm'

--- a/src/adcp/types/generated_poc/enums/watermark_media_type.py
+++ b/src/adcp/types/generated_poc/enums/watermark_media_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class WatermarkMediaType(Enum):
+class WatermarkMediaType(StrEnum):
     audio = 'audio'
     image = 'image'
     video = 'video'

--- a/src/adcp/types/generated_poc/enums/wcag_level.py
+++ b/src/adcp/types/generated_poc/enums/wcag_level.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class WcagLevel(Enum):
+class WcagLevel(StrEnum):
     A = 'A'
     AA = 'AA'
     AAA = 'AAA'

--- a/src/adcp/types/generated_poc/enums/webhook_response_type.py
+++ b/src/adcp/types/generated_poc/enums/webhook_response_type.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class WebhookResponseType(Enum):
+class WebhookResponseType(StrEnum):
     html = 'html'
     json = 'json'
     xml = 'xml'

--- a/src/adcp/types/generated_poc/enums/webhook_security_method.py
+++ b/src/adcp/types/generated_poc/enums/webhook_security_method.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 
 
-class WebhookSecurityMethod(Enum):
+class WebhookSecurityMethod(StrEnum):
     hmac_sha256 = 'hmac_sha256'
     api_key = 'api_key'
     none = 'none'

--- a/src/adcp/types/generated_poc/error_details/billing_not_supported.py
+++ b/src/adcp/types/generated_poc/error_details/billing_not_supported.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from ..enums import billing_party
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     capability = 'capability'
     account = 'account'
 

--- a/src/adcp/types/generated_poc/error_details/rate_limited.py
+++ b/src/adcp/types/generated_poc/error_details/rate_limited.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     account = 'account'
     tool = 'tool'
     global_ = 'global'

--- a/src/adcp/types/generated_poc/error_details/vendor_error_codes.py
+++ b/src/adcp/types/generated_poc/error_details/vendor_error_codes.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, Field
 
 
-class Recovery(Enum):
+class Recovery(StrEnum):
     transient = 'transient'
     correctable = 'correctable'
     terminal = 'terminal'

--- a/src/adcp/types/generated_poc/formats/canonical/_base.py
+++ b/src/adcp/types/generated_poc/formats/canonical/_base.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,12 +14,12 @@ from ...core import downstream_connection_requirement, platform_extension_ref
 from ...enums import logo_slot
 
 
-class CompositionModel(Enum):
+class CompositionModel(StrEnum):
     deterministic = 'deterministic'
     algorithmic = 'algorithmic'
 
 
-class AssetType(Enum):
+class AssetType(StrEnum):
     image = 'image'
     video = 'video'
     audio = 'audio'
@@ -43,7 +43,7 @@ class AssetType(Enum):
     daast_tracker = 'daast_tracker'
 
 
-class ReferenceMutability(Enum):
+class ReferenceMutability(StrEnum):
     immutable_snapshot = 'immutable_snapshot'
     mutable_requires_reapproval = 'mutable_requires_reapproval'
     mutable_auto_recheck = 'mutable_auto_recheck'

--- a/src/adcp/types/generated_poc/formats/canonical/agent_placement.py
+++ b/src/adcp/types/generated_poc/formats/canonical/agent_placement.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field
 from ._base import CanonicalFormatBase
 
 
-class OutputModality(Enum):
+class OutputModality(StrEnum):
     text = 'text'
     audio = 'audio'
     card = 'card'

--- a/src/adcp/types/generated_poc/formats/canonical/audio_daast.py
+++ b/src/adcp/types/generated_poc/formats/canonical/audio_daast.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field, RootModel
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field, RootModel
 from ._base import CanonicalFormatBase
 
 
-class DaastVersion(Enum):
+class DaastVersion(StrEnum):
     field_1_0 = '1.0'
     field_1_1 = '1.1'
 

--- a/src/adcp/types/generated_poc/formats/canonical/audio_hosted.py
+++ b/src/adcp/types/generated_poc/formats/canonical/audio_hosted.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field, RootModel
@@ -16,7 +16,7 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     mp3 = 'mp3'
     aac = 'aac'
     wav = 'wav'
@@ -28,12 +28,12 @@ class AudioSampleRate(RootModel[int]):
     root: Annotated[int, Field(ge=1)]
 
 
-class AudioChannel(Enum):
+class AudioChannel(StrEnum):
     mono = 'mono'
     stereo = 'stereo'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -42,7 +42,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 

--- a/src/adcp/types/generated_poc/formats/canonical/display_tag.py
+++ b/src/adcp/types/generated_poc/formats/canonical/display_tag.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -21,7 +21,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class SupportedTagType(Enum):
+class SupportedTagType(StrEnum):
     iframe = 'iframe'
     javascript = 'javascript'
     field_1x1_redirect = '1x1_redirect'

--- a/src/adcp/types/generated_poc/formats/canonical/html5.py
+++ b/src/adcp/types/generated_poc/formats/canonical/html5.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -21,12 +21,12 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class MraidVersion(Enum):
+class MraidVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
 
 
-class ClicktagMacro(Enum):
+class ClicktagMacro(StrEnum):
     clickTag = 'clickTag'
     clickTAG = 'clickTAG'
 

--- a/src/adcp/types/generated_poc/formats/canonical/image.py
+++ b/src/adcp/types/generated_poc/formats/canonical/image.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -21,7 +21,7 @@ class Size(AdCPBaseModel):
     height: Annotated[int, Field(ge=1)]
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -30,7 +30,7 @@ class ImageFormat(Enum):
     svg = 'svg'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -39,7 +39,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 

--- a/src/adcp/types/generated_poc/formats/canonical/image_carousel.py
+++ b/src/adcp/types/generated_poc/formats/canonical/image_carousel.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field
 from ._base import CanonicalFormatBase
 
 
-class AllowedCardMediaAssetType(Enum):
+class AllowedCardMediaAssetType(StrEnum):
     image = 'image'
     video = 'video'
 

--- a/src/adcp/types/generated_poc/formats/canonical/native_in_feed.py
+++ b/src/adcp/types/generated_poc/formats/canonical/native_in_feed.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -25,7 +25,7 @@ class IconSize(MainImageSize):
     pass
 
 
-class ImageFormat(Enum):
+class ImageFormat(StrEnum):
     jpg = 'jpg'
     jpeg = 'jpeg'
     png = 'png'
@@ -33,7 +33,7 @@ class ImageFormat(Enum):
     webp = 'webp'
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'
@@ -41,7 +41,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 

--- a/src/adcp/types/generated_poc/formats/canonical/sponsored_placement.py
+++ b/src/adcp/types/generated_poc/formats/canonical/sponsored_placement.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field
 from ._base import CanonicalFormatBase
 
 
-class SupportedCatalogType(Enum):
+class SupportedCatalogType(StrEnum):
     product = 'product'
     store = 'store'
     offering = 'offering'
@@ -27,13 +27,13 @@ class SupportedCatalogType(Enum):
     inventory = 'inventory'
 
 
-class FanoutMode(Enum):
+class FanoutMode(StrEnum):
     per_item = 'per_item'
     multi_item_in_creative = 'multi_item_in_creative'
     single_item = 'single_item'
 
 
-class SupportedIdType(Enum):
+class SupportedIdType(StrEnum):
     asin = 'asin'
     sku = 'sku'
     gtin = 'gtin'
@@ -49,7 +49,7 @@ class SupportedIdType(Enum):
     job_id = 'job_id'
 
 
-class ItemProductionModel(Enum):
+class ItemProductionModel(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
     seller_human_designed = 'seller_human_designed'

--- a/src/adcp/types/generated_poc/formats/canonical/video_hosted.py
+++ b/src/adcp/types/generated_poc/formats/canonical/video_hosted.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field, RootModel
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field, RootModel
 from ._base import CanonicalFormatBase
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
@@ -22,7 +22,7 @@ class DurationMsRange(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
-class VideoCodec(Enum):
+class VideoCodec(StrEnum):
     h264 = 'h264'
     h265 = 'h265'
     vp8 = 'vp8'
@@ -31,20 +31,20 @@ class VideoCodec(Enum):
     prores = 'prores'
 
 
-class AudioCodec(Enum):
+class AudioCodec(StrEnum):
     aac = 'aac'
     mp3 = 'mp3'
     opus = 'opus'
     pcm = 'pcm'
 
 
-class Container(Enum):
+class Container(StrEnum):
     mp4 = 'mp4'
     webm = 'webm'
     mov = 'mov'
 
 
-class Captions(Enum):
+class Captions(StrEnum):
     required = 'required'
     recommended = 'recommended'
     not_required = 'not_required'
@@ -58,7 +58,7 @@ class CompanionBannerHeight(CompanionBannerWidth):
     pass
 
 
-class AssetSource(Enum):
+class AssetSource(StrEnum):
     buyer_uploaded = 'buyer_uploaded'
     publisher_host_recorded = 'publisher_host_recorded'
     seller_pre_rendered_from_brief = 'seller_pre_rendered_from_brief'
@@ -67,7 +67,7 @@ class AssetSource(Enum):
     publisher_owned_reference = 'publisher_owned_reference'
 
 
-class BuyerAssetAcceptance(Enum):
+class BuyerAssetAcceptance(StrEnum):
     accepted = 'accepted'
     rejected = 'rejected'
 

--- a/src/adcp/types/generated_poc/formats/canonical/video_vast.py
+++ b/src/adcp/types/generated_poc/formats/canonical/video_vast.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field, RootModel
@@ -12,13 +12,13 @@ from pydantic import ConfigDict, Field, RootModel
 from ._base import CanonicalFormatBase
 
 
-class Orientation(Enum):
+class Orientation(StrEnum):
     vertical = 'vertical'
     horizontal = 'horizontal'
     square = 'square'
 
 
-class VastVersion(Enum):
+class VastVersion(StrEnum):
     field_2_0 = '2.0'
     field_3_0 = '3.0'
     field_4_0 = '4.0'
@@ -26,7 +26,7 @@ class VastVersion(Enum):
     field_4_2 = '4.2'
 
 
-class VpaidVersion(Enum):
+class VpaidVersion(StrEnum):
     field_1_0 = '1.0'
     field_2_0 = '2.0'
 

--- a/src/adcp/types/generated_poc/governance/check_governance_request.py
+++ b/src/adcp/types/generated_poc/governance/check_governance_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -27,13 +27,13 @@ class ReportingPeriod(AdCPBaseModel):
     end: AwareDatetime
 
 
-class Pacing(Enum):
+class Pacing(StrEnum):
     ahead = 'ahead'
     on_track = 'on_track'
     behind = 'behind'
 
 
-class Baseline(Enum):
+class Baseline(StrEnum):
     census = 'census'
     platform = 'platform'
     custom = 'custom'

--- a/src/adcp/types/generated_poc/governance/get_plan_audit_logs_response.py
+++ b/src/adcp/types/generated_poc/governance/get_plan_audit_logs_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -18,7 +18,7 @@ from ..enums import escalation_severity, governance_decision, governance_mode, o
 from ..enums import purchase_type as purchase_type_1
 
 
-class Status(Enum):
+class Status(StrEnum):
     active = 'active'
     suspended = 'suspended'
     completed = 'completed'
@@ -82,7 +82,7 @@ class Escalation(AdCPBaseModel):
     ] = None
 
 
-class EscalationRateTrend(Enum):
+class EscalationRateTrend(StrEnum):
     increasing = 'increasing'
     stable = 'stable'
     declining = 'declining'
@@ -188,12 +188,12 @@ class Summary(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     check = 'check'
     outcome = 'outcome'
 
 
-class CheckType(Enum):
+class CheckType(StrEnum):
     intent = 'intent'
     execution = 'execution'
 

--- a/src/adcp/types/generated_poc/governance/policy_entry.py
+++ b/src/adcp/types/generated_poc/governance/policy_entry.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -16,7 +16,7 @@ from ..enums import channels as channels_1
 from ..enums import governance_domain, policy_category, policy_enforcement
 
 
-class Source(Enum):
+class Source(StrEnum):
     registry = 'registry'
     inline = 'inline'
 

--- a/src/adcp/types/generated_poc/governance/report_plan_outcome_response.py
+++ b/src/adcp/types/generated_poc/governance/report_plan_outcome_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -16,7 +16,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import escalation_severity
 
 
-class OutcomeState(Enum):
+class OutcomeState(StrEnum):
     accepted = 'accepted'
     findings = 'findings'
 

--- a/src/adcp/types/generated_poc/governance/sync_plans_response.py
+++ b/src/adcp/types/generated_poc/governance/sync_plans_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -17,12 +17,12 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import policy_enforcement
 
 
-class Status(Enum):
+class Status(StrEnum):
     active = 'active'
     error = 'error'
 
 
-class Status206(Enum):
+class Status206(StrEnum):
     active = 'active'
     inactive = 'inactive'
 
@@ -37,7 +37,7 @@ class Category(AdCPBaseModel):
     ]
 
 
-class Source(Enum):
+class Source(StrEnum):
     explicit = 'explicit'
     auto_applied = 'auto_applied'
 

--- a/src/adcp/types/generated_poc/manifest_schema.py
+++ b/src/adcp/types/generated_poc/manifest_schema.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AwareDatetime, ConfigDict, Field
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
     governance = 'governance'
@@ -82,7 +82,7 @@ class Tools(AdCPBaseModel):
     ] = None
 
 
-class DefaultUnknownRecovery(Enum):
+class DefaultUnknownRecovery(StrEnum):
     correctable = 'correctable'
     transient = 'transient'
     terminal = 'terminal'

--- a/src/adcp/types/generated_poc/media_buy/build_creative_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/media_buy/build_creative_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ..core import error
 from ..core import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CREATIVE_DIRECTION_NEEDED = 'CREATIVE_DIRECTION_NEEDED'
     ASSET_SELECTION_NEEDED = 'ASSET_SELECTION_NEEDED'

--- a/src/adcp/types/generated_poc/media_buy/build_creative_request.py
+++ b/src/adcp/types/generated_poc/media_buy/build_creative_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -23,7 +23,7 @@ from ..enums import creative_quality, creative_selection_strategy
 from ..enums import preview_output_format as preview_output_format_1
 
 
-class Mode(Enum):
+class Mode(StrEnum):
     execute = 'execute'
     estimate = 'estimate'
 
@@ -53,7 +53,7 @@ class SignalCondition4(AdCPBaseModel):
     ] = None
 
 
-class Dimension(Enum):
+class Dimension(StrEnum):
     voice = 'voice'
     theme = 'theme'
     best_of_n = 'best_of_n'
@@ -90,7 +90,7 @@ class VariantAxis(AdCPBaseModel):
     ] = None
 
 
-class KeepMode(Enum):
+class KeepMode(StrEnum):
     keep_all = 'keep_all'
     keep_one = 'keep_one'
     keep_some = 'keep_some'

--- a/src/adcp/types/generated_poc/media_buy/create_media_buy_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/media_buy/create_media_buy_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ..core import error
 from ..core import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     BUDGET_EXCEEDS_LIMIT = 'BUDGET_EXCEEDS_LIMIT'
 

--- a/src/adcp/types/generated_poc/media_buy/create_media_buy_request.py
+++ b/src/adcp/types/generated_poc/media_buy/create_media_buy_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 from collections.abc import Sequence
 
@@ -78,12 +78,12 @@ class Authentication(AdCPBaseModel):
     ]
 
 
-class DeliveryMode(Enum):
+class DeliveryMode(StrEnum):
     realtime = 'realtime'
     batched = 'batched'
 
 
-class BatchFrequency(Enum):
+class BatchFrequency(StrEnum):
     hourly = 'hourly'
     daily = 'daily'
 

--- a/src/adcp/types/generated_poc/media_buy/get_media_buy_delivery_response.py
+++ b/src/adcp/types/generated_poc/media_buy/get_media_buy_delivery_response.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -27,7 +27,7 @@ from ..enums import pricing_model as pricing_model_1
 from ..enums import reach_unit as reach_unit_1
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -49,7 +49,7 @@ class ReportingPeriod(AdCPBaseModel):
     ]
 
 
-class Status(Enum):
+class Status(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     pending = 'pending'
@@ -62,7 +62,7 @@ class Status(Enum):
     reporting_delayed = 'reporting_delayed'
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     completed = 'completed'
     budget_exhausted = 'budget_exhausted'

--- a/src/adcp/types/generated_poc/media_buy/get_media_buys_response.py
+++ b/src/adcp/types/generated_poc/media_buy/get_media_buys_response.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -116,7 +116,7 @@ class CreativeApproval(AdCPBaseModel):
     ] = None
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     not_delivering = 'not_delivering'
     completed = 'completed'

--- a/src/adcp/types/generated_poc/media_buy/get_products_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/media_buy/get_products_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ..core import ext as ext_1
 from ..core import product
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     CLARIFICATION_NEEDED = 'CLARIFICATION_NEEDED'
     BUDGET_REQUIRED = 'BUDGET_REQUIRED'
 

--- a/src/adcp/types/generated_poc/media_buy/get_products_request.py
+++ b/src/adcp/types/generated_poc/media_buy/get_products_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -21,7 +21,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import delivery_type as delivery_type_1
 
 
-class BuyingMode(Enum):
+class BuyingMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
     refine = 'refine'
@@ -46,7 +46,7 @@ class Refine1(AdCPBaseModel):
     ]
 
 
-class Action(Enum):
+class Action(StrEnum):
     include = 'include'
     omit = 'omit'
     more_like_this = 'more_like_this'
@@ -75,7 +75,7 @@ class Refine2(AdCPBaseModel):
     ] = None
 
 
-class Action3(Enum):
+class Action3(StrEnum):
     include = 'include'
     omit = 'omit'
     finalize = 'finalize'
@@ -114,7 +114,7 @@ class Refine(RootModel[Refine1 | Refine2 | Refine3]):
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Field1(Enum):
+class Field1(StrEnum):
     product_id = 'product_id'
     name = 'name'
     description = 'description'

--- a/src/adcp/types/generated_poc/media_buy/get_products_response.py
+++ b/src/adcp/types/generated_poc/media_buy/get_products_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -43,7 +43,7 @@ class Extensions(AdCPBaseModel):
     description: str | None = None
 
 
-class Status(Enum):
+class Status(StrEnum):
     applied = 'applied'
     partial = 'partial'
     unable = 'unable'
@@ -131,7 +131,7 @@ class RefinementApplied(RootModel[RefinementApplied1 | RefinementApplied2 | Refi
             raise AttributeError(name)
         return getattr(self.root, name)
 
-class Scope(Enum):
+class Scope(StrEnum):
     products = 'products'
     pricing = 'pricing'
     forecast = 'forecast'
@@ -160,7 +160,7 @@ class IncompleteItem(AdCPBaseModel):
     ] = None
 
 
-class Semantics(Enum):
+class Semantics(StrEnum):
     only = 'only'
     any = 'any'
     approximate = 'approximate'
@@ -216,7 +216,7 @@ class FilterDiagnostics(AdCPBaseModel):
     ] = None
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 

--- a/src/adcp/types/generated_poc/media_buy/list_creative_formats_response.py
+++ b/src/adcp/types/generated_poc/media_buy/list_creative_formats_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -19,7 +19,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import creative_agent_capability
 
 
-class Source(Enum):
+class Source(StrEnum):
     publisher = 'publisher'
     aao_mirror = 'aao_mirror'
     agent_derived = 'agent_derived'

--- a/src/adcp/types/generated_poc/media_buy/media_buy_delivery_webhook_result.py
+++ b/src/adcp/types/generated_poc/media_buy/media_buy_delivery_webhook_result.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -18,7 +18,7 @@ from ..core.delivery_metrics import DeliveryMetrics
 from ..enums import pricing_model as pricing_model_1
 
 
-class NotificationType(Enum):
+class NotificationType(StrEnum):
     scheduled = 'scheduled'
     final = 'final'
     delayed = 'delayed'
@@ -34,7 +34,7 @@ class ReportingPeriod(AdCPBaseModel):
     end: AwareDatetime
 
 
-class Status(Enum):
+class Status(StrEnum):
     pending_creatives = 'pending_creatives'
     pending_start = 'pending_start'
     pending = 'pending'
@@ -47,7 +47,7 @@ class Status(Enum):
     reporting_delayed = 'reporting_delayed'
 
 
-class DeliveryStatus(Enum):
+class DeliveryStatus(StrEnum):
     delivering = 'delivering'
     completed = 'completed'
     budget_exhausted = 'budget_exhausted'

--- a/src/adcp/types/generated_poc/media_buy/sync_audiences_request.py
+++ b/src/adcp/types/generated_poc/media_buy/sync_audiences_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -17,7 +17,7 @@ from ..core.version_envelope import AdcpVersionEnvelope
 from ..enums import consent_basis as consent_basis_1
 
 
-class AudienceType(Enum):
+class AudienceType(StrEnum):
     crm = 'crm'
     suppression = 'suppression'
     lookalike_seed = 'lookalike_seed'

--- a/src/adcp/types/generated_poc/media_buy/sync_catalogs_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/media_buy/sync_catalogs_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..core import context as context_1
 from ..core import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     FEED_VALIDATION = 'FEED_VALIDATION'
     ITEM_REVIEW = 'ITEM_REVIEW'

--- a/src/adcp/types/generated_poc/media_buy/update_media_buy_async_response_input_required.py
+++ b/src/adcp/types/generated_poc/media_buy/update_media_buy_async_response_input_required.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -14,7 +14,7 @@ from ..core import context as context_1
 from ..core import ext as ext_1
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
     CHANGE_CONFIRMATION = 'CHANGE_CONFIRMATION'
 

--- a/src/adcp/types/generated_poc/pricing_options/time_option.py
+++ b/src/adcp/types/generated_poc/pricing_options/time_option.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from . import price_breakdown as price_breakdown_1
 from . import price_guidance as price_guidance_1
 
 
-class TimeUnit(Enum):
+class TimeUnit(StrEnum):
     hour = 'hour'
     day = 'day'
     week = 'week'

--- a/src/adcp/types/generated_poc/property/authorization_result.py
+++ b/src/adcp/types/generated_poc/property/authorization_result.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, ConfigDict, Field
 
 
-class Status(Enum):
+class Status(StrEnum):
     authorized = 'authorized'
     unauthorized = 'unauthorized'
     unknown = 'unknown'

--- a/src/adcp/types/generated_poc/property/property_error.py
+++ b/src/adcp/types/generated_poc/property/property_error.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from ..core import property as property_1
 
 
-class Code(Enum):
+class Code(StrEnum):
     PROPERTY_NOT_FOUND = 'PROPERTY_NOT_FOUND'
     PROPERTY_NOT_MONITORED = 'PROPERTY_NOT_MONITORED'
     LIST_NOT_FOUND = 'LIST_NOT_FOUND'

--- a/src/adcp/types/generated_poc/property/property_feature_definition.py
+++ b/src/adcp/types/generated_poc/property/property_feature_definition.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -13,7 +13,7 @@ from pydantic import AnyUrl, ConfigDict, Field
 from ..core import ext as ext_1
 
 
-class Type(Enum):
+class Type(StrEnum):
     binary = 'binary'
     quantitative = 'quantitative'
     categorical = 'categorical'

--- a/src/adcp/types/generated_poc/property/property_feature_result.py
+++ b/src/adcp/types/generated_poc/property/property_feature_result.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ..core import property_id
 from . import property_feature_value
 
 
-class CoverageStatus(Enum):
+class CoverageStatus(StrEnum):
     covered = 'covered'
     not_covered = 'not_covered'
     pending = 'pending'

--- a/src/adcp/types/generated_poc/property/validation_result.py
+++ b/src/adcp/types/generated_poc/property/validation_result.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -16,7 +16,7 @@ from ..enums import feature_check_status
 from . import authorization_result
 
 
-class Status(Enum):
+class Status(StrEnum):
     compliant = 'compliant'
     non_compliant = 'non_compliant'
     not_covered = 'not_covered'

--- a/src/adcp/types/generated_poc/protocol/get_adcp_capabilities_request.py
+++ b/src/adcp/types/generated_poc/protocol/get_adcp_capabilities_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field
@@ -14,7 +14,7 @@ from ..core import ext as ext_1
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class Protocol(Enum):
+class Protocol(StrEnum):
     media_buy = 'media_buy'
     signals = 'signals'
     governance = 'governance'

--- a/src/adcp/types/generated_poc/protocol/get_adcp_capabilities_response.py
+++ b/src/adcp/types/generated_poc/protocol/get_adcp_capabilities_response.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import date as date_aliased
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
@@ -123,7 +123,7 @@ class Adcp(AdCPBaseModel):
     ]
 
 
-class SupportedProtocol(Enum):
+class SupportedProtocol(StrEnum):
     media_buy = 'media_buy'
     signals = 'signals'
     governance = 'governance'
@@ -173,29 +173,29 @@ class Account(AdCPBaseModel):
     ] = False
 
 
-class BuyingMode(Enum):
+class BuyingMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
     refine = 'refine'
 
 
-class ReportingDeliveryMethod(Enum):
+class ReportingDeliveryMethod(StrEnum):
     webhook = 'webhook'
     offline = 'offline'
 
 
-class PropagationSurface(Enum):
+class PropagationSurface(StrEnum):
     snapshot = 'snapshot'
     webhook = 'webhook'
     out_of_band = 'out_of_band'
 
 
-class CreativeApprovalMode(Enum):
+class CreativeApprovalMode(StrEnum):
     auto_approve = 'auto_approve'
     require_human = 'require_human'
 
 
-class Surface(Enum):
+class Surface(StrEnum):
     website = 'website'
     mobile_app = 'mobile_app'
     ctv_app = 'ctv_app'
@@ -274,7 +274,7 @@ class AgeRestriction(AdCPBaseModel):
     ] = None
 
 
-class SupportedIdentifierType(Enum):
+class SupportedIdentifierType(StrEnum):
     hashed_email = 'hashed_email'
     hashed_phone = 'hashed_phone'
 
@@ -287,7 +287,7 @@ class MatchingLatencyHours(AdCPBaseModel):
     max: Annotated[int | None, Field(ge=0)] = None
 
 
-class SupportedOptimizationMetric(Enum):
+class SupportedOptimizationMetric(StrEnum):
     clicks = 'clicks'
     views = 'views'
     completed_views = 'completed_views'
@@ -301,7 +301,7 @@ class SupportedOptimizationMetric(Enum):
     reach = 'reach'
 
 
-class SupportedTarget(Enum):
+class SupportedTarget(StrEnum):
     cost_per = 'cost_per'
     threshold_rate = 'threshold_rate'
 
@@ -319,7 +319,7 @@ class VendorMetricOptimization(AdCPBaseModel):
     ] = None
 
 
-class SupportedTarget1(Enum):
+class SupportedTarget1(StrEnum):
     cost_per = 'cost_per'
     per_ad_spend = 'per_ad_spend'
     maximize_value = 'maximize_value'
@@ -416,7 +416,7 @@ class DataProviderDomain(PublisherDomain):
     pass
 
 
-class DiscoveryMode(Enum):
+class DiscoveryMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
 
@@ -451,7 +451,7 @@ class Signals(AdCPBaseModel):
     ] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     binary = 'binary'
     quantitative = 'quantitative'
     categorical = 'categorical'
@@ -545,7 +545,7 @@ class Governance(AdCPBaseModel):
     ] = None
 
 
-class Type9(Enum):
+class Type9(StrEnum):
     mcp = 'mcp'
     a2a = 'a2a'
 
@@ -571,7 +571,7 @@ class Endpoint(AdCPBaseModel):
     ] = None
 
 
-class VariantDimension(Enum):
+class VariantDimension(StrEnum):
     voice = 'voice'
     theme = 'theme'
     best_of_n = 'best_of_n'
@@ -628,7 +628,7 @@ class Multiplicity(AdCPBaseModel):
     ] = None
 
 
-class CoversContentDigest(Enum):
+class CoversContentDigest(StrEnum):
     required = 'required'
     forbidden = 'forbidden'
     either = 'either'
@@ -700,7 +700,7 @@ class RequestSigning(AdCPBaseModel):
     ] = []
 
 
-class Algorithm(Enum):
+class Algorithm(StrEnum):
     ed25519 = 'ed25519'
     ecdsa_p256_sha256 = 'ecdsa-p256-sha256'
 
@@ -886,7 +886,7 @@ class WholesaleFeedVersioning(AdCPBaseModel):
     ] = None
 
 
-class EventType(Enum):
+class EventType(StrEnum):
     product_created = 'product.created'
     product_updated = 'product.updated'
     product_priced = 'product.priced'

--- a/src/adcp/types/generated_poc/protocol/get_task_status_response.py
+++ b/src/adcp/types/generated_poc/protocol/get_task_status_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -57,7 +57,7 @@ class Error(AdCPBaseModel):
     details: Annotated[Details | None, Field(description='Additional error context')] = None
 
 
-class Type(Enum):
+class Type(StrEnum):
     request = 'request'
     response = 'response'
 

--- a/src/adcp/types/generated_poc/protocol/list_tasks_request.py
+++ b/src/adcp/types/generated_poc/protocol/list_tasks_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -18,7 +18,7 @@ from ..enums import adcp_protocol, sort_direction, task_status
 from ..enums import task_type as task_type_1
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     created_at = 'created_at'
     updated_at = 'updated_at'
     status = 'status'

--- a/src/adcp/types/generated_poc/protocol/list_tasks_response.py
+++ b/src/adcp/types/generated_poc/protocol/list_tasks_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
@@ -32,7 +32,7 @@ class DomainBreakdown(AdCPBaseModel):
     ] = None
 
 
-class Direction(Enum):
+class Direction(StrEnum):
     asc = 'asc'
     desc = 'desc'
 
@@ -70,7 +70,7 @@ class QuerySummary(AdCPBaseModel):
     ] = None
 
 
-class Domain(Enum):
+class Domain(StrEnum):
     media_buy = 'media-buy'
     signals = 'signals'
 

--- a/src/adcp/types/generated_poc/signals/activate_signal_request.py
+++ b/src/adcp/types/generated_poc/signals/activate_signal_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field
@@ -16,7 +16,7 @@ from ..core import ext as ext_1
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class Action(Enum):
+class Action(StrEnum):
     activate = 'activate'
     deactivate = 'deactivate'
 

--- a/src/adcp/types/generated_poc/signals/get_signals_request.py
+++ b/src/adcp/types/generated_poc/signals/get_signals_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from pydantic import ConfigDict, Field, RootModel
@@ -21,7 +21,7 @@ from ..core import signal_ref as signal_ref_1
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class DiscoveryMode(Enum):
+class DiscoveryMode(StrEnum):
     brief = 'brief'
     wholesale = 'wholesale'
 
@@ -30,7 +30,7 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class Field1(Enum):
+class Field1(StrEnum):
     signal_ref = 'signal_ref'
     signal_id = 'signal_id'
     signal_agent_segment_id = 'signal_agent_segment_id'

--- a/src/adcp/types/generated_poc/signals/get_signals_response.py
+++ b/src/adcp/types/generated_poc/signals/get_signals_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 from collections.abc import Sequence
 
@@ -52,7 +52,7 @@ class ValueMapping(AdCPBaseModel):
     modifiers: list[str] | None = None
 
 
-class ParentMatchBehavior(Enum):
+class ParentMatchBehavior(StrEnum):
     exact_only = 'exact_only'
     descendants_supported = 'descendants_supported'
     unknown = 'unknown'
@@ -71,7 +71,7 @@ class Taxonomy(AdCPBaseModel):
     parent_match_behavior: ParentMatchBehavior | None = None
 
 
-class DataSource(Enum):
+class DataSource(StrEnum):
     app_behavior = 'app_behavior'
     app_usage = 'app_usage'
     web_usage = 'web_usage'
@@ -91,7 +91,7 @@ class DataSource(Enum):
     offline_transaction = 'offline_transaction'
 
 
-class Methodology(Enum):
+class Methodology(StrEnum):
     observed = 'observed'
     declared = 'declared'
     derived = 'derived'
@@ -99,7 +99,7 @@ class Methodology(Enum):
     modeled = 'modeled'
 
 
-class RefreshCadence(Enum):
+class RefreshCadence(StrEnum):
     intra_day = 'intra_day'
     daily = 'daily'
     weekly = 'weekly'
@@ -110,7 +110,7 @@ class RefreshCadence(Enum):
     annually = 'annually'
 
 
-class MatchKey(Enum):
+class MatchKey(StrEnum):
     name = 'name'
     address = 'address'
     email = 'email'
@@ -123,7 +123,7 @@ class MatchKey(Enum):
     phone = 'phone'
 
 
-class PreOnboardingPrecisionLevel(Enum):
+class PreOnboardingPrecisionLevel(StrEnum):
     individual = 'individual'
     household = 'household'
     business = 'business'
@@ -144,21 +144,21 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class Art9Basis(Enum):
+class Art9Basis(StrEnum):
     explicit_consent = 'explicit_consent'
     manifestly_made_public = 'manifestly_made_public'
     substantial_public_interest = 'substantial_public_interest'
     vital_interests = 'vital_interests'
 
 
-class Method(Enum):
+class Method(StrEnum):
     lookalike = 'lookalike'
     supervised = 'supervised'
     embedding = 'embedding'
     rules = 'rules'
 
 
-class Type(Enum):
+class Type(StrEnum):
     first_party_crm = 'first_party_crm'
     panel = 'panel'
     declared_survey = 'declared_survey'
@@ -183,13 +183,13 @@ class TrainingDataJurisdiction(Country):
     pass
 
 
-class AiActRiskClass(Enum):
+class AiActRiskClass(StrEnum):
     minimal = 'minimal'
     limited = 'limited'
     high_risk = 'high_risk'
 
 
-class Right(Enum):
+class Right(StrEnum):
     access = 'access'
     rectification = 'rectification'
     erasure = 'erasure'
@@ -224,7 +224,7 @@ class DataSubjectRights(AdCPBaseModel):
     ccpa_opt_out_url: AnyUrl | None = None
 
 
-class Scope(Enum):
+class Scope(StrEnum):
     signals = 'signals'
     pricing = 'pricing'
     wholesale_feed = 'wholesale_feed'
@@ -251,7 +251,7 @@ class IncompleteItem(AdCPBaseModel):
     ] = None
 
 
-class CacheScope(Enum):
+class CacheScope(StrEnum):
     public = 'public'
     account = 'account'
 

--- a/src/adcp/types/generated_poc/sponsored_intelligence/si_capabilities.py
+++ b/src/adcp/types/generated_poc/sponsored_intelligence/si_capabilities.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -57,7 +57,7 @@ class Modalities(AdCPBaseModel):
     ] = None
 
 
-class StandardEnum(Enum):
+class StandardEnum(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'

--- a/src/adcp/types/generated_poc/sponsored_intelligence/si_identity.py
+++ b/src/adcp/types/generated_poc/sponsored_intelligence/si_identity.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field
 
 
-class ConsentScopeEnum(Enum):
+class ConsentScopeEnum(StrEnum):
     name = 'name'
     email = 'email'
     shipping_address = 'shipping_address'

--- a/src/adcp/types/generated_poc/sponsored_intelligence/si_send_message_response.py
+++ b/src/adcp/types/generated_poc/sponsored_intelligence/si_send_message_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -20,7 +20,7 @@ from ..enums import si_session_status
 from . import si_ui_element
 
 
-class Type(Enum):
+class Type(StrEnum):
     transaction = 'transaction'
     complete = 'complete'
 

--- a/src/adcp/types/generated_poc/sponsored_intelligence/si_terminate_session_request.py
+++ b/src/adcp/types/generated_poc/sponsored_intelligence/si_terminate_session_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -15,7 +15,7 @@ from ..core import ext as ext_1
 from ..core.version_envelope import AdcpVersionEnvelope
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     handoff_transaction = 'handoff_transaction'
     handoff_complete = 'handoff_complete'
     user_exit = 'user_exit'
@@ -23,7 +23,7 @@ class Reason(Enum):
     host_terminated = 'host_terminated'
 
 
-class Action(Enum):
+class Action(StrEnum):
     purchase = 'purchase'
     subscribe = 'subscribe'
 

--- a/src/adcp/types/generated_poc/sponsored_intelligence/si_terminate_session_response.py
+++ b/src/adcp/types/generated_poc/sponsored_intelligence/si_terminate_session_response.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
@@ -48,7 +48,7 @@ class AcpHandoff(AdCPBaseModel):
     ] = None
 
 
-class Action(Enum):
+class Action(StrEnum):
     save_for_later = 'save_for_later'
     set_reminder = 'set_reminder'
     subscribe_updates = 'subscribe_updates'

--- a/src/adcp/types/generated_poc/sponsored_intelligence/si_ui_element.py
+++ b/src/adcp/types/generated_poc/sponsored_intelligence/si_ui_element.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Any
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Type(Enum):
+class Type(StrEnum):
     text = 'text'
     link = 'link'
     image = 'image'

--- a/src/adcp/types/generated_poc/tmp/context_match_request.py
+++ b/src/adcp/types/generated_poc/tmp/context_match_request.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 from uuid import UUID
 
@@ -17,7 +17,7 @@ from ..enums import metro_system
 from ..enums import property_type as property_type_1
 
 
-class Type(Enum):
+class Type(StrEnum):
     url = 'url'
     url_hash = 'url_hash'
     eidr = 'eidr'
@@ -47,7 +47,7 @@ class ArtifactRef(AdCPBaseModel):
     ]
 
 
-class Sentiment(Enum):
+class Sentiment(StrEnum):
     positive = 'positive'
     negative = 'negative'
     neutral = 'neutral'

--- a/src/adcp/types/generated_poc/tmp/error.py
+++ b/src/adcp/types/generated_poc/tmp/error.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated, Literal
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Code(Enum):
+class Code(StrEnum):
     invalid_request = 'invalid_request'
     unknown_package = 'unknown_package'
     seller_not_authorized = 'seller_not_authorized'

--- a/src/adcp/types/generated_poc/tmp/offer_price.py
+++ b/src/adcp/types/generated_poc/tmp/offer_price.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Annotated
 
 from adcp.types.base import AdCPBaseModel
 from pydantic import ConfigDict, Field
 
 
-class Model(Enum):
+class Model(StrEnum):
     cpm = 'cpm'
     cpc = 'cpc'
     cpcv = 'cpcv'

--- a/src/adcp/types/generated_poc/tmp/provider_registration.py
+++ b/src/adcp/types/generated_poc/tmp/provider_registration.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from adcp.types._str_enum import StrEnum
 from typing import Any, Annotated, Literal
 from uuid import UUID
 
@@ -18,7 +18,7 @@ class Country(RootModel[str]):
     root: Annotated[str, Field(pattern='^[A-Z]{2}$')]
 
 
-class Status(Enum):
+class Status(StrEnum):
     active = 'active'
     inactive = 'inactive'
     draining = 'draining'

--- a/tests/test_generated_enum_strenum.py
+++ b/tests/test_generated_enum_strenum.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from adcp.types import CreativeAction, GetProductsRequest, MediaBuyStatus
+from adcp.types.generated_poc.media_buy.get_products_request import BuyingMode
+from tests.conftest import validate_union
+
+GENERATED_TYPES_DIR = Path(__file__).parents[1] / "src" / "adcp" / "types" / "generated_poc"
+
+
+def test_generated_enums_are_string_comparable() -> None:
+    assert MediaBuyStatus.active == "active"
+    assert "active" == MediaBuyStatus.active
+    assert isinstance(MediaBuyStatus.active, str)
+    assert str(MediaBuyStatus.active) == "active"
+
+
+def test_generated_enums_hash_like_strings() -> None:
+    values = {"created"}
+
+    assert CreativeAction.created in values
+    assert values == {CreativeAction.created}
+
+
+def test_generated_enum_sources_use_strenum() -> None:
+    for path in GENERATED_TYPES_DIR.rglob("*.py"):
+        source = path.read_text()
+        assert "from enum import Enum" not in source, path
+        assert "(Enum):" not in source, path
+
+
+def test_enum_coercion_still_returns_enum_members() -> None:
+    req = validate_union(GetProductsRequest, {"buying_mode": "wholesale"})
+
+    assert req.buying_mode == BuyingMode.wholesale
+    assert isinstance(req.buying_mode, BuyingMode)


### PR DESCRIPTION
Converts generated string-valued schema enums from plain Enum to StrEnum-compatible classes while leaving IntEnum members, field annotations, and acceptable values unchanged.
Adds a Python 3.10-compatible StrEnum shim and makes post-generation fixes apply the conversion reproducibly, including targeted mypy suppressions for enum members that intentionally shadow str methods.
Adds regression coverage for string equality, hashing, source generation, and existing enum coercion behavior.

Validation: pre-commit hooks passed during commit, plus focused pytest and mypy checks passed locally.