### PR TITLE
fix(release): compare normalized prerelease versions

### DIFF
--- a/tests/test_release_configuration.py
+++ b/tests/test_release_configuration.py
@@ -6,10 +6,12 @@ import json
 import re
 from pathlib import Path
 
+from scripts.normalize_pyproject_prerelease import pep440_prerelease
+
 ROOT = Path(__file__).parent.parent
 
 
-def test_worktree_version_matches_last_release_manifest() -> None:
+def test_worktree_version_matches_normalized_release_manifest() -> None:
     pyproject = (ROOT / "pyproject.toml").read_text()
     project_section = re.search(
         r'^\[project\]\s*$.*?^version\s*=\s*"([^"]+)"',
@@ -18,7 +20,7 @@ def test_worktree_version_matches_last_release_manifest() -> None:
     )
     assert project_section is not None
     manifest = json.loads((ROOT / ".release-please-manifest.json").read_text())
-    assert project_section.group(1) == manifest["."]
+    assert project_section.group(1) == pep440_prerelease(manifest["."])
 
 
 def test_release_please_targets_v7_rc_from_breaking_commit() -> None:


### PR DESCRIPTION
## Summary

- compare the release manifest version after applying the same SemVer-to-PEP-440 normalization used by the release workflow
- keep stable-version comparisons unchanged

## Root cause

Release Please stores `7.0.0-rc.1` in its manifest, while Python packaging correctly requires `7.0.0rc1` in `pyproject.toml`. The release configuration test compared these equivalent versions as raw strings, blocking the `7.0.0-rc.1` release PR.

## Validation

- `pytest tests/test_release_configuration.py tests/test_normalize_pyproject_prerelease.py`: 6 passed
- Ruff and format checks passed
- full pre-commit suite passed