### PR TITLE
fix(codegen): rewrite compact ConfigDict extra in place

### DIFF
--- a/scripts/post_generate_fixes.py
+++ b/scripts/post_generate_fixes.py
@@ -514,6 +514,11 @@ def _set_class_extra_allow(content: str, class_name: str) -> tuple[str, str]:
     body = match.group(2)
     config_pattern = re.compile(r"(    model_config = ConfigDict\(\n)(.*?)(    \)\n)", re.DOTALL)
     config_match = config_pattern.search(body)
+    # Compact single-line form: `    model_config = ConfigDict(<args>)`. The
+    # open paren is not immediately followed by a newline, so the multi-line
+    # pattern above never matches it.
+    compact_pattern = re.compile(r"(    model_config = ConfigDict\()([^\n]*?)(\)\n)")
+    compact_match = compact_pattern.search(body)
     if config_match is not None:
         config_body = config_match.group(2)
         if re.search(r"extra=(['\"])allow\1", config_body):
@@ -533,6 +538,28 @@ def _set_class_extra_allow(content: str, class_name: str) -> tuple[str, str]:
             + new_config_body
             + config_match.group(3)
             + body[config_match.end() :]
+        )
+    elif compact_match is not None:
+        config_args = compact_match.group(2)
+        if re.search(r"extra=(['\"])allow\1", config_args):
+            return content, "already"
+        if re.search(r"extra=(['\"])(?:forbid|ignore)\1", config_args):
+            new_config_args = re.sub(
+                r"extra=(['\"])(?:forbid|ignore)\1",
+                "extra='allow'",
+                config_args,
+                count=1,
+            )
+        elif config_args.strip():
+            new_config_args = "extra='allow', " + config_args
+        else:
+            new_config_args = "extra='allow'"
+        new_body = (
+            body[: compact_match.start()]
+            + compact_match.group(1)
+            + new_config_args
+            + compact_match.group(3)
+            + body[compact_match.end() :]
         )
     else:
         new_body = "    model_config = ConfigDict(\n        extra='allow',\n    )\n" + body

--- a/tests/test_extra_policy.py
+++ b/tests/test_extra_policy.py
@@ -125,6 +125,28 @@ class TestGeneratedTypeOverrides:
         assert "from pydantic import ConfigDict, Field" in updated
         assert "model_config = ConfigDict(\n        extra='allow',\n    )" in updated
 
+    def test_compact_configdict_forbid_rewritten_in_place(self) -> None:
+        """Compact single-line ConfigDict(extra='forbid') is rewritten, not duplicated.
+
+        The compact form `model_config = ConfigDict(extra='forbid')` must be
+        flipped to extra='allow' in place. Prepending a second model_config
+        block instead produces two declarations and breaks Pydantic at import.
+        """
+        content = (
+            "from __future__ import annotations\n\n"
+            "from pydantic import ConfigDict, Field\n\n\n"
+            "class PartnerPayload(AdCPBaseModel):\n"
+            "    model_config = ConfigDict(extra='forbid')\n"
+            "    name: str\n"
+        )
+        updated, status = _set_class_extra_allow(content, "PartnerPayload")
+
+        assert status == "updated"
+        assert "model_config = ConfigDict(extra='allow')" in updated
+        assert "extra='forbid'" not in updated
+        # Exactly one model_config declaration — no duplicate prepended block.
+        assert updated.count("model_config") == 1
+
 
 class TestConsumerSubclassing:
     """Consumers can override extra policy on subclasses."""


### PR DESCRIPTION
## Summary

Fixes the one remaining gap in #907: `_set_class_extra_allow` in
`scripts/post_generate_fixes.py` only matched the multi-line
`model_config = ConfigDict(\n ...)` form. A **compact single-line**
`model_config = ConfigDict(extra='forbid')` did not match, so it fell
through to the else branch that **prepends** a fresh `model_config` block —
producing two `model_config` declarations in the same class, which breaks
Pydantic at import time.

The other #907 sub-items (missing `ConfigDict` import injection, enum-base
exclusion for the title-less root sentinel, the `#902` short-circuit note,
docs follow-ups) are already shipped. This PR closes the compact-ConfigDict
residual only.

## Repro (before fix)

A compact `ConfigDict(extra='forbid')` on a class that should get
`extra='allow'` produced a duplicate:

```python
class PartnerPayload(AdCPBaseModel):
    model_config = ConfigDict(
        extra='allow',
    )
    model_config = ConfigDict(extra='forbid')   # duplicate — last one wins
    name: str
```

## Change

`_set_class_extra_allow` now matches the compact single-line form
(`ConfigDict(<args>)` where the open paren is not followed by a newline) and
rewrites it in place:

- `extra='allow'` already present → returns `"already"`, no change
- `extra='forbid'`/`'ignore'` → flipped to `extra='allow'` in place
- other args, no `extra=` → `extra='allow'` inserted into the call
- empty args → `extra='allow'` inserted

Exactly one `model_config` is emitted; the multi-line and no-config paths are
unchanged.

## Tests

Added `test_compact_configdict_forbid_rewritten_in_place` to
`tests/test_extra_policy.py` asserting the compact `extra='forbid'` →
`extra='allow'` rewrite and that no duplicate `model_config` is produced.

## Verification

- `uv run --extra dev pytest tests/test_extra_policy.py -q` → 14 passed
- `make lint` → passed
- `make typecheck` → passed
- `make validate-generated` → passed
- No regen needed; no generated files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)