### PR TITLE
fix(signing): reject malformed structured-field input at step 1

### DIFF
--- a/src/adcp/decisioning/context.py
+++ b/src/adcp/decisioning/context.py
@@ -210,6 +210,12 @@ class AuthInfo:
                 headers=dict(request.headers),
                 body=request.get_data(),
                 options=VerifyOptions(...),
+                # Pass the as-received header list when your framework has one
+                # (ASGI: ``request.headers.raw``). ``dict(request.headers)``
+                # resolves a repeated header name to a single value, so the
+                # step-1 rejection of a proxy-inserted second line cannot fire
+                # without it.
+                raw_headers=getattr(request.headers, "raw", None),
             )
             ctx.metadata["adcp.auth_info"] = AuthInfo.from_verified_signer(
                 signer, max_verified_age_s=300.0,

--- a/src/adcp/signing/_header_precheck.py
+++ b/src/adcp/signing/_header_precheck.py
@@ -1,0 +1,186 @@
+"""RFC 9421 checklist step 1: strict structured-field rejection.
+
+The verifier's later stages are permissive by design -- they resolve ambiguity
+so that well-formed-but-unusual input still verifies. That is wrong at step 1.
+Input that is *ambiguous* must be refused before anything downstream picks an
+interpretation, because "pick one" is exactly what an attacker inserting a
+second header line is counting on.
+
+The rules are a predicate table rather than an if-chain: the same predicate can
+be reused at another call site that raises a different code at a different step.
+`host_has_raw_non_ascii` is shared with `canonical` for precisely that reason --
+canonicalization rejects a malformed authority as `request_target_uri_malformed`
+at step 6, while a U-label arriving on the wire is `request_signature_header_malformed`
+at step 1. Same rule, two codes, two steps.
+
+## What "raw headers" buys, and where it does not
+
+The single-value rules below are only as strong as the header view they run
+over. Every dict view of headers resolves a repeated name to ONE value -- first
+or last depending on the framework -- so a proxy-inserted second line vanishes
+before any check runs. Passing `raw_headers` preserves the repetition and lets
+rule `repeated-line` see it.
+
+This works on ASGI/Starlette, where `request.headers.raw` is the wire order.
+It does NOT work on WSGI/Flask, and that is not fixable here: PEP 3333 folds
+repeated `HTTP_*` headers into a comma-joined string and writes `CONTENT_TYPE`
+and `CONTENT_LENGTH` to bare environ keys with last-wins and no join. The
+repetition is destroyed one layer above this SDK. A Flask `raw_headers` list
+therefore carries the same information as the mapping, and the `repeated-line`
+rule is inert there -- the comma-joined rules below still apply.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from adcp.signing.canonical import (
+    TargetUriMalformedError,
+    _split_or_reject,
+    host_has_raw_non_ascii,
+    split_structured_field,
+)
+
+#: Headers that must arrive exactly once. Each is either a singleton by RFC
+#: (`Content-Type`, RFC 9110 §8.3; `Host`, §7.2) or is a signed component whose
+#: value the signature is computed over -- where a second line would split the
+#: signed view from the parsed view even when RFC 9110 §5.3 would permit
+#: combining. Rejecting a legally-split `Signature-Input` or `Content-Digest` is
+#: a deliberate profile choice: the ambiguity it removes is worth more than the
+#: flexibility it costs, and no known producer splits them.
+_SINGLE_LINE_SIGNED_HEADERS = frozenset(
+    {"signature", "signature-input", "content-type", "content-digest", "host"}
+)
+
+#: Headers whose value must be a single entry, i.e. carry no top-level comma.
+#: `Content-Type` is a singleton by RFC 9110 §8.3, so a comma means two values
+#: were folded together regardless of whether the signature covers it.
+_SINGLE_VALUE_HEADERS = frozenset({"content-type"})
+
+
+def strict_header_precheck(
+    *,
+    headers: Mapping[str, str],
+    raw_headers: Sequence[tuple[bytes, bytes]] | None,
+    url: str,
+) -> str | None:
+    """Why this request's headers are malformed at step 1, or `None`.
+
+    Returns a reason string rather than raising so the caller owns the error
+    type and step number -- the same table is reusable at a call site that
+    raises a different code.
+    """
+    pairs = _header_pairs(headers=headers, raw_headers=raw_headers)
+
+    if raw_headers is not None:
+        seen: set[str] = set()
+        for name, _ in pairs:
+            if name in _SINGLE_LINE_SIGNED_HEADERS and name in seen:
+                return (
+                    f"{name!r} arrived on more than one header line; a repeated "
+                    "signed field is ambiguous and MUST be rejected rather than folded"
+                )
+            seen.add(name)
+
+    for name, value in pairs:
+        if name in _SINGLE_VALUE_HEADERS and len(split_structured_field(value, ",")) > 1:
+            return (
+                f"{name!r} carries more than one value; it is a singleton field "
+                "and a comma-joined value means two were folded together"
+            )
+        if name == "signature-input":
+            reason = _duplicate_dictionary_key_reason(value, "Signature-Input")
+            if reason is not None:
+                return reason
+        if name == "content-digest":
+            reason = _duplicate_dictionary_key_reason(value, "Content-Digest")
+            if reason is not None:
+                return reason
+
+    return _non_ascii_authority_reason(pairs=pairs, url=url)
+
+
+def _header_pairs(
+    *,
+    headers: Mapping[str, str],
+    raw_headers: Sequence[tuple[bytes, bytes]] | None,
+) -> list[tuple[str, str]]:
+    """Lower-cased (name, value) pairs, preferring the raw list when supplied.
+
+    The raw list is the only view that preserves a repeated header name; the
+    mapping has already resolved it. Undecodable bytes are not an error to
+    diagnose here -- they cannot match any rule, so they are skipped and left to
+    the framework.
+    """
+    if raw_headers is None:
+        return [(k.lower(), v) for k, v in headers.items()]
+    pairs: list[tuple[str, str]] = []
+    for raw_name, raw_value in raw_headers:
+        try:
+            pairs.append((raw_name.decode("latin-1").lower(), raw_value.decode("latin-1")))
+        except (UnicodeDecodeError, AttributeError):
+            continue
+    return pairs
+
+
+def _duplicate_dictionary_key_reason(value: str, header_name: str) -> str | None:
+    """RFC 8941 §3.2: a duplicate dictionary key MUST be rejected, not resolved.
+
+    "Retaining only the last value" is the other option the RFC allows, and it
+    is the one a parser reaches for by default -- `d[key] = v` in a loop. That
+    is the smuggling vector: a proxy appends a second entry with the same label
+    and a weaker covered-component set, the parser keeps the last, and the
+    signature verifies over fewer components than the producer signed.
+    """
+    keys: set[str] = set()
+    for entry in split_structured_field(value, ","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        key = entry.split("=", 1)[0].strip()
+        if not key:
+            continue
+        if key in keys:
+            return (
+                f"{header_name} carries duplicate dictionary key {key!r}; RFC 8941 §3.2 "
+                "requires rejecting rather than resolving, since resolving lets a "
+                "repeated key downgrade what was signed"
+            )
+        keys.add(key)
+    return None
+
+
+def _non_ascii_authority_reason(*, pairs: Sequence[tuple[str, str]], url: str) -> str | None:
+    """A host carrying raw non-ASCII bytes MUST be rejected, never re-normalized.
+
+    Checked against BOTH the `Host` header and the URL's authority, because
+    neither alone is sufficient: ASGI frameworks drop a non-ASCII Host when
+    building `request.url` (Starlette's `URL` falls back to `scope["server"]`
+    when the Host header fails its host regex), so the U-label survives only on
+    the header -- while the conformance vectors carry no Host header at all and
+    express the case through the URL.
+
+    Re-normalizing instead of rejecting would pick one of several legitimate
+    UTS-46 outcomes and risk disagreeing with whoever signed. Converting is the
+    producer's job.
+    """
+    for name, value in pairs:
+        if name == "host" and host_has_raw_non_ascii(value):
+            return (
+                "the Host header carries raw non-ASCII bytes; the producer must send an "
+                "A-label, and a comparer that re-normalized could disagree with the signer"
+            )
+    try:
+        netloc = _split_or_reject(url).netloc
+    except TargetUriMalformedError:
+        # A malformed authority is canonicalization's rejection to make, with
+        # its own code at its own step. Not this gate's business -- but it must
+        # not escape as an uncaught ValueError either, which is why it is caught
+        # here and handed on rather than left to propagate from a bare urlsplit.
+        return None
+    if host_has_raw_non_ascii(netloc):
+        return (
+            "the request URL's authority carries raw non-ASCII bytes; the producer must "
+            "send an A-label, and a comparer that re-normalized could disagree with the signer"
+        )
+    return None

--- a/src/adcp/signing/middleware.py
+++ b/src/adcp/signing/middleware.py
@@ -22,6 +22,29 @@ def unauthorized_response_headers(exc: SignatureVerificationError) -> dict[str, 
     return {"WWW-Authenticate": f'Signature error="{exc.code}"'}
 
 
+def _wsgi_raw_headers(request: Any) -> list[tuple[bytes, bytes]] | None:
+    """Best-effort raw header list from a WSGI request.
+
+    Deliberately weaker than the ASGI equivalent, and it cannot be otherwise:
+    PEP 3333 folds repeated `HTTP_*` headers into one comma-joined environ value
+    and writes `CONTENT_TYPE` / `CONTENT_LENGTH` to bare environ keys with
+    last-wins and no join. A second `Content-Type` line is therefore already
+    gone before any WSGI app runs. This list carries the same information as
+    `dict(request.headers)`; it exists so the comma-joined rules run over the
+    same shape on both frameworks, not because it recovers the repetition.
+
+    Returns `None` rather than raising if the headers cannot be encoded — a
+    header outside latin-1 is not something to turn a 401 into a 500 over.
+    """
+    try:
+        return [
+            (name.encode("latin-1"), value.encode("latin-1"))
+            for name, value in request.headers.items()
+        ]
+    except (AttributeError, UnicodeEncodeError):
+        return None
+
+
 def verify_flask_request(request: Any, *, options: VerifyOptions) -> VerifiedSigner:
     """Verify a Flask `request` object against the AdCP profile."""
     return verify_request_signature(
@@ -30,6 +53,7 @@ def verify_flask_request(request: Any, *, options: VerifyOptions) -> VerifiedSig
         headers=dict(request.headers),
         body=request.get_data(),
         options=options,
+        raw_headers=_wsgi_raw_headers(request),
     )
 
 
@@ -64,6 +88,14 @@ async def verify_starlette_request(request: Any, *, options: VerifyOptions) -> V
         headers=dict(request.headers),
         body=body,
         options=options,
+        # The as-received list, wire order intact. This is the arm where the
+        # step-1 repeated-line rule actually bites: `dict(request.headers)`
+        # resolves a repeated name to one value, so a proxy-inserted second
+        # `Content-Type` is invisible without it. It also carries a raw
+        # non-ASCII Host, which `str(request.url)` drops -- Starlette's `URL`
+        # falls back to `scope["server"]` when the Host header fails its host
+        # regex, so the U-label survives only here.
+        raw_headers=getattr(request.headers, "raw", None),
     )
 
 

--- a/src/adcp/signing/verifier.py
+++ b/src/adcp/signing/verifier.py
@@ -9,11 +9,12 @@ taxonomy — conformance requires byte-for-byte match on the code string.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal
 
+from adcp.signing._header_precheck import strict_header_precheck
 from adcp.signing.canonical import (
     TargetUriMalformedError,
     _lookup,
@@ -175,10 +176,20 @@ def verify_request_signature(
     headers: Mapping[str, str],
     body: bytes,
     options: VerifyOptions,
+    raw_headers: Sequence[tuple[bytes, bytes]] | None = None,
 ) -> VerifiedSigner:
     """Run the AdCP request-signing verifier checklist against a request.
 
     Raises SignatureVerificationError with the spec error code on failure.
+
+    `raw_headers` is the as-received header list, wire order preserved, e.g.
+    Starlette's `request.headers.raw`. Supply it when you can: `headers` is a
+    mapping, and every mapping has already resolved a repeated header name to a
+    single value, so a proxy-inserted second line is invisible to the step-1
+    checks without it. Omitting it does not weaken any other stage -- the
+    comma-joined form of each malformed shape is still rejected -- but the
+    repeated-line rule cannot fire. See `_header_precheck` for why WSGI cannot
+    supply a meaningful raw list at all.
     """
     sig_input_raw = _lookup(headers, "signature-input")
     sig_raw = _lookup(headers, "signature")
@@ -190,6 +201,19 @@ def verify_request_signature(
         required_for=options.capability.required_for,
     )
     assert sig_input_raw is not None and sig_raw is not None
+
+    # Step 1, and it must precede the parse below rather than wrap it: the
+    # parser resolves ambiguity (RFC 8941 lets a duplicate dictionary key be
+    # dropped rather than rejected), and once resolved the ambiguity is
+    # invisible. Runs after the presence pre-check so a request with no
+    # signature at all still reports `request_signature_required`.
+    precheck_reason = strict_header_precheck(headers=headers, raw_headers=raw_headers, url=url)
+    if precheck_reason is not None:
+        raise SignatureVerificationError(
+            REQUEST_SIGNATURE_HEADER_MALFORMED,
+            step=1,
+            message=precheck_reason,
+        )
 
     try:
         labels = parse_signature_input_header(sig_input_raw)

--- a/tests/conformance/signing/test_header_precheck.py
+++ b/tests/conformance/signing/test_header_precheck.py
@@ -1,0 +1,174 @@
+"""Step-1 strict rejection, graded in the form the vectors cannot express.
+
+`negative/021`, `022`, `023` and `026` each ship their malformed shape as a
+single comma-joined header value, because a JSON vector has nowhere to put two
+lines with the same name. But the threat their own `$comment`s describe is a
+proxy inserting a **second header line** — and every mapping view of headers
+resolves that to one value before any check runs, so a gate written over the
+mapping passes all four vectors while missing the attack entirely.
+
+These tests drive the two-line form. Without them the conformance suite is
+green and the threat is open.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from adcp.signing import (
+    InMemoryReplayStore,
+    SignatureVerificationError,
+    VerifierCapability,
+    VerifyOptions,
+    verify_request_signature,
+)
+from adcp.signing.errors import REQUEST_SIGNATURE_HEADER_MALFORMED
+
+_URL = "https://seller.example.com/adcp/create_media_buy"
+_SIG_INPUT = (
+    'sig1=("@method" "@target-uri" "@authority" "content-type");created=1776520800;'
+    'expires=1776521100;nonce="KXYnfEfJ0PBRZXQyVXfVQA";keyid="test-ed25519-2026";'
+    'alg="ed25519";tag="adcp/request-signing/v1"'
+)
+_SIG = "sig1=:" + "A" * 86 + ":"
+
+
+def _options() -> VerifyOptions:
+    return VerifyOptions(
+        now=1776520800.0,
+        capability=VerifierCapability(),
+        operation="create_media_buy",
+        jwks_resolver=lambda keyid: None,
+        replay_store=InMemoryReplayStore(),
+    )
+
+
+def _verify(raw: list[tuple[bytes, bytes]] | None, headers: dict[str, str]) -> None:
+    verify_request_signature(
+        method="POST",
+        url=_URL,
+        headers=headers,
+        body=b'{"plan_id":"plan_001"}',
+        options=_options(),
+        raw_headers=raw,
+    )
+
+
+def test_second_content_type_line_is_rejected_at_step_1() -> None:
+    """The attack the vectors describe but cannot express.
+
+    A proxy appends a second `Content-Type`. `dict(headers)` keeps exactly one
+    of them — first or last depending on the framework — so the signed view and
+    the parsed view can disagree while every conformance vector still passes.
+    """
+    raw = [
+        (b"content-type", b"application/json"),
+        (b"content-type", b"text/plain"),
+        (b"signature-input", _SIG_INPUT.encode()),
+        (b"signature", _SIG.encode()),
+    ]
+    # The mapping a framework would hand us has already lost the second line.
+    collapsed = {
+        "Content-Type": "application/json",
+        "Signature-Input": _SIG_INPUT,
+        "Signature": _SIG,
+    }
+
+    with pytest.raises(SignatureVerificationError) as exc_info:
+        _verify(raw, collapsed)
+    assert exc_info.value.code == REQUEST_SIGNATURE_HEADER_MALFORMED
+    assert exc_info.value.step == 1
+
+
+def test_second_signature_input_line_is_rejected_at_step_1() -> None:
+    """Two `Signature-Input` lines are the covered-component smuggling vector.
+
+    Same shape as `negative/021`'s duplicate dictionary key, arriving by the
+    other route: a second line whose component list is shorter than the one the
+    producer signed.
+    """
+    weaker = 'sig1=("@method" "@target-uri");created=1776520800;expires=1776521100;nonce="AAAAAAAAAAAAAAAAAAAAAA";keyid="test-ed25519-2026";alg="ed25519";tag="adcp/request-signing/v1"'
+    raw = [
+        (b"content-type", b"application/json"),
+        (b"signature-input", _SIG_INPUT.encode()),
+        (b"signature-input", weaker.encode()),
+        (b"signature", _SIG.encode()),
+    ]
+    collapsed = {
+        "Content-Type": "application/json",
+        "Signature-Input": _SIG_INPUT,
+        "Signature": _SIG,
+    }
+
+    with pytest.raises(SignatureVerificationError) as exc_info:
+        _verify(raw, collapsed)
+    assert exc_info.value.code == REQUEST_SIGNATURE_HEADER_MALFORMED
+    assert exc_info.value.step == 1
+
+
+def test_repeated_line_is_invisible_without_raw_headers() -> None:
+    """The documented limit of the mapping-only path, pinned so it stays honest.
+
+    This is not a bug being enshrined -- it is the reason `raw_headers` exists.
+    If this ever starts raising, the mapping grew the ability to carry a
+    repeated name and the docstring on `verify_request_signature` is stale.
+    """
+    collapsed = {
+        "Content-Type": "application/json",
+        "Signature-Input": _SIG_INPUT,
+        "Signature": _SIG,
+    }
+    with pytest.raises(SignatureVerificationError) as exc_info:
+        _verify(None, collapsed)
+    # Fails later, on the unknown key -- NOT at step 1 as malformed.
+    assert exc_info.value.code != REQUEST_SIGNATURE_HEADER_MALFORMED
+
+
+def test_non_ascii_host_header_is_rejected_even_when_the_url_is_clean() -> None:
+    """The real-traffic shape of `negative/026`, which no vector can carry.
+
+    ASGI frameworks drop a non-ASCII Host when building `request.url`
+    (Starlette's `URL` falls back to `scope["server"]` when the Host header
+    fails its host regex), so in production the U-label survives only on the
+    header. A gate that checked the URL alone would pass vector 026 -- which
+    ships no Host header -- and miss every real request.
+    """
+    raw = [
+        (b"host", "bücher.example.com".encode()),
+        (b"content-type", b"application/json"),
+        (b"signature-input", _SIG_INPUT.encode()),
+        (b"signature", _SIG.encode()),
+    ]
+    collapsed = {
+        "Host": "bücher.example.com",
+        "Content-Type": "application/json",
+        "Signature-Input": _SIG_INPUT,
+        "Signature": _SIG,
+    }
+    with pytest.raises(SignatureVerificationError) as exc_info:
+        _verify(raw, collapsed)
+    assert exc_info.value.code == REQUEST_SIGNATURE_HEADER_MALFORMED
+    assert exc_info.value.step == 1
+
+
+def test_multi_algorithm_content_digest_is_not_rejected() -> None:
+    """False-positive guard: distinct algorithms are legal, duplicates are not.
+
+    RFC 9530 permits a `Content-Digest` carrying several algorithms. Only a
+    repeated *key* is the defect `negative/023` describes. A gate that rejected
+    every comma would refuse traffic the spec requires accepting -- worse than
+    the bug it closes.
+    """
+    digest = (
+        "sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:, "
+        "sha-512=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:"
+    )
+    headers = {
+        "Content-Type": "application/json",
+        "Content-Digest": digest,
+        "Signature-Input": _SIG_INPUT,
+        "Signature": _SIG,
+    }
+    with pytest.raises(SignatureVerificationError) as exc_info:
+        _verify(None, headers)
+    assert exc_info.value.code != REQUEST_SIGNATURE_HEADER_MALFORMED

--- a/tests/conformance/signing/test_verifier_vectors.py
+++ b/tests/conformance/signing/test_verifier_vectors.py
@@ -35,28 +35,7 @@ KEYS_BY_KID = {k["kid"]: k for k in json.loads((VECTORS_DIR / "keys.json").read_
 # Marked strict: when the verifier is fixed the vector XPASSes and this module
 # goes red, which is the signal to delete the entry rather than leave a stale
 # exemption behind.
-KNOWN_VERIFIER_GAPS: dict[str, str] = {
-    "021-duplicate-signature-input-label.json": (
-        "#976: duplicate Signature-Input dictionary key is silently resolved instead of "
-        "rejected (RFC 8941 §3.2 / covered-component smuggling)"
-    ),
-    "022-multi-valued-content-type.json": (
-        "#976: multi-valued Content-Type on a covered non-list field is not rejected at parse"
-    ),
-    "023-multi-valued-content-digest.json": (
-        "#976: multi-valued Content-Digest (duplicate RFC 9530 algorithm) is not rejected at parse"
-    ),
-    # The signer half of #977 has landed: @target-uri canonicalization now
-    # converts a U-label to its A-label form. This vector is the verifier half
-    # -- a U-label arriving on the wire must be REJECTED, not converted -- and
-    # it expects request_signature_header_malformed at step 1, which is #976's
-    # precheck. Same predicate (canonical.host_has_raw_non_ascii), different
-    # code at a different step; it retires with #976, not with the conversion.
-    "026-non-ascii-host.json": (
-        "#977 (verifier half): raw IDN U-label on the wire is not rejected at step 1; "
-        "lands with #976's strict header precheck"
-    ),
-}
+KNOWN_VERIFIER_GAPS: dict[str, str] = {}
 
 
 def _operation_from_url(url: str) -> str:


### PR DESCRIPTION
> **Stacked on #985, which is stacked on #980 — merge order: #980 → #985 → this.**
> Own commit: `051c717a`. Everything else in the diff belongs to #980 and #985.
> Incremental diff: https://github.com/KonstantinMirin/adcp-client-python/compare/fix/target-uri-malformed-authority...fix/strict-header-precheck

Fixes #976. Closes #977 (verifier half — #985 closed the signer half).

> **Please read the "Known limit" section before approving.** This PR cannot fully close the threat on WSGI, and I would rather that be an explicit review decision than a footnote.

## What was wrong

The verifier had no strict step-1 stage, so malformed or ambiguous input flowed on to a later check that rejected it for a different reason. Conformance grades the code byte-for-byte, so "rejected anyway" is not a pass.

| vector | today | required |
|---|---|---|
| `021` duplicate `Signature-Input` key | `components_incomplete`, step 6 | `header_malformed`, step 1 |
| `022` multi-valued `Content-Type` | `invalid`, step 10 | `header_malformed`, step 1 |
| `023` duplicate `Content-Digest` key | `invalid`, step 10 | `header_malformed`, step 1 |
| `026` non-ASCII `Host` | `invalid`, step 10 | `header_malformed`, step 1 |

## Design

**A predicate table, not an if-chain**, so a rule has one definition and can raise a different code at a different step elsewhere. `host_has_raw_non_ascii` is shared with canonicalization — which rejects a malformed authority as `request_target_uri_malformed` at step 6 — exactly so the U-label rule is not written twice. One rule, two codes, two steps.

**Placed before the parse, not around it.** RFC 8941 §3.2 permits a duplicate dictionary key to be *dropped* rather than rejected, and `d[key] = v` in a loop is what a parser reaches for by default. That is the smuggling vector: append a second entry with the same label and a weaker covered-component set, the parser keeps one, and the signature verifies over fewer components than the producer signed. Once resolved, the ambiguity is invisible.

**Placed after the presence pre-check**, so an unsigned request still reports `request_signature_required` rather than `header_malformed`. No vector covers that combination.

## The `raw_headers` parameter

New, optional, keyword-only; both framework wrappers pass it. Non-breaking.

Every mapping view of headers resolves a repeated name to one value — measured on starlette 0.52.1, `dict(...)` is **first-wins**, so an injected second line is the one that disappears. The vectors express each malformed shape as a single comma-joined value because JSON has nowhere to put two lines with the same name; the threat their own `$comment`s describe is a proxy inserting that second line. **A gate written over the mapping passes all four vectors and misses the attack.** Both forms are now graded.

## Known limit — please review this explicitly

**The repeated-line rule only bites on ASGI.** This is not an implementation shortcut; it is a WSGI property and cannot be fixed here:

- PEP 3333 folds repeated `HTTP_*` headers into one comma-joined environ value, and
- `make_environ` writes `CONTENT_TYPE` / `CONTENT_LENGTH` to **bare environ keys with last-wins and no join**.

So `022`'s exact shape is destroyed one layer above this SDK, and werkzeug's `EnvironHeaders.__iter__` iterates the environ dict — `.items()` structurally cannot yield a repeated name. The Flask `raw_headers` list therefore carries the same information as `dict(request.headers)`.

Flask still gets every comma-joined rule and still passes all four vectors. It cannot get two-line protection from anywhere. The wrapper passes the list anyway so both arms run the same code path, and `_header_precheck`'s module docstring says why it is inert there. **If you would rather not ship an inert Flask arm, say so and I will drop it and document the asymmetry instead.**

## `026` is checked twice, deliberately

Against the `Host` header **and** the URL authority. Neither alone is sufficient:

- Starlette **drops** a non-ASCII Host when building `request.url` — `URL.__init__` gates on `_HOST_RE.fullmatch` and falls back to `scope["server"]` (measured: `http://test:None/x` while `request.headers.raw` still held the U-label bytes). In production the U-label survives only on the header.
- The vector ships **no Host header at all** and expresses the case through the URL.

Checking either one alone passes conformance while missing the other half of reality.

## Not changed, on purpose

`negative/011` and `negative/024` already return the correct code and are untouched — a gate that cannot *prove* malformation must pass traffic through. A predicate simulation over all 40 vectors hits exactly these 4 with zero false positives.

Rejecting a repeated line does 401 an RFC 9110 §5.3-**legal** split of `Signature-Input` or `Content-Digest`. That is a deliberate profile choice: the ambiguity removed is worth more than the flexibility lost, and no known producer splits them. Flagging it because it is a real trade-off, not a free win.

## Test plan

`make ci-local`: **5962 passed, 0 failed, 41 skipped, 2 xfailed** (#985's baseline: 5953 / 6). Exactly +9 passed / −4 xfailed: four retired ledger entries plus five new tests.

`tests/conformance/signing/test_header_precheck.py` drives the **two-line form** the vectors cannot carry, plus two guards that matter as much as the rejections:

- a multi-*algorithm* `Content-Digest` (`sha-256=…, sha-512=…`) must NOT be rejected — RFC 9530 permits it, only a repeated key is the defect. A gate that rejected every comma would refuse traffic the spec requires accepting.
- the mapping-only path's blindness to a repeated line is pinned by a test, so if it ever changes the docstring is caught being stale.

`KNOWN_VERIFIER_GAPS` is now empty. **All 40 request-signing vectors pass with zero xfail** — with #985 and #987, that is the complete 3.1.8 request-signing vector set green.

