### PR TITLE
fix(packaging): trim prerelease schema bundles

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,9 @@ include LICENSE
 recursive-include src/adcp py.typed
 # Bundled AdCP JSON schemas. ``scripts/bundle_schemas.py`` mirrors
 # ``schemas/cache/`` into ``src/adcp/_schemas/`` before ``python -m
-# build`` so the validator ships with the wheel.
-recursive-include src/adcp/_schemas *.json
+# build`` so the validator ships with the wheel. Keep distributions on
+# stable supported bundles; historical prerelease caches are dev-only.
+recursive-include src/adcp/_schemas/2.5 *.json
+recursive-include src/adcp/_schemas/3.0 *.json
+recursive-include src/adcp/_schemas/3.1 *.json
+prune src/adcp/_schemas/3.1.0-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,9 @@ adcp = [
     # AdCP JSON schemas, mirrored from ``schemas/cache/`` by
     # ``scripts/bundle_schemas.py`` so the wheel ships them for
     # ``adcp.validation.schema_loader``.
-    "_schemas/**/*.json",
+    "_schemas/2.5/**/*.json",
+    "_schemas/3.0/**/*.json",
+    "_schemas/3.1/**/*.json",
     # Vendored canonical-formats reference fixtures (14 v2 products +
     # 50-entry v1 catalog) so :mod:`adcp.canonical_formats.fixtures`
     # can serve them to adopter test suites without forcing each
@@ -190,6 +192,12 @@ adcp = [
 # Named schemas bundled directly with the SDK (committed, not generated).
 # These live in src/adcp/schemas/ and are loaded via adcp.schemas.load_schema.
 "adcp.schemas" = ["*.json"]
+
+[tool.setuptools.exclude-package-data]
+adcp = [
+    "_schemas/3.1.0-*/*.json",
+    "_schemas/3.1.0-*/**/*.json",
+]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Summary

- restrict packaged schema data to stable supported bundles (`2.5`, `3.0`, `3.1`)
- explicitly prune/exclude historical `3.1.0-*` beta/RC schema caches from sdist/wheel artifacts
- keeps prerelease schema caches available in the repo for development, but stops shipping them to PyPI

## Root Cause

The `6.3.0` release workflow created a GitHub release and built successfully, but PyPI rejected the upload with HTTP 400 after Twine uploaded a 115.2 MB wheel. The wheel exceeded PyPI's default 100 MB file limit because package data included every historical `3.1.0-*` prerelease schema bundle plus stable `3.1`.

## Validation

- `.context/release-build-venv/bin/python -m build`
- rebuilt artifacts are `20M` wheel and `19M` sdist
- inspected wheel: `prerelease_schema_files=0`, `stable_31_schema_files=758`
- installed rebuilt wheel in `.context/pkg-size-smoke` and loaded validators for `2.5`, `3.0`, `3.1`
- `PYTHONPATH=src python3 -m pytest tests/test_schema_loader_per_version.py tests/test_validation_version.py tests/test_legacy_schema_bundle_v2_5.py`
