### PR TITLE
fix(server): centralize pre-validation hooks and attribute chain failures

### DIFF
--- a/src/adcp/server/__init__.py
+++ b/src/adcp/server/__init__.py
@@ -53,6 +53,13 @@ What the framework does automatically:
 from __future__ import annotations
 
 from adcp.capabilities import validate_capabilities
+from adcp.server._hooks import (
+    PreValidationHook,
+    PreValidationHookChain,
+    PreValidationHookError,
+    PreValidationHooks,
+    compose_pre_validation_hooks,
+)
 from adcp.server.a2a_server import (
     ADCPAgentExecutor,
     MessageParser,
@@ -153,10 +160,6 @@ from adcp.server.serve import (
 )
 from adcp.server.spec_compat import (
     CANONICAL_CREATIVE_AGENT_URL,
-    PreValidationHook,
-    PreValidationHookChain,
-    PreValidationHooks,
-    compose_pre_validation_hooks,
     spec_compat_hooks,
 )
 from adcp.server.sponsored_intelligence import SponsoredIntelligenceHandler
@@ -273,6 +276,7 @@ __all__ = [
     "CANONICAL_CREATIVE_AGENT_URL",
     "PreValidationHook",
     "PreValidationHookChain",
+    "PreValidationHookError",
     "PreValidationHooks",
     "compose_pre_validation_hooks",
     "spec_compat_hooks",

--- a/src/adcp/server/_hooks.py
+++ b/src/adcp/server/_hooks.py
@@ -1,0 +1,121 @@
+"""Shared pre-validation hook types, composition, and application.
+
+Single source of truth for the per-tool pre-validation hook machinery used by
+both the MCP and A2A transports. :mod:`adcp.server.spec_compat` re-exports the
+public names (``PreValidationHook``, ``PreValidationHookChain``,
+``PreValidationHooks``, ``compose_pre_validation_hooks``) for backward
+compatibility, so adopters can keep importing them from either module.
+
+This module has no transport or framework dependencies — it depends only on the
+standard library — so it sits at the bottom of the server import layering and
+every other ``adcp.server`` module may import from it freely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, TypeAlias
+
+PreValidationHook: TypeAlias = Callable[[str, dict[str, Any]], dict[str, Any]]
+"""Callable shape for a pre-validation hook."""
+
+PreValidationHookChain: TypeAlias = PreValidationHook | Sequence[PreValidationHook]
+"""One hook or an ordered sequence of hooks for a single tool."""
+
+PreValidationHooks: TypeAlias = dict[str, PreValidationHookChain]
+"""Type alias for the ``pre_validation_hooks`` parameter of ``serve()``."""
+
+__all__ = [
+    "PreValidationHook",
+    "PreValidationHookChain",
+    "PreValidationHookError",
+    "PreValidationHooks",
+    "compose_pre_validation_hooks",
+]
+
+
+class PreValidationHookError(Exception):
+    """A single hook in an ordered pre-validation chain failed.
+
+    Carries the zero-based ``index`` of the failing hook within its chain and
+    the resolved ``hook_name`` so the dispatcher can surface both in the
+    ``INVALID_REQUEST`` message — naming the exact callable instead of a
+    generic "pre_validation_hook raised ...".
+    """
+
+    def __init__(self, *, index: int, hook_name: str, message: str) -> None:
+        self.index = index
+        self.hook_name = hook_name
+        super().__init__(f"pre_validation_hook[{index}] {hook_name} {message}")
+
+
+def _hook_name(hook: PreValidationHook) -> str:
+    """Best-effort human name for a hook (function ``__name__`` or class name)."""
+    name = getattr(hook, "__name__", None)
+    if isinstance(name, str) and name:
+        return name
+    return hook.__class__.__name__
+
+
+def _flatten_pre_validation_hooks(
+    hooks: PreValidationHookChain | None,
+) -> tuple[PreValidationHook, ...]:
+    """Normalize ``None`` / one hook / a sequence into a flat hook tuple."""
+    if hooks is None:
+        return ()
+    if callable(hooks):
+        return (hooks,)
+    flattened = tuple(hooks)
+    for hook in flattened:
+        if not callable(hook):
+            raise TypeError("pre-validation hook chains must contain callables")
+    return flattened
+
+
+def _apply_pre_validation_hooks(
+    hooks: tuple[PreValidationHook, ...],
+    tool_name: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Run an ordered hook chain, threading each hook's output into the next.
+
+    Each hook receives a shallow copy of the running params dict. A hook that
+    raises, or returns a non-dict, is wrapped in :class:`PreValidationHookError`
+    naming its chain index and callable.
+    """
+    next_params = params
+    for index, hook in enumerate(hooks):
+        hook_name = _hook_name(hook)
+        try:
+            next_params = hook(tool_name, dict(next_params))
+        except Exception as exc:
+            raise PreValidationHookError(
+                index=index,
+                hook_name=hook_name,
+                message=f"raised {type(exc).__name__}: {exc}",
+            ) from exc
+        if not isinstance(next_params, dict):
+            raise PreValidationHookError(
+                index=index,
+                hook_name=hook_name,
+                message=f"returned {type(next_params).__name__}, expected dict",
+            )
+    return next_params
+
+
+def compose_pre_validation_hooks(
+    *hook_maps: Mapping[str, PreValidationHookChain] | None,
+) -> dict[str, tuple[PreValidationHook, ...]]:
+    """Compose ordered pre-validation hook maps.
+
+    Later maps append to earlier maps for overlapping tool names. Each
+    tool's hooks run left-to-right, feeding the returned args from one hook
+    into the next.
+    """
+    composed: dict[str, list[PreValidationHook]] = {}
+    for hook_map in hook_maps:
+        if hook_map is None:
+            continue
+        for tool_name, chain in hook_map.items():
+            composed.setdefault(tool_name, []).extend(_flatten_pre_validation_hooks(chain))
+    return {tool_name: tuple(hooks) for tool_name, hooks in composed.items()}

--- a/src/adcp/server/a2a_server.py
+++ b/src/adcp/server/a2a_server.py
@@ -36,9 +36,9 @@ from google.protobuf.struct_pb2 import Value
 from starlette.applications import Starlette
 
 from adcp.exceptions import ADCPError
+from adcp.server._hooks import PreValidationHooks
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.helpers import ResponseEnhancer, _apply_response_enhancer
-from adcp.server.spec_compat import PreValidationHooks
 
 # Decisioning-layer ``AdcpError`` (from ``adcp.decisioning.types``) is the
 # wire-shaped structured error platform methods raise. It is NOT a subclass

--- a/src/adcp/server/mcp_tools.py
+++ b/src/adcp/server/mcp_tools.py
@@ -25,9 +25,15 @@ import os
 from collections.abc import Callable, Iterable
 from typing import Any
 
+from adcp.server._hooks import (
+    PreValidationHookChain,
+    PreValidationHookError,
+    PreValidationHooks,
+    _apply_pre_validation_hooks,
+    _flatten_pre_validation_hooks,
+)
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.helpers import ResponseEnhancer, _apply_response_enhancer
-from adcp.server.spec_compat import PreValidationHook, PreValidationHookChain
 from adcp.server.test_controller import SCENARIOS as _CONTROLLER_SCENARIOS
 from adcp.types import (
     MEDIA_BUY_LEGACY_STATUS_VALUES,
@@ -2097,33 +2103,6 @@ def _resolve_params_pydantic_model(method: Any) -> type[Any] | None:
     return None
 
 
-def _flatten_pre_validation_hooks(
-    hooks: PreValidationHookChain | None,
-) -> tuple[PreValidationHook, ...]:
-    if hooks is None:
-        return ()
-    if callable(hooks):
-        return (hooks,)
-    flattened = tuple(hooks)
-    for hook in flattened:
-        if not callable(hook):
-            raise TypeError("pre-validation hook chains must contain callables")
-    return flattened
-
-
-def _apply_pre_validation_hooks(
-    hooks: tuple[PreValidationHook, ...],
-    method_name: str,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    next_params = params
-    for hook in hooks:
-        next_params = hook(method_name, dict(next_params))
-        if not isinstance(next_params, dict):
-            raise TypeError("pre-validation hooks must return dict arguments")
-    return next_params
-
-
 def _normalize_unknown_field_policy(
     policy: UnknownFieldPolicy | str | None,
 ) -> UnknownFieldPolicy:
@@ -2336,13 +2315,13 @@ def create_tool_caller(
                 params = _apply_pre_validation_hooks(
                     pre_validation_hooks, method_name, dict(params)
                 )
-            except Exception as exc:
+            except PreValidationHookError as exc:
                 raise ADCPTaskError(
                     operation=method_name,
                     errors=[
                         Error(
                             code="INVALID_REQUEST",
-                            message=f"pre_validation_hook raised {type(exc).__name__}: {exc}",
+                            message=str(exc),
                         )
                     ],
                 ) from exc
@@ -2707,7 +2686,7 @@ class MCPToolSet:
         *,
         advertise_all: bool = False,
         validation: ValidationHookConfig | None = None,
-        pre_validation_hooks: dict[str, PreValidationHookChain] | None = None,
+        pre_validation_hooks: PreValidationHooks | None = None,
         response_enhancer: ResponseEnhancer | None = None,
     ):
         """Create tool set from handler.
@@ -2777,7 +2756,7 @@ def create_mcp_tools(
     *,
     advertise_all: bool = False,
     validation: ValidationHookConfig | None = None,
-    pre_validation_hooks: dict[str, PreValidationHookChain] | None = None,
+    pre_validation_hooks: PreValidationHooks | None = None,
     response_enhancer: ResponseEnhancer | None = None,
 ) -> MCPToolSet:
     """Create MCP tools from an ADCP handler.

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 logger = logging.getLogger("adcp.server")
 
+from adcp.server._hooks import PreValidationHooks
 from adcp.server.base import ADCPHandler, ToolContext
 from adcp.server.helpers import ResponseEnhancer
 from adcp.server.mcp_sessions import ADCPStreamableHTTPSessionManager
@@ -36,7 +37,6 @@ from adcp.server.mcp_tools import (
     create_tool_caller,
     get_tools_for_handler,
 )
-from adcp.server.spec_compat import PreValidationHooks
 from adcp.validation.client_hooks import (
     SERVER_DEFAULT_VALIDATION as DEFAULT_VALIDATION,
 )

--- a/src/adcp/server/spec_compat.py
+++ b/src/adcp/server/spec_compat.py
@@ -31,17 +31,26 @@ framework dependencies so they compose cleanly with adopter-specific hooks::
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Collection, Mapping, Sequence
-from typing import Any, TypeAlias
+from collections.abc import Callable, Collection
+from typing import Any
 
-PreValidationHook: TypeAlias = Callable[[str, dict[str, Any]], dict[str, Any]]
-"""Callable shape for a pre-validation hook."""
+from adcp.server._hooks import (
+    PreValidationHook,
+    PreValidationHookChain,
+    PreValidationHookError,
+    PreValidationHooks,
+    compose_pre_validation_hooks,
+)
 
-PreValidationHookChain: TypeAlias = PreValidationHook | Sequence[PreValidationHook]
-"""One hook or an ordered sequence of hooks for a single tool."""
-
-PreValidationHooks: TypeAlias = dict[str, PreValidationHookChain]
-"""Type alias for the ``pre_validation_hooks`` parameter of ``serve()``."""
+__all__ = [
+    "CANONICAL_CREATIVE_AGENT_URL",
+    "PreValidationHook",
+    "PreValidationHookChain",
+    "PreValidationHookError",
+    "PreValidationHooks",
+    "compose_pre_validation_hooks",
+    "spec_compat_hooks",
+]
 
 CANONICAL_CREATIVE_AGENT_URL = "https://creative.adcontextprotocol.org"
 """Canonical ``agent_url`` for the AdCP standard creative-format registry.
@@ -78,35 +87,6 @@ _KNOWN_ASSET_TYPES: frozenset[str] = frozenset(
         "catalog",
     }
 )
-
-
-def _flatten_hook_chain(chain: PreValidationHookChain) -> tuple[PreValidationHook, ...]:
-    if callable(chain):
-        return (chain,)
-    hooks = tuple(chain)
-    for hook in hooks:
-        if not callable(hook):
-            raise TypeError("pre-validation hook chains must contain callables")
-    return hooks
-
-
-def compose_pre_validation_hooks(
-    *hook_maps: Mapping[str, PreValidationHookChain] | None,
-) -> dict[str, tuple[PreValidationHook, ...]]:
-    """Compose ordered pre-validation hook maps.
-
-    Later maps append to earlier maps for overlapping tool names. Each
-    tool's hooks run left-to-right, feeding the returned args from one hook
-    into the next.
-    """
-
-    composed: dict[str, list[PreValidationHook]] = {}
-    for hook_map in hook_maps:
-        if hook_map is None:
-            continue
-        for tool_name, chain in hook_map.items():
-            composed.setdefault(tool_name, []).extend(_flatten_hook_chain(chain))
-    return {tool_name: tuple(hooks) for tool_name, hooks in composed.items()}
 
 
 def _hook_get_products(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
@@ -297,8 +277,8 @@ def _spec_compat_hooks_impl(
         Adopters who need granular control over the three sub-behaviors
         should copy the relevant logic from
         ``adcp.server.spec_compat._coerce_asset`` / ``_hook_get_products``
-        rather than trying to layer hooks — ``pre_validation_hooks`` allows
-        only one callable per tool name.
+        or compose an ordered hook chain with
+        :func:`adcp.server.compose_pre_validation_hooks`.
 
     Args:
         exclude: Tool names to exclude from the returned dict. Names not in

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -244,6 +244,90 @@ async def test_execute_with_datapart():
     assert result["products"][0]["id"] == "p1"
 
 
+async def test_pre_validation_hook_chain_runs_through_a2a_executor():
+    """A2A executor applies the same ordered hook-chain behavior as MCP."""
+
+    class _HookHandler(ADCPHandler):
+        async def get_products(self, params: dict[str, Any], context: Any = None):
+            return {"params_received": dict(params)}
+
+    calls: list[str] = []
+
+    def first(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"first:{tool_name}")
+        return {**args, "first": True}
+
+    def second(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"second:{tool_name}:{args['first']}")
+        return {**args, "second": True}
+
+    executor = ADCPAgentExecutor(
+        _HookHandler(),
+        pre_validation_hooks={"get_products": [first, second]},
+    )
+    ctx = RequestContext(
+        request=MessageSendParams(
+            message=_make_datapart_msg("get_products", {"buying_mode": "brief"})
+        )
+    )
+    queue = EventQueue()
+
+    await executor.execute(ctx, queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, Task)
+    assert event.status.state == pb.TaskState.TASK_STATE_COMPLETED
+    result = _first_data_part(event)
+    assert calls == ["first:get_products", "second:get_products:True"]
+    assert result["params_received"]["first"] is True
+    assert result["params_received"]["second"] is True
+
+
+async def test_pre_validation_hook_chain_failure_attributes_index_and_callable():
+    """A2A hook-chain failures surface the failing index + callable name."""
+
+    class _HookHandler(ADCPHandler):
+        async def get_products(self, params: dict[str, Any], context: Any = None):
+            return {"params_received": dict(params)}
+
+    def first(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {**args, "first": True}
+
+    def boom(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("hook exploded")
+
+    executor = ADCPAgentExecutor(
+        _HookHandler(),
+        pre_validation_hooks={"get_products": [first, boom]},
+    )
+    ctx = RequestContext(
+        request=MessageSendParams(
+            message=_make_datapart_msg("get_products", {"buying_mode": "brief"})
+        )
+    )
+    queue = EventQueue()
+
+    await executor.execute(ctx, queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, Task)
+    assert event.status.state == pb.TaskState.TASK_STATE_FAILED
+
+    # The structured ``adcp_error`` envelope carries the attributed message.
+    adcp_error = _first_data_part(event)["adcp_error"]
+    assert adcp_error["code"] == "INVALID_REQUEST"
+    assert "pre_validation_hook[1]" in adcp_error["message"]
+    assert "boom" in adcp_error["message"]
+    assert "RuntimeError" in adcp_error["message"]
+
+    # The same message is mirrored to a human-readable TextPart.
+    text = " ".join(
+        part.text for part in event.artifacts[0].parts if part.WhichOneof("content") == "text"
+    )
+    assert "pre_validation_hook[1]" in text
+    assert "boom" in text
+
+
 async def test_execute_skips_scalar_datapart_and_uses_text_fallback():
     """Scalar protobuf Value payloads are not AdCP DataPart objects."""
     executor = ADCPAgentExecutor(_TestHandler())

--- a/tests/test_pre_validation_hooks.py
+++ b/tests/test_pre_validation_hooks.py
@@ -186,7 +186,54 @@ async def test_hook_exception_surfaces_as_invalid_request() -> None:
     errors = exc_info.value.errors
     assert errors, "ADCPTaskError must carry at least one error"
     assert errors[0].code == "INVALID_REQUEST"
+    assert "pre_validation_hook[0]" in errors[0].message
+    assert "bad_hook" in errors[0].message
     assert "ValueError" in errors[0].message
+
+
+@pytest.mark.asyncio
+async def test_hook_chain_exception_identifies_failing_hook() -> None:
+    """Hook-chain failures name the index and callable that raised."""
+
+    def first_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {**args, "first": True}
+
+    def second_hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("second failed")
+
+    handler = _MinimalHandler()
+    caller = create_tool_caller(
+        handler,
+        "get_products",
+        pre_validation_hook=[first_hook, second_hook],
+    )
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"buying_mode": "brief"})
+
+    message = exc_info.value.errors[0].message
+    assert "pre_validation_hook[1]" in message
+    assert "second_hook" in message
+    assert "RuntimeError" in message
+
+
+@pytest.mark.asyncio
+async def test_hook_chain_non_dict_return_identifies_failing_hook() -> None:
+    """Invalid hook return values also include chain index and hook name."""
+
+    def bad_return(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return ["not", "a", "dict"]  # type: ignore[return-value]
+
+    handler = _MinimalHandler()
+    caller = create_tool_caller(handler, "get_products", pre_validation_hook=[bad_return])
+
+    with pytest.raises(ADCPTaskError) as exc_info:
+        await caller({"buying_mode": "brief"})
+
+    message = exc_info.value.errors[0].message
+    assert "pre_validation_hook[0]" in message
+    assert "bad_return" in message
+    assert "returned list, expected dict" in message
 
 
 # ---------------------------------------------------------------------------
@@ -253,33 +300,52 @@ async def test_in_place_mutation_is_safe_for_context_echo() -> None:
 
 
 # ---------------------------------------------------------------------------
-# MCPToolSet threading
+# MCPToolSet real-path behavior
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_tool_set_threads_hook_to_tool_caller() -> None:
-    """MCPToolSet must forward pre_validation_hooks to create_tool_caller."""
-    import importlib
-    from unittest.mock import patch
-
-    _serve_mod = importlib.import_module("adcp.server.mcp_tools")
+@pytest.mark.asyncio
+async def test_mcp_tool_set_applies_hook_chain_for_matching_tool() -> None:
+    """MCPToolSet applies ordered hook chains through the real call_tool path."""
+    from adcp.server.mcp_tools import MCPToolSet
 
     handler = _MinimalHandler()
-    captured_hooks: list[Any] = []
-    real = _serve_mod.create_tool_caller
+    calls: list[str] = []
 
-    def spy(h: Any, name: str, **kw: Any) -> Any:
-        captured_hooks.append(kw.get("pre_validation_hook"))
-        return real(h, name, **kw)
+    def first(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"first:{tool_name}")
+        return {**args, "first": True}
 
-    my_hook = lambda n, a: a  # noqa: E731
-    hooks = {"get_products": my_hook}
+    def second(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(f"second:{tool_name}:{args['first']}")
+        return {**args, "second": True}
 
-    with patch.object(_serve_mod, "create_tool_caller", side_effect=spy):
-        from adcp.server.mcp_tools import MCPToolSet
+    tool_set = MCPToolSet(
+        handler,
+        validation=None,
+        pre_validation_hooks={"get_products": [first, second]},
+    )
+    result = await tool_set.call_tool("get_products", {"buying_mode": "brief"})
 
-        MCPToolSet(handler, pre_validation_hooks=hooks)
+    assert calls == ["first:get_products", "second:get_products:True"]
+    assert result["params_received"]["first"] is True
+    assert result["params_received"]["second"] is True
 
-    assert any(
-        h is my_hook for h in captured_hooks
-    ), "my_hook was not forwarded to create_tool_caller for get_products"
+
+def test_mcp_tool_set_does_not_apply_hooks_to_other_tools() -> None:
+    """Hooks registered for one tool are not threaded into other tools."""
+    from adcp.server.mcp_tools import MCPToolSet
+
+    handler = _MinimalHandler()
+    calls: list[str] = []
+
+    def hook(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        calls.append(tool_name)
+        return args
+
+    tool_set = MCPToolSet(handler, pre_validation_hooks={"get_products": hook})
+
+    # get_adcp_capabilities is advertised for every handler; its caller must
+    # not carry the get_products hook.
+    assert "get_products" in tool_set.get_tool_names()
+    assert calls == []


### PR DESCRIPTION
## Summary

Diagnostics + test-quality follow-up to the pre-validation hook composition work that shipped in #860. The ordered-chain core (`PreValidationHook` / `PreValidationHookChain` / `compose_pre_validation_hooks`) already lives on `main`; this PR re-applies the remaining substance from @sangilish's draft #882 freshly onto current `main` (which moved substantially via #930/#933, rewriting `serve.py` / `a2a_server.py` / `mcp_tools.py`).

### Changes

- **Single source of truth.** Move the hook types, `compose_pre_validation_hooks`, and the `_flatten` / `_apply` helpers into a new `adcp.server._hooks` module. `spec_compat.py` re-imports and re-exports the public names (with `__all__`) so existing imports — including `adcp.testing.decisioning`'s `from adcp.server.spec_compat import PreValidationHooks` — keep working. `__init__.py`, `a2a_server.py`, `mcp_tools.py`, and `serve.py` now import from `_hooks`.
- **Failure attribution.** Add `PreValidationHookError` so `INVALID_REQUEST` names the failing chain index and callable, e.g. `pre_validation_hook[1] second_hook raised RuntimeError: ...` (and `pre_validation_hook[0] bad_return returned list, expected dict`) instead of a generic `pre_validation_hook raised ...`. The dispatcher catches it on the shared `create_tool_caller` path, so MCP and A2A both surface the attributed message (A2A via the `adcp_error` envelope + mirrored TextPart).
- **Real-path tests.** Replace the mock/spy `MCPToolSet` test with a real `MCPToolSet.call_tool(...)` behavior test; add an A2A ordered-chain executor test; add MCP + A2A chain-failure attribution tests asserting the index and callable appear in the error.

### Import layering

`_hooks.py` depends only on the standard library, so it sits at the bottom of the `adcp.server` layering — every other server module may import from it freely, and it adds no `generated_poc` / `_generated` access. `tests/test_import_layering.py` passes.

### Verification

- `tests/test_import_layering.py`, `tests/test_public_api.py` — pass
- `tests/test_pre_validation_hooks.py`, `tests/test_a2a_server.py`, `tests/test_spec_compat_hooks.py` (+ deprecation), unknown-field / schema-validation / serve-passthrough / testing-decisioning — pass
- Full suite: 5613 passed, 38 skipped
- `make lint`, `make typecheck`, `make typecheck-all`, `make validate-generated` — all green

Credit to @sangilish, whose draft #882 this re-applies; that PR can be closed as superseded.

Closes #859
Supersedes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)