### PR TITLE
fix(signing): preserve a trailing empty query in @target-uri

### DIFF
--- a/src/adcp/signing/canonical.py
+++ b/src/adcp/signing/canonical.py
@@ -126,7 +126,17 @@ def canonicalize_target_uri(url: str) -> str:
         path = "/"
     # RFC 9421 §2.2.2 + RFC 7230 §5.5: effective request URI excludes the
     # fragment (client-local, never sent on wire).
-    return urlunsplit((scheme, netloc, path, parts.query, ""))
+    target = urlunsplit((scheme, netloc, path, parts.query, ""))
+    if not parts.query and "?" in url.split("#", 1)[0]:
+        # `urlsplit` maps both `/p` and `/p?` to `query == ""`, and `urlunsplit`
+        # emits no `?` for an empty string -- so the two collapse to one
+        # signature base. A signer that sent `/p?` and a verifier that
+        # reconstructs `/p` then sign different bytes for different URLs and
+        # agree, which is exactly the confusion `@target-uri` exists to prevent.
+        # The distinction has to be recovered from the raw URL because it is
+        # already lost by the time `parts` exists.
+        target += "?"
+    return target
 
 
 def canonicalize_authority(url: str) -> str:

--- a/tests/conformance/signing/test_canonicalization.py
+++ b/tests/conformance/signing/test_canonicalization.py
@@ -29,11 +29,7 @@ from tests.conformance.signing.vectors import (
 # Cases from canonicalization.json that the SDK does not yet satisfy, mapped to
 # the issue tracking each gap. Marked strict so a fix XPASSes and forces the
 # entry to be retired instead of lingering.
-KNOWN_CANONICALIZATION_GAPS: dict[str, str] = {
-    # urlunsplit() cannot distinguish "no query" from "empty query", so the
-    # trailing '?' is dropped and signer/verifier can disagree on the base.
-    "trailing-empty-query-preserved": "#979: trailing '?' with an empty query is dropped",
-}
+KNOWN_CANONICALIZATION_GAPS: dict[str, str] = {}
 
 
 def _vectors_with_expected_base() -> list[tuple[str, Path]]:


### PR DESCRIPTION
> **Stacked on #985, which is itself stacked on #980 — merge order: #980 → #985 → this.**
> Own commit: `81648470`. Everything else in the diff below belongs to #980 and #985.
> Incremental diff: https://github.com/KonstantinMirin/adcp-client-python/compare/fix/target-uri-malformed-authority...fix/trailing-empty-query

Fixes #979.

## What was wrong

`urlsplit` maps both `/p` and `/p?` to `query == ""`, and `urlunsplit` emits no `?` for an empty string. So `https://seller.example.com/p?` and `https://seller.example.com/p` produced the **same** signature base: a signer that sent `/p?` and a verifier that reconstructed `/p` signed identical bytes for different URLs and agreed — exactly the confusion `@target-uri` exists to prevent.

## The fix

The distinction is already gone by the time the split result exists, so it is recovered from the raw URL — but the fragment has to be excluded first, and that is the part worth reviewing:

| input | correct output | a plain `"?" in url` test |
|---|---|---|
| `https://e.com/p?` | `https://e.com/p?` | ✅ |
| `https://e.com/p?#frag` | `https://e.com/p?` | ✅ |
| `https://e.com/p#f?x` | `https://e.com/p` | ❌ resurrects a `?` that belongs to the fragment |

**No vector combines a fragment with a query**, so the naive test passes the conformance case and still gets the third row wrong. Splitting on `#` first is what makes it correct rather than merely green.

## Why this had to be fixed here

No downstream consumer can prove this fix. ASGI hands `query_string=b""` for both `/p` and `/p?`, so the distinction is destroyed before any verifier sees it. Same reason #977's IDN cases are producer-side. That is the argument for fixing it in the SDK against `canonicalization.json` directly rather than waiting for an adopter to demonstrate it — no adopter can.

## Ledger

Retires the last entry in `KNOWN_CANONICALIZATION_GAPS`. **All 31 canonicalization cases now pass with zero xfail and zero skip.**

The ledger *mechanism* stays in place, empty. Deleting it would re-create #975 the next time the vectors are refreshed — an empty ratchet is the point.

## Test plan

`make ci-local`: **5954 passed, 0 failed, 41 skipped, 5 xfailed** (#985's baseline: 5953 / 6). The one retired xfail becomes the one new pass.

The four remaining xfails in the signing tree are `negative/021`, `022`, `023` and `026` — all #976, which is PR B.
