### PR TITLE
ci: point storyboard runner at @adcp/sdk latest instead of adcp-3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,12 +361,14 @@ jobs:
     name: AdCP storyboard runner — examples/seller_agent.py (@adcp/sdk ${{ matrix.adcp-sdk-tag }})
     runs-on: ubuntu-latest
     # Blocking gate: examples/seller_agent.py is the Python-owned
-    # reference target for bidirectional storyboard interop. ``latest``
+    # reference target for bidirectional storyboard interop. The matrix
+    # runs two legs: the sticky ``adcp-3.0`` tag is a fixed, reproducible
+    # backwards-compat floor (the AdCP 3.0 runner line), while ``latest``
     # tracks the current stable @adcp/sdk release (the AdCP 3.1 line).
     strategy:
       fail-fast: false
       matrix:
-        adcp-sdk-tag: ["latest"]
+        adcp-sdk-tag: ["adcp-3.0", "latest"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ on:
   pull_request:
     branches: [main]
 
-# Default @adcp/sdk runner alias for non-matrix storyboard jobs.
-# The reference seller storyboard job below runs both sticky 3.0 and 3.1 tags.
+# Default @adcp/sdk runner alias for storyboard jobs. Tracks the current
+# stable @adcp/sdk release via the ``latest`` npm dist-tag.
 env:
-  ADCP_SDK_VERSION: "adcp-3.1"
+  ADCP_SDK_VERSION: "latest"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -361,15 +361,12 @@ jobs:
     name: AdCP storyboard runner — examples/seller_agent.py (@adcp/sdk ${{ matrix.adcp-sdk-tag }})
     runs-on: ubuntu-latest
     # Blocking gate: examples/seller_agent.py is the Python-owned
-    # reference target for bidirectional storyboard interop. The npm
-    # dist-tags are sticky compatibility gates: ``adcp-3.0`` stays on
-    # the 3.0 runner line, while ``adcp-3.1`` tracks the current 3.1
-    # runner. Downstream SDKs and adopters can assert backwards
-    # compatibility without depending on moving latest/beta semantics.
+    # reference target for bidirectional storyboard interop. ``latest``
+    # tracks the current stable @adcp/sdk release (the AdCP 3.1 line).
     strategy:
       fail-fast: false
       matrix:
-        adcp-sdk-tag: ["adcp-3.0", "adcp-3.1"]
+        adcp-sdk-tag: ["latest"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why

Every \`AdCP storyboard runner\` job is failing on \`npm error notarget No matching version found for @adcp/sdk@adcp-3.1\`. This is not a defect in any PR — the \`adcp-3.1\` npm dist-tag was removed from the registry.

Root cause (traced in \`adcontextprotocol/adcp-client\`): commit \`509ed55b fix: publish stable releases to latest\` (2026-06-26) changed the SDK release process. It previously auto-published every stable release under a protocol-derived tag (\`adcp-3.1\`); it now publishes stable under \`latest\` and no longer emits \`adcp-3.1\`. AdCP 3.1 is the current stable line, shipped as \`@adcp/sdk@latest\` (currently 9.3.0). The SDK's \`NPM-DIST-TAGS.md\` now states an \`adcp-3.X\` compat tag exists only once that line becomes a *maintenance* line behind a newer stable — so there is intentionally no \`adcp-3.1\` tag today.

This passed on main as recently as June 20 (when the tag still existed) and started failing for all PRs after June 26. It blocks every PR because the storyboard jobs are required checks.

## What changed

- \`ADCP_SDK_VERSION\` default and the seller_agent.py storyboard matrix leg now track \`latest\` (which *is* the AdCP 3.1 GA line) instead of the removed \`adcp-3.1\` tag.
- Kept the sticky \`adcp-3.0\` tag for backwards-compatibility coverage.
- Updated the stale comments that described \`adcp-3.1\` as the current-line tag.

## Tradeoff

\`latest\` is a moving target, so a future \`@adcp/sdk\` release could change storyboard behavior without a tag bump here. That is acceptable (and arguably desirable — we want to know): the sticky \`adcp-3.0\` leg still provides a fixed backwards-compat gate. If the org later wants a stable \`adcp-3.1\` compat tag, that is a separate change in the SDK repo's publish process.