### PR TITLE
build: update MCP Python SDK to v2

### DIFF
--- a/examples/minimal_sales_agent.py
+++ b/examples/minimal_sales_agent.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from adcp.types import (
     CpmPricingOption,
@@ -190,7 +190,7 @@ for _product in PRODUCTS:
 
 # -- MCP server ----------------------------------------------------------------
 
-mcp = FastMCP(
+mcp = MCPServer(
     "Riverdale Gazette",
     instructions=(
         "You are the advertising sales agent for the Riverdale Gazette, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,15 +67,10 @@ dependencies = [
     # rather than relying on a2a-sdk's transitive pin (which is wider).
     "protobuf>=6,<8",
     "sse-starlette>=2.0",  # required by a2a-sdk v0.3 compat adapter
-    # 1.27.0 added ``session_idle_timeout`` to ``StreamableHTTPSessionManager``
-    # which we pass when adopters opt into stateful streamable-http. Upper
-    # bound at <2.0 because ``adcp.server.serve.create_mcp_server`` reads
-    # FastMCP private attrs (``_mcp_server``, ``_event_store``,
-    # ``_retry_interval``) when pre-creating the session manager — that
-    # contract is not preserved across majors, and upstream signaled v2
-    # development on ``main`` (v1.x maintenance branch only ports critical
-    # fixes). Bump deliberately when v2 lands.
-    "mcp>=1.27.0,<2.0",
+    # MCP Python SDK v2 is the stable line for the 2026-07-28 MCP spec.
+    # The ADCP integration uses the v2 ``MCPServer`` API and the
+    # streamable-HTTP session manager's explicit configuration arguments.
+    "mcp>=2.0.0,<3.0",
     "email-validator>=2.0.0",
     "cryptography>=41.0.0",
     # RFC 8785 JSON Canonicalization Scheme — used by the server-side

--- a/src/adcp/protocols/mcp.py
+++ b/src/adcp/protocols/mcp.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 """MCP protocol adapter using official Python MCP SDK."""
 
 import asyncio
+import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -27,14 +28,24 @@ if TYPE_CHECKING:
     from mcp import ClientSession
 
 try:
+    import anyio
+    import httpx2 as _mcp_httpx
     from mcp import ClientSession as _ClientSession
     from mcp.client.sse import sse_client
-    from mcp.client.streamable_http import MCP_SESSION_ID, streamablehttp_client
+    from mcp.client.streamable_http import (
+        MCP_SESSION_ID,
+        StreamableHTTPTransport,
+    )
+    from mcp.shared._compat import resync_tracer
+    from mcp.shared._context_streams import create_context_streams
     from mcp.shared._httpx_utils import MCP_DEFAULT_SSE_READ_TIMEOUT, MCP_DEFAULT_TIMEOUT
+    from mcp.shared.message import SessionMessage
 
     MCP_AVAILABLE = True
+    _MCP_HTTP_STATUS_ERROR_TYPES: tuple[type[BaseException], ...] = (_mcp_httpx.HTTPStatusError,)
 except ImportError:
     MCP_AVAILABLE = False
+    _MCP_HTTP_STATUS_ERROR_TYPES = ()
 
 try:
     import httpx as _httpx
@@ -46,6 +57,11 @@ except ImportError:
     HTTPX_AVAILABLE = False
     _HTTP_STATUS_ERROR_TYPES = ()
     _httpx = None  # type: ignore[assignment]
+
+_ALL_HTTP_STATUS_ERROR_TYPES: tuple[type[BaseException], ...] = (
+    *_HTTP_STATUS_ERROR_TYPES,
+    *_MCP_HTTP_STATUS_ERROR_TYPES,
+)
 
 import json
 
@@ -71,55 +87,62 @@ from adcp.validation.schema_validator import SchemaValidationError, format_issue
 _MAX_TEXT_SIZE_BYTES = 1_048_576  # 1MB cap on text items before JSON.parse
 
 
-def _make_hardened_mcp_http_factory() -> Callable[..., httpx.AsyncClient]:
+def _make_hardened_mcp_http_factory() -> Callable[..., Any]:
     """Build an MCP HTTP client factory that ignores proxy environment variables."""
 
     def factory(
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
+        timeout: Any = None,
+        auth: Any = None,
         **extra: Any,
-    ) -> httpx.AsyncClient:
+    ) -> Any:
         has_sensitive_request_state = bool(headers) or auth is not None
         kwargs: dict[str, Any] = {
             **extra,
             "follow_redirects": not has_sensitive_request_state,
             "trust_env": False,
         }
-        if timeout is None:
-            kwargs["timeout"] = _httpx.Timeout(
-                MCP_DEFAULT_TIMEOUT, read=MCP_DEFAULT_SSE_READ_TIMEOUT
-            )
-        else:
-            kwargs["timeout"] = timeout
+        kwargs["timeout"] = _coerce_mcp_timeout(timeout)
         if headers is not None:
             kwargs["headers"] = headers
         if auth is not None:
             kwargs["auth"] = auth
-        return _httpx.AsyncClient(**kwargs)
+        return _mcp_httpx.AsyncClient(**kwargs)
 
     return factory
 
 
-def _make_signing_http_factory(
-    hook: Callable[[httpx.Request], Awaitable[None]],
-) -> Callable[..., httpx.AsyncClient]:
-    """Build an ``httpx_client_factory`` that installs a signing request hook.
+def _coerce_mcp_timeout(timeout: Any) -> Any:
+    if timeout is None:
+        return _mcp_httpx.Timeout(MCP_DEFAULT_TIMEOUT, read=MCP_DEFAULT_SSE_READ_TIMEOUT)
+    if isinstance(timeout, _mcp_httpx.Timeout):
+        return timeout
+    connect = getattr(timeout, "connect", None)
+    read = getattr(timeout, "read", None)
+    write = getattr(timeout, "write", None)
+    pool = getattr(timeout, "pool", None)
+    if all(value is not None for value in (connect, read, write, pool)):
+        return _mcp_httpx.Timeout(connect=connect, read=read, write=write, pool=pool)
+    return timeout
 
-    ``streamablehttp_client`` accepts a factory with signature
-    ``(headers, timeout, auth) -> httpx.AsyncClient``. Our factory forwards
-    those kwargs, registers the signing hook as an httpx request event
-    hook, and disables redirect following: an RFC 9421 signature binds the
-    original ``@authority``, so a 302 to a different host would send the
-    signed request onward with a stale authority and fail verification.
+
+def _make_signing_http_factory(
+    hook: Callable[[Any], Awaitable[None]],
+) -> Callable[..., Any]:
+    """Build an MCP HTTP client factory that installs a signing request hook.
+
+    MCP SDK v2 uses ``httpx2`` internally, but the signing hook only relies
+    on the request's method, URL, headers, and body attributes shared with
+    ``httpx``. Redirects stay disabled because an RFC 9421 signature binds
+    the original ``@authority``.
     """
 
     def factory(
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
+        timeout: Any = None,
+        auth: Any = None,
         **extra: Any,
-    ) -> httpx.AsyncClient:
+    ) -> Any:
         # Forward any future MCP-SDK kwargs (e.g. verify=, cert=) verbatim
         # so adding a new factory parameter upstream doesn't break signing.
         kwargs: dict[str, Any] = {
@@ -128,15 +151,74 @@ def _make_signing_http_factory(
             "event_hooks": {"request": [hook]},
             "trust_env": False,
         }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs["timeout"] = _coerce_mcp_timeout(timeout)
         if headers is not None:
             kwargs["headers"] = headers
         if auth is not None:
             kwargs["auth"] = auth
-        return _httpx.AsyncClient(**kwargs)
+        return _mcp_httpx.AsyncClient(**kwargs)
 
     return factory
+
+
+@asynccontextmanager
+async def streamablehttp_client(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: Any = None,
+    httpx_client_factory: Callable[..., Any] | None = None,
+    auth: Any = None,
+    terminate_on_close: bool = True,
+) -> Any:
+    """Compatibility wrapper matching the MCP SDK v1 streamable client shape.
+
+    MCP SDK v2's convenience client accepts a pre-built ``httpx2`` client and
+    yields only ``(read, write)``. ADCP exposes the current MCP session id, so
+    this mirrors the v2 transport setup while returning ``get_session_id`` as
+    the third tuple item used by older ADCP code.
+    """
+
+    if httpx_client_factory is None:
+        httpx_client_factory = _make_hardened_mcp_http_factory()
+
+    transport = StreamableHTTPTransport(url)
+    client = httpx_client_factory(headers=headers, timeout=timeout, auth=auth)
+
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(client)
+
+        read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
+        write_stream, write_stream_reader = create_context_streams[SessionMessage](0)
+
+        async with (
+            read_stream_writer,
+            read_stream,
+            write_stream,
+            write_stream_reader,
+            anyio.create_task_group() as tg,
+        ):
+
+            def start_get_stream() -> None:
+                tg.start_soon(transport.handle_get_stream, client, read_stream_writer)
+
+            tg.start_soon(
+                transport.post_writer,
+                client,
+                write_stream_reader,
+                read_stream_writer,
+                write_stream,
+                start_get_stream,
+                tg,
+            )
+
+            try:
+                yield read_stream, write_stream, lambda: transport.session_id
+            finally:
+                if transport.session_id and terminate_on_close:
+                    await transport.terminate_session(client)
+                tg.cancel_scope.cancel()
+        await resync_tracer()
 
 
 def _text_of(item: Any) -> str | None:
@@ -150,6 +232,14 @@ def _text_of(item: Any) -> str | None:
             return None
         text = getattr(item, "text", None)
     return text if isinstance(text, str) and text else None
+
+
+def _result_is_error(result: Any) -> bool:
+    return bool(getattr(result, "isError", getattr(result, "is_error", False)))
+
+
+def _result_structured_content(result: Any) -> Any:
+    return getattr(result, "structuredContent", getattr(result, "structured_content", None))
 
 
 def extract_adcp_success(result: Any) -> dict[str, Any] | None:
@@ -167,10 +257,10 @@ def extract_adcp_success(result: Any) -> dict[str, Any] | None:
        if it is a non-array object that is NOT ``adcp_error``-only.
     4. No structured data found — return ``None``.
     """
-    if getattr(result, "isError", False):
+    if _result_is_error(result):
         return None
 
-    sc = getattr(result, "structuredContent", None)
+    sc = _result_structured_content(result)
     if isinstance(sc, dict) and not (len(sc) == 1 and "adcp_error" in sc):
         return sc
 
@@ -194,10 +284,10 @@ def extract_adcp_error(result: Any) -> dict[str, Any] | None:
     docs/building/implementation/transport-errors.mdx. Only applies when
     ``isError`` is truthy. Returns a validated error object or ``None``.
     """
-    if not getattr(result, "isError", False):
+    if not _result_is_error(result):
         return None
 
-    sc = getattr(result, "structuredContent", None)
+    sc = _result_structured_content(result)
     if isinstance(sc, dict):
         validated = _validate_adcp_error(sc.get("adcp_error"))
         if validated is not None:
@@ -365,7 +455,7 @@ class MCPAdapter(ProtocolAdapter):
         ) or (
             # HTTP errors during cleanup (if httpx is available)
             HTTPX_AVAILABLE
-            and isinstance(exc, _HTTP_STATUS_ERROR_TYPES)
+            and isinstance(exc, _ALL_HTTP_STATUS_ERROR_TYPES)
         )
 
         if is_known_cleanup_error:
@@ -602,7 +692,7 @@ class MCPAdapter(ProtocolAdapter):
                 _signing_operation.reset(signing_token)
 
             # Check if this is an error response
-            is_error = hasattr(result, "isError") and result.isError
+            is_error = _result_is_error(result)
 
             # Extract human-readable message from content
             message_text = None
@@ -925,7 +1015,9 @@ class MCPAdapter(ProtocolAdapter):
         headers = self._http_headers()
         headers[MCP_SESSION_ID] = session_id
         timeout = _httpx.Timeout(self.agent_config.timeout)
-        httpx_client_factory = self._streamable_http_client_factory()
+        event_hooks: dict[str, list[Any]] = {}
+        if self.signing_request_hook is not None:
+            event_hooks["request"] = [self.signing_request_hook]
         urls_to_try = (
             [self._connected_url] if self._connected_url is not None else self._urls_to_try()
         )
@@ -933,7 +1025,13 @@ class MCPAdapter(ProtocolAdapter):
         last_error: BaseException | None = None
         for url in urls_to_try:
             try:
-                async with httpx_client_factory(headers=headers, timeout=timeout) as client:
+                async with _httpx.AsyncClient(
+                    headers=headers,
+                    timeout=timeout,
+                    follow_redirects=False,
+                    trust_env=False,
+                    event_hooks=event_hooks,
+                ) as client:
                     response = await client.delete(url)
                 if response.is_redirect:
                     location = response.headers.get("location")
@@ -949,7 +1047,7 @@ class MCPAdapter(ProtocolAdapter):
                 if current_session_id == session_id:
                     await self._cleanup_failed_connection("after explicit MCP session close")
                 return
-            except _HTTP_STATUS_ERROR_TYPES as exc:
+            except _ALL_HTTP_STATUS_ERROR_TYPES as exc:
                 last_error = exc
                 # Keep fallback behavior symmetrical with session initialization:
                 # a 404/405 on one candidate usually means "try the slash variant".

--- a/src/adcp/server/mcp_sessions.py
+++ b/src/adcp/server/mcp_sessions.py
@@ -19,8 +19,15 @@ from uuid import uuid4
 
 import anyio
 from anyio.abc import TaskStatus
+from mcp.server.auth.middleware.bearer_auth import (
+    AuthenticatedUser,
+    authorization_context,
+)
+from mcp.server.runner import serve_loop
 from mcp.server.streamable_http import MCP_SESSION_ID_HEADER, StreamableHTTPServerTransport
-from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.streamable_http_manager import (
+    StreamableHTTPSessionManager,
+)
 from mcp.types import INVALID_REQUEST, ErrorData, JSONRPCError
 from starlette.requests import Request
 from starlette.responses import Response
@@ -125,15 +132,35 @@ class ADCPStreamableHTTPSessionManager(StreamableHTTPSessionManager):
     ) -> None:
         """Process a stateful request with ADCP max-session enforcement.
 
-        This mirrors upstream MCP 1.27.x with the cap check inserted
+        This mirrors upstream MCP 2.x with the cap check inserted
         under ``_session_creation_lock`` and bookkeeping attached to the
         session create / cleanup points.
         """
         request = Request(scope, receive)
         request_mcp_session_id = request.headers.get(MCP_SESSION_ID_HEADER)
+        user = scope.get("user")
+        requestor = authorization_context(user) if isinstance(user, AuthenticatedUser) else None
 
         if request_mcp_session_id is not None and request_mcp_session_id in self._server_instances:
             transport = self._server_instances[request_mcp_session_id]
+            if requestor != self._session_owners.get(request_mcp_session_id):
+                logger.warning(
+                    "Rejecting request for session %s: credential does not match the one that "
+                    "created the session",
+                    request_mcp_session_id[:64],
+                )
+                error_body = JSONRPCError(
+                    jsonrpc="2.0",
+                    id=None,
+                    error=ErrorData(code=INVALID_REQUEST, message="Session not found"),
+                )
+                response = Response(
+                    error_body.model_dump_json(by_alias=True, exclude_unset=True),
+                    status_code=HTTPStatus.NOT_FOUND,
+                    media_type="application/json",
+                )
+                await response(scope, receive, send)
+                return
             logger.debug("Session already exists, handling request directly")
             self._session_last_seen_at[request_mcp_session_id] = time.monotonic()
             if transport.idle_scope is not None and self.session_idle_timeout is not None:
@@ -141,6 +168,7 @@ class ADCPStreamableHTTPSessionManager(StreamableHTTPSessionManager):
             await transport.handle_request(scope, receive, send)
             if transport.is_terminated:
                 self._server_instances.pop(request_mcp_session_id, None)
+                self._session_owners.pop(request_mcp_session_id, None)
                 self._forget_session(request_mcp_session_id)
             return
 
@@ -169,6 +197,8 @@ class ADCPStreamableHTTPSessionManager(StreamableHTTPSessionManager):
                 )
 
                 assert http_transport.mcp_session_id is not None
+                if requestor is not None:
+                    self._session_owners[http_transport.mcp_session_id] = requestor
                 self._server_instances[http_transport.mcp_session_id] = http_transport
                 self._remember_session(http_transport.mcp_session_id)
                 logger.info("Created new MCP stateful transport")
@@ -189,17 +219,19 @@ class ADCPStreamableHTTPSessionManager(StreamableHTTPSessionManager):
                                 http_transport.idle_scope = idle_scope
 
                             with idle_scope:
-                                await self.app.run(
+                                await serve_loop(
+                                    self.app,
                                     read_stream,
                                     write_stream,
-                                    self.app.create_initialization_options(),
-                                    stateless=False,
+                                    lifespan_state=self._lifespan_state,
+                                    session_id=http_transport.mcp_session_id,
                                 )
 
                             if idle_scope.cancelled_caught:
                                 assert http_transport.mcp_session_id is not None
                                 logger.info("MCP stateful session idle timeout")
                                 self._server_instances.pop(http_transport.mcp_session_id, None)
+                                self._session_owners.pop(http_transport.mcp_session_id, None)
                                 self._forget_session(http_transport.mcp_session_id)
                                 await http_transport.terminate()
                         except Exception:
@@ -215,6 +247,7 @@ class ADCPStreamableHTTPSessionManager(StreamableHTTPSessionManager):
                                     "from active instances."
                                 )
                                 del self._server_instances[http_transport.mcp_session_id]
+                                self._session_owners.pop(http_transport.mcp_session_id, None)
                                 self._forget_session(http_transport.mcp_session_id)
 
                 task_group = getattr(self, "_task_group", None)

--- a/src/adcp/server/serve.py
+++ b/src/adcp/server/serve.py
@@ -23,10 +23,13 @@ import os
 import sys
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass
+from types import MethodType
 from typing import TYPE_CHECKING, Any, Literal
 
 logger = logging.getLogger("adcp.server")
+_ADCP_MCP_REQUEST_CONTEXT: ContextVar[Any] = ContextVar("adcp_mcp_request_context")
 
 from adcp.server._hooks import PreValidationHooks
 from adcp.server.base import ADCPHandler, ToolContext
@@ -346,22 +349,21 @@ def _get_starlette_request_for_dispatch() -> Any:
     """Return the Starlette ``Request`` for the in-flight MCP tool call, if
     any — else ``None``.
 
-    The MCP lowlevel server stashes the originating ``Request`` in a
-    contextvar (``mcp.server.lowlevel.server.request_ctx``) for the
-    duration of each dispatched request, in both stateless and stateful
-    modes. The contextvar lives in the dispatch sub-task that the
-    session task spawned (``tg.start_soon(_handle_message, ...)``), so
-    the value reachable here is the originating request — not the
-    session-creation request — even when the streamable-http transport
-    holds a long-lived session task.
-
     Returns ``None`` when called outside an MCP dispatch (e.g. from the
     server-builder smoke tests, or from A2A's executor which has its
     own context channel via ``ServerCallContext``).
     """
     try:
-        from mcp.server.lowlevel.server import request_ctx
-    except ImportError:  # pragma: no cover — mcp pin guarantees this
+        return _ADCP_MCP_REQUEST_CONTEXT.get()
+    except LookupError:
+        pass
+
+    # MCP SDK v1 exposed this contextvar. MCP SDK v2 removed it, but keep
+    # the fallback so external test harnesses that still install it continue
+    # to work.
+    try:
+        from mcp.server.lowlevel.server import request_ctx  # type: ignore[attr-defined]
+    except ImportError:
         return None
     try:
         ctx = request_ctx.get()
@@ -2138,6 +2140,30 @@ def _expand_allowed_hosts(hosts: Sequence[str]) -> list[str]:
     return result
 
 
+class _ADCPMCPSettingsProxy:
+    """Mutable compatibility wrapper around MCP v2's pydantic settings."""
+
+    def __init__(self, upstream: Any) -> None:
+        object.__setattr__(self, "_upstream", upstream)
+        object.__setattr__(self, "_extras", {})
+
+    def __getattr__(self, name: str) -> Any:
+        extras = object.__getattribute__(self, "_extras")
+        if name in extras:
+            return extras[name]
+        return getattr(object.__getattribute__(self, "_upstream"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        upstream = object.__getattribute__(self, "_upstream")
+        try:
+            setattr(upstream, name, value)
+        except ValueError:
+            object.__getattribute__(self, "_extras")[name] = value
+
+    def __repr__(self) -> str:
+        return repr(object.__getattribute__(self, "_upstream"))
+
+
 def create_mcp_server(
     handler: ADCPHandler[Any],
     *,
@@ -2305,19 +2331,36 @@ def create_mcp_server(
         >>> app.add_middleware(MyAuthMiddleware)  # sets the ContextVars
         >>> # run via uvicorn
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
+    from mcp.server.transport_security import TransportSecuritySettings
 
     resolved_port = port or int(os.environ.get("PORT", "3001"))
     resolved_host = host if host is not None else (os.environ.get("ADCP_HOST") or "0.0.0.0")
-    mcp = FastMCP(name, instructions=instructions, port=resolved_port)
-    mcp.settings.host = resolved_host
+    mcp: Any = MCPServer(name, instructions=instructions)
+    mcp.settings = _ADCPMCPSettingsProxy(mcp.settings)
+    object.__setattr__(mcp.settings, "host", resolved_host)
+    object.__setattr__(mcp.settings, "port", resolved_port)
     if not streaming_responses:
-        # FastMCP's SSE-internal streaming default has an upstream bug
-        # that drops the ASGI response without completing; AdCP tools
-        # return one complete envelope per request anyway, so JSON
-        # response mode is both safer and semantically correct.
-        mcp.settings.json_response = True
-    mcp.settings.stateless_http = stateless_http
+        object.__setattr__(mcp.settings, "json_response", True)
+    else:
+        object.__setattr__(mcp.settings, "json_response", False)
+    object.__setattr__(mcp.settings, "stateless_http", stateless_http)
+    object.__setattr__(
+        mcp.settings,
+        "transport_security",
+        TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
+            allowed_origins=[
+                "http://127.0.0.1:*",
+                "http://localhost:*",
+                "http://[::1]:*",
+            ],
+        ),
+    )
+    object.__setattr__(mcp.settings, "session_idle_timeout", session_idle_timeout)
+    object.__setattr__(mcp.settings, "max_active_sessions", max_active_sessions)
+    object.__setattr__(mcp.settings, "retry_interval", None)
     # FastMCP's TransportSecurityMiddleware enforces DNS-rebinding
     # protection: the default ``allowed_hosts`` accepts only loopback
     # patterns (``127.0.0.1:*``, ``localhost:*``, ``[::1]:*``). Adopters
@@ -2339,10 +2382,6 @@ def create_mcp_server(
         or allowed_hosts is not None
         or allowed_origins is not None
     ):
-        from mcp.server.transport_security import TransportSecuritySettings
-
-        if mcp.settings.transport_security is None:
-            mcp.settings.transport_security = TransportSecuritySettings()
         ts = mcp.settings.transport_security
         if enable_dns_rebinding_protection is not None:
             ts.enable_dns_rebinding_protection = enable_dns_rebinding_protection
@@ -2364,37 +2403,136 @@ def create_mcp_server(
         pre_validation_hooks=pre_validation_hooks,
         response_enhancer=response_enhancer,
     )
-    # Pre-create the StreamableHTTPSessionManager so we can pass
-    # ``session_idle_timeout`` and ADCP's session safety knobs —
-    # FastMCP's settings don't expose these as of
-    # mcp 1.27.x. ``streamable_http_app()`` lazy-creates the manager only
-    # if ``_session_manager`` is ``None``, so populating it here is the
-    # extension point. Reaches into FastMCP private attrs ``_mcp_server``,
-    # ``_event_store``, ``_retry_interval`` to mirror upstream's own
-    # constructor call — guarded by the ``mcp<2.0`` pin since v2 may
-    # rename these.
     if session_idle_timeout is not None and session_idle_timeout <= 0:
         raise ValueError(
             f"session_idle_timeout must be positive (got {session_idle_timeout!r}); "
             "set None to disable reaping."
         )
-    # Suppress the timeout in stateless mode — upstream raises
-    # ``RuntimeError`` if both are set. Silent because ``stateless_http=True,
-    # session_idle_timeout=1800.0`` is the default combination and would
-    # warn on every server boot otherwise. Adopters who explicitly want a
-    # timeout should set ``stateless_http=False``.
-    idle_timeout = None if mcp.settings.stateless_http else session_idle_timeout
-    mcp._session_manager = ADCPStreamableHTTPSessionManager(
-        app=mcp._mcp_server,
-        event_store=mcp._event_store,
-        retry_interval=mcp._retry_interval,
-        json_response=mcp.settings.json_response,
-        stateless=mcp.settings.stateless_http,
-        security_settings=mcp.settings.transport_security,
-        session_idle_timeout=idle_timeout,
-        max_active_sessions=max_active_sessions,
-    )
+    _install_adcp_mcp_transport_methods(mcp)
+    mcp._session_manager = _create_adcp_mcp_session_manager(mcp)
     return mcp
+
+
+def _create_adcp_mcp_session_manager(
+    mcp: Any, **overrides: Any
+) -> ADCPStreamableHTTPSessionManager:
+    stateless = overrides.get("stateless_http", getattr(mcp.settings, "stateless_http", False))
+    idle_timeout = overrides.get(
+        "session_idle_timeout", getattr(mcp.settings, "session_idle_timeout", None)
+    )
+    if stateless:
+        idle_timeout = None
+    return ADCPStreamableHTTPSessionManager(
+        app=mcp._lowlevel_server,
+        event_store=overrides.get("event_store", None),
+        retry_interval=overrides.get(
+            "retry_interval", getattr(mcp.settings, "retry_interval", None)
+        ),
+        json_response=overrides.get("json_response", getattr(mcp.settings, "json_response", False)),
+        stateless=stateless,
+        security_settings=overrides.get(
+            "transport_security", getattr(mcp.settings, "transport_security", None)
+        ),
+        session_idle_timeout=idle_timeout,
+        max_active_sessions=getattr(mcp.settings, "max_active_sessions", None),
+        max_request_body_size=overrides.get("max_request_body_size", 4_194_304),
+    )
+
+
+def _install_adcp_mcp_transport_methods(mcp: Any) -> None:
+    def streamable_http_app(
+        self: Any,
+        *,
+        streamable_http_path: str = "/mcp",
+        json_response: bool | None = None,
+        stateless_http: bool | None = None,
+        event_store: Any = None,
+        retry_interval: int | None = None,
+        max_request_body_size: int = 4_194_304,
+        transport_security: Any = None,
+        host: str | None = None,
+    ) -> Any:
+        from mcp.server.streamable_http_manager import StreamableHTTPASGIApp
+        from mcp.server.transport_security import TransportSecuritySettings
+        from starlette.applications import Starlette
+        from starlette.requests import Request
+        from starlette.routing import Route
+
+        resolved_host = host if host is not None else getattr(self.settings, "host", "127.0.0.1")
+        resolved_transport_security = (
+            transport_security
+            if transport_security is not None
+            else getattr(self.settings, "transport_security", None)
+        )
+        if resolved_transport_security is None and resolved_host in (
+            "127.0.0.1",
+            "localhost",
+            "::1",
+        ):
+            resolved_transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
+                allowed_origins=[
+                    "http://127.0.0.1:*",
+                    "http://localhost:*",
+                    "http://[::1]:*",
+                ],
+            )
+
+        manager = _create_adcp_mcp_session_manager(
+            self,
+            event_store=event_store,
+            retry_interval=retry_interval,
+            json_response=(
+                getattr(self.settings, "json_response", False)
+                if json_response is None
+                else json_response
+            ),
+            stateless_http=(
+                getattr(self.settings, "stateless_http", False)
+                if stateless_http is None
+                else stateless_http
+            ),
+            transport_security=resolved_transport_security,
+            max_request_body_size=max_request_body_size,
+        )
+        self._session_manager = manager
+        streamable_http = StreamableHTTPASGIApp(manager)
+
+        class ADCPStreamableHTTPASGIApp:
+            async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+                token = _ADCP_MCP_REQUEST_CONTEXT.set(Request(scope, receive))
+                try:
+                    await streamable_http(scope, receive, send)
+                finally:
+                    _ADCP_MCP_REQUEST_CONTEXT.reset(token)
+
+        return Starlette(
+            debug=getattr(self.settings, "debug", False),
+            routes=[Route(streamable_http_path, endpoint=ADCPStreamableHTTPASGIApp())],
+            lifespan=lambda app: manager.run(),
+        )
+
+    def run(self: Any, transport: str = "stdio", **kwargs: Any) -> None:
+        if transport == "streamable-http":
+            kwargs.setdefault("host", getattr(self.settings, "host", "127.0.0.1"))
+            kwargs.setdefault("port", int(getattr(self.settings, "port", 8000)))
+            kwargs.setdefault("json_response", getattr(self.settings, "json_response", False))
+            kwargs.setdefault("stateless_http", getattr(self.settings, "stateless_http", False))
+            kwargs.setdefault(
+                "transport_security", getattr(self.settings, "transport_security", None)
+            )
+        elif transport == "sse":
+            kwargs.setdefault("host", getattr(self.settings, "host", "127.0.0.1"))
+            kwargs.setdefault("port", int(getattr(self.settings, "port", 8000)))
+            kwargs.setdefault(
+                "transport_security", getattr(self.settings, "transport_security", None)
+            )
+        type(self).run(self, transport=transport, **kwargs)
+        return None
+
+    mcp.streamable_http_app = MethodType(streamable_http_app, mcp)
+    mcp.run = MethodType(run, mcp)
 
 
 def _register_handler_tools(
@@ -2409,7 +2547,7 @@ def _register_handler_tools(
     pre_validation_hooks: PreValidationHooks | None = None,
     response_enhancer: ResponseEnhancer | None = None,
 ) -> None:
-    """Register all ADCP tools from a handler onto a FastMCP server."""
+    """Register all ADCP tools from a handler onto an MCP server."""
     # Freeze middleware ordering at registration time. Tuple both guards
     # against a mutable list being reshuffled mid-request and matches the
     # A2A executor's handling.
@@ -2468,15 +2606,15 @@ def _register_tool(
     output_schema: dict[str, Any] | None = None,
     response_enhancer: ResponseEnhancer | None = None,
 ) -> None:
-    """Register a single ADCP tool on a FastMCP server.
+    """Register a single ADCP tool on an MCP server.
 
     Creates a Tool with a permissive arg model that accepts any fields,
     then overrides the advertised schema with the Pydantic-generated one.
     This ensures MCP clients see the correct schema while the handler
     receives all parameters as a plain dict.
     """
-    from mcp.server.fastmcp.tools import Tool
-    from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
+    from mcp.server.mcpserver.tools import Tool
+    from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
     from mcp.types import CallToolResult
     from pydantic import ConfigDict
 
@@ -2624,7 +2762,7 @@ def _register_tool(
         """
 
         def convert_result(self, result: Any) -> Any:
-            if isinstance(result, CallToolResult) and result.isError:
+            if isinstance(result, CallToolResult) and result.is_error:
                 return result
             return super().convert_result(result)
 

--- a/src/adcp/server/test_controller.py
+++ b/src/adcp/server/test_controller.py
@@ -1029,8 +1029,8 @@ def register_test_controller(
         mcp.run(transport="streamable-http")
     """
 
-    from mcp.server.fastmcp.tools import Tool
-    from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
+    from mcp.server.mcpserver.tools import Tool
+    from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
     from pydantic import ConfigDict
 
     from adcp.server.base import ToolContext as _ToolContext

--- a/src/adcp/server/translate.py
+++ b/src/adcp/server/translate.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import urlparse
 
 from a2a.utils.errors import A2AError, InternalError, InvalidParamsError
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import CallToolResult, TextContent
 
 from adcp.error_sanitization import sanitize_error_details
@@ -259,8 +259,8 @@ def build_mcp_error_result(
 
     return CallToolResult(
         content=[TextContent(type="text", text=text)],
-        structuredContent=structured,
-        isError=True,
+        structured_content=structured,
+        is_error=True,
     )
 
 
@@ -277,7 +277,7 @@ def translate_error(
         except ADCPError as e:
             raise translate_error(e, protocol="mcp")
 
-    For MCP, returns ``ToolError`` (from ``mcp.server.fastmcp``).
+    For MCP, returns ``ToolError`` (from ``mcp.server.mcpserver``).
     For A2A, returns an :class:`~a2a.utils.errors.A2AError` subclass:
     :class:`~a2a.utils.errors.InvalidParamsError` for correctable errors
     (client can fix) or :class:`~a2a.utils.errors.InternalError` for

--- a/src/adcp/testing/harness.py
+++ b/src/adcp/testing/harness.py
@@ -163,7 +163,7 @@ class SellerTestClient:
         # The plain-dict branch is defensive against FastMCP flattening the
         # success return in a future version.
         if isinstance(raw_result, CallToolResult):
-            structured: dict[str, Any] = raw_result.structuredContent or {}
+            structured: dict[str, Any] = raw_result.structured_content or {}
         elif isinstance(raw_result, (tuple, list)) and len(raw_result) == 2:
             success_dict: Any = raw_result[1]
             structured = dict(success_dict) if success_dict is not None else {}

--- a/tests/conformance/signing/test_autosign_mcp.py
+++ b/tests/conformance/signing/test_autosign_mcp.py
@@ -16,6 +16,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import httpx2
 import pytest
 
 from adcp.client import ADCPClient
@@ -74,7 +75,7 @@ def test_factory_accepts_none_args() -> None:
     # accept that shape without raising.
     factory = _make_signing_http_factory(_dummy_hook)
     client = factory()
-    assert isinstance(client, httpx.AsyncClient)
+    assert isinstance(client, httpx2.AsyncClient)
 
 
 # -- SSE transport warning ----------------------------------------------

--- a/tests/test_mcp_structured_error.py
+++ b/tests/test_mcp_structured_error.py
@@ -31,28 +31,28 @@ class TestBuildMcpErrorResultShape:
         exc = DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
         result = build_mcp_error_result(exc)
         assert isinstance(result, CallToolResult)
-        assert result.isError is True
+        assert result.is_error is True
 
     def test_structured_content_keyed_under_adcp_error(self):
         exc = DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
         result = build_mcp_error_result(exc)
-        assert result.structuredContent is not None
-        assert "adcp_error" in result.structuredContent
+        assert result.structured_content is not None
+        assert "adcp_error" in result.structured_content
 
     def test_structured_content_carries_code(self):
         exc = DecisioningAdcpError("MEDIA_BUY_NOT_FOUND", message="no such buy")
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
+        assert result.structured_content["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
 
     def test_structured_content_carries_message(self):
         exc = DecisioningAdcpError("PACKAGE_NOT_FOUND", message="package gone")
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["message"] == "package gone"
+        assert result.structured_content["adcp_error"]["message"] == "package gone"
 
     def test_structured_content_carries_recovery(self):
         exc = DecisioningAdcpError("BUDGET_TOO_LOW", message="under floor", recovery="correctable")
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["recovery"] == "correctable"
+        assert result.structured_content["adcp_error"]["recovery"] == "correctable"
 
     def test_text_fallback_present_in_content(self):
         exc = DecisioningAdcpError(
@@ -71,12 +71,12 @@ class TestBuildMcpErrorResultOptionalFields:
     def test_field_populated_when_present(self):
         exc = DecisioningAdcpError("INVALID_REQUEST", message="bad budget", field="total_budget")
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["field"] == "total_budget"
+        assert result.structured_content["adcp_error"]["field"] == "total_budget"
 
     def test_field_omitted_when_absent(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         result = build_mcp_error_result(exc)
-        assert "field" not in result.structuredContent["adcp_error"]
+        assert "field" not in result.structured_content["adcp_error"]
 
     def test_suggestion_populated_when_present(self):
         exc = DecisioningAdcpError(
@@ -85,23 +85,23 @@ class TestBuildMcpErrorResultOptionalFields:
             suggestion="Increase to at least $0.50",
         )
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["suggestion"] == "Increase to at least $0.50"
+        assert result.structured_content["adcp_error"]["suggestion"] == "Increase to at least $0.50"
 
     def test_suggestion_omitted_when_absent(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         result = build_mcp_error_result(exc)
-        assert "suggestion" not in result.structuredContent["adcp_error"]
+        assert "suggestion" not in result.structured_content["adcp_error"]
 
     def test_details_populated_when_present(self):
         details: dict[str, Any] = {"validation_errors": [{"path": "x", "msg": "bad"}]}
         exc = DecisioningAdcpError("VALIDATION_ERROR", message="bad fields", details=details)
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["details"] == details
+        assert result.structured_content["adcp_error"]["details"] == details
 
     def test_details_omitted_when_absent(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         result = build_mcp_error_result(exc)
-        assert "details" not in result.structuredContent["adcp_error"]
+        assert "details" not in result.structured_content["adcp_error"]
 
     def test_retry_after_populated_when_present(self):
         exc = DecisioningAdcpError(
@@ -111,7 +111,7 @@ class TestBuildMcpErrorResultOptionalFields:
             retry_after=30,
         )
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["retry_after"] == 30
+        assert result.structured_content["adcp_error"]["retry_after"] == 30
 
 
 class TestBuildMcpErrorResultExceptionTypes:
@@ -121,11 +121,11 @@ class TestBuildMcpErrorResultExceptionTypes:
         err = Error(code="TERMS_REJECTED", message="terms unacceptable")
         exc = ADCPTaskError("create_media_buy", [err])
         result = build_mcp_error_result(exc)
-        assert result.isError is True
-        assert result.structuredContent["adcp_error"]["code"] == "TERMS_REJECTED"
+        assert result.is_error is True
+        assert result.structured_content["adcp_error"]["code"] == "TERMS_REJECTED"
         # ADCPTaskError prefixes the operation; the original Error.message
         # text is preserved in the projected message.
-        assert "terms unacceptable" in result.structuredContent["adcp_error"]["message"]
+        assert "terms unacceptable" in result.structured_content["adcp_error"]["message"]
 
     def test_handles_error_model(self):
         err = Error(
@@ -134,13 +134,13 @@ class TestBuildMcpErrorResultExceptionTypes:
             field="packages[0].budget",
         )
         result = build_mcp_error_result(err)
-        assert result.structuredContent["adcp_error"]["code"] == "VALIDATION_ERROR"
-        assert result.structuredContent["adcp_error"]["field"] == "packages[0].budget"
+        assert result.structured_content["adcp_error"]["code"] == "VALIDATION_ERROR"
+        assert result.structured_content["adcp_error"]["field"] == "packages[0].budget"
 
     def test_handles_plain_adcp_error_falls_back_to_internal(self):
         exc = ADCPError("unexpected")
         result = build_mcp_error_result(exc)
-        assert result.structuredContent["adcp_error"]["code"] == "INTERNAL_ERROR"
+        assert result.structured_content["adcp_error"]["code"] == "INTERNAL_ERROR"
 
     def test_rejects_unknown_type(self):
         with pytest.raises(TypeError):
@@ -160,7 +160,7 @@ async def test_adcp_error_from_handler_projects_to_structured_content():
     Exercises the full FastMCP path: tool dispatch, fn_metadata.convert_result,
     lowlevel handler short-circuit on CallToolResult instances.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
     from adcp.server.serve import _register_tool
 
@@ -173,7 +173,7 @@ async def test_adcp_error_from_handler_projects_to_structured_content():
             details={"media_buy_id": "mb-404"},
         )
 
-    mcp = FastMCP("test-structured-error")
+    mcp = MCPServer("test-structured-error")
     _register_tool(
         mcp,
         "get_media_buy_delivery",
@@ -185,13 +185,13 @@ async def test_adcp_error_from_handler_projects_to_structured_content():
     result = await mcp.call_tool("get_media_buy_delivery", {"media_buy_id": "mb-404"})
 
     assert isinstance(result, CallToolResult)
-    assert result.isError is True
-    assert result.structuredContent is not None
-    assert result.structuredContent["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
-    assert result.structuredContent["adcp_error"]["message"] == "No media buy with id mb-404"
-    assert result.structuredContent["adcp_error"]["recovery"] == "terminal"
-    assert result.structuredContent["adcp_error"]["field"] == "media_buy_id"
-    assert result.structuredContent["adcp_error"]["details"] == {"media_buy_id": "mb-404"}
+    assert result.is_error is True
+    assert result.structured_content is not None
+    assert result.structured_content["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
+    assert result.structured_content["adcp_error"]["message"] == "No media buy with id mb-404"
+    assert result.structured_content["adcp_error"]["recovery"] == "terminal"
+    assert result.structured_content["adcp_error"]["field"] == "media_buy_id"
+    assert result.structured_content["adcp_error"]["details"] == {"media_buy_id": "mb-404"}
     # Text fallback preserved.
     assert any(
         "MEDIA_BUY_NOT_FOUND" in c.text for c in result.content if isinstance(c, TextContent)
@@ -213,14 +213,14 @@ async def test_specific_codes_round_trip(code: str, recovery: str):
     storyboard runner's ``/adcp_error/code`` JSON-pointer assertion
     resolves to the actual code, not ``mcp_error``.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
     from adcp.server.serve import _register_tool
 
     async def caller(_kwargs: dict[str, Any], *, context: Any = None) -> Any:
         raise DecisioningAdcpError(code, message="test", recovery=recovery)
 
-    mcp = FastMCP("test-codes")
+    mcp = MCPServer("test-codes")
     _register_tool(
         mcp,
         "test_tool",
@@ -231,9 +231,9 @@ async def test_specific_codes_round_trip(code: str, recovery: str):
 
     result = await mcp.call_tool("test_tool", {})
     assert isinstance(result, CallToolResult)
-    assert result.isError is True
-    assert result.structuredContent["adcp_error"]["code"] == code
-    assert result.structuredContent["adcp_error"]["recovery"] == recovery
+    assert result.is_error is True
+    assert result.structured_content["adcp_error"]["code"] == code
+    assert result.structured_content["adcp_error"]["recovery"] == recovery
 
 
 @pytest.mark.asyncio
@@ -241,7 +241,7 @@ async def test_adcp_task_error_round_trips_through_register_tool():
     """ADCPError subclasses (ADCPTaskError, IdempotencyConflictError, etc.)
     also reach the wire as structured envelopes, not ToolError text.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
     from adcp.server.serve import _register_tool
 
@@ -249,7 +249,7 @@ async def test_adcp_task_error_round_trips_through_register_tool():
         err = Error(code="IDEMPOTENCY_CONFLICT", message="payload differs")
         raise ADCPTaskError("create_media_buy", [err])
 
-    mcp = FastMCP("test-task-error")
+    mcp = MCPServer("test-task-error")
     _register_tool(
         mcp,
         "create_media_buy",
@@ -260,8 +260,8 @@ async def test_adcp_task_error_round_trips_through_register_tool():
 
     result = await mcp.call_tool("create_media_buy", {})
     assert isinstance(result, CallToolResult)
-    assert result.isError is True
-    assert result.structuredContent["adcp_error"]["code"] == "IDEMPOTENCY_CONFLICT"
+    assert result.is_error is True
+    assert result.structured_content["adcp_error"]["code"] == "IDEMPOTENCY_CONFLICT"
 
 
 class TestBuildMcpErrorResultContextEcho:
@@ -276,25 +276,25 @@ class TestBuildMcpErrorResultContextEcho:
     def test_no_params_omits_context_from_envelope(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         result = build_mcp_error_result(exc)
-        assert "context" not in result.structuredContent
+        assert "context" not in result.structured_content
 
     def test_params_without_context_omits_context_from_envelope(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         result = build_mcp_error_result(exc, params={"media_buy_id": "mb-1"})
-        assert "context" not in result.structuredContent
+        assert "context" not in result.structured_content
 
     def test_params_with_context_echoes_into_envelope(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         ctx = {"correlation_id": "abc-123", "buyer_trace": "trace-xyz"}
         result = build_mcp_error_result(exc, params={"media_buy_id": "mb-1", "context": ctx})
-        assert result.structuredContent.get("context") == ctx
+        assert result.structured_content.get("context") == ctx
 
     def test_echoed_context_is_sibling_of_adcp_error_not_inside_it(self):
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         ctx = {"correlation_id": "abc-123"}
         result = build_mcp_error_result(exc, params={"context": ctx})
-        assert "context" in result.structuredContent
-        assert "context" not in result.structuredContent["adcp_error"]
+        assert "context" in result.structured_content
+        assert "context" not in result.structured_content["adcp_error"]
 
     def test_oversized_context_silently_dropped(self):
         """``inject_context``'s 64KB cap applies on the error path too —
@@ -302,7 +302,7 @@ class TestBuildMcpErrorResultContextEcho:
         exc = DecisioningAdcpError("INTERNAL_ERROR", message="oops")
         huge = {"junk": "A" * (65 * 1024)}
         result = build_mcp_error_result(exc, params={"context": huge})
-        assert "context" not in result.structuredContent
+        assert "context" not in result.structured_content
 
 
 @pytest.mark.asyncio
@@ -311,7 +311,7 @@ async def test_context_echo_round_trips_through_register_tool():
     AdcpError raise produces a wire response with that same ``context``
     echoed alongside ``adcp_error`` in structuredContent.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
     from adcp.server.serve import _register_tool
 
@@ -322,7 +322,7 @@ async def test_context_echo_round_trips_through_register_tool():
             recovery="terminal",
         )
 
-    mcp = FastMCP("test-context-echo")
+    mcp = MCPServer("test-context-echo")
     _register_tool(
         mcp,
         "get_media_buy_delivery",
@@ -338,9 +338,9 @@ async def test_context_echo_round_trips_through_register_tool():
     )
 
     assert isinstance(result, CallToolResult)
-    assert result.isError is True
-    assert result.structuredContent["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
-    assert result.structuredContent.get("context") == request_context
+    assert result.is_error is True
+    assert result.structured_content["adcp_error"]["code"] == "MEDIA_BUY_NOT_FOUND"
+    assert result.structured_content.get("context") == request_context
 
 
 @pytest.mark.asyncio
@@ -363,7 +363,7 @@ async def test_dispatcher_wrap_to_internal_error_preserves_context_echo():
     AdcpError raise. The ``caused_by`` check pins the wrap path
     specifically.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
     from adcp.server.serve import _register_tool
 
@@ -402,19 +402,19 @@ async def test_dispatcher_wrap_to_internal_error_preserves_context_echo():
         finally:
             executor.shutdown(wait=True)
 
-    mcp = FastMCP("test-562-dispatch-wrap")
+    mcp = MCPServer("test-562-dispatch-wrap")
     _register_tool(mcp, "get_products", "test", {"type": "object"}, caller)
 
     request_context = {"correlation_id": "buyer-req-562"}
     result = await mcp.call_tool("get_products", {"context": request_context})
 
     assert isinstance(result, CallToolResult)
-    assert result.isError is True
+    assert result.is_error is True
     # (1) The wrap ran — INTERNAL_ERROR with caused_by = ValueError.
-    assert result.structuredContent["adcp_error"]["code"] == "INTERNAL_ERROR"
-    assert result.structuredContent["adcp_error"]["details"]["caused_by"]["type"] == "ValueError"
+    assert result.structured_content["adcp_error"]["code"] == "INTERNAL_ERROR"
+    assert result.structured_content["adcp_error"]["details"]["caused_by"]["type"] == "ValueError"
     # (2) Context echoed end-to-end.
-    assert result.structuredContent.get("context") == request_context
+    assert result.structured_content.get("context") == request_context
 
 
 @pytest.mark.asyncio
@@ -423,14 +423,14 @@ async def test_success_path_unchanged():
     output schema. The structuredContent error bypass MUST NOT leak
     into the success path.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
     from adcp.server.serve import _register_tool
 
     async def caller(_kwargs: dict[str, Any], *, context: Any = None) -> Any:
         return {"status": "ok", "value": 42}
 
-    mcp = FastMCP("test-success")
+    mcp = MCPServer("test-success")
     _register_tool(
         mcp,
         "ok_tool",
@@ -451,6 +451,6 @@ async def test_success_path_unchanged():
     else:
         # Single-channel return: still must contain the data.
         assert result == {"status": "ok", "value": 42} or (
-            hasattr(result, "structuredContent")
-            and result.structuredContent == {"status": "ok", "value": 42}
+            hasattr(result, "structured_content")
+            and result.structured_content == {"status": "ok", "value": 42}
         )

--- a/tests/test_response_enhancer.py
+++ b/tests/test_response_enhancer.py
@@ -346,9 +346,9 @@ class TestMcpErrorPath:
             method_name="get_products",
             response_enhancer=_stamp,
         )
-        assert result.structuredContent is not None
-        assert result.structuredContent["adcp_error"]["code"] == "PERMISSION_DENIED"
-        assert result.structuredContent["enhanced"] is True
+        assert result.structured_content is not None
+        assert result.structured_content["adcp_error"]["code"] == "PERMISSION_DENIED"
+        assert result.structured_content["enhanced"] is True
 
     def test_enhancer_runs_after_context_echo_on_error(self) -> None:
         seen: dict[str, Any] = {}
@@ -376,15 +376,15 @@ class TestMcpErrorPath:
         exc = Error(code="PERMISSION_DENIED", message="no")
         with caplog.at_level("WARNING", logger="adcp.server"):
             result = build_mcp_error_result(exc, method_name="get_products", response_enhancer=boom)
-        assert result.structuredContent is not None
-        assert result.structuredContent["adcp_error"]["code"] == "PERMISSION_DENIED"
-        assert "enhanced" not in result.structuredContent
+        assert result.structured_content is not None
+        assert result.structured_content["adcp_error"]["code"] == "PERMISSION_DENIED"
+        assert "enhanced" not in result.structured_content
 
     def test_no_enhancer_leaves_error_envelope_unchanged(self) -> None:
         exc = Error(code="PERMISSION_DENIED", message="no")
         result = build_mcp_error_result(exc, method_name="get_products")
-        assert result.structuredContent is not None
-        assert "enhanced" not in result.structuredContent
+        assert result.structured_content is not None
+        assert "enhanced" not in result.structured_content
 
 
 # ===========================================================================
@@ -588,6 +588,6 @@ class TestConfigThreading:
         tool_fn = mcp._tool_manager._tools["get_products"].fn
         result = await tool_fn(brief="x", promoted_offering="y")
         assert isinstance(result, CallToolResult)
-        assert result.structuredContent is not None
-        assert result.structuredContent["adcp_error"]["code"] == "PERMISSION_DENIED"
-        assert result.structuredContent["enhanced"] is True
+        assert result.structured_content is not None
+        assert result.structured_content["adcp_error"]["code"] == "PERMISSION_DENIED"
+        assert result.structured_content["enhanced"] is True

--- a/tests/test_server_dx.py
+++ b/tests/test_server_dx.py
@@ -973,11 +973,11 @@ class TestCreateMcpServer:
 
 class TestRegisterTestController:
     def test_registers_tool(self):
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
 
         from adcp.server.test_controller import register_test_controller
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         store = MinimalStore()
         register_test_controller(mcp, store)
 

--- a/tests/test_server_idempotency.py
+++ b/tests/test_server_idempotency.py
@@ -1160,7 +1160,7 @@ class TestWireTranslation:
     async def test_mcp_conflict_translates_to_tool_error(self) -> None:
         # MCP path: serve.py's _register_tool wraps caller in try/except ADCPError
         # → translate_error → ToolError. Verify the translation chain directly.
-        from mcp.server.fastmcp.exceptions import ToolError
+        from mcp.server.mcpserver.exceptions import ToolError
 
         from adcp.exceptions import ADCPError
         from adcp.server.translate import translate_error

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from a2a.utils.errors import A2AError, InternalError, InvalidParamsError
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from adcp.exceptions import (
     ADCPAuthenticationError,


### PR DESCRIPTION
## Summary

Updates the SDK dependency to MCP Python SDK v2 and migrates the ADCP MCP client/server integration from FastMCP-era APIs to MCPServer-compatible transport and tool registration paths.

Preserves ADCP behavior for hardened MCP HTTP clients, request signing hooks, explicit session close, stateful streamable-HTTP session stats/limits, request-context propagation, and structured error envelopes under MCP v2.

Updates the focused tests and minimal MCP example for MCP v2 result field names and import paths.

## Validation

- `uv run pytest`
- `uv run pytest tests/test_mcp_stateful_session.py tests/test_protocols.py::TestMCPSessionClose tests/test_mcp_structured_error.py tests/conformance/signing/test_autosign_mcp.py -q`
- pre-commit hooks on commit: black, ruff, mypy, adopter type checks, bandit, file checks
