### PR TITLE
chore: update Argus to Opus 4.8

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,7 +96,8 @@ jobs:
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh api:*),Read,Glob,Grep,Task"
             --max-turns 60
-            --model claude-opus-4-7
+            --model claude-opus-4-8
+            --effort high
 
       - name: Verify Argus posted a review
         id: verify


### PR DESCRIPTION
## Summary
- update Argus PR review from Claude Opus 4.7 to Claude Opus 4.8
- set Claude Code effort explicitly to high

## Verification
- ruby YAML parse for .github/workflows/ai-review.yml